### PR TITLE
Add OSS CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: Talon OSS CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "internal-preview/**"
+
+concurrency:
+  group: talon-oss-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo:
+    name: Cargo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends pkg-config libssl-dev protobuf-compiler
+
+      - name: Cargo metadata
+        run: cargo metadata --locked
+
+      - name: Cargo build
+        run: cargo build --locked --bins
+
+      - name: Cargo test
+        run: cargo test --locked
+
+  runtime_image:
+    name: Runtime Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/oss-runtime.Dockerfile
+          push: false
+          load: false
+
+  envoy_image:
+    name: Envoy Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protobuf compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends protobuf-compiler
+
+      - name: Generate descriptor set
+        run: |
+          protoc -I. -Iproto -Ithird_party/googleapis \
+            --include_imports \
+            --include_source_info \
+            --experimental_allow_proto3_optional \
+            --descriptor_set_out=talon_gateway_proto-descriptor-set.proto.bin \
+            proto/gateway.proto
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build envoy image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/envoy-cloudrun.Dockerfile
+          push: false
+          load: false
+
+  ui:
+    name: UI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: ui/pnpm-lock.yaml
+
+      - name: Install UI dependencies
+        working-directory: ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Build UI
+        working-directory: ui
+        run: pnpm build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build UI image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/oss-ui.Dockerfile
+          push: false
+          load: false
+          build-args: |
+            NEXT_PUBLIC_GATEWAY_URL=http://localhost:18789

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           file: dockerfiles/oss-runtime.Dockerfile
           push: false
           load: false
+          cache-from: type=gha,scope=talon-runtime-image
+          cache-to: type=gha,mode=max,scope=talon-runtime-image
 
   envoy_image:
     name: Envoy Image
@@ -85,6 +87,8 @@ jobs:
           file: dockerfiles/envoy-cloudrun.Dockerfile
           push: false
           load: false
+          cache-from: type=gha,scope=talon-envoy-image
+          cache-to: type=gha,mode=max,scope=talon-envoy-image
 
   ui:
     name: UI
@@ -122,5 +126,7 @@ jobs:
           file: dockerfiles/oss-ui.Dockerfile
           push: false
           load: false
+          cache-from: type=gha,scope=talon-ui-image
+          cache-to: type=gha,mode=max,scope=talon-ui-image
           build-args: |
             NEXT_PUBLIC_GATEWAY_URL=http://localhost:18789

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           push: false
           load: false
           cache-from: type=gha,scope=talon-runtime-image
-          cache-to: type=gha,mode=max,scope=talon-runtime-image
+          cache-to: type=gha,mode=min,scope=talon-runtime-image
 
   envoy_image:
     name: Envoy Image

--- a/dockerfiles/oss-runtime.Dockerfile
+++ b/dockerfiles/oss-runtime.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM rust:1.88-slim AS builder
+FROM rust:1.91.1-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \

--- a/dockerfiles/oss-runtime.Dockerfile
+++ b/dockerfiles/oss-runtime.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM rust:1.91.1-slim AS builder
+FROM rust:1.91.1-slim AS chef
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
@@ -8,15 +8,36 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
+RUN cargo install cargo-chef --locked
+
 WORKDIR /usr/src/talon
 
+FROM chef AS planner
+
 COPY Cargo.toml Cargo.lock build.rs ./
+COPY third_party ./third_party
 COPY proto ./proto
 COPY src ./src
-COPY third_party ./third_party
 COPY talon.yaml ./talon.yaml
+RUN cargo chef prepare --recipe-path recipe.json
 
-RUN cargo build --release --locked --bins
+FROM chef AS builder
+
+COPY --from=planner /usr/src/talon/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/src/talon/target \
+    cargo chef cook --release --recipe-path recipe.json
+
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY third_party ./third_party
+COPY proto ./proto
+COPY src ./src
+COPY talon.yaml ./talon.yaml
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/src/talon/target \
+    cargo build --release --locked --bins
 
 FROM debian:bookworm-slim
 

--- a/dockerfiles/oss-runtime.Dockerfile
+++ b/dockerfiles/oss-runtime.Dockerfile
@@ -27,7 +27,7 @@ COPY --from=planner /usr/src/talon/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/src/talon/target \
-    cargo chef cook --release --recipe-path recipe.json
+    CARGO_TARGET_DIR=/usr/src/talon/target cargo chef cook --release --recipe-path recipe.json
 
 COPY Cargo.toml Cargo.lock build.rs ./
 COPY third_party ./third_party
@@ -37,7 +37,11 @@ COPY talon.yaml ./talon.yaml
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/src/talon/target \
-    cargo build --release --locked --bins
+    CARGO_TARGET_DIR=/usr/src/talon/target cargo build --release --locked --bins && \
+    mkdir -p /usr/src/talon/dist && \
+    cp /usr/src/talon/target/release/talon-server /usr/src/talon/dist/talon-server && \
+    cp /usr/src/talon/target/release/talon-worker /usr/src/talon/dist/talon-worker && \
+    cp /usr/src/talon/target/release/talon-cli /usr/src/talon/dist/talon-cli
 
 FROM debian:bookworm-slim
 
