### PR TITLE
Add Talon CLA and license header enforcement

### DIFF
--- a/.github/license-header.txt
+++ b/.github/license-header.txt
@@ -1,0 +1,2 @@
+Copyright (C) 2026 Impala Systems, Inc.
+SPDX-License-Identifier: AGPL-3.0-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  license_headers:
+    name: License Headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Verify Rust license headers
+        run: ./scripts/check_rust_license_headers.sh
+
   cargo:
     name: Cargo
     runs-on: ubuntu-latest

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,38 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: CLA
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify contributor CLA
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: ".github/cla-signatures/version1/cla.json"
+          path-to-document: "https://github.com/impalasys/talon/blob/main/CLA.md"
+          branch: "cla-signatures"
+          allowlist: "ShukantPal,dependabot[bot],github-actions[bot]"
+          create-file-commit-message: "Create CLA signature store"
+          signed-commit-message: "$contributorName signed the Talon CLA for $owner/$repo#$pullRequestNo"
+          custom-notsigned-prcomment: >
+            Thanks for the contribution. Before we can review or merge this pull request,
+            every contributor on it needs to sign the Talon CLA by replying on this PR with:
+            `I have read the CLA Document and I hereby sign the CLA`
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: "All contributors on this pull request have signed the Talon CLA."
+          lock-pullrequest-aftermerge: false

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,88 @@
+# Impala Systems Individual Contributor License Agreement
+
+Thank you for contributing to Talon.
+
+In order to accept your contribution, Impala Systems, Inc. ("Impala") needs a
+record that you grant the rights described below for your contribution. This
+Contributor License Agreement ("Agreement") applies to any past, present, and
+future contribution you submit to the Talon repository unless you and Impala
+agree otherwise in writing.
+
+## 1. Definitions
+
+"You" means the individual who is submitting a contribution and who has the
+legal authority to agree to this Agreement.
+
+"Contribution" means any source code, object code, patch, bug fix,
+documentation, test, design, issue text, pull request content, or other work
+you intentionally submit to Talon or related repositories controlled by Impala
+for inclusion in the project.
+
+"Submitted" means any form of electronic, verbal, or written communication sent
+to Impala or its representatives for the purpose of discussing or improving the
+project, including communication on GitHub, email, or other project channels,
+excluding communication that is clearly marked in writing as not a
+contribution.
+
+## 2. Copyright License Grant
+
+You grant to Impala and to recipients of software distributed by Impala a
+perpetual, worldwide, non-exclusive, irrevocable, royalty-free, fully paid-up
+license to use, reproduce, modify, prepare derivative works of, publicly
+display, publicly perform, sublicense, and distribute your Contributions and
+such derivative works.
+
+This license grant includes the right for Impala to distribute your
+Contributions under the current open-source license for Talon and under other
+license terms, including commercial, source-available, or proprietary terms.
+
+## 3. Patent License Grant
+
+If your Contribution includes a patentable invention, you grant to Impala and
+to recipients of software distributed by Impala a perpetual, worldwide,
+non-exclusive, irrevocable, royalty-free, fully paid-up license under your
+patent claims that are necessarily infringed by your Contribution alone or by
+combination of your Contribution with the project to make, have made, use, sell,
+offer for sale, import, and otherwise transfer the Contribution.
+
+If you institute patent litigation against Impala or any entity asserting that
+the project or a Contribution infringes a patent, then any patent licenses
+granted by you to Impala under this Agreement for that Contribution shall
+terminate as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that:
+
+- you are legally entitled to grant the above rights;
+- each Contribution is your original creation, or you have sufficient rights to
+  submit it under this Agreement;
+- to the best of your knowledge, each Contribution does not intentionally
+  include material that is subject to license or contractual terms that would
+  prevent Impala from exercising the rights granted in this Agreement.
+
+If you submit a Contribution on behalf of your employer or another legal
+entity, you represent that you are authorized to do so.
+
+## 5. Project License
+
+You understand that Talon is currently distributed under the GNU Affero General
+Public License v3.0, but that Impala may also distribute the project or your
+Contributions under other license terms.
+
+## 6. No Obligation
+
+You understand that Impala is not required to use, merge, distribute, or
+support any Contribution.
+
+## 7. No Warranty
+
+You provide each Contribution "as is," without warranties or conditions of any
+kind, express or implied, including merchantability, fitness for a particular
+purpose, non-infringement, or title.
+
+## 8. Acceptance
+
+You accept this Agreement by submitting a pull request comment containing the
+text requested by the CLA workflow. That acceptance applies to all of your
+Contributions unless replaced by a later written agreement with Impala.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@
 - Open pull requests against `main`.
 - Keep changes scoped to Talon runtime, UI, tests, or supporting docs.
 - Do not add private infrastructure, secrets, or deployment configuration.
