### PR TITLE
Restore Talon monorepo import notifier

### DIFF
--- a/.github/workflows/talon-sync-notify.yml
+++ b/.github/workflows/talon-sync-notify.yml
@@ -1,0 +1,19 @@
+name: Trigger Talon Monorepo Import
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  notify_import:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch monorepo import
+        env:
+          GH_TOKEN: ${{ secrets.COPYBARA_GITHUB_TOKEN }}
+        run: |
+          gh api repos/impalasys/code/dispatches \
+            -f event_type=talon_public_main_updated \
+            -F client_payload[public_sha]="${GITHUB_SHA}"


### PR DESCRIPTION
## Summary
- restore the workflow that dispatches  to  on pushes to 
- restore manual  support for debugging import notifications

## Why
The public Talon repo stopped emitting the repository dispatch event that  listens to in , so merged Talon PRs no longer auto-opened import PRs in the monorepo.

## Testing
- inspected completed	success	Talon Sync Import	Talon Sync Import	main	workflow_dispatch	26008079030	50s	2026-05-18T01:03:53Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	26006803619	59s	2026-05-18T00:12:35Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	26005503249	51s	2026-05-17T23:12:22Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	26003963042	51s	2026-05-17T22:02:01Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	26002548112	52s	2026-05-17T20:58:58Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	26001012623	54s	2026-05-17T19:51:52Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	25999282465	49s	2026-05-17T18:35:32Z
completed	success	Talon Sync Import	Talon Sync Import	main	schedule	25997519742	58s	2026-05-17T17:18:20Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	25996003253	53s	2026-05-17T16:12:43Z
completed	success	Talon Sync Import	Talon Sync Import	fix/talon-copybara-shared-excludes	workflow_dispatch	25994881952	55s	2026-05-17T15:25:30Z
completed	success	Talon Sync Import	Talon Sync Import	fix/talon-copybara-shared-excludes	workflow_dispatch	25994691522	59s	2026-05-17T15:17:27Z
completed	success	Talon Sync Import	Talon Sync Import	fix/talon-import-managed-excludes	workflow_dispatch	25994569836	54s	2026-05-17T15:12:09Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	25994491617	50s	2026-05-17T15:08:45Z
completed	failure	talon_public_main_updated	Talon Sync Import	main	repository_dispatch	25994449891	59s	2026-05-17T15:06:54Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	25992877112	52s	2026-05-17T13:58:30Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	25990256715	1m1s	2026-05-17T12:01:02Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	25988809309	49s	2026-05-17T10:51:44Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	25986930904	51s	2026-05-17T09:19:48Z
completed	failure	Talon Sync Import	Talon Sync Import	main	schedule	25984423331	54s	2026-05-17T07:16:42Z
completed	success	Talon Sync Import	Talon Sync Import	fix/talon-import-boundary	workflow_dispatch	25983228105	56s	2026-05-17T06:13:32Z to confirm imports had stopped after the notifier disappeared
- restored the workflow file content previously used for dispatching