@@ -47,9 +51,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/src/talon/target/release/talon-server /usr/local/bin/talon-server
-COPY --from=builder /usr/src/talon/target/release/talon-worker /usr/local/bin/talon-worker
-COPY --from=builder /usr/src/talon/target/release/talon-cli /usr/local/bin/talon-cli
+COPY --from=builder /usr/src/talon/dist/talon-server /usr/local/bin/talon-server
+COPY --from=builder /usr/src/talon/dist/talon-worker /usr/local/bin/talon-worker
+COPY --from=builder /usr/src/talon/dist/talon-cli /usr/local/bin/talon-cli
 COPY --from=builder /usr/src/talon/talon.yaml /data/talon/talon.yaml
 
 RUN mkdir -p /data/talon

--- a/dockerfiles/oss-runtime.Dockerfile
+++ b/dockerfiles/oss-runtime.Dockerfile
@@ -26,8 +26,7 @@ FROM chef AS builder
 COPY --from=planner /usr/src/talon/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/usr/src/talon/target \
-    CARGO_TARGET_DIR=/usr/src/talon/target cargo chef cook --release --recipe-path recipe.json
+    cargo chef cook --release --recipe-path recipe.json
 
 COPY Cargo.toml Cargo.lock build.rs ./
 COPY third_party ./third_party
@@ -36,8 +35,7 @@ COPY src ./src
 COPY talon.yaml ./talon.yaml
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/usr/src/talon/target \
-    CARGO_TARGET_DIR=/usr/src/talon/target cargo build --release --locked --bins && \
+    cargo build --release --locked --bins && \
     mkdir -p /usr/src/talon/dist && \
     cp /usr/src/talon/target/release/talon-server /usr/src/talon/dist/talon-server && \
     cp /usr/src/talon/target/release/talon-worker /usr/src/talon/dist/talon-worker && \

--- a/dockerfiles/oss-ui.Dockerfile
+++ b/dockerfiles/oss-ui.Dockerfile
@@ -17,7 +17,19 @@ FROM deps AS builder
 ARG NEXT_PUBLIC_GATEWAY_URL=""
 ENV NEXT_PUBLIC_GATEWAY_URL=$NEXT_PUBLIC_GATEWAY_URL
 
-COPY ui ./
+COPY ui/app ./app
+COPY ui/components ./components
+COPY ui/lib ./lib
+COPY ui/proto ./proto
+COPY ui/public ./public
+COPY ui/utils ./utils
+COPY ui/global.d.ts ./global.d.ts
+COPY ui/next-env.d.ts ./next-env.d.ts
+COPY ui/next.config.mjs ./next.config.mjs
+COPY ui/postcss.config.mjs ./postcss.config.mjs
+COPY ui/tailgrids.config.json ./tailgrids.config.json
+COPY ui/tsconfig.json ./tsconfig.json
+COPY ui/types.d.ts ./types.d.ts
 RUN pnpm run build
 
 FROM node:22-slim AS runner
@@ -35,7 +47,7 @@ COPY --from=builder /repo/ui/package.json ./package.json
 COPY --from=builder /repo/ui/.next ./.next
 COPY --from=builder /repo/ui/node_modules ./node_modules
 COPY --from=builder /repo/ui/public ./public
-COPY --from=builder /repo/ui/next.config.ts ./next.config.ts
+COPY --from=builder /repo/ui/next.config.mjs ./next.config.mjs
 
 EXPOSE 3000
 

--- a/dockerfiles/oss-ui.Dockerfile
+++ b/dockerfiles/oss-ui.Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /repo/ui
 
 COPY ui/package.json ./
 COPY ui/pnpm-lock.yaml ./pnpm-lock.yaml
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --config.node-linker=hoisted
 
 FROM deps AS builder
 

--- a/dockerfiles/oss-ui.Dockerfile
+++ b/dockerfiles/oss-ui.Dockerfile
@@ -9,7 +9,7 @@ RUN corepack enable
 WORKDIR /repo/ui
 
 COPY ui/package.json ./
-COPY .copybara/talon/public/ui/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY ui/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS builder

--- a/dockerfiles/oss-ui.Dockerfile
+++ b/dockerfiles/oss-ui.Dockerfile
@@ -21,7 +21,6 @@ COPY ui/app ./app
 COPY ui/components ./components
 COPY ui/lib ./lib
 COPY ui/proto ./proto
-COPY ui/public ./public
 COPY ui/utils ./utils
 COPY ui/global.d.ts ./global.d.ts
 COPY ui/next-env.d.ts ./next-env.d.ts
@@ -46,7 +45,6 @@ WORKDIR /app/ui
 COPY --from=builder /repo/ui/package.json ./package.json
 COPY --from=builder /repo/ui/.next ./.next
 COPY --from=builder /repo/ui/node_modules ./node_modules
-COPY --from=builder /repo/ui/public ./public
 COPY --from=builder /repo/ui/next.config.mjs ./next.config.mjs
 
 EXPOSE 3000

--- a/dockerfiles/oss-ui.Dockerfile
+++ b/dockerfiles/oss-ui.Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /repo/ui
 
 COPY ui/package.json ./
 COPY ui/pnpm-lock.yaml ./pnpm-lock.yaml
-RUN pnpm install --frozen-lockfile --config.node-linker=hoisted
+RUN --mount=type=cache,target=/pnpm/store \
+    pnpm install --frozen-lockfile --config.node-linker=hoisted
 
 FROM deps AS builder
 


### PR DESCRIPTION
Adds the standalone GitHub Actions CI workflow for the Talon OSS repo and fixes the OSS UI Dockerfile to use the repo-local lockfile path.