### PR TITLE
Trigger monorepo import on Talon main pushes

### DIFF
--- a/.github/workflows/talon-sync-notify.yml
+++ b/.github/workflows/talon-sync-notify.yml
@@ -1,0 +1,19 @@
+name: Trigger Talon Monorepo Import
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  notify_import:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch monorepo import
+        env:
+          GH_TOKEN: ${{ secrets.COPYBARA_GITHUB_TOKEN }}
+        run: |
+          gh api repos/impalasys/code/dispatches \
+            -f event_type=talon_public_main_updated \
+            -F client_payload[public_sha]="${GITHUB_SHA}"


### PR DESCRIPTION
## Summary
- add a lightweight workflow that dispatches `talon_public_main_updated` to `impalasys/code`
- trigger on pushes to `main` and allow manual `workflow_dispatch` for debugging
- use the existing `COPYBARA_GITHUB_TOKEN` secret so imports no longer rely only on the 15-minute cron

## Why
The code repo already has `talon-sync-import.yml` listening for `repository_dispatch`, but the public Talon repo was not sending that event after merges to `main`.