+- By contributing, you agree to the Talon Contributor License Agreement in
+  `CLA.md`. The CLA workflow will ask you to sign it once per identity.
 
 ## Validation
 
@@ -23,6 +25,29 @@ cd ui
 pnpm install --frozen-lockfile
 pnpm build
 ```
+
+## License headers
+
+Rust source files in this repository carry the following header:
+
+```rust
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+```
+
+To apply headers across the tracked Rust files:
+
+```bash
+./scripts/apply_rust_license_headers.sh
+```
+
+To check that headers are present:
+
+```bash
+./scripts/check_rust_license_headers.sh
+```
+
+The scripts use `google/addlicense` pinned at `v1.2.0`.
 
 ## Scope notes
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,662 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.
+

--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ docker build -f dockerfiles/envoy-cloudrun.Dockerfile .
 ## License
 
 This repository is licensed under the GNU Affero General Public License v3.0. See `LICENSE`.
+
+## Contributions
+
+External contributions are accepted under the Talon Contributor License
+Agreement in `CLA.md`. Rust source files use the repository's standard copyright
+and SPDX header, enforced in CI.

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 fn main() -> std::io::Result<()> {
     // All message types in the manifests package get serde support so they can
     // be deserialized directly from YAML/JSON without shadow structs.

--- a/scripts/apply_rust_license_headers.sh
+++ b/scripts/apply_rust_license_headers.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+mapfile -d '' files < <(git ls-files -z '*.rs')
+
+if [[ "${#files[@]}" -eq 0 ]]; then
+  exit 0
+fi
+
+go run github.com/google/addlicense@v1.2.0 \
+  -f .github/license-header.txt \
+  "${files[@]}"

--- a/scripts/apply_rust_license_headers.sh
+++ b/scripts/apply_rust_license_headers.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-mapfile -d '' files < <(git ls-files -z '*.rs')
+files=()
+while IFS= read -r -d '' file; do
+  files+=("$file")
+done < <(git ls-files -z '*.rs')
 
 if [[ "${#files[@]}" -eq 0 ]]; then
   exit 0

--- a/scripts/check_rust_license_headers.sh
+++ b/scripts/check_rust_license_headers.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-mapfile -d '' files < <(git ls-files -z '*.rs')
+files=()
+while IFS= read -r -d '' file; do
+  files+=("$file")
+done < <(git ls-files -z '*.rs')
 
 if [[ "${#files[@]}" -eq 0 ]]; then
   exit 0

--- a/scripts/check_rust_license_headers.sh
+++ b/scripts/check_rust_license_headers.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+mapfile -d '' files < <(git ls-files -z '*.rs')
+
+if [[ "${#files[@]}" -eq 0 ]]; then
+  exit 0
+fi
+
+go run github.com/google/addlicense@v1.2.0 \
+  -check \
+  -f .github/license-header.txt \
+  "${files[@]}"

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -1,1 +1,4 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pub mod resolver;

--- a/src/agents/resolver.rs
+++ b/src/agents/resolver.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use std::collections::HashSet;
 
 use anyhow::{anyhow, bail, Result};

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::{Context, Result};
 use base64::Engine;
 use clap::{Parser, Subcommand};

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::Result;
 use std::sync::Arc;
 use talon::config::{Config, ConfigExt};

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::Result;
 use axum::{
     body::Bytes, extract::State, http::HeaderMap, response::IntoResponse, routing::post, Json,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::{anyhow, Result};
 use prost::Message;
 use serde::Deserialize;

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::config::proto;
 use anyhow::{anyhow, Result};
 use std::process::Command;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 #[cfg(test)]
 mod tests {
     use crate::config::{proto, Config, ConfigExt, Secret, SecretExt};

--- a/src/connectors/mcp.rs
+++ b/src/connectors/mcp.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::gateway::rpc::manifests;
 use anyhow::{anyhow, Result};
 use axum::http::{HeaderName, HeaderValue};

--- a/src/connectors/mcp_tests.rs
+++ b/src/connectors/mcp_tests.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 #[cfg(test)]
 mod tests {
     use crate::connectors::mcp::{

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pub mod mcp;
 
 pub use mcp::{McpClient, McpTool};

--- a/src/control/events.rs
+++ b/src/control/events.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 #[cfg(not(feature = "bazel"))]
 pub mod proto {
     tonic::include_proto!("talon.events");

--- a/src/control/keys.rs
+++ b/src/control/keys.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /// Generates the standard KeyValue store path for an Agent
 /// e.g., "Agent/billing-bot-abc123"
 pub fn agent(id: &str) -> String {

--- a/src/control/kv.rs
+++ b/src/control/kv.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::control::KeyValueStore;
 use anyhow::Result;
 use serde::{de::DeserializeOwned, Serialize};

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use std::pin::Pin;
 pub mod events;
 pub mod keys;

--- a/src/control/ns.rs
+++ b/src/control/ns.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /// Core system namespace for Talon Control Plane resources.
 /// Similar to Kubernetes' `kube-system`, this namespace is strictly for
 /// internal platform logic, template artifacts, and manifests that are globally accessible

--- a/src/control/pubsub.rs
+++ b/src/control/pubsub.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::control::MessagePublisher;
 use anyhow::Result;
 use google_cloud_googleapis::pubsub::v1::PubsubMessage;

--- a/src/control/scheduler.rs
+++ b/src/control/scheduler.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 mod cloud_tasks;
 mod local_postgres;
 mod noop;

--- a/src/control/scheduler/cloud_tasks.rs
+++ b/src/control/scheduler/cloud_tasks.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::config::{proto::CloudTasksSchedulerConfig, SecretExt};
 use anyhow::{anyhow, Context, Result};
 use base64::Engine as _;

--- a/src/control/scheduler/local_postgres.rs
+++ b/src/control/scheduler/local_postgres.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::{anyhow, Result};
 use chrono::Utc;
 use futures::stream::{FuturesUnordered, StreamExt};

--- a/src/control/scheduler/noop.rs
+++ b/src/control/scheduler/noop.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::Result;
 
 use super::{ScheduleWakeupRequest, ScheduledWakeup, SchedulerBackend};

--- a/src/control/topics.rs
+++ b/src/control/topics.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 

--- a/src/core/context_budget.rs
+++ b/src/core/context_budget.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use super::executor::LoopMessage;
 use serde_json::{json, Map, Value};
 

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::StreamExt;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pub mod context_budget;
 pub mod executor;
 pub mod rpc;

--- a/src/core/rpc.rs
+++ b/src/core/rpc.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/core/task.rs
+++ b/src/core/task.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/gateway/auth.rs
+++ b/src/gateway/auth.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Gateway Authentication - token/password auth middleware for the Gateway
 // This file is owned by: Agent 4 (Gateway Auth & Tools)
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pub mod auth;
 pub mod rpc;
 pub mod server;

--- a/src/gateway/rpc/agents.rs
+++ b/src/gateway/rpc/agents.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use super::{models, proto, GrpcGatewayHandler};
 use crate::agents::resolver::resolve_agent_definition;
 use crate::control::keys;

--- a/src/gateway/rpc/knowledge.rs
+++ b/src/gateway/rpc/knowledge.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use super::{models, proto, GrpcGatewayHandler};
 use crate::control::keys;
 use crate::control::ns;

--- a/src/gateway/rpc/knowledge_resources.rs
+++ b/src/gateway/rpc/knowledge_resources.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::control::keys;
 use crate::control::ProtoKeyValueStoreExt;
 use crate::gateway::rpc::{manifests, proto, GrpcGatewayHandler};

--- a/src/gateway/rpc/mcp_bindings.rs
+++ b/src/gateway/rpc/mcp_bindings.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use super::{manifests, proto, GrpcGatewayHandler};
 use crate::control::{events, keys, topics, ProtoKeyValueStoreExt};
 use prost::Message;

--- a/src/gateway/rpc/mcp_servers.rs
+++ b/src/gateway/rpc/mcp_servers.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use super::{manifests, proto, GrpcGatewayHandler};
 use crate::control::{events, keys, ns, topics, ProtoKeyValueStoreExt};
 use prost::Message;

--- a/src/gateway/rpc/mod.rs
+++ b/src/gateway/rpc/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::gateway::server::Gateway;
 use std::sync::Arc;
 

--- a/src/gateway/rpc/namespaces.rs
+++ b/src/gateway/rpc/namespaces.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::control::ns;
 use crate::control::ProtoKeyValueStoreExt;
 use crate::gateway::rpc::{models, proto, GrpcGatewayHandler};

--- a/src/gateway/rpc/schedules.rs
+++ b/src/gateway/rpc/schedules.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use super::{models, proto, GrpcGatewayHandler};
 use crate::control::{keys, ProtoKeyValueStoreExt};
 use crate::scheduling;

--- a/src/gateway/rpc/sessions.rs
+++ b/src/gateway/rpc/sessions.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use super::{models, proto, GrpcGatewayHandler};
 use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;

--- a/src/gateway/rpc/sessions_tests.rs
+++ b/src/gateway/rpc/sessions_tests.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 #[cfg(test)]
 mod tests {
     use crate::control::{

--- a/src/gateway/rpc/templates.rs
+++ b/src/gateway/rpc/templates.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use super::manifests;
 use super::proto;
 use super::GrpcGatewayHandler;

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::control::{scheduler::SchedulerBackend, KeyValueStore, MessagePublisher};
 use crate::gateway::auth::AuthConfig;
 use crate::gateway::session_streams::SessionStreamHub;

--- a/src/gateway/session_streams.rs
+++ b/src/gateway/session_streams.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/src/gateway/ui.rs
+++ b/src/gateway/ui.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::control::events::{self, StepType};
 use crate::gateway::rpc::{proto, GrpcGatewayHandler};
 use crate::gateway::Gateway;

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::Result;
 use serde_json::{json, Value};
 use std::sync::Arc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pub mod agents;
 pub mod config;
 pub mod connectors;

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::llm::provider::{ChatMessage, ChatResponse, ChatStream, ChatStreamEvent, LlmProvider};
 use crate::memory::Embedding;
 use anyhow::{anyhow, Result};

--- a/src/llm/failover.rs
+++ b/src/llm/failover.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::llm::provider::{ChatMessage, ChatResponse, ChatStream, ChatStreamEvent, LlmProvider};
 use crate::memory::Embedding;
 use anyhow::{anyhow, Result};

--- a/src/llm/mock.rs
+++ b/src/llm/mock.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::llm::provider::{ChatMessage, ChatResponse, ChatStream, ChatStreamEvent, LlmProvider};
 use crate::memory::Embedding;
 use anyhow::Result;

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pub mod anthropic;
 pub mod failover;
 pub mod mock;

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::llm::provider::{
     ChatMessage, ChatResponse, ChatStream, ChatStreamEvent, LlmProvider, ToolCallDelta,
 };

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::memory::Embedding;
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/llm/resolver.rs
+++ b/src/llm/resolver.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::Result;
 use std::sync::Arc;
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use std::collections::HashMap;
 
 use anyhow::{anyhow, bail, Context, Result};

--- a/src/memory/context.rs
+++ b/src/memory/context.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pub mod context;
 pub mod store;
 pub mod vector;

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::memory::context::MemoryContext;
 use anyhow::Result;
 use std::sync::Arc;

--- a/src/memory/vector.rs
+++ b/src/memory/vector.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::Result;
 use redb::{Database, ReadableTable, TableDefinition};
 use serde::{Deserialize, Serialize};

--- a/src/native_tools.rs
+++ b/src/native_tools.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::{anyhow, Result};
 use prost::Message;
 use serde_json::{json, Value};

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -1,1 +1,4 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Orchestrator module - skeletal for now

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Duration, LocalResult, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Tz;

--- a/src/security/encryption.rs
+++ b/src/security/encryption.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::{EncryptedResult, TaskResult};
 use anyhow::Result;
 

--- a/src/security/jwt.rs
+++ b/src/security/jwt.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use std::sync::OnceLock;
 
 /// Install jsonwebtoken's process-global crypto provider exactly once.

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pub mod encryption;
 pub mod jwt;
 pub mod sandbox;

--- a/src/security/sandbox.rs
+++ b/src/security/sandbox.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::Result;
 use bollard::Docker;
 use serde::{Deserialize, Serialize};

--- a/src/skills/loader.rs
+++ b/src/skills/loader.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Skill directory scanner and SKILL.md parser
 use anyhow::{anyhow, Result};
 use serde::Deserialize;

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Skills Platform - directory-based skill loading with SKILL.md metadata
 // This file is owned by: Agent 5 (Skills & Built-in Tools)
 

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Unified tool registry merging MCP + built-in + skill tools
 use serde_json::{json, Value};
 use std::collections::HashMap;

--- a/src/worker/mcp_registry.rs
+++ b/src/worker/mcp_registry.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::{anyhow, Result};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::config::Config;
 use crate::connectors::mcp::{invalidate_all_broker_auth_cache, invalidate_broker_auth_cache};
 use crate::control::topics;

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
 

--- a/src/worker/scheduler_auth.rs
+++ b/src/worker/scheduler_auth.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::{anyhow, Result};
 use axum::http::{header, HeaderMap};
 use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::Result;
 use futures::FutureExt;
 use std::panic::AssertUnwindSafe;

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use async_trait::async_trait;
 use prost::Message;
 use serde_json::Value;

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use anyhow::{anyhow, Result};
 use axum::{
     extract::State,


### PR DESCRIPTION
## Summary
- add a root AGPL-3.0 license and a standard individual CLA
- enforce CLA signing on PRs via Contributor Assistant using a dedicated cla-signatures branch
- add google/addlicense-based Rust header tooling and apply the standard header across tracked Rust files

## Validation
- ./scripts/check_rust_license_headers.sh
- cargo metadata --locked
- git diff --check