### PR TITLE
Fix quickstart validation gaps

### DIFF
--- a/dockerfiles/envoy.Dockerfile
+++ b/dockerfiles/envoy.Dockerfile
@@ -1,0 +1,4 @@
+FROM envoyproxy/envoy:v1.30-latest
+
+COPY talon_gateway_proto-descriptor-set.proto.bin /etc/envoy/talon_gateway_proto-descriptor-set.proto.bin
+COPY envoy.yaml /etc/envoy/envoy.yaml

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -19,10 +19,10 @@ From the repository root:
 cp .env.example .env
 ```
 
-Then edit `.env` and set at least one real provider key. The tutorial examples in this repo use OpenAI by default:
+Then edit `.env` and set at least one real provider key. The checked-in local stack is wired to the `novita` provider in `talon.compose.yaml`, so the quickstart examples below use that configuration:
 
 ```bash
-OPENAI_API_KEY=your-real-api-key
+NOVITA_API_KEY=your-real-api-key
 ```
 
 ## 2. Start Talon locally
@@ -99,8 +99,8 @@ definition:
       profiles:
         - name: default
           model:
-            provider: openai
-            name: gpt-4.1-mini
+            provider: novita
+            name: google/gemma-4-31b-it
             temperature: 0.0
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -63,31 +63,96 @@ Use Sightline to inspect:
 
 This is the fastest way to see Talon’s runtime model in action rather than only reading the APIs.
 
-## 4. Create or inspect an agent
+## 4. Create a namespace
 
-Talon models runtime resources around namespaces and agents. The default operator flow is:
+Create `quickstart-namespace.yaml`:
 
-1. choose a namespace
-2. select or create an agent
-3. create a session
-4. send a message
-5. stream the response and tool activity
-
-## 5. Try the CLI
-
-The admin CLI targets the native gRPC gateway by default:
-
-```bash
-cargo run --bin talon-cli -- --gateway http://localhost:50051 get agenttemplate <name>
+```yaml
+apiVersion: talon.impalasys.com/v1
+kind: Namespace
+metadata:
+  name: quickstart
 ```
 
-If you want the HTTP-transcoded surface instead:
+Apply it:
 
 ```bash
-cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest get agenttemplate <name>
+cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest apply -f quickstart-namespace.yaml
 ```
 
-## 6. Read the contracts
+## 5. Create an agent directly
+
+The quickstart does not require an agent template first. Create `quickstart-agent.yaml`:
+
+```yaml
+apiVersion: talon.impalasys.com/v1
+kind: Agent
+metadata:
+  name: hello-agent
+  namespace: quickstart
+definition:
+  customSpec:
+    systemPrompt: |
+      You are a concise quickstart assistant for Talon.
+      Answer directly and keep the response short.
+    modelPolicy:
+      profiles:
+        - name: default
+          model:
+            provider: openai
+            name: gpt-4.1-mini
+            temperature: 0.0
+```
+
+Apply it:
+
+```bash
+cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest apply -f quickstart-agent.yaml
+```
+
+Verify it exists:
+
+```bash
+cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest get agent hello-agent --namespace quickstart
+```
+
+## 6. Create a session
+
+Create a session through the gateway REST surface:
+
+```bash
+curl -sS http://localhost:18789/v1/ns/quickstart/agents/hello-agent/sessions \
+  -X POST \
+  -H 'content-type: application/json' \
+  -d '{"ns":"quickstart","agent":"hello-agent"}'
+```
+
+The response includes a `sessionId`.
+
+## 7. Chat with the agent over `curl`
+
+Replace `<session-id>` with the value from the previous step:
+
+```bash
+curl -sS http://localhost:18789/v1/ui/ns/quickstart/agents/hello-agent/sessions/<session-id> \
+  -X POST \
+  -H 'content-type: application/json' \
+  -d '{"messages":[{"content":"Explain what Talon is in two bullets."}]}'
+```
+
+This uses the same browser-oriented UI session surface that Sightline and `@talonai/copilot` use.
+
+## 8. Inspect the run in Sightline
+
+In Sightline:
+
+1. open the `quickstart` namespace
+2. select `hello-agent`
+3. open the session you just created
+
+Look for the persisted messages and streamed execution steps.
+
+## 9. Read the contracts
 
 - [How Talon Works](../concepts/how-talon-works.md)
 - [Runtime Topology](../concepts/runtime-topology.md)
@@ -102,5 +167,7 @@ After the quickstart, you should know:
 
 - which processes Talon starts locally
 - which ports correspond to UI, edge, gRPC, and UI-session traffic
+- how to create an agent directly without introducing an agent template first
+- how to create a session and send a browser-style chat request with `curl`
 - where to inspect runtime resources
 - where to go next for deeper runtime or API detail

--- a/docs/tutorials/build-a-client.md
+++ b/docs/tutorials/build-a-client.md
@@ -43,7 +43,7 @@ await client.createAgent({
           profiles: [
             {
               name: "default",
-              model: { provider: "openai", name: "gpt-4.1-mini", temperature: 0.0 },
+              model: { provider: "novita", name: "google/gemma-4-31b-it", temperature: 0.0 },
             },
           ],
         },
@@ -57,7 +57,7 @@ const session = await client.createSession({ ns: "client-demo", agent: "docs-age
 
 Use this path when Talon is one service inside a larger typed system.
 
-Before you run a real client, create `.env` from `.env.example` and set `OPENAI_API_KEY`.
+Before you run a real client, create `.env` from `.env.example` and set `NOVITA_API_KEY`.
 
 ## Option 2: CRUD with REST
 

--- a/docs/tutorials/chatgpt-app.md
+++ b/docs/tutorials/chatgpt-app.md
@@ -27,7 +27,7 @@ cp .env.example .env
 Then set a real provider key:
 
 ```bash
-OPENAI_API_KEY=your-real-api-key
+NOVITA_API_KEY=your-real-api-key
 ```
 
 From the repository root:
@@ -126,7 +126,7 @@ This is the fastest way to debug whether the browser app and the control plane a
 - the manifest files are valid `talon-cli apply` inputs
 - the knowledge sync command is real
 - the browser chat route is the real gateway UI surface
-- the manifests point at a real OpenAI provider already wired through `talon.compose.yaml`
+- the manifests point at a real Novita provider already wired through `talon.compose.yaml`
 
 ## What is intentionally not included
 

--- a/docs/tutorials/customer-retention-system.md
+++ b/docs/tutorials/customer-retention-system.md
@@ -5,7 +5,7 @@ sidebar_position: 5
 
 This tutorial makes Talon’s scheduler concrete by pairing a real agent with a real schedule created through the gateway API.
 
-Before you begin, create `.env` from `.env.example` and set `OPENAI_API_KEY` so the example agent uses a real model provider.
+Before you begin, create `.env` from `.env.example` and set `NOVITA_API_KEY` so the example agent uses a real model provider.
 
 ## What you are building
 

--- a/docs/tutorials/first-agent.md
+++ b/docs/tutorials/first-agent.md
@@ -22,10 +22,10 @@ Create a local `.env` file:
 cp .env.example .env
 ```
 
-Then set a real provider key. This tutorial uses OpenAI:
+Then set a real provider key. This tutorial uses the `novita` provider already defined in `talon.compose.yaml`:
 
 ```bash
-OPENAI_API_KEY=your-real-api-key
+NOVITA_API_KEY=your-real-api-key
 ```
 
 From the repository root:
@@ -70,8 +70,8 @@ definition:
       profiles:
         - name: default
           model:
-            provider: openai
-            name: gpt-4.1-mini
+            provider: novita
+            name: google/gemma-4-31b-it
             temperature: 0.0
 ```
 

--- a/docs/tutorials/internal-ops-copilot.md
+++ b/docs/tutorials/internal-ops-copilot.md
@@ -5,7 +5,7 @@ sidebar_position: 6
 
 This tutorial shows a narrower, safer Talon pattern: an internal agent with bounded operational tools.
 
-Before you begin, create `.env` from `.env.example` and set `OPENAI_API_KEY` so the example agent uses a real model provider.
+Before you begin, create `.env` from `.env.example` and set `NOVITA_API_KEY` so the example agent uses a real model provider.
 
 ## What you are building
 

--- a/docs/tutorials/marketing-agency.md
+++ b/docs/tutorials/marketing-agency.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 
 This tutorial shows how to model a multi-role workspace around shared knowledge and distinct agents.
 
-Before you begin, create `.env` from `.env.example` and set `OPENAI_API_KEY` so the example agents use a real model provider.
+Before you begin, create `.env` from `.env.example` and set `NOVITA_API_KEY` so the example agents use a real model provider.
 
 ## What you are building
 

--- a/manifests/examples/chatgpt-app/support-docs-template.yaml
+++ b/manifests/examples/chatgpt-app/support-docs-template.yaml
@@ -12,6 +12,6 @@ definition:
       profiles:
         - name: default
           model:
-            provider: openai
-            name: gpt-4.1-mini
+            provider: novita
+            name: google/gemma-4-31b-it
             temperature: 0.0

--- a/manifests/examples/customer-retention-system/retention-review-template.yaml
+++ b/manifests/examples/customer-retention-system/retention-review-template.yaml
@@ -11,6 +11,6 @@ definition:
       profiles:
         - name: default
           model:
-            provider: openai
-            name: gpt-4.1-mini
+            provider: novita
+            name: google/gemma-4-31b-it
             temperature: 0.0

--- a/manifests/examples/internal-ops-copilot/ops-copilot-template.yaml
+++ b/manifests/examples/internal-ops-copilot/ops-copilot-template.yaml
@@ -11,8 +11,8 @@ definition:
       profiles:
         - name: default
           model:
-            provider: openai
-            name: gpt-4.1-mini
+            provider: novita
+            name: google/gemma-4-31b-it
             temperature: 0.0
     mcpServerRefs:
       - talon-ops

--- a/manifests/examples/marketing-agency/strategist-template.yaml
+++ b/manifests/examples/marketing-agency/strategist-template.yaml
@@ -11,6 +11,6 @@ definition:
       profiles:
         - name: default
           model:
-            provider: openai
-            name: gpt-4.1-mini
+            provider: novita
+            name: google/gemma-4-31b-it
             temperature: 0.0

--- a/src/llm/resolver.rs
+++ b/src/llm/resolver.rs
@@ -1,10 +1,11 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use std::sync::Arc;
 
 use crate::config::Config;
+use crate::config::secrets::SecretExt;
 use crate::gateway::rpc::manifests::{self, AgentSpec};
 use crate::llm::LlmProvider;
 
@@ -26,7 +27,8 @@ pub fn resolve_model_profile(
 /// system configuration. Preference order:
 ///   1. Provider + model from AgentSpec.model_policy profile "default"
 ///   2. Config's default_provider
-///   3. Falls back to MockLlmProvider (never returns an error for missing keys)
+/// Returns an error when the selected provider is missing, unsupported, or
+/// cannot resolve its credentials.
 pub async fn resolve_llm(
     spec: &AgentSpec,
     config: &Config,
@@ -51,19 +53,54 @@ pub async fn resolve_llm(
     let provider_cfg = config
         .providers
         .get(provider_name)
-        .ok_or_else(|| anyhow::anyhow!("LLM provider '{}' not found in config", provider_name))?;
+        .ok_or_else(|| anyhow!("LLM provider '{}' not found in config", provider_name))?;
 
     match &provider_cfg.config {
+        Some(crate::config::proto::llm_provider_config::Config::Openai(openai)) => {
+            let api_key = openai
+                .api_key
+                .as_ref()
+                .context("OpenAI provider config is missing api_key")?
+                .resolve()
+                .await
+                .with_context(|| format!("Failed to resolve API key for '{}'", provider_name))?;
+
+            let base_url = std::env::var("OPENAI_BASE_URL")
+                .unwrap_or_else(|_| "https://api.openai.com/v1".to_string());
+            let model = spec_model
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&openai.model)
+                .to_string();
+
+            Ok(Arc::new(crate::llm::openai::OpenAiCompatibleProvider::new(
+                api_key, base_url, model,
+            )))
+        }
+        Some(crate::config::proto::llm_provider_config::Config::Anthropic(anthropic)) => {
+            let api_key = anthropic
+                .api_key
+                .as_ref()
+                .context("Anthropic provider config is missing api_key")?
+                .resolve()
+                .await
+                .with_context(|| format!("Failed to resolve API key for '{}'", provider_name))?;
+            let model = spec_model
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&anthropic.model)
+                .to_string();
+
+            Ok(Arc::new(crate::llm::anthropic::AnthropicProvider::new(
+                api_key, model,
+            )))
+        }
         Some(crate::config::proto::llm_provider_config::Config::OpenaiCompatible(generic)) => {
-            use crate::config::secrets::SecretExt;
-            let api_key = if let Some(secret) = &generic.api_key {
-                secret.resolve().await.unwrap_or_else(|e| {
-                    tracing::warn!("Failed to resolve API key for '{}': {}", provider_name, e);
-                    "sk_dummy".to_string()
-                })
-            } else {
-                std::env::var("NOVITA_API_KEY").unwrap_or_else(|_| "sk_dummy".to_string())
-            };
+            let api_key = generic
+                .api_key
+                .as_ref()
+                .context("OpenAI-compatible provider config is missing api_key")?
+                .resolve()
+                .await
+                .with_context(|| format!("Failed to resolve API key for '{}'", provider_name))?;
 
             // Allow env-var override of base URL (useful in local dev / CI)
             let base_url = if let Ok(env_url) = std::env::var("NOVITA_BASE_URL") {
@@ -82,13 +119,16 @@ pub async fn resolve_llm(
                 api_key, base_url, model,
             )))
         }
-        _ => {
-            tracing::warn!(
-                "No recognized LLM config for provider '{}'; using MockLlmProvider",
+        Some(crate::config::proto::llm_provider_config::Config::Google(_)) => {
+            Err(anyhow!(
+                "LLM provider '{}' uses Google config, which is not supported by this runtime yet",
                 provider_name
-            );
-            Ok(Arc::new(crate::llm::mock::MockLlmProvider))
+            ))
         }
+        None => Err(anyhow!(
+            "LLM provider '{}' has no config; refusing to fall back to a mock provider",
+            provider_name
+        )),
     }
 }
 
@@ -168,7 +208,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_llm_uses_mock_when_provider_config_is_unrecognized() {
+    async fn resolve_llm_errors_when_provider_config_is_unrecognized() {
         let config = Config {
             providers: HashMap::from([("primary".to_string(), ProviderConfig { config: None })]),
             default_provider: "primary".to_string(),
@@ -176,9 +216,14 @@ mod tests {
         };
         let spec = manifests::AgentSpec::default();
 
-        let llm = resolve_llm(&spec, &config).await.unwrap();
-        let response = llm.completion("hello").await.unwrap();
-        assert_eq!(response, "Mock response for: hello");
+        let err = match resolve_llm(&spec, &config).await {
+            Ok(_) => panic!("expected provider config error"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("refusing to fall back to a mock provider")
+        );
     }
 
     #[tokio::test]
@@ -237,7 +282,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_llm_uses_env_fallbacks_for_api_key_and_base_url() {
+    async fn resolve_llm_uses_env_override_for_base_url() {
         let _guard = crate::test_support::async_env_mutex().lock().await;
         let app = Router::new().route(
             "/chat/completions",
@@ -257,12 +302,16 @@ mod tests {
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
         unsafe {
-            std::env::set_var("NOVITA_API_KEY", "env-key");
             std::env::set_var("NOVITA_BASE_URL", format!("http://{addr}"));
         }
         let config = config_with_provider(
             "primary",
-            openai_compatible_provider("https://unused.example.com".to_string(), None),
+            openai_compatible_provider(
+                "https://unused.example.com".to_string(),
+                Some(Secret {
+                    source: Some(proto::secret::Source::Plain("config-key".to_string())),
+                }),
+            ),
         );
         let llm = resolve_llm(&manifests::AgentSpec::default(), &config)
             .await
@@ -271,7 +320,6 @@ mod tests {
         assert_eq!(response, "resolved via env override");
 
         unsafe {
-            std::env::remove_var("NOVITA_API_KEY");
             std::env::remove_var("NOVITA_BASE_URL");
         }
         server.abort();

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -368,7 +368,7 @@ mod tests {
         visible_tools_for_agent, AgentRuntime,
     };
     use crate::connectors::mcp::McpConnectionConfig;
-    use crate::config::{Config, ProviderConfig};
+    use crate::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::{
         events::{SessionStepEvent, StepType},
         scheduler::NoopSchedulerBackend,
@@ -482,10 +482,23 @@ mod tests {
     fn runtime_config() -> Config {
         Config {
             providers: HashMap::from([(
-                "mock".to_string(),
-                ProviderConfig { config: None },
+                "novita".to_string(),
+                ProviderConfig {
+                    config: Some(proto::llm_provider_config::Config::OpenaiCompatible(
+                        proto::GenericConfig {
+                            name: "novita".to_string(),
+                            base_url: "http://127.0.0.1:1".to_string(),
+                            model: "test-model".to_string(),
+                            api_key: Some(Secret {
+                                source: Some(proto::secret::Source::Plain(
+                                    "test-key".to_string(),
+                                )),
+                            }),
+                        },
+                    )),
+                },
             )]),
-            default_provider: "mock".to_string(),
+            default_provider: "novita".to_string(),
             ..Config::default()
         }
     }

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -206,7 +206,7 @@ impl WorkerEventHandler {
 #[cfg(test)]
 mod tests {
     use super::{execute_with_panic_boundary, SessionCompletionStatus};
-    use crate::config::Config;
+    use crate::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::{
         events::{MessageDirection, SessionMessageEvent},
         scheduler::NoopSchedulerBackend, ControlPlane, KeyValueStore, MessagePublisher,
@@ -218,13 +218,16 @@ mod tests {
         mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator,
         WorkerEventHandler,
     };
+    use axum::{routing::post, Json, Router};
     use async_trait::async_trait;
     use futures::stream;
+    use serde_json::json;
     use std::collections::HashMap;
     use std::pin::Pin;
     use std::sync::Arc;
     use serde_json::Value;
     use std::sync::Mutex;
+    use tokio::net::TcpListener;
     use tokio::sync::Mutex as AsyncMutex;
     use tokio_util::sync::CancellationToken;
 
@@ -348,10 +351,23 @@ mod tests {
             }),
             config: Arc::new(Config {
                 providers: HashMap::from([(
-                    "mock".to_string(),
-                    crate::config::ProviderConfig { config: None },
+                    "novita".to_string(),
+                    ProviderConfig {
+                        config: Some(proto::llm_provider_config::Config::OpenaiCompatible(
+                            proto::GenericConfig {
+                                name: "novita".to_string(),
+                                base_url: "https://unused.example.com".to_string(),
+                                model: "test-model".to_string(),
+                                api_key: Some(Secret {
+                                    source: Some(proto::secret::Source::Plain(
+                                        "test-key".to_string(),
+                                    )),
+                                }),
+                            },
+                        )),
+                    },
                 )]),
-                default_provider: "mock".to_string(),
+                default_provider: "novita".to_string(),
                 ..Config::default()
             }),
             mcp_registry: Arc::new(McpRegistry::new()),
@@ -516,6 +532,28 @@ mod tests {
 
     #[tokio::test]
     async fn handle_session_message_runs_end_to_end_and_releases_lock() {
+        let _guard = crate::test_support::async_env_mutex().lock().await;
+        let app = Router::new().route(
+            "/chat/completions",
+            post(|| async {
+                Json(json!({
+                    "choices": [{
+                        "message": {
+                            "content": "assistant reply"
+                        }
+                    }]
+                }))
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        unsafe {
+            std::env::set_var("NOVITA_BASE_URL", format!("http://{addr}"));
+        }
+
         let kv = Arc::new(MockKvStore::default());
         let handler = handler_with_kv(kv.clone());
         let spec = manifests::AgentSpec {
@@ -610,5 +648,10 @@ mod tests {
         }
         let reply = reply.expect("assistant reply should be stored");
         assert_eq!(reply.role, 2);
+
+        unsafe {
+            std::env::remove_var("NOVITA_BASE_URL");
+        }
+        server.abort();
     }
 }


### PR DESCRIPTION
## Summary
- rewrite the quickstart around direct namespace/agent/session creation and a curl chat flow
- add the local Envoy Dockerfile used by Docker Compose so the public edge port routes to the gateway correctly
- remove the runtime mock-provider fallback so missing OpenAI credentials fail explicitly instead of returning fake success

## Validation
- 
running 4 tests
test llm::resolver::tests::resolve_llm_errors_when_selected_provider_is_missing ... ok
test llm::resolver::tests::resolve_llm_errors_when_provider_config_is_unrecognized ... ok
test llm::resolver::tests::resolve_llm_uses_env_override_for_base_url ... ok
test llm::resolver::tests::resolve_llm_prefers_spec_provider_and_model_for_openai_compatible ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 365 filtered out; finished in 1.11s
- #1 [internal] load local bake definitions
#1 reading from stdin 1.48kB done
#1 DONE 0.0s

#2 [envoy internal] load build definition from envoy.Dockerfile
#2 transferring dockerfile: 225B done
#2 DONE 0.0s

#3 [gateway internal] load build definition from oss-runtime.Dockerfile
#3 transferring dockerfile: 1.98kB done
#3 DONE 0.0s

#4 [gateway] resolve image config for docker-image://docker.io/docker/dockerfile:1.7
#4 DONE 0.3s

#5 [gateway] docker-image://docker.io/docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
#5 CACHED

#6 [envoy internal] load metadata for docker.io/envoyproxy/envoy:v1.30-latest
#6 DONE 0.4s

#7 [envoy internal] load .dockerignore
#7 transferring context: 2B done
#7 DONE 0.0s

#8 [envoy 1/3] FROM docker.io/envoyproxy/envoy:v1.30-latest@sha256:b5cc70f5fe5503858817e897ae1da5d873dc32cbc493790b4e330b8a42c4af9d
#8 DONE 0.0s

#9 [worker internal] load build definition from oss-runtime.Dockerfile
#9 transferring dockerfile: 1.98kB done
#9 DONE 0.0s

#10 [gateway internal] load build definition from oss-runtime.Dockerfile
#10 transferring dockerfile: 1.98kB done
#10 DONE 0.0s

#11 [envoy internal] load build context
#11 transferring context: 145.36kB done
#11 DONE 0.0s

#12 [worker internal] load metadata for docker.io/library/debian:trixie-slim
#12 ...

#13 [envoy 2/3] COPY talon_gateway_proto-descriptor-set.proto.bin /etc/envoy/talon_gateway_proto-descriptor-set.proto.bin
#13 CACHED

#14 [envoy 3/3] COPY envoy.yaml /etc/envoy/envoy.yaml
#14 CACHED

#15 [envoy] exporting to image
#15 exporting layers done
#15 writing image sha256:8c56b76c09d5a7b82910b9ae132a0345882f0c7fcfa0e0ba4ae6fda25af0514c done
#15 naming to docker.io/library/talon-envoy done
#15 DONE 0.0s

#16 [envoy] resolving provenance for metadata file
#16 DONE 0.0s

#12 [gateway internal] load metadata for docker.io/library/debian:trixie-slim
#12 DONE 0.3s

#17 [worker internal] load metadata for docker.io/library/rust:1.91.1-slim
#17 DONE 0.3s

#18 [worker internal] load .dockerignore
#18 transferring context: 2B done
#18 DONE 0.0s

#19 [gateway internal] load .dockerignore
#19 transferring context: 2B done
#19 DONE 0.0s

#20 [worker chef 1/4] FROM docker.io/library/rust:1.91.1-slim@sha256:f75071363e7f4771769d4cf81b1b7b290e607f4d4459e8731f6abdcee9982dc8
#20 DONE 0.0s

#21 [worker stage-3 1/8] FROM docker.io/library/debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8
#21 DONE 0.0s

#22 [gateway internal] load build context
#22 transferring context: 1.80MB 0.0s done
#22 DONE 0.0s

#23 [worker internal] load build context
#23 transferring context: 4.69kB done
#23 DONE 0.0s

#24 [worker builder 7/8] COPY talon.yaml ./talon.yaml
#24 CACHED

#25 [worker builder 1/8] COPY --from=planner /usr/src/talon/recipe.json recipe.json
#25 CACHED

#26 [worker planner 2/6] COPY third_party ./third_party
#26 CACHED

#27 [worker planner 4/6] COPY src ./src
#27 CACHED

#28 [worker stage-3 6/8] COPY --from=builder /usr/src/talon/talon.yaml /data/talon/talon.yaml
#28 CACHED

#29 [worker chef 2/4] RUN apt-get update && apt-get install -y --no-install-recommends     pkg-config     libssl-dev     protobuf-compiler     && rm -rf /var/lib/apt/lists/*
#29 CACHED

#30 [worker stage-3 3/8] COPY --from=builder /usr/src/talon/dist/talon-server /usr/local/bin/talon-server
#30 CACHED

#31 [worker chef 4/4] WORKDIR /usr/src/talon
#31 CACHED

#32 [worker stage-3 5/8] COPY --from=builder /usr/src/talon/dist/talon-cli /usr/local/bin/talon-cli
#32 CACHED

#33 [worker chef 3/4] RUN cargo install cargo-chef --locked
#33 CACHED

#34 [worker planner 5/6] COPY talon.yaml ./talon.yaml
#34 CACHED

#35 [worker planner 6/6] RUN cargo chef prepare --recipe-path recipe.json
#35 CACHED

#36 [worker builder 4/8] COPY third_party ./third_party
#36 CACHED

#37 [worker builder 5/8] COPY proto ./proto
#37 CACHED

#38 [worker stage-3 4/8] COPY --from=builder /usr/src/talon/dist/talon-worker /usr/local/bin/talon-worker
#38 CACHED

#39 [worker stage-3 7/8] RUN mkdir -p /data/talon
#39 CACHED

#40 [worker planner 3/6] COPY proto ./proto
#40 CACHED

#41 [worker builder 2/8] RUN --mount=type=cache,target=/usr/local/cargo/registry     --mount=type=cache,target=/usr/local/cargo/git     cargo chef cook --release --recipe-path recipe.json
#41 CACHED

#42 [worker builder 3/8] COPY Cargo.toml Cargo.lock build.rs ./
#42 CACHED

#43 [worker builder 6/8] COPY src ./src
#43 CACHED

#44 [worker builder 8/8] RUN --mount=type=cache,target=/usr/local/cargo/registry     --mount=type=cache,target=/usr/local/cargo/git     cargo build --release --locked --bins &&     mkdir -p /usr/src/talon/dist &&     cp /usr/src/talon/target/release/talon-server /usr/src/talon/dist/talon-server &&     cp /usr/src/talon/target/release/talon-worker /usr/src/talon/dist/talon-worker &&     cp /usr/src/talon/target/release/talon-cli /usr/src/talon/dist/talon-cli
#44 CACHED

#45 [worker stage-3 2/8] RUN apt-get update && apt-get install -y --no-install-recommends     ca-certificates     curl     libssl3     && rm -rf /var/lib/apt/lists/*
#45 CACHED

#46 [worker planner 1/6] COPY Cargo.toml Cargo.lock build.rs ./
#46 CACHED

#47 [gateway stage-3 8/8] WORKDIR /data/talon
#47 CACHED

#48 [worker] exporting to image
#48 exporting layers done
#48 writing image sha256:bde840791b7c3847dbc0e619c9b2119f8f3d35100f67363bf42751e11bda285f done
#48 naming to docker.io/library/talon-worker done
#48 DONE 0.0s

#49 [gateway] exporting to image
#49 exporting layers done
#49 writing image sha256:41c27f501bf791bf3ff65cdebc618db8601cbfc171c598a9a8333fe7db45414c done
#49 naming to docker.io/library/talon-gateway done
#49 DONE 0.0s

#50 [worker] resolving provenance for metadata file
#50 DONE 0.0s

#51 [gateway] resolving provenance for metadata file
#51 DONE 0.0s
- ✓ Namespace 'quickstart' applied successfully.
- ✓ Agent 'quickstart/hello-agent' applied successfully.
- {
 "sessionId": "019e4e4f-ee08-75a2-bd30-29901a160b2e",
 "agent": "hello-agent",
 "state": "ACTIVE",
 "messages": [],
 "steps": [],
 "labels": {}
}

## Notes
- This machine does not currently have  in , so I could not validate a real model response end to end.
- The quickstart flow now reaches the worker correctly, and missing provider credentials fail explicitly in logs instead of silently returning a mock response.