### PR TITLE
[codex] add sqlite single-host control plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,31 @@ jobs:
           load: false
           build-args: |
             NEXT_PUBLIC_GATEWAY_URL=http://localhost:18789
+
+  copilot_package:
+    name: Copilot Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build copilot package
+        run: pnpm --filter @talonai/copilot build
+
+      - name: Validate npm package contents
+        working-directory: packages/copilot
+        run: npm pack --dry-run

--- a/.github/workflows/publish-copilot.yml
+++ b/.github/workflows/publish-copilot.yml
@@ -22,12 +22,13 @@ jobs:
           version: 10.17.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
+          package-manager-cache: false
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
@@ -50,6 +51,4 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/copilot
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/publish-copilot.yml
+++ b/.github/workflows/publish-copilot.yml
@@ -1,0 +1,55 @@
+name: Publish Copilot Package
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "copilot-v*"
+
+jobs:
+  publish:
+    name: Publish @talonai/copilot
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Ensure tag matches package version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          VERSION=$(node -p "require('./packages/copilot/package.json').version")
+          if [ "${GITHUB_REF_NAME}" != "copilot-v${VERSION}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match packages/copilot version ${VERSION}"
+            exit 1
+          fi
+
+      - name: Build copilot package
+        run: pnpm --filter @talonai/copilot build
+
+      - name: Validate npm package contents
+        working-directory: packages/copilot
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        working-directory: packages/copilot
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,6 +2701,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ aws-sdk-secretsmanager = "1.103"
 azure_identity = "0.33"
 azure_security_keyvault_secrets = "0.12"
 uuid = { version = "1.23.0", features = ["v7"] }
-sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio"] }
+sqlx = { version = "0.8.6", features = ["postgres", "sqlite", "runtime-tokio"] }
 google-cloud-pubsub = "0.25.0"
 google-cloud-googleapis = { version = "0.13.0", features = ["pubsub"] }
 clap = { version = "4.6.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Talon is a Rust-based agent runtime and control plane with a gateway API, worker
 
 This repository is the open-source home for Talon runtime and UI code. It intentionally excludes Impala's private marketing site and internal deployment plumbing.
 
+For single-host deployments, Talon can run its control plane on SQLite and use a local Unix-socket message broker. The default Docker compose stack in this repository still uses Postgres and GCP Pub/Sub-compatible wiring.
+
 ## Included
 
 - Rust runtime, worker, and CLI

--- a/dockerfiles/oss-ui.Dockerfile
+++ b/dockerfiles/oss-ui.Dockerfile
@@ -25,7 +25,9 @@ COPY ui/components ./components
 COPY ui/lib ./lib
 COPY ui/proto ./proto
 COPY ui/utils ./utils
-COPY packages/copilot /repo/packages/copilot
+COPY packages/copilot/src /repo/packages/copilot/src
+COPY packages/copilot/README.md /repo/packages/copilot/README.md
+COPY packages/copilot/tsup.config.ts /repo/packages/copilot/tsup.config.ts
 COPY ui/global.d.ts ./global.d.ts
 COPY ui/next-env.d.ts ./next-env.d.ts
 COPY ui/next.config.mjs ./next.config.mjs

--- a/docs/concepts/runtime-topology.md
+++ b/docs/concepts/runtime-topology.md
@@ -18,6 +18,8 @@ Running `docker compose up --build -d` from the repository root starts:
 - `pubsub` emulator
 - `init-manifests` bootstrap for the default template
 
+This default topology is Postgres-backed. A smaller same-host deployment can also run Talon with a local SQLite control-plane database instead of Postgres.
+
 ## Traffic paths
 
 ### Browser / operator path

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -32,6 +32,61 @@ The control plane config defines:
 - message broker driver
 - scheduler backend configuration
 
+### Local socket broker
+
+For a single-host deployment, the control-plane message broker can use a local Unix socket:
+
+```yaml
+control_plane:
+  database:
+    driver: sqlite
+    data_dir: ./var/talon
+  message_broker:
+    driver: local_socket
+```
+
+Notes:
+
+- This mode is intended for one host running the gateway and one or more workers locally.
+- The broker socket defaults to `talon-broker.sock` under the SQLite `data_dir` when one is available.
+- Override the socket path with `TALON_LOCAL_SOCKET_PATH=/absolute/path/talon-broker.sock`.
+- `local_socket` is lightweight and non-durable. It is best for same-host dispatch where queued events do not need to survive process restarts.
+
+### SQLite control plane
+
+For a single-host deployment, the control plane database can use SQLite:
+
+```yaml
+control_plane:
+  database:
+    driver: sqlite
+    data_dir: ./var/talon
+  message_broker:
+    driver: gcp_pubsub
+```
+
+Notes:
+
+- Talon will create `talon-control-plane.db` under `data_dir`.
+- You can also set `control_plane.database.url` directly to a SQLite URL such as `sqlite:///absolute/path/talon.db`.
+- SQLite is intended for same-host access. Keep the database on a local filesystem, not a network filesystem.
+- For local schedule delivery with the same SQLite file, set `TALON_SCHEDULER_DRIVER=local_sqlite`.
+
+### Postgres control plane
+
+For multi-service or existing Postgres-backed deployments:
+
+```yaml
+control_plane:
+  database:
+    driver: postgres
+    url:
+      source: env
+      key: TALON_DATABASE_URL
+  message_broker:
+    driver: gcp_pubsub
+```
+
 ## Local environment
 
 The local compose stack sets most runtime wiring automatically, including:

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -21,6 +21,19 @@ This starts the local compose stack and brings up:
 - the Pub/Sub emulator
 - the default template bootstrap
 
+## SQLite development
+
+The default local stack still uses Postgres.
+
+If you want to run Talon directly on a single machine without Postgres, configure:
+
+- `control_plane.database.driver: sqlite`
+- `control_plane.database.data_dir: <local directory>`
+- `control_plane.message_broker.driver: local_socket`
+- `TALON_SCHEDULER_DRIVER=local_sqlite`
+
+Keep the SQLite database on a local filesystem and run the gateway and worker on the same host.
+
 ## Useful endpoints
 
 - Gateway edge: `http://localhost:18789`

--- a/docs/operations/scheduling-and-background-work.md
+++ b/docs/operations/scheduling-and-background-work.md
@@ -27,7 +27,18 @@ Instead:
 
 ## Local mode
 
-In the local stack, Talon uses the `local_postgres` scheduler backend with a shared secret for wakeup authentication.
+In the default Docker compose stack, Talon uses the `local_postgres` scheduler backend with a shared secret for wakeup authentication.
+
+For a same-host SQLite deployment, Talon also supports `local_sqlite`. In that mode, the scheduler stores wakeups in the same local SQLite database used by the control plane.
+
+Use:
+
+- `TALON_SCHEDULER_DRIVER=local_postgres` for the current local Postgres stack
+- `TALON_SCHEDULER_DRIVER=local_sqlite` for a same-host SQLite deployment
+
+Both local backends expect the gateway and worker to access the database from the same machine.
+
+In the smallest same-host setup, Talon can pair `local_sqlite` scheduling with the `local_socket` message broker so wakeups and worker dispatch both stay local to the machine.
 
 ## Cloud mode
 

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -7,3 +7,7 @@ Promotion flow:
 1. draft or iterate here
 2. curate and tighten the content
 3. move the final version into `talon/docs/`
+
+Current drafts:
+
+- `local-single-host-development.md`: single-host gateway + worker startup with SQLite and local Unix sockets, without Compose, using host-native Envoy as the Sightline edge

--- a/docs/wiki/local-single-host-development.md
+++ b/docs/wiki/local-single-host-development.md
@@ -1,0 +1,342 @@
+# Local Single-Host Development Without Docker
+
+This document covers the smallest local Talon stack that still works with the current Sightline UI.
+
+This mode runs:
+
+- gateway as a local process
+- worker as a local process
+- SQLite for control-plane storage
+- Unix socket broker for same-host event delivery
+- Envoy as a host-native browser-facing edge
+
+This mode does not use:
+
+- `docker compose`
+- Postgres
+- Pub/Sub emulator
+
+It is intended for one machine running both gateway and worker.
+
+## What each component does
+
+- `SQLite`: durable control-plane state
+- `local_socket`: same-host broker transport between gateway and worker
+- `Envoy`: browser-facing edge for the current Sightline UI
+- `scheduler backend`: delayed/background job storage and delivery, separate from the broker
+
+Important separation:
+
+- switching to `local_socket` does not remove scheduler storage
+- `TALON_SCHEDULER_DRIVER=local_sqlite` will still create scheduler tables in SQLite
+- if you do not want scheduler tables, do not enable `local_sqlite`
+
+## Current UI requirement
+
+The current Sightline UI expects a single edge URL that supports:
+
+- gRPC-Web
+- REST-transcoded `/v1/...` routes
+- `/v1/ui/...` session routes
+
+That means the current UI should connect to Envoy, not directly to the raw gateway gRPC port.
+
+Use:
+
+- Sightline UI: `http://localhost:3000`
+- Envoy edge: `http://127.0.0.1:18789`
+
+Do not point the UI at:
+
+- `http://127.0.0.1:51051`
+
+That port is the raw gateway gRPC/gRPC-Web surface, not the full browser edge expected by the current UI.
+
+## Prerequisites
+
+- Rust toolchain
+- Envoy installed on the host
+- repository checked out locally
+
+If `envoy` is not already installed:
+
+```bash
+brew install envoy
+```
+
+## 1. Build the binaries
+
+From the repository root:
+
+```bash
+cargo build --offline --bin talon-server --bin talon-worker --bin talon-cli
+```
+
+If you are not using offline mode locally:
+
+```bash
+cargo build --bin talon-server --bin talon-worker --bin talon-cli
+```
+
+## 2. Create a temporary runtime directory
+
+```bash
+ROOT="$(mktemp -d /tmp/talon-local-XXXXXX)"
+mkdir -p "$ROOT/data" "$ROOT/manifests"
+```
+
+This directory will hold:
+
+- the config file
+- the SQLite database
+- the Unix socket broker
+- any temporary manifests
+
+## 3. Write the local config
+
+Create `$ROOT/config.yaml`:
+
+```yaml
+providers: {}
+default_provider: ""
+workspace_dir: .
+
+control_plane:
+  database:
+    driver: sqlite
+    data_dir: ./data
+  message_broker:
+    driver: local_socket
+```
+
+`data_dir` is resolved relative to the config file directory.
+
+With the config above, the live runtime artifacts will be created under:
+
+- `$ROOT/data/talon-control-plane.db`
+- `$ROOT/data/talon-broker.sock`
+
+## 4. Start the gateway
+
+From the repository root:
+
+```bash
+env \
+  TALON_CONFIG_PATH="$ROOT/config.yaml" \
+  GRPC_ADDR=127.0.0.1:51051 \
+  GATEWAY_UI_ADDR=127.0.0.1:51052 \
+  RUST_LOG=info \
+  ./target/debug/talon-server
+```
+
+Expected startup lines include:
+
+```text
+Connecting to SqliteKvStore at sqlite://$ROOT/data/talon-control-plane.db...
+Initializing LocalSocketMessagePublisher at $ROOT/data/talon-broker.sock...
+gRPC Gateway listening on: 127.0.0.1:51051
+```
+
+## 5. Start the worker
+
+In a second terminal:
+
+```bash
+env \
+  TALON_CONFIG_PATH="$ROOT/config.yaml" \
+  PORT=18081 \
+  PULL_MODE=1 \
+  RUST_LOG=info \
+  ./target/debug/talon-worker
+```
+
+Expected startup lines include:
+
+```text
+Connecting to SqliteKvStore at sqlite://$ROOT/data/talon-control-plane.db...
+Initializing LocalSocketMessagePublisher at $ROOT/data/talon-broker.sock...
+Starting worker background subscriptions transport="local_socket"
+```
+
+If you explicitly want durable local scheduler storage too, add:
+
+```bash
+TALON_SCHEDULER_DRIVER=local_sqlite
+TALON_LOCAL_SCHEDULER_RUNNER=1
+```
+
+Only add those when you want the scheduler tables and runner behavior.
+
+## 6. Start Envoy for the UI edge
+
+The repository `envoy.yaml` targets compose service names, so for this direct local mode use a host-targeted Envoy config.
+
+Write `$ROOT/envoy.yaml`:
+
+```yaml
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 127.0.0.1, port_value: 18789 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/v1/ui/" }
+                route:
+                  cluster: talon_ui_http_service
+                  timeout: 0s
+              - match: { prefix: "/" }
+                route:
+                  cluster: talon_grpc_service
+                  timeout: 60s
+              cors:
+                allow_origin_string_match:
+                - safe_regex:
+                    google_re2: {}
+                    regex: ".*"
+                allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization
+                max_age: "1728000"
+                expose_headers: grpc-status,grpc-message
+          http_filters:
+          - name: envoy.filters.http.grpc_web
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.cors
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+          - name: envoy.filters.http.grpc_json_transcoder
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
+              proto_descriptor: "/etc/envoy/talon_gateway_proto-descriptor-set.proto.bin"
+              services: ["talon.gateway.GatewayService"]
+              max_response_body_size: 33554432
+              print_options:
+                add_whitespace: true
+                always_print_primitive_fields: true
+                always_print_enums_as_ints: false
+                preserve_proto_field_names: false
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: talon_grpc_service
+    connect_timeout: 0.25s
+    type: LOGICAL_DNS
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: talon_grpc_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 51051
+  - name: talon_ui_http_service
+    connect_timeout: 0.25s
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: talon_ui_http_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 51052
+```
+
+Then start Envoy:
+
+```bash
+envoy -c "$ROOT/envoy.yaml"
+```
+
+Run Envoy in its own terminal so you can see config or routing errors directly.
+
+## 7. Verify listeners
+
+```bash
+lsof -iTCP:51051 -iTCP:51052 -iTCP:18081 -iTCP:18789 -sTCP:LISTEN
+```
+
+You should see:
+
+- gateway on `51051`
+- gateway UI HTTP on `51052`
+- worker on `18081`
+- Envoy on `18789`
+
+## 8. Connect the UI
+
+In Sightline, connect to:
+
+```text
+http://127.0.0.1:18789
+```
+
+Do not connect the UI to `51051`.
+
+## 9. Apply resources
+
+Create the namespace:
+
+```bash
+./target/debug/talon-cli --rest \
+  --gateway http://127.0.0.1:18789 \
+  apply --file "$ROOT/manifests/pretzel.namespace.yaml"
+```
+
+Create the agent:
+
+```bash
+./target/debug/talon-cli \
+  --gateway http://127.0.0.1:51051 \
+  apply --file "$ROOT/manifests/dj.agent.yaml"
+```
+
+Verify through the edge:
+
+```bash
+curl -sS http://127.0.0.1:18789/v1/ns/pretzel/agents/dj
+```
+
+## Runtime artifacts
+
+After startup, the runtime directory should contain:
+
+- `$ROOT/data/talon-control-plane.db`
+- `$ROOT/data/talon-broker.sock`
+
+Depending on SQLite activity, you may also see:
+
+- `$ROOT/data/talon-control-plane.db-wal`
+- `$ROOT/data/talon-control-plane.db-shm`
+
+If `local_sqlite` scheduler is enabled, you should also expect scheduler tables inside the same SQLite database.
+
+## Cleanup
+
+Stop the Envoy, worker, and gateway processes, then remove the temp directory:
+
+```bash
+rm -rf "$ROOT"
+```

--- a/packages/copilot/README.md
+++ b/packages/copilot/README.md
@@ -2,6 +2,14 @@
 
 `@talonai/copilot` provides a React chat panel for Talon agent sessions.
 
+## Install
+
+```bash
+pnpm add @talonai/copilot
+```
+
+`react` and `react-dom` are required peer dependencies.
+
 ## Usage
 
 ```tsx

--- a/packages/copilot/package.json
+++ b/packages/copilot/package.json
@@ -2,16 +2,42 @@
   "name": "@talonai/copilot",
   "version": "0.1.0",
   "description": "React copilot chat panel for Talon agent sessions",
+  "type": "module",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/impalasys/talon.git",
+    "directory": "packages/copilot"
+  },
+  "homepage": "https://github.com/impalasys/talon/tree/main/packages/copilot",
+  "bugs": {
+    "url": "https://github.com/impalasys/talon/issues"
+  },
+  "packageManager": "pnpm@10.17.1",
   "sideEffects": false,
-  "main": "./src/index.ts",
-  "module": "./src/index.ts",
+  "files": [
+    "dist",
+    "src/index.d.ts",
+    "README.md"
+  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./src/index.d.ts",
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
-      "default": "./src/index.ts"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
     }
+  },
+  "scripts": {
+    "build": "tsup --config tsup.config.ts",
+    "clean": "rm -rf dist",
+    "prepack": "pnpm run build"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "peerDependencies": {
     "react": "^19.0.0",
@@ -20,5 +46,11 @@
   "dependencies": {
     "lucide-react": "^0.400.0",
     "streamdown": "^2.5.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/copilot/tsup.config.ts
+++ b/packages/copilot/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  outDir: "dist",
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  bundle: true,
+  minify: false,
+  target: "es2020",
+  external: ["react", "react-dom", "lucide-react", "streamdown"],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,19 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.2
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.2
+        version: 19.2.3(@types/react@19.2.14)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   ui:
     dependencies:
@@ -457,6 +470,162 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -828,6 +997,144 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
@@ -1154,6 +1461,9 @@ packages:
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -1331,6 +1641,11 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1364,6 +1679,9 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -1439,6 +1757,16 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1476,6 +1804,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -1515,6 +1847,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -1525,6 +1861,13 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1812,6 +2155,11 @@ packages:
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1857,9 +2205,21 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2222,6 +2582,10 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2352,8 +2716,16 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -2564,6 +2936,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   motion-dom@12.38.0:
     resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
 
@@ -2572,6 +2947,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -2632,6 +3010,10 @@ packages:
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2699,6 +3081,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2718,6 +3103,9 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
@@ -2733,6 +3121,24 @@ packages:
 
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2795,6 +3201,10 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -2841,6 +3251,11 @@ packages:
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
@@ -2909,6 +3324,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -2987,6 +3406,11 @@ packages:
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3024,13 +3448,27 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -3050,6 +3488,10 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -3060,8 +3502,30 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -3080,6 +3544,14 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -3598,6 +4070,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@3.1.3':
@@ -3994,6 +4544,81 @@ snapshots:
     dependencies:
       react: 19.2.3
 
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
   '@sinclair/typebox@0.34.49': {}
 
   '@sinonjs/commons@3.0.1':
@@ -4352,6 +4977,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  '@types/estree@1.0.8': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
@@ -4486,6 +5113,8 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  acorn@8.16.0: {}
+
   agent-base@7.1.4: {}
 
   ai@5.0.188(zod@3.25.76):
@@ -4511,6 +5140,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -4614,6 +5245,13 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
   callsites@3.1.0: {}
 
   camelcase@5.3.1: {}
@@ -4638,6 +5276,10 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
 
   ci-info@4.4.0: {}
 
@@ -4669,11 +5311,17 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@4.1.1: {}
+
   commander@7.2.0: {}
 
   commander@8.3.0: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4966,6 +5614,35 @@ snapshots:
 
   es-toolkit@1.46.1: {}
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   escape-string-regexp@2.0.0: {}
@@ -5009,10 +5686,20 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.4
 
   foreground-child@3.3.1:
     dependencies:
@@ -5597,6 +6284,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -5710,7 +6399,11 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -6140,6 +6833,13 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   motion-dom@12.38.0:
     dependencies:
       motion-utils: 12.36.0
@@ -6147,6 +6847,12 @@ snapshots:
   motion-utils@12.36.0: {}
 
   ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.12: {}
 
@@ -6201,6 +6907,8 @@ snapshots:
       path-key: 3.1.1
 
   nwsapi@2.2.23: {}
+
+  object-assign@4.1.1: {}
 
   once@1.4.0:
     dependencies:
@@ -6268,6 +6976,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -6279,6 +6989,12 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   playwright-core@1.60.0: {}
 
@@ -6294,6 +7010,13 @@ snapshots:
     dependencies:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
+
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.14):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.7.0
+      postcss: 8.5.14
 
   postcss@8.4.31:
     dependencies:
@@ -6374,6 +7097,8 @@ snapshots:
 
   react@19.2.3: {}
 
+  readdirp@4.1.2: {}
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -6441,6 +7166,37 @@ snapshots:
   resolve-from@5.0.0: {}
 
   robust-predicates@3.0.3: {}
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
 
   roughjs@4.6.6:
     dependencies:
@@ -6524,6 +7280,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
 
@@ -6613,6 +7371,16 @@ snapshots:
 
   stylis@4.4.0: {}
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -6647,9 +7415,24 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   throttleit@2.1.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tldts-core@6.1.86: {}
 
@@ -6667,13 +7450,45 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
 
   ts-dedent@2.2.0: {}
 
+  ts-interface-checker@0.1.13: {}
+
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.14)(typescript@6.0.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.14)
+      resolve-from: 5.0.0
+      rollup: 4.60.4
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.14
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   type-detect@4.0.8: {}
 
@@ -6682,6 +7497,10 @@ snapshots:
   typescript@5.4.5: {}
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
+
+  ufo@1.6.4: {}
 
   undici-types@7.18.2: {}
 

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -7,10 +7,14 @@ use axum::{
     Router,
 };
 use serde::Deserialize;
+use std::path::PathBuf;
 use std::sync::Arc;
 use talon::config::{Config, ConfigExt};
 use talon::control::build_control_plane;
-use talon::control::pubsub::{fully_qualified_subscription_name, fully_qualified_topic_name};
+use talon::control::pubsub::{
+    configured_local_socket_path, fully_qualified_subscription_name, fully_qualified_topic_name,
+    LocalSocketMessagePublisher,
+};
 use talon::control::topics;
 use talon::control::ControlPlane;
 use talon::worker::{scheduler_auth::SchedulerRequestAuthenticator, WorkerEventHandler};
@@ -49,7 +53,17 @@ trait PullSubscriptionBackend: Send + Sync {
     ) -> Result<()>;
 }
 
-async fn handle_pull_message<FDispatch, FutDispatch, FAck, FutAck, FNack, FutNack, EDispatch, EAck, ENack>(
+async fn handle_pull_message<
+    FDispatch,
+    FutDispatch,
+    FAck,
+    FutAck,
+    FNack,
+    FutNack,
+    EDispatch,
+    EAck,
+    ENack,
+>(
     event_type: &str,
     cancellation_token: &CancellationToken,
     receive_cancellation_token: &CancellationToken,
@@ -173,6 +187,25 @@ fn resolved_pull_subscription_specs(project_id: &str) -> Vec<ResolvedPullSubscri
         .collect()
 }
 
+fn local_socket_subscription_specs() -> Vec<ResolvedPullSubscriptionSpec> {
+    pull_subscription_specs()
+        .into_iter()
+        .map(|spec| ResolvedPullSubscriptionSpec {
+            topic_name: spec.topic_name.to_string(),
+            subscription_name: spec.subscription_name.to_string(),
+            event_type: spec.event_type.to_string(),
+        })
+        .collect()
+}
+
+fn message_broker_driver(config: &Config) -> Option<&str> {
+    config
+        .control_plane
+        .as_ref()
+        .and_then(|cp| cp.message_broker.as_ref())
+        .map(|mb| mb.driver.as_str())
+}
+
 fn build_worker_handler(
     cp: Arc<ControlPlane>,
     config: Arc<Config>,
@@ -204,6 +237,12 @@ struct GcpPullSubscriptionBackend {
     subscription_name: String,
 }
 
+struct LocalSocketPullSubscriptionBackend {
+    subscriber: talon::control::pubsub::LocalSocketSubscriber,
+    topic_name: String,
+    subscription_name: String,
+}
+
 impl GcpPullSubscriptionBackend {
     async fn new(
         project_id: String,
@@ -217,6 +256,21 @@ impl GcpPullSubscriptionBackend {
         let client = Client::new(pubsub_config).await?;
         Ok(Self {
             client,
+            topic_name,
+            subscription_name,
+        })
+    }
+}
+
+impl LocalSocketPullSubscriptionBackend {
+    async fn new(
+        socket_path: PathBuf,
+        topic_name: String,
+        subscription_name: String,
+    ) -> Result<Self> {
+        let publisher = LocalSocketMessagePublisher::new(socket_path).await?;
+        Ok(Self {
+            subscriber: publisher.subscriber(),
             topic_name,
             subscription_name,
         })
@@ -288,6 +342,40 @@ impl PullSubscriptionBackend for GcpPullSubscriptionBackend {
                 None,
             )
             .await?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl PullSubscriptionBackend for LocalSocketPullSubscriptionBackend {
+    async fn ensure_topic(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn ensure_subscription(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn receive(
+        &self,
+        handler: WorkerEventHandler,
+        event_type: String,
+        cancellation_token: CancellationToken,
+    ) -> Result<()> {
+        use futures::StreamExt;
+
+        let mut stream = self
+            .subscriber
+            .subscribe_named(&self.topic_name, &self.subscription_name)
+            .await?;
+        while let Some(payload) = stream.next().await {
+            if cancellation_token.is_cancelled() {
+                break;
+            }
+            if let Err(err) = handler.dispatch(Some(&event_type), &payload).await {
+                tracing::error!(event_type = %event_type, error = %err, "Local socket dispatch failed");
+            }
+        }
         Ok(())
     }
 }
@@ -423,16 +511,44 @@ fn spawn_pull_subscription_task(
             subscription_name: subscription_name.clone(),
             event_type,
         };
+        let use_local_socket = matches!(
+            message_broker_driver(pull_handler.config.as_ref()),
+            Some("local_socket")
+        );
+        let config = pull_handler.config.clone();
         run_pull_subscription_loop(
             || {
                 let project_id = project_id.clone();
                 let topic_name = topic_name.clone();
                 let subscription_name = subscription_name.clone();
+                let config = config.clone();
                 async move {
-                    Ok::<Box<dyn PullSubscriptionBackend>, anyhow::Error>(Box::new(
-                        GcpPullSubscriptionBackend::new(project_id, topic_name, subscription_name)
+                    if use_local_socket {
+                        let default_root = config
+                            .control_plane
+                            .as_ref()
+                            .and_then(|cp| cp.database.as_ref())
+                            .filter(|db| db.driver == "sqlite" && !db.data_dir.trim().is_empty())
+                            .map(|db| PathBuf::from(db.data_dir.trim()));
+                        let socket_path = configured_local_socket_path(default_root.as_deref());
+                        Ok::<Box<dyn PullSubscriptionBackend>, anyhow::Error>(Box::new(
+                            LocalSocketPullSubscriptionBackend::new(
+                                socket_path,
+                                topic_name,
+                                subscription_name,
+                            )
                             .await?,
-                    ))
+                        ))
+                    } else {
+                        Ok::<Box<dyn PullSubscriptionBackend>, anyhow::Error>(Box::new(
+                            GcpPullSubscriptionBackend::new(
+                                project_id,
+                                topic_name,
+                                subscription_name,
+                            )
+                            .await?,
+                        ))
+                    }
                 }
             },
             pull_handler,
@@ -462,9 +578,25 @@ where
         return Vec::new();
     }
 
-    tracing::info!("Starting in PULL mode (background thread)...");
+    let use_local_socket = matches!(
+        message_broker_driver(handler.config.as_ref()),
+        Some("local_socket")
+    );
+    tracing::info!(
+        transport = if use_local_socket {
+            "local_socket"
+        } else {
+            "gcp_pubsub"
+        },
+        "Starting worker background subscriptions"
+    );
     let mut tasks = Vec::new();
-    for spec in resolved_pull_subscription_specs(&project_id) {
+    let specs = if use_local_socket {
+        local_socket_subscription_specs()
+    } else {
+        resolved_pull_subscription_specs(&project_id)
+    };
+    for spec in specs {
         tasks.push(spawn(
             handler.clone(),
             project_id.clone(),
@@ -698,7 +830,8 @@ mod tests {
         next_pull_reconnect_delay, pubsub_project_id, pull_mode_enabled, pull_subscription_specs,
         push_webhook, resolved_pull_subscription_specs, run_pull_subscription_loop,
         run_pull_subscription_with_backend, run_worker_main_with, run_worker_with, schedule_fire,
-        serve_worker_http, worker_bind_addr, worker_port, worker_router, PullSubscriptionBackend,
+        serve_worker_http, worker_bind_addr, worker_port, worker_router,
+        LocalSocketMessagePublisher, LocalSocketPullSubscriptionBackend, PullSubscriptionBackend,
         ResolvedPullSubscriptionSpec, HEALTHY_PULL_RUNTIME_RESET,
     };
     use anyhow::Result;
@@ -715,8 +848,10 @@ mod tests {
     use std::sync::Arc;
     use talon::config::Config;
     use talon::control::{
-        events::LifecycleEvent, keys, scheduler::NoopSchedulerBackend, ControlPlane,
-        KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
+        events::{LifecycleEvent, SessionControlEvent},
+        keys,
+        scheduler::NoopSchedulerBackend,
+        ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use talon::gateway::rpc::models;
     use talon::test_support::{EmptyPubSub, MockKvStore};
@@ -724,6 +859,7 @@ mod tests {
         mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator,
         WorkerEventHandler,
     };
+    use tempfile::tempdir;
     use tokio::sync::Mutex;
     use tokio_util::sync::CancellationToken;
     use tower::ServiceExt;
@@ -1027,6 +1163,111 @@ mod tests {
             .all(|(project_id, _, _)| project_id == "demo"));
         assert!(spawned[0].1.starts_with("projects/demo/topics/"));
         assert!(spawned[0].2.starts_with("projects/demo/subscriptions/"));
+    }
+
+    #[tokio::test]
+    async fn maybe_spawn_pull_subscriptions_uses_local_socket_specs_when_configured() {
+        let mut config = Config::default();
+        config.control_plane = Some(talon::config::proto::ControlPlaneConfig {
+            database: Some(talon::config::proto::DatabaseConfig {
+                data_dir: String::new(),
+                driver: "sqlite".to_string(),
+                url: None,
+            }),
+            message_broker: Some(talon::config::proto::MessageBrokerConfig {
+                driver: "local_socket".to_string(),
+            }),
+            scheduler: None,
+        });
+        let handler = WorkerEventHandler {
+            cp: Arc::new(ControlPlane {
+                kv: Arc::new(MockKvStore::default()),
+                pubsub: Arc::new(EmptyPubSub),
+                scheduler: Arc::new(NoopSchedulerBackend),
+            }),
+            config: Arc::new(config),
+            mcp_registry: Arc::new(McpRegistry::new()),
+            scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),
+            session_cancellations: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let spawned = std::sync::Mutex::new(Vec::<(String, String, String)>::new());
+
+        maybe_spawn_pull_subscriptions(
+            handler,
+            true,
+            "demo".to_string(),
+            CancellationToken::new(),
+            |_h, project_id, spec, _shutdown_token| {
+                spawned.lock().expect("spawned lock poisoned").push((
+                    project_id,
+                    spec.topic_name,
+                    spec.subscription_name,
+                ));
+                tokio::spawn(async {})
+            },
+        );
+        let spawned = spawned.lock().expect("spawned lock poisoned");
+        assert_eq!(spawned.len(), 3);
+        assert_eq!(spawned[0].0, "demo");
+        assert_eq!(spawned[0].1, talon::control::topics::SESSION_DISPATCH_TOPIC);
+        assert_eq!(spawned[0].2, "talon-session-dispatch-sub");
+    }
+
+    #[tokio::test]
+    async fn local_socket_pull_backend_delivers_session_control_end_to_end() {
+        let dir = tempdir().unwrap();
+        let socket_path = dir.path().join("talon-broker.sock");
+        let publisher = LocalSocketMessagePublisher::new(socket_path.clone())
+            .await
+            .unwrap();
+        let backend = LocalSocketPullSubscriptionBackend::new(
+            socket_path,
+            talon::control::topics::SESSION_CONTROL_TOPIC.to_string(),
+            "talon-session-control-sub".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let cancellation = CancellationToken::new();
+        let handler = handler_with_auth(SchedulerRequestAuthenticator::deny_all());
+        handler
+            .session_cancellations
+            .lock()
+            .await
+            .insert("session-1".to_string(), cancellation.clone());
+
+        let shutdown = CancellationToken::new();
+        let receive_task = tokio::spawn({
+            let handler = handler.clone();
+            let shutdown = shutdown.clone();
+            async move {
+                backend
+                    .receive(handler, "session_control".to_string(), shutdown)
+                    .await
+            }
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        publisher
+            .publish(
+                talon::control::topics::SESSION_CONTROL_TOPIC,
+                &SessionControlEvent {
+                    session_id: "session-1".to_string(),
+                    agent: "assistant".to_string(),
+                    ns: "default".to_string(),
+                    action: "stop_generation".to_string(),
+                    timestamp: 0,
+                }
+                .encode_to_vec(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), cancellation.cancelled())
+            .await
+            .unwrap();
+        shutdown.cancel();
+        receive_task.abort();
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -241,6 +241,28 @@ fn resolve_config_relative_data_dir(path: &Path, data_dir: &mut Option<String>) 
     *data_dir = Some(normalize_path(base_dir.join(dir)).display().to_string());
 }
 
+fn resolve_config_relative_string_path(path: &Path, value: &mut Option<String>) {
+    let Some(raw) = value.as_ref() else {
+        return;
+    };
+
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    let resolved = if Path::new(trimmed).is_absolute() {
+        PathBuf::from(trimmed)
+    } else {
+        let base_dir = path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        normalize_path(base_dir.join(trimmed))
+    };
+    *value = Some(resolved.display().to_string());
+}
+
 fn resolve_config_relative_paths(path: &Path, config: &mut SerdeConfig) {
     if let Some(database) = config.database.as_mut() {
         resolve_config_relative_data_dir(path, &mut database.data_dir);
@@ -249,6 +271,8 @@ fn resolve_config_relative_paths(path: &Path, config: &mut SerdeConfig) {
     if let Some(control_plane) = config.control_plane.as_mut() {
         resolve_config_relative_data_dir(path, &mut control_plane.database.data_dir);
     }
+
+    resolve_config_relative_string_path(path, &mut config.workspace_dir);
 }
 
 impl From<SchedulerConfigWrapper> for proto::SchedulerConfig {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,7 +6,7 @@ use prost::Message;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 pub mod secrets;
 
@@ -205,6 +205,52 @@ impl From<SerdeConfig> for Config {
     }
 }
 
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn resolve_config_relative_data_dir(path: &Path, data_dir: &mut Option<String>) {
+    let Some(raw) = data_dir.as_ref() else {
+        return;
+    };
+
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    let dir = Path::new(trimmed);
+    if dir.is_absolute() {
+        return;
+    }
+
+    let base_dir = path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    *data_dir = Some(normalize_path(base_dir.join(dir)).display().to_string());
+}
+
+fn resolve_config_relative_paths(path: &Path, config: &mut SerdeConfig) {
+    if let Some(database) = config.database.as_mut() {
+        resolve_config_relative_data_dir(path, &mut database.data_dir);
+    }
+
+    if let Some(control_plane) = config.control_plane.as_mut() {
+        resolve_config_relative_data_dir(path, &mut control_plane.database.data_dir);
+    }
+}
+
 impl From<SchedulerConfigWrapper> for proto::SchedulerConfig {
     fn from(s: SchedulerConfigWrapper) -> Self {
         match s {
@@ -290,12 +336,13 @@ impl ConfigExt for Config {
         let content = std::fs::read_to_string(path)?;
         let extension = path.extension().and_then(|s| s.to_str()).unwrap_or("toml");
 
-        let serde_config: SerdeConfig = match extension {
+        let mut serde_config: SerdeConfig = match extension {
             "toml" => toml::from_str(&content)?,
             "yaml" | "yml" => serde_yaml::from_str(&content)?,
             "json" => serde_json::from_str(&content)?,
             _ => return Err(anyhow!("Unsupported config format: {}", extension)),
         };
+        resolve_config_relative_paths(path, &mut serde_config);
         Ok(serde_config.into())
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -209,11 +209,20 @@ fn normalize_path(path: PathBuf) -> PathBuf {
     let mut normalized = PathBuf::new();
     for component in path.components() {
         match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
+            Component::RootDir | Component::Prefix(_) => {
+                normalized.push(component.as_os_str());
             }
-            other => normalized.push(other.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => match normalized.components().next_back() {
+                Some(Component::Normal(_)) => {
+                    normalized.pop();
+                }
+                Some(Component::ParentDir) | None if !path.is_absolute() => {
+                    normalized.push("..");
+                }
+                _ => {}
+            },
+            Component::Normal(part) => normalized.push(part),
         }
     }
     normalized

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{proto, Config, ConfigExt, Secret, SecretExt};
+    use crate::config::{normalize_path, proto, Config, ConfigExt, Secret, SecretExt};
     use prost::Message;
     use std::env;
     use std::io::Write;
@@ -40,7 +40,11 @@ server:
         assert_eq!(config.providers.len(), 1);
         assert_eq!(
             config.database.as_ref().unwrap().data_dir,
-            path.parent().unwrap().join("test-data").display().to_string()
+            path.parent()
+                .unwrap()
+                .join("test-data")
+                .display()
+                .to_string()
         );
 
         let novita = config.providers.get("my-novita").unwrap();
@@ -303,6 +307,52 @@ workspace_dir: ./workspace
                 .join("workspace")
                 .display()
                 .to_string()
+        );
+    }
+
+    #[test]
+    fn test_relative_paths_preserve_parent_dir_components() {
+        assert_eq!(
+            normalize_path(std::path::PathBuf::from("../workspace")),
+            std::path::PathBuf::from("../workspace")
+        );
+        assert_eq!(
+            normalize_path(std::path::PathBuf::from("../../data")),
+            std::path::PathBuf::from("../../data")
+        );
+
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("configs").join("nested").join("talon.yaml");
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &config_path,
+            r#"
+workspace_dir: ../../workspace
+control_plane:
+  database:
+    driver: sqlite
+    data_dir: ../../data
+  message_broker:
+    driver: local_socket
+"#,
+        )
+        .unwrap();
+
+        let config = Config::from_file(&config_path).unwrap();
+        assert_eq!(
+            config.workspace_dir,
+            dir.path().join("workspace").display().to_string()
+        );
+        assert_eq!(
+            config
+                .control_plane
+                .as_ref()
+                .unwrap()
+                .database
+                .as_ref()
+                .unwrap()
+                .data_dir,
+            dir.path().join("data").display().to_string()
         );
     }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -38,6 +38,10 @@ server:
 
         let config = Config::from_file(&path).unwrap();
         assert_eq!(config.providers.len(), 1);
+        assert_eq!(
+            config.database.as_ref().unwrap().data_dir,
+            path.parent().unwrap().join("test-data").display().to_string()
+        );
 
         let novita = config.providers.get("my-novita").unwrap();
         if let Some(proto::llm_provider_config::Config::OpenaiCompatible(c)) = &novita.config {
@@ -238,6 +242,43 @@ api_key = "secret"
         std::fs::write(&txt_path, "invalid").unwrap();
         let err = Config::from_file(&txt_path).unwrap_err();
         assert!(err.to_string().contains("Unsupported config format"));
+    }
+
+    #[test]
+    fn test_control_plane_relative_data_dir_resolves_from_config_file_directory() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("nested").join("talon.yaml");
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &config_path,
+            r#"
+control_plane:
+  database:
+    driver: sqlite
+    data_dir: ./data
+  message_broker:
+    driver: local_socket
+"#,
+        )
+        .unwrap();
+
+        let config = Config::from_file(&config_path).unwrap();
+        assert_eq!(
+            config
+                .control_plane
+                .as_ref()
+                .unwrap()
+                .database
+                .as_ref()
+                .unwrap()
+                .data_dir,
+            config_path
+                .parent()
+                .unwrap()
+                .join("data")
+                .display()
+                .to_string()
+        );
     }
 
     #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -282,6 +282,31 @@ control_plane:
     }
 
     #[test]
+    fn test_relative_workspace_dir_resolves_from_config_file_directory() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("nested").join("talon.yaml");
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &config_path,
+            r#"
+workspace_dir: ./workspace
+"#,
+        )
+        .unwrap();
+
+        let config = Config::from_file(&config_path).unwrap();
+        assert_eq!(
+            config.workspace_dir,
+            config_path
+                .parent()
+                .unwrap()
+                .join("workspace")
+                .display()
+                .to_string()
+        );
+    }
+
+    #[test]
     fn test_load_default_uses_env_override_and_fallback_search() {
         let _guard = crate::test_support::env_lock();
         let dir = tempdir().unwrap();

--- a/src/control/kv/mod.rs
+++ b/src/control/kv/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+mod postgres;
+mod shared;
+mod sqlite;
+
+pub use postgres::PostgresKvStore;
+pub use shared::sqlite_url_for_path;
+pub use sqlite::SqliteKvStore;

--- a/src/control/kv/mod.rs
+++ b/src/control/kv/mod.rs
@@ -6,5 +6,6 @@ mod shared;
 mod sqlite;
 
 pub use postgres::PostgresKvStore;
+pub(crate) use shared::validate_identifier;
 pub use shared::sqlite_url_for_path;
 pub use sqlite::SqliteKvStore;

--- a/src/control/kv/postgres.rs
+++ b/src/control/kv/postgres.rs
@@ -1,0 +1,306 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use crate::control::KeyValueStore;
+use anyhow::Result;
+use sqlx::{PgPool, Row};
+
+use super::shared::{like_prefix_pattern, quoted_identifier, validate_identifier};
+
+fn create_table_statement(table: &str) -> String {
+    let table = quoted_identifier(table);
+    format!(
+        "CREATE TABLE IF NOT EXISTS {} (
+                namespace VARCHAR(255) NOT NULL,
+                key VARCHAR(255) NOT NULL,
+                value BYTEA NOT NULL,
+                PRIMARY KEY (namespace, key)
+            )",
+        table
+    )
+}
+
+fn get_query(table: &str) -> String {
+    format!(
+        "SELECT value FROM {} WHERE namespace = $1 AND key = $2",
+        quoted_identifier(table)
+    )
+}
+
+fn set_query(table: &str) -> String {
+    let table = quoted_identifier(table);
+    format!(
+        "INSERT INTO {} (namespace, key, value) VALUES ($1, $2, $3) 
+             ON CONFLICT (namespace, key) DO UPDATE SET value = $3",
+        table
+    )
+}
+
+fn compare_and_swap_query(table: &str, expected: bool) -> String {
+    let table = quoted_identifier(table);
+    if expected {
+        format!(
+            "UPDATE {} SET value = $3
+                 WHERE namespace = $1 AND key = $2 AND value = $4",
+            table
+        )
+    } else {
+        format!(
+            "INSERT INTO {} (namespace, key, value) VALUES ($1, $2, $3)
+                 ON CONFLICT (namespace, key) DO NOTHING",
+            table
+        )
+    }
+}
+
+fn delete_query(table: &str) -> String {
+    format!(
+        "DELETE FROM {} WHERE namespace = $1 AND key = $2",
+        quoted_identifier(table)
+    )
+}
+
+fn list_keys_query(table: &str) -> String {
+    format!(
+        "SELECT key FROM {} WHERE namespace = $1 AND key LIKE $2 ESCAPE '\\'",
+        quoted_identifier(table)
+    )
+}
+
+fn list_entries_query(table: &str) -> String {
+    format!(
+        "SELECT key, value FROM {} WHERE namespace = $1 AND key LIKE $2 ESCAPE '\\'",
+        quoted_identifier(table)
+    )
+}
+
+fn delete_prefix_query(table: &str) -> String {
+    format!(
+        "DELETE FROM {} WHERE namespace = $1 AND key LIKE $2 ESCAPE '\\'",
+        quoted_identifier(table)
+    )
+}
+
+pub struct PostgresKvStore {
+    pool: PgPool,
+    table: String,
+}
+
+impl PostgresKvStore {
+    pub async fn new(url: &str, table: &str) -> Result<Self> {
+        validate_identifier(table)?;
+        let pool = PgPool::connect(url).await?;
+
+        let create_stmt = create_table_statement(table);
+        sqlx::query(&create_stmt).execute(&pool).await?;
+
+        Ok(Self {
+            pool,
+            table: table.to_string(),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl KeyValueStore for PostgresKvStore {
+    async fn get(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>> {
+        let query = get_query(&self.table);
+        let row = sqlx::query(&query)
+            .bind(namespace)
+            .bind(key)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        if let Some(row) = row {
+            let value: Vec<u8> = row.try_get("value")?;
+            Ok(Some(value))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn set(&self, namespace: &str, key: &str, value: &[u8]) -> Result<()> {
+        let query = set_query(&self.table);
+        sqlx::query(&query)
+            .bind(namespace)
+            .bind(key)
+            .bind(value)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn compare_and_swap(
+        &self,
+        namespace: &str,
+        key: &str,
+        expected: Option<&[u8]>,
+        value: &[u8],
+    ) -> Result<bool> {
+        let query = compare_and_swap_query(&self.table, expected.is_some());
+
+        let mut q = sqlx::query(&query).bind(namespace).bind(key).bind(value);
+        if let Some(expected) = expected {
+            q = q.bind(expected);
+        }
+        let rows_affected = q.execute(&self.pool).await?.rows_affected();
+        Ok(rows_affected == 1)
+    }
+
+    async fn delete(&self, namespace: &str, key: &str) -> Result<()> {
+        let query = delete_query(&self.table);
+        sqlx::query(&query)
+            .bind(namespace)
+            .bind(key)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn list_keys(&self, namespace: &str, prefix: &str) -> Result<Vec<String>> {
+        let query = list_keys_query(&self.table);
+        let prefix_pattern = like_prefix_pattern(prefix);
+        let rows = sqlx::query(&query)
+            .bind(namespace)
+            .bind(prefix_pattern)
+            .fetch_all(&self.pool)
+            .await?;
+
+        let mut keys = Vec::new();
+        for row in rows {
+            keys.push(row.try_get("key")?);
+        }
+        Ok(keys)
+    }
+
+    async fn list_entries(&self, namespace: &str, prefix: &str) -> Result<Vec<(String, Vec<u8>)>> {
+        let query = list_entries_query(&self.table);
+        let prefix_pattern = like_prefix_pattern(prefix);
+        let rows = sqlx::query(&query)
+            .bind(namespace)
+            .bind(prefix_pattern)
+            .fetch_all(&self.pool)
+            .await?;
+
+        let mut entries = Vec::with_capacity(rows.len());
+        for row in rows {
+            entries.push((row.try_get("key")?, row.try_get("value")?));
+        }
+        Ok(entries)
+    }
+
+    async fn delete_prefix(&self, namespace: &str, prefix: &str) -> Result<()> {
+        let query = delete_prefix_query(&self.table);
+        let prefix_pattern = like_prefix_pattern(prefix);
+        sqlx::query(&query)
+            .bind(namespace)
+            .bind(prefix_pattern)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        compare_and_swap_query, create_table_statement, delete_prefix_query, delete_query,
+        get_query, list_entries_query, list_keys_query, set_query, PostgresKvStore,
+    };
+    use crate::control::KeyValueStore;
+    use crate::test_support::{docker_test_guard, PostgresContainer};
+    use std::time::Duration;
+
+    #[test]
+    fn sql_builders_use_expected_table_and_clauses() {
+        let create = create_table_statement("talon_kv");
+        assert!(create.contains("CREATE TABLE IF NOT EXISTS \"talon_kv\""));
+        assert!(create.contains("PRIMARY KEY (namespace, key)"));
+
+        assert_eq!(
+            get_query("talon_kv"),
+            "SELECT value FROM \"talon_kv\" WHERE namespace = $1 AND key = $2"
+        );
+        assert!(set_query("talon_kv").contains("ON CONFLICT (namespace, key) DO UPDATE"));
+        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = $4"));
+        assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
+        assert_eq!(
+            delete_query("talon_kv"),
+            "DELETE FROM \"talon_kv\" WHERE namespace = $1 AND key = $2"
+        );
+        assert!(list_keys_query("talon_kv").contains("LIKE $2 ESCAPE '\\'"));
+        assert!(list_entries_query("talon_kv").contains("SELECT key, value"));
+        assert!(delete_prefix_query("talon_kv").contains("DELETE FROM \"talon_kv\""));
+    }
+
+    async fn init_test_store(database_url: &str) -> PostgresKvStore {
+        let mut last_error = None;
+        for _ in 0..20 {
+            match PostgresKvStore::new(database_url, "talon_kv_store_test").await {
+                Ok(store) => return store,
+                Err(err) => {
+                    last_error = Some(err);
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            }
+        }
+        panic!(
+            "store should initialize: {}",
+            last_error.expect("expected initialization error")
+        );
+    }
+
+    #[tokio::test]
+    async fn postgres_kv_round_trip_compare_and_swap_and_prefix_ops() {
+        let _guard = docker_test_guard();
+        let pg = PostgresContainer::start("talon-kv-pg");
+        let store = init_test_store(&pg.database_url()).await;
+
+        assert!(store.get("ns", "missing").await.unwrap().is_none());
+
+        store.set("ns", "prefix/a", b"one").await.unwrap();
+        store.set("ns", "prefix/b", b"two").await.unwrap();
+        store.set("ns", "other/c", b"three").await.unwrap();
+        assert_eq!(
+            store.get("ns", "prefix/a").await.unwrap(),
+            Some(b"one".to_vec())
+        );
+
+        let mut keys = store.list_keys("ns", "prefix/").await.unwrap();
+        keys.sort();
+        assert_eq!(keys, vec!["prefix/a".to_string(), "prefix/b".to_string()]);
+
+        let mut entries = store.list_entries("ns", "prefix/").await.unwrap();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(entries[0], ("prefix/a".to_string(), b"one".to_vec()));
+        assert_eq!(entries[1], ("prefix/b".to_string(), b"two".to_vec()));
+
+        assert!(store
+            .compare_and_swap("ns", "prefix/a", Some(b"one"), b"updated")
+            .await
+            .unwrap());
+        assert!(!store
+            .compare_and_swap("ns", "prefix/a", Some(b"wrong"), b"nope")
+            .await
+            .unwrap());
+        assert!(store
+            .compare_and_swap("ns", "new/key", None, b"created")
+            .await
+            .unwrap());
+        assert!(!store
+            .compare_and_swap("ns", "new/key", None, b"duplicate")
+            .await
+            .unwrap());
+
+        store.delete("ns", "new/key").await.unwrap();
+        assert!(store.get("ns", "new/key").await.unwrap().is_none());
+
+        store.delete_prefix("ns", "prefix/").await.unwrap();
+        assert!(store.get("ns", "prefix/a").await.unwrap().is_none());
+        assert!(store.get("ns", "prefix/b").await.unwrap().is_none());
+        assert_eq!(
+            store.get("ns", "other/c").await.unwrap(),
+            Some(b"three".to_vec())
+        );
+    }
+}

--- a/src/control/kv/shared.rs
+++ b/src/control/kv/shared.rs
@@ -1,0 +1,193 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use anyhow::Result;
+use std::path::Path;
+
+const RESERVED_IDENTIFIERS: &[&str] = &[
+    "all",
+    "analyse",
+    "analyze",
+    "and",
+    "any",
+    "array",
+    "as",
+    "asc",
+    "asymmetric",
+    "authorization",
+    "between",
+    "binary",
+    "both",
+    "case",
+    "cast",
+    "check",
+    "collate",
+    "column",
+    "constraint",
+    "create",
+    "current_catalog",
+    "current_date",
+    "current_role",
+    "current_schema",
+    "current_time",
+    "current_timestamp",
+    "current_user",
+    "default",
+    "deferrable",
+    "desc",
+    "distinct",
+    "do",
+    "else",
+    "end",
+    "except",
+    "false",
+    "fetch",
+    "for",
+    "foreign",
+    "from",
+    "grant",
+    "group",
+    "having",
+    "in",
+    "initially",
+    "intersect",
+    "into",
+    "is",
+    "leading",
+    "limit",
+    "localtime",
+    "localtimestamp",
+    "not",
+    "null",
+    "offset",
+    "on",
+    "only",
+    "or",
+    "order",
+    "placing",
+    "primary",
+    "references",
+    "returning",
+    "select",
+    "session_user",
+    "some",
+    "symmetric",
+    "table",
+    "then",
+    "to",
+    "trailing",
+    "true",
+    "union",
+    "unique",
+    "user",
+    "using",
+    "variadic",
+    "when",
+    "where",
+    "window",
+    "with",
+];
+
+pub(crate) fn validate_identifier(table: &str) -> Result<()> {
+    if table.is_empty() || table.len() > 63 {
+        anyhow::bail!(
+            "Invalid table name '{}': must be between 1 and 63 characters",
+            table
+        );
+    }
+    let mut chars = table.chars();
+    let first = chars.next().expect("table name is not empty");
+    if !first.is_ascii_alphabetic() && first != '_' {
+        anyhow::bail!(
+            "Invalid table name '{}': must start with a letter or underscore",
+            table
+        );
+    }
+    if !chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_') {
+        anyhow::bail!(
+            "Invalid table name '{}': only ASCII letters, numbers, and underscores are allowed",
+            table
+        );
+    }
+    if RESERVED_IDENTIFIERS
+        .binary_search(&table.to_ascii_lowercase().as_str())
+        .is_ok()
+    {
+        anyhow::bail!(
+            "Invalid table name '{}': SQL reserved keywords are not allowed",
+            table
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn quoted_identifier(table: &str) -> String {
+    format!("\"{}\"", table)
+}
+
+pub(crate) fn like_prefix_pattern(prefix: &str) -> String {
+    let mut escaped = String::with_capacity(prefix.len() + 1);
+    for ch in prefix.chars() {
+        match ch {
+            '\\' | '%' | '_' => {
+                escaped.push('\\');
+                escaped.push(ch);
+            }
+            _ => escaped.push(ch),
+        }
+    }
+    escaped.push('%');
+    escaped
+}
+
+pub fn sqlite_url_for_path(path: &Path) -> String {
+    format!("sqlite://{}", path.display())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{like_prefix_pattern, sqlite_url_for_path, validate_identifier};
+    use std::path::Path;
+
+    #[test]
+    fn like_prefix_pattern_appends_sql_wildcard() {
+        assert_eq!(like_prefix_pattern("Agent/test"), "Agent/test%");
+    }
+
+    #[test]
+    fn like_prefix_pattern_escapes_like_metacharacters() {
+        assert_eq!(like_prefix_pattern(r"Agent_%\path"), r"Agent\_\%\\path%");
+    }
+
+    #[test]
+    fn validate_identifier_rejects_invalid_table_names() {
+        validate_identifier("talon_kv").expect("underscores should be allowed");
+        validate_identifier("talon123").expect("alphanumeric names should be allowed");
+        validate_identifier("_talon").expect("leading underscore should be allowed");
+
+        let err = validate_identifier("talon-kv").unwrap_err();
+        assert!(err.to_string().contains("Invalid table name"));
+
+        let empty = validate_identifier("").unwrap_err();
+        assert!(empty.to_string().contains("Invalid table name"));
+
+        let starts_with_digit = validate_identifier("1talon").unwrap_err();
+        assert!(starts_with_digit.to_string().contains("must start"));
+
+        let too_long = validate_identifier(&"a".repeat(64)).unwrap_err();
+        assert!(too_long.to_string().contains("between 1 and 63"));
+
+        let reserved = validate_identifier("select").unwrap_err();
+        assert!(reserved.to_string().contains("reserved keywords"));
+
+        validate_identifier("select_log").expect("non-keyword identifiers should be allowed");
+    }
+
+    #[test]
+    fn sqlite_url_formats_paths() {
+        assert_eq!(
+            sqlite_url_for_path(Path::new("/tmp/talon.db")),
+            "sqlite:///tmp/talon.db"
+        );
+    }
+}

--- a/src/control/kv/sqlite.rs
+++ b/src/control/kv/sqlite.rs
@@ -113,7 +113,7 @@ async fn sqlite_pool(url: &str) -> Result<SqlitePool> {
         .busy_timeout(Duration::from_secs(5))
         .foreign_keys(true);
     Ok(SqlitePoolOptions::new()
-        .max_connections(1)
+        .max_connections(5)
         .connect_with(options)
         .await?)
 }

--- a/src/control/kv/sqlite.rs
+++ b/src/control/kv/sqlite.rs
@@ -3,80 +3,21 @@
 
 use crate::control::KeyValueStore;
 use anyhow::Result;
-use sqlx::{PgPool, Row};
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
+    Row, SqlitePool,
+};
+use std::{str::FromStr, time::Duration};
 
-const RESERVED_IDENTIFIERS: &[&str] = &[
-    "all", "analyse", "analyze", "and", "any", "array", "as", "asc", "asymmetric",
-    "authorization", "between", "binary", "both", "case", "cast", "check", "collate",
-    "column", "constraint", "create", "current_catalog", "current_date", "current_role",
-    "current_schema", "current_time", "current_timestamp", "current_user", "default",
-    "deferrable", "desc", "distinct", "do", "else", "end", "except", "false", "fetch",
-    "for", "foreign", "from", "grant", "group", "having", "in", "initially", "intersect",
-    "into", "is", "leading", "limit", "localtime", "localtimestamp", "not", "null",
-    "offset", "on", "only", "or", "order", "placing", "primary", "references", "returning",
-    "select", "session_user", "some", "symmetric", "table", "then", "to", "trailing", "true",
-    "union", "unique", "user", "using", "variadic", "when", "where", "window", "with",
-];
-
-fn validate_identifier(table: &str) -> Result<()> {
-    if table.is_empty() || table.len() > 63 {
-        anyhow::bail!(
-            "Invalid table name '{}': must be between 1 and 63 characters",
-            table
-        );
-    }
-    let mut chars = table.chars();
-    let first = chars.next().expect("table name is not empty");
-    if !first.is_ascii_alphabetic() && first != '_' {
-        anyhow::bail!(
-            "Invalid table name '{}': must start with a letter or underscore",
-            table
-        );
-    }
-    if !chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_') {
-        anyhow::bail!(
-            "Invalid table name '{}': only ASCII letters, numbers, and underscores are allowed",
-            table
-        );
-    }
-    if RESERVED_IDENTIFIERS
-        .binary_search(&table.to_ascii_lowercase().as_str())
-        .is_ok()
-    {
-        anyhow::bail!(
-            "Invalid table name '{}': SQL reserved keywords are not allowed",
-            table
-        );
-    }
-    Ok(())
-}
-
-fn quoted_identifier(table: &str) -> String {
-    format!("\"{}\"", table)
-}
-
-fn like_prefix_pattern(prefix: &str) -> String {
-    let mut escaped = String::with_capacity(prefix.len() + 1);
-    for ch in prefix.chars() {
-        match ch {
-            '\\' | '%' | '_' => {
-                escaped.push('\\');
-                escaped.push(ch);
-            }
-            _ => escaped.push(ch),
-        }
-    }
-    escaped.push('%');
-    escaped
-}
+use super::shared::{like_prefix_pattern, quoted_identifier, validate_identifier};
 
 fn create_table_statement(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
         "CREATE TABLE IF NOT EXISTS {} (
-                namespace VARCHAR(255) NOT NULL,
-                key VARCHAR(255) NOT NULL,
-                value BYTEA NOT NULL,
+                namespace TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value BLOB NOT NULL,
                 PRIMARY KEY (namespace, key)
             )",
         table
@@ -85,7 +26,7 @@ fn create_table_statement(table: &str) -> String {
 
 fn get_query(table: &str) -> String {
     format!(
-        "SELECT value FROM {} WHERE namespace = $1 AND key = $2",
+        "SELECT value FROM {} WHERE namespace = ?1 AND key = ?2",
         quoted_identifier(table)
     )
 }
@@ -93,8 +34,8 @@ fn get_query(table: &str) -> String {
 fn set_query(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
-        "INSERT INTO {} (namespace, key, value) VALUES ($1, $2, $3) 
-             ON CONFLICT (namespace, key) DO UPDATE SET value = $3",
+        "INSERT INTO {} (namespace, key, value) VALUES (?1, ?2, ?3)
+             ON CONFLICT (namespace, key) DO UPDATE SET value = excluded.value",
         table
     )
 }
@@ -103,13 +44,13 @@ fn compare_and_swap_query(table: &str, expected: bool) -> String {
     let table = quoted_identifier(table);
     if expected {
         format!(
-            "UPDATE {} SET value = $3
-                 WHERE namespace = $1 AND key = $2 AND value = $4",
+            "UPDATE {} SET value = ?3
+                 WHERE namespace = ?1 AND key = ?2 AND value = ?4",
             table
         )
     } else {
         format!(
-            "INSERT INTO {} (namespace, key, value) VALUES ($1, $2, $3)
+            "INSERT INTO {} (namespace, key, value) VALUES (?1, ?2, ?3)
                  ON CONFLICT (namespace, key) DO NOTHING",
             table
         )
@@ -118,41 +59,41 @@ fn compare_and_swap_query(table: &str, expected: bool) -> String {
 
 fn delete_query(table: &str) -> String {
     format!(
-        "DELETE FROM {} WHERE namespace = $1 AND key = $2",
+        "DELETE FROM {} WHERE namespace = ?1 AND key = ?2",
         quoted_identifier(table)
     )
 }
 
 fn list_keys_query(table: &str) -> String {
     format!(
-        "SELECT key FROM {} WHERE namespace = $1 AND key LIKE $2 ESCAPE '\\'",
+        "SELECT key FROM {} WHERE namespace = ?1 AND key LIKE ?2 ESCAPE '\\'",
         quoted_identifier(table)
     )
 }
 
 fn list_entries_query(table: &str) -> String {
     format!(
-        "SELECT key, value FROM {} WHERE namespace = $1 AND key LIKE $2 ESCAPE '\\'",
+        "SELECT key, value FROM {} WHERE namespace = ?1 AND key LIKE ?2 ESCAPE '\\'",
         quoted_identifier(table)
     )
 }
 
 fn delete_prefix_query(table: &str) -> String {
     format!(
-        "DELETE FROM {} WHERE namespace = $1 AND key LIKE $2 ESCAPE '\\'",
+        "DELETE FROM {} WHERE namespace = ?1 AND key LIKE ?2 ESCAPE '\\'",
         quoted_identifier(table)
     )
 }
 
-pub struct PostgresKvStore {
-    pool: PgPool,
+pub struct SqliteKvStore {
+    pool: SqlitePool,
     table: String,
 }
 
-impl PostgresKvStore {
+impl SqliteKvStore {
     pub async fn new(url: &str, table: &str) -> Result<Self> {
         validate_identifier(table)?;
-        let pool = PgPool::connect(url).await?;
+        let pool = sqlite_pool(url).await?;
 
         let create_stmt = create_table_statement(table);
         sqlx::query(&create_stmt).execute(&pool).await?;
@@ -164,8 +105,21 @@ impl PostgresKvStore {
     }
 }
 
+async fn sqlite_pool(url: &str) -> Result<SqlitePool> {
+    let options = SqliteConnectOptions::from_str(url)?
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Normal)
+        .busy_timeout(Duration::from_secs(5))
+        .foreign_keys(true);
+    Ok(SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await?)
+}
+
 #[async_trait::async_trait]
-impl KeyValueStore for PostgresKvStore {
+impl KeyValueStore for SqliteKvStore {
     async fn get(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>> {
         let query = get_query(&self.table);
         let row = sqlx::query(&query)
@@ -201,7 +155,6 @@ impl KeyValueStore for PostgresKvStore {
         value: &[u8],
     ) -> Result<bool> {
         let query = compare_and_swap_query(&self.table, expected.is_some());
-
         let mut q = sqlx::query(&query).bind(namespace).bind(key).bind(value);
         if let Some(expected) = expected {
             q = q.bind(expected);
@@ -268,91 +221,41 @@ impl KeyValueStore for PostgresKvStore {
 mod tests {
     use super::{
         compare_and_swap_query, create_table_statement, delete_prefix_query, delete_query,
-        get_query, like_prefix_pattern, list_entries_query, list_keys_query, set_query,
-        validate_identifier, PostgresKvStore,
+        get_query, list_entries_query, list_keys_query, set_query, SqliteKvStore,
     };
+    use crate::control::kv::sqlite_url_for_path;
     use crate::control::KeyValueStore;
-    use crate::test_support::{docker_test_guard, PostgresContainer};
-    use std::time::Duration;
-
-    #[test]
-    fn like_prefix_pattern_appends_sql_wildcard() {
-        assert_eq!(like_prefix_pattern("Agent/test"), "Agent/test%");
-    }
-
-    #[test]
-    fn like_prefix_pattern_escapes_like_metacharacters() {
-        assert_eq!(like_prefix_pattern(r"Agent_%\path"), r"Agent\_\%\\path%");
-    }
+    use tempfile::tempdir;
 
     #[test]
     fn sql_builders_use_expected_table_and_clauses() {
         let create = create_table_statement("talon_kv");
         assert!(create.contains("CREATE TABLE IF NOT EXISTS \"talon_kv\""));
-        assert!(create.contains("PRIMARY KEY (namespace, key)"));
+        assert!(create.contains("value BLOB NOT NULL"));
 
         assert_eq!(
             get_query("talon_kv"),
-            "SELECT value FROM \"talon_kv\" WHERE namespace = $1 AND key = $2"
+            "SELECT value FROM \"talon_kv\" WHERE namespace = ?1 AND key = ?2"
         );
-        assert!(set_query("talon_kv").contains("ON CONFLICT (namespace, key) DO UPDATE"));
-        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = $4"));
+        assert!(set_query("talon_kv").contains("excluded.value"));
+        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = ?4"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
         assert_eq!(
             delete_query("talon_kv"),
-            "DELETE FROM \"talon_kv\" WHERE namespace = $1 AND key = $2"
+            "DELETE FROM \"talon_kv\" WHERE namespace = ?1 AND key = ?2"
         );
-        assert!(list_keys_query("talon_kv").contains("LIKE $2 ESCAPE '\\'"));
+        assert!(list_keys_query("talon_kv").contains("LIKE ?2 ESCAPE '\\'"));
         assert!(list_entries_query("talon_kv").contains("SELECT key, value"));
         assert!(delete_prefix_query("talon_kv").contains("DELETE FROM \"talon_kv\""));
     }
 
-    #[test]
-    fn validate_identifier_rejects_invalid_table_names() {
-        validate_identifier("talon_kv").expect("underscores should be allowed");
-        validate_identifier("talon123").expect("alphanumeric names should be allowed");
-        validate_identifier("_talon").expect("leading underscore should be allowed");
-
-        let err = validate_identifier("talon-kv").unwrap_err();
-        assert!(err.to_string().contains("Invalid table name"));
-
-        let empty = validate_identifier("").unwrap_err();
-        assert!(empty.to_string().contains("Invalid table name"));
-
-        let starts_with_digit = validate_identifier("1talon").unwrap_err();
-        assert!(starts_with_digit.to_string().contains("must start"));
-
-        let too_long = validate_identifier(&"a".repeat(64)).unwrap_err();
-        assert!(too_long.to_string().contains("between 1 and 63"));
-
-        let reserved = validate_identifier("select").unwrap_err();
-        assert!(reserved.to_string().contains("reserved keywords"));
-
-        validate_identifier("select_log").expect("non-keyword identifiers should be allowed");
-    }
-
-    async fn init_test_store(database_url: &str) -> PostgresKvStore {
-        let mut last_error = None;
-        for _ in 0..20 {
-            match PostgresKvStore::new(database_url, "talon_kv_store_test").await {
-                Ok(store) => return store,
-                Err(err) => {
-                    last_error = Some(err);
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-                }
-            }
-        }
-        panic!(
-            "store should initialize: {}",
-            last_error.expect("expected initialization error")
-        );
-    }
-
     #[tokio::test]
-    async fn postgres_kv_round_trip_compare_and_swap_and_prefix_ops() {
-        let _guard = docker_test_guard();
-        let pg = PostgresContainer::start("talon-kv-pg");
-        let store = init_test_store(&pg.database_url()).await;
+    async fn sqlite_kv_round_trip_compare_and_swap_and_prefix_ops() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("talon-kv.db");
+        let store = SqliteKvStore::new(&sqlite_url_for_path(&db_path), "talon_kv_store_test")
+            .await
+            .unwrap();
 
         assert!(store.get("ns", "missing").await.unwrap().is_none());
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -324,7 +324,7 @@ async fn sqlite_database_url(
     }
     let db_path = PathBuf::from(data_dir).join("talon-control-plane.db");
     if let Some(parent) = db_path.parent() {
-        std::fs::create_dir_all(parent)?;
+        tokio::fs::create_dir_all(parent).await?;
     }
     Ok(kv::sqlite_url_for_path(&db_path))
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -11,6 +11,7 @@ pub mod scheduler;
 pub mod topics;
 
 use serde::{de::DeserializeOwned, Serialize};
+use std::path::PathBuf;
 
 #[async_trait::async_trait]
 pub trait KeyValueStore: Send + Sync {
@@ -125,7 +126,7 @@ fn message_broker_config(
         .message_broker
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("control_plane.message_broker configuration is missing"))?;
-    if mb_config.driver != "gcp_pubsub" {
+    if mb_config.driver != "gcp_pubsub" && mb_config.driver != "local_socket" {
         return Err(anyhow::anyhow!(
             "Unsupported message broker driver: {}",
             mb_config.driver
@@ -146,45 +147,108 @@ pub async fn build_control_plane(config: &crate::config::Config) -> anyhow::Resu
         .database
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("control_plane.database configuration is missing"))?;
-    if db_config.driver != "postgres" {
-        return Err(anyhow::anyhow!(
-            "Unsupported database driver: {}",
-            db_config.driver
-        ));
+    let kv: std::sync::Arc<dyn KeyValueStore + Send + Sync>;
+    let scheduler_database_url: Option<String>;
+    match db_config.driver.as_str() {
+        "postgres" => {
+            let url_secret = db_config
+                .url
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("Database URL secret is missing"))?;
+            let pg_url: String = url_secret.resolve().await?;
+            println!("Connecting to PostgresKvStore at {}...", pg_url);
+            kv = std::sync::Arc::new(kv::PostgresKvStore::new(&pg_url, "talon_kv_store").await?);
+            scheduler_database_url = Some(pg_url);
+        }
+        "sqlite" => {
+            let sqlite_url = sqlite_database_url(db_config).await?;
+            println!("Connecting to SqliteKvStore at {}...", sqlite_url);
+            kv = std::sync::Arc::new(kv::SqliteKvStore::new(&sqlite_url, "talon_kv_store").await?);
+            scheduler_database_url = Some(sqlite_url);
+        }
+        other => {
+            return Err(anyhow::anyhow!("Unsupported database driver: {}", other));
+        }
     }
-    let url_secret = db_config
-        .url
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("Database URL secret is missing"))?;
-    let pg_url: String = url_secret.resolve().await?;
-    println!("Connecting to PostgresKvStore at {}...", pg_url);
-    let kv = std::sync::Arc::new(kv::PostgresKvStore::new(&pg_url, "talon_kv_store").await?);
 
-    let _mb_config = message_broker_config(cp)?;
-    println!("Initializing GcpPubSubPublisher...");
-    let pubsub = std::sync::Arc::new(pubsub::GcpPubSubPublisher::new().await?);
+    let mb_config = message_broker_config(cp)?;
+    let pubsub: std::sync::Arc<dyn MessagePublisher + Send + Sync> = match mb_config.driver.as_str()
+    {
+        "gcp_pubsub" => {
+            println!("Initializing GcpPubSubPublisher...");
+            std::sync::Arc::new(pubsub::GcpPubSubPublisher::new().await?)
+        }
+        "local_socket" => {
+            let default_root =
+                if db_config.driver == "sqlite" && !db_config.data_dir.trim().is_empty() {
+                    Some(PathBuf::from(db_config.data_dir.trim()))
+                } else {
+                    None
+                };
+            let socket_path = pubsub::configured_local_socket_path(default_root.as_deref());
+            println!(
+                "Initializing LocalSocketMessagePublisher at {}...",
+                socket_path.display()
+            );
+            std::sync::Arc::new(pubsub::LocalSocketMessagePublisher::new(socket_path).await?)
+        }
+        other => {
+            return Err(anyhow::anyhow!(
+                "Unsupported message broker driver: {}",
+                other
+            ));
+        }
+    };
 
     let scheduler: std::sync::Arc<dyn scheduler::SchedulerBackend + Send + Sync> =
-        if matches!(scheduler_driver().as_deref(), Some("local_postgres")) {
-            match scheduler::LocalPostgresSchedulerBackend::new(
-                &pg_url,
-                std::env::var("TALON_LOCAL_SCHEDULER_TABLE").ok(),
-                std::env::var("TALON_LOCAL_SCHEDULER_TARGET_URL").ok(),
-                std::env::var("TALON_SCHEDULER_AUTH_TOKEN").ok(),
-                std::env::var("TALON_LOCAL_SCHEDULER_RUNNER")
-                    .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-                    .unwrap_or(false),
-            )
-            .await
-            {
-                Ok(backend) => std::sync::Arc::new(backend),
-                Err(err) => {
-                    tracing::warn!(error = %err, "Failed to initialize local_postgres scheduler; using noop");
+        match scheduler_driver().as_deref() {
+            Some("local_postgres") => {
+                if let Some(database_url) = scheduler_database_url.as_deref() {
+                    match scheduler::LocalPostgresSchedulerBackend::new(
+                        database_url,
+                        std::env::var("TALON_LOCAL_SCHEDULER_TABLE").ok(),
+                        std::env::var("TALON_LOCAL_SCHEDULER_TARGET_URL").ok(),
+                        std::env::var("TALON_SCHEDULER_AUTH_TOKEN").ok(),
+                        std::env::var("TALON_LOCAL_SCHEDULER_RUNNER")
+                            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+                            .unwrap_or(false),
+                    )
+                    .await
+                    {
+                        Ok(backend) => std::sync::Arc::new(backend),
+                        Err(err) => {
+                            tracing::warn!(error = %err, "Failed to initialize local_postgres scheduler; using noop");
+                            std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
+                        }
+                    }
+                } else {
                     std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
                 }
             }
-        } else {
-            match configured_scheduler(cp.scheduler.as_ref()) {
+            Some("local_sqlite") => {
+                if let Some(database_url) = scheduler_database_url.as_deref() {
+                    match scheduler::LocalSqliteSchedulerBackend::new(
+                        database_url,
+                        std::env::var("TALON_LOCAL_SCHEDULER_TABLE").ok(),
+                        std::env::var("TALON_LOCAL_SCHEDULER_TARGET_URL").ok(),
+                        std::env::var("TALON_SCHEDULER_AUTH_TOKEN").ok(),
+                        std::env::var("TALON_LOCAL_SCHEDULER_RUNNER")
+                            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+                            .unwrap_or(false),
+                    )
+                    .await
+                    {
+                        Ok(backend) => std::sync::Arc::new(backend),
+                        Err(err) => {
+                            tracing::warn!(error = %err, "Failed to initialize local_sqlite scheduler; using noop");
+                            std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
+                        }
+                    }
+                } else {
+                    std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
+                }
+            }
+            _ => match configured_scheduler(cp.scheduler.as_ref()) {
                 Some(crate::config::proto::SchedulerConfig {
                     backend: Some(crate::config::proto::scheduler_config::Backend::CloudTasks(cfg)),
                 }) => match scheduler::CloudTasksSchedulerBackend::new(&cfg).await {
@@ -198,7 +262,7 @@ pub async fn build_control_plane(config: &crate::config::Config) -> anyhow::Resu
                     std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
                 }
                 None => std::sync::Arc::new(scheduler::NoopSchedulerBackend::default()),
-            }
+            },
         };
 
     Ok(ControlPlane {
@@ -244,6 +308,27 @@ fn scheduler_driver() -> Option<String> {
     std::env::var("TALON_SCHEDULER_DRIVER").ok()
 }
 
+async fn sqlite_database_url(
+    db_config: &crate::config::proto::DatabaseConfig,
+) -> anyhow::Result<String> {
+    use crate::config::SecretExt;
+
+    if let Some(url_secret) = db_config.url.as_ref() {
+        return Ok(url_secret.resolve().await?);
+    }
+    let data_dir = db_config.data_dir.trim();
+    if data_dir.is_empty() {
+        return Err(anyhow::anyhow!(
+            "SQLite database requires either control_plane.database.url or control_plane.database.data_dir"
+        ));
+    }
+    let db_path = PathBuf::from(data_dir).join("talon-control-plane.db");
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    Ok(kv::sqlite_url_for_path(&db_path))
+}
+
 fn configured_scheduler_callback_auth_from_env(
 ) -> Option<crate::config::proto::SchedulerCallbackAuthConfig> {
     if let Some(token) = std::env::var("TALON_SCHEDULER_AUTH_TOKEN")
@@ -285,13 +370,14 @@ fn configured_scheduler_callback_auth_from_env(
 mod tests {
     use super::{
         build_control_plane, configured_scheduler, configured_scheduler_callback_auth_from_env,
-        message_broker_config, KeyValueStore, ProtoKeyValueStoreExt,
+        message_broker_config, sqlite_database_url, KeyValueStore, ProtoKeyValueStoreExt,
     };
     use crate::config::proto;
     use crate::config::proto::{scheduler_callback_auth_config, scheduler_config, secret};
     use crate::gateway::rpc::models;
-    use std::collections::HashMap;
     use crate::test_support::MockKvStore;
+    use std::collections::HashMap;
+    use tempfile::tempdir;
     struct EnvGuard {
         key: &'static str,
         value: Option<String>,
@@ -448,15 +534,9 @@ mod tests {
         std::env::set_var("TALON_TEST_RESTORE", "before");
         {
             let _guard = EnvGuard::set("TALON_TEST_RESTORE", "after");
-            assert_eq!(
-                std::env::var("TALON_TEST_RESTORE").as_deref(),
-                Ok("after")
-            );
+            assert_eq!(std::env::var("TALON_TEST_RESTORE").as_deref(), Ok("after"));
         }
-        assert_eq!(
-            std::env::var("TALON_TEST_RESTORE").as_deref(),
-            Ok("before")
-        );
+        assert_eq!(std::env::var("TALON_TEST_RESTORE").as_deref(), Ok("before"));
         std::env::remove_var("TALON_TEST_RESTORE");
     }
 
@@ -476,7 +556,10 @@ mod tests {
         kv.delete_prefix("ns", "prefix/").await.unwrap();
         assert!(kv.get("ns", "prefix/a").await.unwrap().is_none());
         assert!(kv.get("ns", "prefix/b").await.unwrap().is_none());
-        assert_eq!(kv.get("ns", "other/c").await.unwrap(), Some(b"three".to_vec()));
+        assert_eq!(
+            kv.get("ns", "other/c").await.unwrap(),
+            Some(b"three".to_vec())
+        );
 
         let session = models::Session {
             id: "session-1".to_string(),
@@ -558,7 +641,7 @@ mod tests {
             control_plane: Some(proto::ControlPlaneConfig {
                 database: Some(proto::DatabaseConfig {
                     data_dir: String::new(),
-                    driver: "sqlite".to_string(),
+                    driver: "badger".to_string(),
                     url: None,
                 }),
                 message_broker: Some(proto::MessageBrokerConfig {
@@ -575,7 +658,7 @@ mod tests {
         };
         assert!(err
             .to_string()
-            .contains("Unsupported database driver: sqlite"));
+            .contains("Unsupported database driver: badger"));
 
         let missing_url = proto::TalonConfig {
             control_plane: Some(proto::ControlPlaneConfig {
@@ -613,6 +696,54 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Unsupported message broker driver: kafka"));
+
+        let local_socket_message_broker = proto::ControlPlaneConfig {
+            database: None,
+            message_broker: Some(proto::MessageBrokerConfig {
+                driver: "local_socket".to_string(),
+            }),
+            scheduler: None,
+        };
+        assert!(message_broker_config(&local_socket_message_broker).is_ok());
+    }
+
+    #[tokio::test]
+    async fn sqlite_database_url_uses_data_dir_or_explicit_url() {
+        let dir = tempdir().unwrap();
+        let cfg = proto::DatabaseConfig {
+            data_dir: dir.path().display().to_string(),
+            driver: "sqlite".to_string(),
+            url: None,
+        };
+        let url = sqlite_database_url(&cfg).await.unwrap();
+        assert!(url.ends_with("/talon-control-plane.db"));
+
+        let explicit = proto::DatabaseConfig {
+            data_dir: String::new(),
+            driver: "sqlite".to_string(),
+            url: Some(crate::config::Secret {
+                source: Some(secret::Source::Plain(
+                    "sqlite:///tmp/explicit.db".to_string(),
+                )),
+            }),
+        };
+        assert_eq!(
+            sqlite_database_url(&explicit).await.unwrap(),
+            "sqlite:///tmp/explicit.db"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_database_url_requires_path_or_url() {
+        let cfg = proto::DatabaseConfig {
+            data_dir: "   ".to_string(),
+            driver: "sqlite".to_string(),
+            url: None,
+        };
+        let err = sqlite_database_url(&cfg).await.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("SQLite database requires either control_plane.database.url or control_plane.database.data_dir"));
     }
 
     #[test]

--- a/src/control/pubsub.rs
+++ b/src/control/pubsub.rs
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
+mod local_socket;
+
 use crate::control::MessagePublisher;
 use anyhow::Result;
 use google_cloud_googleapis::pubsub::v1::ExpirationPolicy;
@@ -9,9 +11,12 @@ use google_cloud_pubsub::client::{Client, ClientConfig};
 use google_cloud_pubsub::publisher::Publisher;
 use google_cloud_pubsub::subscriber::ReceivedMessage;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+pub use local_socket::{LocalSocketMessagePublisher, LocalSocketSubscriber};
 
 pub struct GcpPubSubPublisher {
     backend: Arc<dyn PubSubBackend>,
@@ -37,6 +42,19 @@ struct GcpPubSubBackend {
 
 fn configured_project_id() -> String {
     std::env::var("GCP_PROJECT_ID").unwrap_or_else(|_| "talon-local".to_string())
+}
+
+pub fn configured_local_socket_path(default_root: Option<&std::path::Path>) -> PathBuf {
+    if let Ok(path) = std::env::var("TALON_LOCAL_SOCKET_PATH") {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    if let Some(root) = default_root {
+        return root.join("talon-broker.sock");
+    }
+    PathBuf::from("/tmp/talon-broker.sock")
 }
 
 pub fn fully_qualified_topic_name(project: &str, topic_name: &str) -> String {

--- a/src/control/pubsub/local_socket.rs
+++ b/src/control/pubsub/local_socket.rs
@@ -13,8 +13,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{mpsc, Mutex, OnceCell};
 
-type SubscriberSender = mpsc::UnboundedSender<Vec<u8>>;
+type SubscriberSender = mpsc::Sender<Vec<u8>>;
 const MAX_FRAME_SIZE: usize = 32 * 1024 * 1024;
+const SUBSCRIBER_BUFFER_SIZE: usize = 1024;
 
 #[derive(Default)]
 struct SubscriptionState {
@@ -264,7 +265,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<Mutex<BrokerState>>) -
                 topic,
                 subscription,
             } => {
-                let (tx, mut rx) = mpsc::unbounded_channel::<Vec<u8>>();
+                let (tx, mut rx) = mpsc::channel::<Vec<u8>>(SUBSCRIBER_BUFFER_SIZE);
                 register_subscriber(&state, &topic, &subscription, tx).await;
                 write_frame(&mut writer, &ServerFrame::Ack { request_id }).await?;
                 while let Some(payload) = rx.recv().await {
@@ -341,7 +342,7 @@ async fn distribute_message(state: &Arc<Mutex<BrokerState>>, topic: &str, payloa
                 .expect("payload should be present before final subscriber")
                 .clone()
         };
-        let _ = sender.send(message);
+        let _ = sender.try_send(message);
     }
 }
 

--- a/src/control/pubsub/local_socket.rs
+++ b/src/control/pubsub/local_socket.rs
@@ -33,6 +33,7 @@ struct BrokerState {
 pub struct LocalSocketMessagePublisher {
     socket_path: Arc<PathBuf>,
     server_started: Arc<OnceCell<()>>,
+    connection: Arc<Mutex<Option<UnixStream>>>,
 }
 
 #[derive(Clone)]
@@ -68,6 +69,7 @@ impl LocalSocketMessagePublisher {
         let publisher = Self {
             socket_path: Arc::new(socket_path),
             server_started: Arc::new(OnceCell::new()),
+            connection: Arc::new(Mutex::new(None)),
         };
         publisher.ensure_server().await?;
         Ok(publisher)
@@ -155,28 +157,33 @@ impl LocalSocketSubscriber {
 impl MessagePublisher for LocalSocketMessagePublisher {
     async fn publish(&self, topic: &str, message: &[u8]) -> Result<()> {
         self.ensure_server().await?;
-        let mut stream = connect_stream(&self.socket_path).await?;
-        let request_id = 1;
-        write_frame(
-            &mut stream,
-            &ClientFrame::Publish {
-                request_id,
-                topic: topic.to_string(),
-                payload_b64: general_purpose::STANDARD.encode(message),
-            },
-        )
-        .await?;
-        match read_frame::<_, ServerFrame>(&mut stream).await? {
-            Some(ServerFrame::Ack { request_id: ack_id }) if ack_id == request_id => Ok(()),
-            Some(ServerFrame::Error { message, .. }) => {
-                Err(anyhow!("local socket publish failed: {}", message))
-            }
-            Some(other) => Err(anyhow!(
-                "unexpected local socket publish response: {:?}",
-                other
-            )),
-            None => Err(anyhow!("local socket broker closed before publish ack")),
+        let mut connection = self.connection.lock().await;
+        if connection.is_none() {
+            *connection = Some(connect_stream(&self.socket_path).await?);
         }
+
+        let payload_b64 = general_purpose::STANDARD.encode(message);
+        if let Err(err) = publish_with_stream(
+            connection
+                .as_mut()
+                .expect("connection should be initialized"),
+            topic,
+            &payload_b64,
+        )
+        .await
+        {
+            tracing::warn!(error = %err, topic = %topic, "local socket publish failed; reconnecting");
+            *connection = Some(connect_stream(&self.socket_path).await?);
+            let stream = connection
+                .as_mut()
+                .expect("connection should be reinitialized");
+            if let Err(retry_err) = publish_with_stream(stream, topic, &payload_b64).await {
+                *connection = None;
+                return Err(retry_err);
+            }
+        }
+
+        Ok(())
     }
 
     async fn subscribe(
@@ -223,6 +230,34 @@ async fn connect_stream(path: &Path) -> Result<UnixStream> {
             path.display()
         )
     })
+}
+
+async fn publish_with_stream(
+    stream: &mut UnixStream,
+    topic: &str,
+    payload_b64: &str,
+) -> Result<()> {
+    let request_id = 1;
+    write_frame(
+        stream,
+        &ClientFrame::Publish {
+            request_id,
+            topic: topic.to_string(),
+            payload_b64: payload_b64.to_string(),
+        },
+    )
+    .await?;
+    match read_frame::<_, ServerFrame>(stream).await? {
+        Some(ServerFrame::Ack { request_id: ack_id }) if ack_id == request_id => Ok(()),
+        Some(ServerFrame::Error { message, .. }) => {
+            Err(anyhow!("local socket publish failed: {}", message))
+        }
+        Some(other) => Err(anyhow!(
+            "unexpected local socket publish response: {:?}",
+            other
+        )),
+        None => Err(anyhow!("local socket broker closed before publish ack")),
+    }
 }
 
 async fn remove_stale_socket(path: &Path) -> Result<()> {
@@ -370,6 +405,9 @@ async fn write_frame<W: AsyncWriteExt + Unpin, T: Serialize>(
     frame: &T,
 ) -> Result<()> {
     let bytes = serde_json::to_vec(frame)?;
+    if bytes.len() > MAX_FRAME_SIZE {
+        return Err(anyhow!("frame too large: {}", bytes.len()));
+    }
     let len = u32::try_from(bytes.len()).context("frame too large")?;
     writer.write_all(&len.to_be_bytes()).await?;
     writer.write_all(&bytes).await?;
@@ -533,5 +571,22 @@ mod tests {
         assert!(err
             .to_string()
             .contains("refusing to remove non-socket path"));
+    }
+
+    #[tokio::test]
+    async fn write_frame_rejects_oversized_payloads() {
+        let (mut writer, _) = duplex(64);
+        let err = write_frame(
+            &mut writer,
+            &ClientFrame::Publish {
+                request_id: 1,
+                topic: "events".to_string(),
+                payload_b64: "a".repeat(MAX_FRAME_SIZE),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("frame too large"));
     }
 }

--- a/src/control/pubsub/local_socket.rs
+++ b/src/control/pubsub/local_socket.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -197,9 +198,7 @@ async fn start_or_connect_server(path: &Path) -> Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
-    if path.exists() {
-        let _ = tokio::fs::remove_file(path).await;
-    }
+    remove_stale_socket(path).await?;
     match UnixListener::bind(path) {
         Ok(listener) => {
             let state = Arc::new(Mutex::new(BrokerState::default()));
@@ -221,6 +220,24 @@ async fn connect_stream(path: &Path) -> Result<UnixStream> {
     UnixStream::connect(path).await.with_context(|| {
         format!(
             "failed to connect to local socket broker at {}",
+            path.display()
+        )
+    })
+}
+
+async fn remove_stale_socket(path: &Path) -> Result<()> {
+    let Ok(metadata) = tokio::fs::metadata(path).await else {
+        return Ok(());
+    };
+    if !metadata.file_type().is_socket() {
+        return Err(anyhow!(
+            "refusing to remove non-socket path at {}",
+            path.display()
+        ));
+    }
+    tokio::fs::remove_file(path).await.with_context(|| {
+        format!(
+            "failed to remove stale local socket broker at {}",
             path.display()
         )
     })
@@ -342,7 +359,9 @@ async fn distribute_message(state: &Arc<Mutex<BrokerState>>, topic: &str, payloa
                 .expect("payload should be present before final subscriber")
                 .clone()
         };
-        let _ = sender.try_send(message);
+        if let Err(err) = sender.try_send(message) {
+            tracing::warn!(error = %err, topic = %topic, "local socket broker dropped message");
+        }
     }
 }
 
@@ -379,8 +398,8 @@ async fn read_frame<R: AsyncReadExt + Unpin, T: for<'de> Deserialize<'de>>(
 #[cfg(test)]
 mod tests {
     use super::{
-        read_frame, write_frame, ClientFrame, LocalSocketMessagePublisher, LocalSocketSubscriber,
-        MAX_FRAME_SIZE,
+        read_frame, remove_stale_socket, write_frame, ClientFrame, LocalSocketMessagePublisher,
+        LocalSocketSubscriber, MAX_FRAME_SIZE,
     };
     use crate::control::MessagePublisher;
     use base64::{engine::general_purpose, Engine as _};
@@ -502,5 +521,17 @@ mod tests {
         let err = read_frame::<_, ClientFrame>(&mut reader).await.unwrap_err();
         assert!(err.to_string().contains("frame too large"));
         writer_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn remove_stale_socket_rejects_non_socket_files() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("not-a-socket");
+        tokio::fs::write(&path, b"hello").await.unwrap();
+
+        let err = remove_stale_socket(&path).await.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("refusing to remove non-socket path"));
     }
 }

--- a/src/control/pubsub/local_socket.rs
+++ b/src/control/pubsub/local_socket.rs
@@ -14,6 +14,7 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{mpsc, Mutex, OnceCell};
 
 type SubscriberSender = mpsc::UnboundedSender<Vec<u8>>;
+const MAX_FRAME_SIZE: usize = 32 * 1024 * 1024;
 
 #[derive(Default)]
 struct SubscriptionState {
@@ -237,7 +238,7 @@ async fn run_server(listener: UnixListener, state: Arc<Mutex<BrokerState>>) {
             }
             Err(err) => {
                 tracing::error!(error = %err, "local socket broker accept failed");
-                break;
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
         }
     }
@@ -245,38 +246,38 @@ async fn run_server(listener: UnixListener, state: Arc<Mutex<BrokerState>>) {
 
 async fn handle_connection(stream: UnixStream, state: Arc<Mutex<BrokerState>>) -> Result<()> {
     let (mut reader, mut writer) = stream.into_split();
-    let Some(frame) = read_frame::<_, ClientFrame>(&mut reader).await? else {
-        return Ok(());
-    };
-    match frame {
-        ClientFrame::Publish {
-            request_id,
-            topic,
-            payload_b64,
-        } => {
-            let payload = general_purpose::STANDARD
-                .decode(payload_b64)
-                .map_err(|err| anyhow!("invalid publish payload encoding: {}", err))?;
-            distribute_message(&state, &topic, payload).await;
-            write_frame(&mut writer, &ServerFrame::Ack { request_id }).await?;
-        }
-        ClientFrame::Subscribe {
-            request_id,
-            topic,
-            subscription,
-        } => {
-            let (tx, mut rx) = mpsc::unbounded_channel::<Vec<u8>>();
-            register_subscriber(&state, &topic, &subscription, tx).await;
-            write_frame(&mut writer, &ServerFrame::Ack { request_id }).await?;
-            while let Some(payload) = rx.recv().await {
-                write_frame(
-                    &mut writer,
-                    &ServerFrame::Delivery {
-                        topic: topic.clone(),
-                        payload_b64: general_purpose::STANDARD.encode(payload),
-                    },
-                )
-                .await?;
+    while let Some(frame) = read_frame::<_, ClientFrame>(&mut reader).await? {
+        match frame {
+            ClientFrame::Publish {
+                request_id,
+                topic,
+                payload_b64,
+            } => {
+                let payload = general_purpose::STANDARD
+                    .decode(payload_b64)
+                    .map_err(|err| anyhow!("invalid publish payload encoding: {}", err))?;
+                distribute_message(&state, &topic, payload).await;
+                write_frame(&mut writer, &ServerFrame::Ack { request_id }).await?;
+            }
+            ClientFrame::Subscribe {
+                request_id,
+                topic,
+                subscription,
+            } => {
+                let (tx, mut rx) = mpsc::unbounded_channel::<Vec<u8>>();
+                register_subscriber(&state, &topic, &subscription, tx).await;
+                write_frame(&mut writer, &ServerFrame::Ack { request_id }).await?;
+                while let Some(payload) = rx.recv().await {
+                    write_frame(
+                        &mut writer,
+                        &ServerFrame::Delivery {
+                            topic: topic.clone(),
+                            payload_b64: general_purpose::STANDARD.encode(payload),
+                        },
+                    )
+                    .await?;
+                }
+                return Ok(());
             }
         }
     }
@@ -354,6 +355,9 @@ async fn read_frame<R: AsyncReadExt + Unpin, T: for<'de> Deserialize<'de>>(
         Err(err) => return Err(err.into()),
     }
     let len = u32::from_be_bytes(len_buf) as usize;
+    if len > MAX_FRAME_SIZE {
+        return Err(anyhow!("frame too large: {}", len));
+    }
     let mut payload = vec![0_u8; len];
     reader.read_exact(&mut payload).await?;
     Ok(Some(serde_json::from_slice(&payload)?))
@@ -361,10 +365,12 @@ async fn read_frame<R: AsyncReadExt + Unpin, T: for<'de> Deserialize<'de>>(
 
 #[cfg(test)]
 mod tests {
-    use super::{LocalSocketMessagePublisher, LocalSocketSubscriber};
+    use super::{read_frame, write_frame, ClientFrame, LocalSocketMessagePublisher, LocalSocketSubscriber, MAX_FRAME_SIZE};
+    use base64::{engine::general_purpose, Engine as _};
     use crate::control::MessagePublisher;
     use futures::StreamExt;
     use tempfile::tempdir;
+    use tokio::io::{duplex, AsyncWriteExt};
 
     async fn broker() -> (LocalSocketMessagePublisher, LocalSocketSubscriber) {
         let dir = tempdir().unwrap();
@@ -421,5 +427,60 @@ mod tests {
         publisher.publish("events", b"hello").await.unwrap();
         assert_eq!(first.next().await.unwrap(), b"hello".to_vec());
         assert_eq!(second.next().await.unwrap(), b"hello".to_vec());
+    }
+
+    #[tokio::test]
+    async fn publish_connection_can_send_multiple_frames() {
+        let (publisher, subscriber) = broker().await;
+        let mut first = subscriber.subscribe_named("events", "sub-a").await.unwrap();
+        let mut stream = super::connect_stream(&publisher.socket_path).await.unwrap();
+
+        write_frame(
+            &mut stream,
+            &ClientFrame::Publish {
+                request_id: 1,
+                topic: "events".to_string(),
+                payload_b64: general_purpose::STANDARD.encode(b"one"),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            read_frame::<_, super::ServerFrame>(&mut stream).await.unwrap(),
+            Some(super::ServerFrame::Ack { request_id: 1 })
+        ));
+
+        write_frame(
+            &mut stream,
+            &ClientFrame::Publish {
+                request_id: 2,
+                topic: "events".to_string(),
+                payload_b64: general_purpose::STANDARD.encode(b"two"),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            read_frame::<_, super::ServerFrame>(&mut stream).await.unwrap(),
+            Some(super::ServerFrame::Ack { request_id: 2 })
+        ));
+
+        assert_eq!(first.next().await.unwrap(), b"one".to_vec());
+        assert_eq!(first.next().await.unwrap(), b"two".to_vec());
+    }
+
+    #[tokio::test]
+    async fn read_frame_rejects_oversized_payloads() {
+        let (mut writer, mut reader) = duplex(64);
+        let writer_task = tokio::spawn(async move {
+            writer
+                .write_all(&((MAX_FRAME_SIZE + 1) as u32).to_be_bytes())
+                .await
+                .unwrap();
+        });
+
+        let err = read_frame::<_, ClientFrame>(&mut reader).await.unwrap_err();
+        assert!(err.to_string().contains("frame too large"));
+        writer_task.await.unwrap();
     }
 }

--- a/src/control/pubsub/local_socket.rs
+++ b/src/control/pubsub/local_socket.rs
@@ -328,8 +328,20 @@ async fn distribute_message(state: &Arc<Mutex<BrokerState>>, topic: &str, payloa
         targets
     };
 
-    for sender in targets {
-        let _ = sender.send(payload.clone());
+    let target_count = targets.len();
+    let mut payload = Some(payload);
+    for (index, sender) in targets.into_iter().enumerate() {
+        let message = if index + 1 == target_count {
+            payload
+                .take()
+                .expect("payload should be present for final subscriber")
+        } else {
+            payload
+                .as_ref()
+                .expect("payload should be present before final subscriber")
+                .clone()
+        };
+        let _ = sender.send(message);
     }
 }
 
@@ -365,9 +377,12 @@ async fn read_frame<R: AsyncReadExt + Unpin, T: for<'de> Deserialize<'de>>(
 
 #[cfg(test)]
 mod tests {
-    use super::{read_frame, write_frame, ClientFrame, LocalSocketMessagePublisher, LocalSocketSubscriber, MAX_FRAME_SIZE};
-    use base64::{engine::general_purpose, Engine as _};
+    use super::{
+        read_frame, write_frame, ClientFrame, LocalSocketMessagePublisher, LocalSocketSubscriber,
+        MAX_FRAME_SIZE,
+    };
     use crate::control::MessagePublisher;
+    use base64::{engine::general_purpose, Engine as _};
     use futures::StreamExt;
     use tempfile::tempdir;
     use tokio::io::{duplex, AsyncWriteExt};
@@ -446,7 +461,9 @@ mod tests {
         .await
         .unwrap();
         assert!(matches!(
-            read_frame::<_, super::ServerFrame>(&mut stream).await.unwrap(),
+            read_frame::<_, super::ServerFrame>(&mut stream)
+                .await
+                .unwrap(),
             Some(super::ServerFrame::Ack { request_id: 1 })
         ));
 
@@ -461,7 +478,9 @@ mod tests {
         .await
         .unwrap();
         assert!(matches!(
-            read_frame::<_, super::ServerFrame>(&mut stream).await.unwrap(),
+            read_frame::<_, super::ServerFrame>(&mut stream)
+                .await
+                .unwrap(),
             Some(super::ServerFrame::Ack { request_id: 2 })
         ));
 

--- a/src/control/pubsub/local_socket.rs
+++ b/src/control/pubsub/local_socket.rs
@@ -428,8 +428,18 @@ async fn read_frame<R: AsyncReadExt + Unpin, T: for<'de> Deserialize<'de>>(
     if len > MAX_FRAME_SIZE {
         return Err(anyhow!("frame too large: {}", len));
     }
-    let mut payload = vec![0_u8; len];
-    reader.read_exact(&mut payload).await?;
+    let mut payload = Vec::new();
+    payload
+        .try_reserve_exact(len)
+        .map_err(|err| anyhow!("failed to reserve frame buffer: {}", err))?;
+    let bytes_read = reader.take(len as u64).read_to_end(&mut payload).await?;
+    if bytes_read != len {
+        return Err(anyhow!(
+            "unexpected frame length: expected {} bytes, read {}",
+            len,
+            bytes_read
+        ));
+    }
     Ok(Some(serde_json::from_slice(&payload)?))
 }
 

--- a/src/control/pubsub/local_socket.rs
+++ b/src/control/pubsub/local_socket.rs
@@ -1,0 +1,425 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use crate::control::MessagePublisher;
+use anyhow::{anyhow, Context, Result};
+use base64::{engine::general_purpose, Engine as _};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::{mpsc, Mutex, OnceCell};
+
+type SubscriberSender = mpsc::UnboundedSender<Vec<u8>>;
+
+#[derive(Default)]
+struct SubscriptionState {
+    next_index: usize,
+    subscribers: Vec<SubscriberSender>,
+}
+
+#[derive(Default)]
+struct BrokerState {
+    topics: HashMap<String, HashMap<String, SubscriptionState>>,
+}
+
+#[derive(Clone)]
+pub struct LocalSocketMessagePublisher {
+    socket_path: Arc<PathBuf>,
+    server_started: Arc<OnceCell<()>>,
+}
+
+#[derive(Clone)]
+pub struct LocalSocketSubscriber {
+    socket_path: Arc<PathBuf>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ClientFrame {
+    Publish {
+        request_id: u64,
+        topic: String,
+        payload_b64: String,
+    },
+    Subscribe {
+        request_id: u64,
+        topic: String,
+        subscription: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ServerFrame {
+    Ack { request_id: u64 },
+    Error { request_id: u64, message: String },
+    Delivery { topic: String, payload_b64: String },
+}
+
+impl LocalSocketMessagePublisher {
+    pub async fn new(socket_path: PathBuf) -> Result<Self> {
+        let publisher = Self {
+            socket_path: Arc::new(socket_path),
+            server_started: Arc::new(OnceCell::new()),
+        };
+        publisher.ensure_server().await?;
+        Ok(publisher)
+    }
+
+    pub fn subscriber(&self) -> LocalSocketSubscriber {
+        LocalSocketSubscriber {
+            socket_path: self.socket_path.clone(),
+        }
+    }
+
+    async fn ensure_server(&self) -> Result<()> {
+        if self.server_started.get().is_some() {
+            return Ok(());
+        }
+        start_or_connect_server(&self.socket_path).await?;
+        let _ = self.server_started.set(());
+        Ok(())
+    }
+}
+
+impl LocalSocketSubscriber {
+    pub async fn subscribe_named(
+        &self,
+        topic: &str,
+        subscription: &str,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Vec<u8>> + Send>>> {
+        let mut stream = connect_stream(&self.socket_path).await?;
+        let request_id = 1;
+        write_frame(
+            &mut stream,
+            &ClientFrame::Subscribe {
+                request_id,
+                topic: topic.to_string(),
+                subscription: subscription.to_string(),
+            },
+        )
+        .await?;
+        match read_frame::<_, ServerFrame>(&mut stream).await? {
+            Some(ServerFrame::Ack { request_id: ack_id }) if ack_id == request_id => {}
+            Some(ServerFrame::Error { message, .. }) => {
+                return Err(anyhow!("local socket subscribe failed: {}", message));
+            }
+            Some(other) => {
+                return Err(anyhow!(
+                    "unexpected local socket subscribe response: {:?}",
+                    other
+                ));
+            }
+            None => {
+                return Err(anyhow!("local socket broker closed before subscribe ack"));
+            }
+        }
+
+        let output = async_stream::stream! {
+            loop {
+                match read_frame::<_, ServerFrame>(&mut stream).await {
+                    Ok(Some(ServerFrame::Delivery { payload_b64, .. })) => {
+                        match general_purpose::STANDARD.decode(payload_b64) {
+                            Ok(payload) => yield payload,
+                            Err(err) => {
+                                tracing::error!(error = %err, "failed to decode local socket delivery");
+                                break;
+                            }
+                        }
+                    }
+                    Ok(Some(ServerFrame::Ack { .. })) => {}
+                    Ok(Some(ServerFrame::Error { message, .. })) => {
+                        tracing::error!(message = %message, "local socket broker returned stream error");
+                        break;
+                    }
+                    Ok(None) => break,
+                    Err(err) => {
+                        tracing::error!(error = %err, "local socket subscription stream failed");
+                        break;
+                    }
+                }
+            }
+        };
+        Ok(Box::pin(output))
+    }
+}
+
+#[async_trait::async_trait]
+impl MessagePublisher for LocalSocketMessagePublisher {
+    async fn publish(&self, topic: &str, message: &[u8]) -> Result<()> {
+        self.ensure_server().await?;
+        let mut stream = connect_stream(&self.socket_path).await?;
+        let request_id = 1;
+        write_frame(
+            &mut stream,
+            &ClientFrame::Publish {
+                request_id,
+                topic: topic.to_string(),
+                payload_b64: general_purpose::STANDARD.encode(message),
+            },
+        )
+        .await?;
+        match read_frame::<_, ServerFrame>(&mut stream).await? {
+            Some(ServerFrame::Ack { request_id: ack_id }) if ack_id == request_id => Ok(()),
+            Some(ServerFrame::Error { message, .. }) => {
+                Err(anyhow!("local socket publish failed: {}", message))
+            }
+            Some(other) => Err(anyhow!(
+                "unexpected local socket publish response: {:?}",
+                other
+            )),
+            None => Err(anyhow!("local socket broker closed before publish ack")),
+        }
+    }
+
+    async fn subscribe(
+        &self,
+        topic: &str,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Vec<u8>> + Send>>> {
+        self.ensure_server().await?;
+        let subscription = format!("local-sub-{}", uuid::Uuid::now_v7());
+        self.subscriber()
+            .subscribe_named(topic, &subscription)
+            .await
+    }
+}
+
+async fn start_or_connect_server(path: &Path) -> Result<()> {
+    if connect_stream(path).await.is_ok() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    if path.exists() {
+        let _ = tokio::fs::remove_file(path).await;
+    }
+    match UnixListener::bind(path) {
+        Ok(listener) => {
+            let state = Arc::new(Mutex::new(BrokerState::default()));
+            tokio::spawn(run_server(listener, state));
+            Ok(())
+        }
+        Err(err) => {
+            if connect_stream(path).await.is_ok() {
+                return Ok(());
+            }
+            Err(err).with_context(|| {
+                format!("failed to bind local socket broker at {}", path.display())
+            })
+        }
+    }
+}
+
+async fn connect_stream(path: &Path) -> Result<UnixStream> {
+    UnixStream::connect(path).await.with_context(|| {
+        format!(
+            "failed to connect to local socket broker at {}",
+            path.display()
+        )
+    })
+}
+
+async fn run_server(listener: UnixListener, state: Arc<Mutex<BrokerState>>) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                let state = state.clone();
+                tokio::spawn(async move {
+                    if let Err(err) = handle_connection(stream, state).await {
+                        tracing::error!(error = %err, "local socket broker connection failed");
+                    }
+                });
+            }
+            Err(err) => {
+                tracing::error!(error = %err, "local socket broker accept failed");
+                break;
+            }
+        }
+    }
+}
+
+async fn handle_connection(stream: UnixStream, state: Arc<Mutex<BrokerState>>) -> Result<()> {
+    let (mut reader, mut writer) = stream.into_split();
+    let Some(frame) = read_frame::<_, ClientFrame>(&mut reader).await? else {
+        return Ok(());
+    };
+    match frame {
+        ClientFrame::Publish {
+            request_id,
+            topic,
+            payload_b64,
+        } => {
+            let payload = general_purpose::STANDARD
+                .decode(payload_b64)
+                .map_err(|err| anyhow!("invalid publish payload encoding: {}", err))?;
+            distribute_message(&state, &topic, payload).await;
+            write_frame(&mut writer, &ServerFrame::Ack { request_id }).await?;
+        }
+        ClientFrame::Subscribe {
+            request_id,
+            topic,
+            subscription,
+        } => {
+            let (tx, mut rx) = mpsc::unbounded_channel::<Vec<u8>>();
+            register_subscriber(&state, &topic, &subscription, tx).await;
+            write_frame(&mut writer, &ServerFrame::Ack { request_id }).await?;
+            while let Some(payload) = rx.recv().await {
+                write_frame(
+                    &mut writer,
+                    &ServerFrame::Delivery {
+                        topic: topic.clone(),
+                        payload_b64: general_purpose::STANDARD.encode(payload),
+                    },
+                )
+                .await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn register_subscriber(
+    state: &Arc<Mutex<BrokerState>>,
+    topic: &str,
+    subscription: &str,
+    sender: SubscriberSender,
+) {
+    let mut state = state.lock().await;
+    let subscription_state = state
+        .topics
+        .entry(topic.to_string())
+        .or_default()
+        .entry(subscription.to_string())
+        .or_default();
+    subscription_state.subscribers.push(sender);
+}
+
+async fn distribute_message(state: &Arc<Mutex<BrokerState>>, topic: &str, payload: Vec<u8>) {
+    let targets = {
+        let mut state = state.lock().await;
+        let Some(subscriptions) = state.topics.get_mut(topic) else {
+            return;
+        };
+        let mut targets = Vec::new();
+        let mut empty_subscriptions = Vec::new();
+        for (subscription_name, subscription_state) in subscriptions.iter_mut() {
+            subscription_state
+                .subscribers
+                .retain(|sender| !sender.is_closed());
+            if subscription_state.subscribers.is_empty() {
+                empty_subscriptions.push(subscription_name.clone());
+                continue;
+            }
+            let index = subscription_state.next_index % subscription_state.subscribers.len();
+            let sender = subscription_state.subscribers[index].clone();
+            subscription_state.next_index =
+                (subscription_state.next_index + 1) % subscription_state.subscribers.len();
+            targets.push(sender);
+        }
+        for subscription_name in empty_subscriptions {
+            subscriptions.remove(&subscription_name);
+        }
+        targets
+    };
+
+    for sender in targets {
+        let _ = sender.send(payload.clone());
+    }
+}
+
+async fn write_frame<W: AsyncWriteExt + Unpin, T: Serialize>(
+    writer: &mut W,
+    frame: &T,
+) -> Result<()> {
+    let bytes = serde_json::to_vec(frame)?;
+    let len = u32::try_from(bytes.len()).context("frame too large")?;
+    writer.write_all(&len.to_be_bytes()).await?;
+    writer.write_all(&bytes).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+async fn read_frame<R: AsyncReadExt + Unpin, T: for<'de> Deserialize<'de>>(
+    reader: &mut R,
+) -> Result<Option<T>> {
+    let mut len_buf = [0_u8; 4];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err.into()),
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut payload = vec![0_u8; len];
+    reader.read_exact(&mut payload).await?;
+    Ok(Some(serde_json::from_slice(&payload)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LocalSocketMessagePublisher, LocalSocketSubscriber};
+    use crate::control::MessagePublisher;
+    use futures::StreamExt;
+    use tempfile::tempdir;
+
+    async fn broker() -> (LocalSocketMessagePublisher, LocalSocketSubscriber) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("talon-broker.sock");
+        let publisher = LocalSocketMessagePublisher::new(path).await.unwrap();
+        let subscriber = publisher.subscriber();
+        std::mem::forget(dir);
+        (publisher, subscriber)
+    }
+
+    #[tokio::test]
+    async fn publish_reaches_unique_subscription() {
+        let (publisher, subscriber) = broker().await;
+        let mut stream = subscriber.subscribe_named("events", "sub-1").await.unwrap();
+
+        publisher.publish("events", b"hello").await.unwrap();
+        assert_eq!(stream.next().await.unwrap(), b"hello".to_vec());
+    }
+
+    #[tokio::test]
+    async fn multiple_group_subscribers_share_delivery() {
+        let (publisher, subscriber) = broker().await;
+        let mut first = subscriber
+            .subscribe_named("events", "workers")
+            .await
+            .unwrap();
+        let mut second = subscriber
+            .subscribe_named("events", "workers")
+            .await
+            .unwrap();
+
+        publisher.publish("events", b"one").await.unwrap();
+        publisher.publish("events", b"two").await.unwrap();
+
+        let a = tokio::time::timeout(std::time::Duration::from_secs(1), first.next())
+            .await
+            .unwrap()
+            .unwrap();
+        let b = tokio::time::timeout(std::time::Duration::from_secs(1), second.next())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut got = vec![a, b];
+        got.sort();
+        assert_eq!(got, vec![b"one".to_vec(), b"two".to_vec()]);
+    }
+
+    #[tokio::test]
+    async fn distinct_subscriptions_each_receive_copy() {
+        let (publisher, subscriber) = broker().await;
+        let mut first = subscriber.subscribe_named("events", "sub-a").await.unwrap();
+        let mut second = subscriber.subscribe_named("events", "sub-b").await.unwrap();
+
+        publisher.publish("events", b"hello").await.unwrap();
+        assert_eq!(first.next().await.unwrap(), b"hello".to_vec());
+        assert_eq!(second.next().await.unwrap(), b"hello".to_vec());
+    }
+}

--- a/src/control/scheduler.rs
+++ b/src/control/scheduler.rs
@@ -3,10 +3,12 @@
 
 mod cloud_tasks;
 mod local_postgres;
+mod local_sqlite;
 mod noop;
 
 pub use cloud_tasks::CloudTasksSchedulerBackend;
 pub use local_postgres::LocalPostgresSchedulerBackend;
+pub use local_sqlite::LocalSqliteSchedulerBackend;
 pub use noop::NoopSchedulerBackend;
 
 use anyhow::Result;

--- a/src/control/scheduler/local_sqlite.rs
+++ b/src/control/scheduler/local_sqlite.rs
@@ -166,10 +166,20 @@ impl LocalSqliteSchedulerStore {
         auth_token: Option<String>,
         shutdown: CancellationToken,
     ) {
-        let client = Client::builder()
+        let client = match Client::builder()
             .timeout(Duration::from_secs(DELIVERY_TIMEOUT_SECONDS))
             .build()
-            .expect("failed to build local scheduler client");
+        {
+            Ok(client) => client,
+            Err(err) => {
+                error!(
+                    error = %err,
+                    target_url = %target_url,
+                    "failed to build local scheduler client; exiting runner loop"
+                );
+                return;
+            }
+        };
         loop {
             if shutdown.is_cancelled() {
                 return;

--- a/src/control/scheduler/local_sqlite.rs
+++ b/src/control/scheduler/local_sqlite.rs
@@ -13,6 +13,7 @@ use std::{str::FromStr, time::Duration};
 use tracing::{error, warn};
 
 use super::{ScheduleWakeupRequest, ScheduledWakeup, SchedulerBackend, SCHEDULER_AUTH_HEADER};
+use crate::control::kv::validate_identifier;
 
 const DEFAULT_TABLE: &str = "talon_local_scheduler_jobs";
 const CLAIM_TIMEOUT_SECONDS: i64 = 60;
@@ -363,13 +364,6 @@ impl LocalSqliteSchedulerBackend {
     }
 }
 
-fn validate_identifier(value: &str) -> Result<()> {
-    if value.is_empty() || !value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
-        anyhow::bail!("invalid identifier: {}", value);
-    }
-    Ok(())
-}
-
 fn compute_retry_delay_seconds(attempts: i32) -> i64 {
     let exponent = attempts.saturating_sub(1).clamp(0, 10) as u32;
     (INITIAL_RETRY_DELAY_SECONDS * (1_i64 << exponent)).min(MAX_RETRY_DELAY_SECONDS)
@@ -615,7 +609,7 @@ mod tests {
         .await
         .err()
         .unwrap();
-        assert!(err.to_string().contains("invalid identifier"));
+        assert!(err.to_string().contains("Invalid table name"));
     }
 
     #[tokio::test]

--- a/src/control/scheduler/local_sqlite.rs
+++ b/src/control/scheduler/local_sqlite.rs
@@ -1,0 +1,899 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use futures::stream::{FuturesUnordered, StreamExt};
+use reqwest::Client;
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
+    Row, SqlitePool,
+};
+use std::{str::FromStr, time::Duration};
+use tracing::{error, warn};
+
+use super::{ScheduleWakeupRequest, ScheduledWakeup, SchedulerBackend, SCHEDULER_AUTH_HEADER};
+
+const DEFAULT_TABLE: &str = "talon_local_scheduler_jobs";
+const CLAIM_TIMEOUT_SECONDS: i64 = 60;
+const DELIVERY_TIMEOUT_SECONDS: u64 = 15;
+const POLL_INTERVAL_MILLIS: u64 = 1_000;
+const MAX_CONCURRENT_DELIVERIES: usize = 10;
+const MAX_DELIVERY_ATTEMPTS: i32 = 20;
+const INITIAL_RETRY_DELAY_SECONDS: i64 = 5;
+const MAX_RETRY_DELAY_SECONDS: i64 = 300;
+
+#[derive(Clone)]
+pub struct LocalSqliteSchedulerBackend {
+    pool: SqlitePool,
+    table: String,
+}
+
+#[derive(Clone)]
+struct DueWakeup {
+    handle: String,
+    namespace: String,
+    schedule_id: String,
+    revision: i64,
+    fire_at_micros: i64,
+    payload: Vec<u8>,
+    attempts: i32,
+}
+
+impl LocalSqliteSchedulerBackend {
+    pub async fn new(
+        database_url: &str,
+        table: Option<String>,
+        runner_target_url: Option<String>,
+        auth_token: Option<String>,
+        runner_enabled: bool,
+    ) -> Result<Self> {
+        let options = SqliteConnectOptions::from_str(database_url)?
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .busy_timeout(Duration::from_secs(5))
+            .foreign_keys(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await?;
+        let table = table.unwrap_or_else(|| DEFAULT_TABLE.to_string());
+        validate_identifier(&table)?;
+        let create_stmt = format!(
+            "CREATE TABLE IF NOT EXISTS {table} (
+                handle TEXT PRIMARY KEY,
+                namespace TEXT NOT NULL,
+                schedule_id TEXT NOT NULL,
+                revision INTEGER NOT NULL,
+                fire_at_micros INTEGER NOT NULL,
+                payload BLOB NOT NULL,
+                canceled_at_micros INTEGER NULL,
+                delivered_at_micros INTEGER NULL,
+                claimed_at_micros INTEGER NULL,
+                claim_until_micros INTEGER NULL,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT NULL,
+                created_at_micros INTEGER NOT NULL
+            )",
+            table = table
+        );
+        sqlx::query(&create_stmt).execute(&pool).await?;
+        let index_stmt = format!(
+            "CREATE INDEX IF NOT EXISTS {table}_due_idx ON {table} (fire_at_micros) WHERE canceled_at_micros IS NULL AND delivered_at_micros IS NULL",
+            table = table
+        );
+        sqlx::query(&index_stmt).execute(&pool).await?;
+
+        if runner_enabled {
+            let Some(target_url) = runner_target_url.filter(|value| !value.trim().is_empty())
+            else {
+                warn!("local_sqlite scheduler runner enabled without target URL; wakeups will not fire");
+                return Ok(Self { pool, table });
+            };
+            let runner = Self {
+                pool: pool.clone(),
+                table: table.clone(),
+            };
+            tokio::spawn(async move {
+                runner
+                    .run_loop(
+                        target_url,
+                        auth_token.filter(|value| !value.trim().is_empty()),
+                    )
+                    .await;
+            });
+        }
+
+        Ok(Self { pool, table })
+    }
+
+    async fn run_loop(self, target_url: String, auth_token: Option<String>) {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(DELIVERY_TIMEOUT_SECONDS))
+            .build()
+            .expect("failed to build local scheduler client");
+        loop {
+            let mut has_more = false;
+            match self.claim_due_wakeups(MAX_CONCURRENT_DELIVERIES).await {
+                Ok(wakeups) => {
+                    if !wakeups.is_empty() {
+                        tracing::info!(
+                            claimed_wakeups = wakeups.len(),
+                            target_url = %target_url,
+                            "local_sqlite scheduler claimed due wakeups"
+                        );
+                    }
+                    has_more = wakeups.len() == MAX_CONCURRENT_DELIVERIES;
+                    let mut deliveries = FuturesUnordered::new();
+                    for wakeup in wakeups {
+                        let backend = self.clone();
+                        let client = client.clone();
+                        let target_url = target_url.clone();
+                        let auth_token = auth_token.clone();
+                        deliveries.push(async move {
+                            let handle = wakeup.handle.clone();
+                            let namespace = wakeup.namespace.clone();
+                            let schedule_id = wakeup.schedule_id.clone();
+                            let revision = wakeup.revision;
+                            let fire_at_micros = wakeup.fire_at_micros;
+                            let attempts = wakeup.attempts;
+                            let result = tokio::time::timeout(
+                                Duration::from_secs(DELIVERY_TIMEOUT_SECONDS + 5),
+                                backend.deliver_wakeup(
+                                    &client,
+                                    &target_url,
+                                    auth_token.as_deref(),
+                                    &wakeup,
+                                ),
+                            )
+                            .await
+                            .map_err(|_| {
+                                anyhow!("timed out delivering scheduler wakeup to {}", target_url)
+                            })
+                            .and_then(|result| result);
+                            (
+                                handle,
+                                namespace,
+                                schedule_id,
+                                revision,
+                                fire_at_micros,
+                                attempts,
+                                result,
+                                backend,
+                            )
+                        });
+                    }
+                    while let Some((
+                        handle,
+                        namespace,
+                        schedule_id,
+                        revision,
+                        fire_at_micros,
+                        attempts,
+                        result,
+                        backend,
+                    )) = deliveries.next().await
+                    {
+                        if let Err(err) = result {
+                            warn!(
+                                handle = %handle,
+                                namespace = %namespace,
+                                schedule_id = %schedule_id,
+                                revision = revision,
+                                fire_at_micros = fire_at_micros,
+                                attempts = attempts,
+                                error = %err,
+                                "failed to deliver local scheduler wakeup"
+                            );
+                            if let Err(mark_err) = backend
+                                .mark_delivery_failed(&handle, attempts, &err.to_string())
+                                .await
+                            {
+                                error!(
+                                    handle = %handle,
+                                    namespace = %namespace,
+                                    schedule_id = %schedule_id,
+                                    revision = revision,
+                                    fire_at_micros = fire_at_micros,
+                                    attempts = attempts,
+                                    error = %mark_err,
+                                    "failed to record local scheduler delivery failure"
+                                );
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    error!(error = %err, "local_sqlite scheduler poll failed");
+                }
+            }
+            if !has_more {
+                tokio::time::sleep(Duration::from_millis(POLL_INTERVAL_MILLIS)).await;
+            }
+        }
+    }
+
+    async fn claim_due_wakeups(&self, limit: usize) -> Result<Vec<DueWakeup>> {
+        let now_micros = Utc::now().timestamp_micros();
+        let select_query = format!(
+            "SELECT handle, namespace, schedule_id, revision, fire_at_micros, payload, attempts
+             FROM {table}
+             WHERE canceled_at_micros IS NULL
+               AND delivered_at_micros IS NULL
+               AND attempts < ?2
+               AND fire_at_micros <= ?1
+               AND (claim_until_micros IS NULL OR claim_until_micros < ?1)
+             ORDER BY fire_at_micros
+             LIMIT ?3",
+            table = self.table
+        );
+        let update_query = format!(
+            "UPDATE {table}
+             SET claimed_at_micros = ?2,
+                 claim_until_micros = ?3,
+                 attempts = attempts + 1
+             WHERE handle = ?1
+               AND canceled_at_micros IS NULL
+               AND delivered_at_micros IS NULL
+               AND attempts < ?4
+               AND fire_at_micros <= ?2
+               AND (claim_until_micros IS NULL OR claim_until_micros < ?2)",
+            table = self.table
+        );
+        let claim_until_micros = now_micros + CLAIM_TIMEOUT_SECONDS * 1_000_000;
+
+        let mut tx = self.pool.begin().await?;
+        let rows = sqlx::query(&select_query)
+            .bind(now_micros)
+            .bind(MAX_DELIVERY_ATTEMPTS)
+            .bind(limit as i64)
+            .fetch_all(&mut *tx)
+            .await?;
+
+        let mut wakeups = Vec::with_capacity(rows.len());
+        for row in rows {
+            let handle: String = row.try_get("handle")?;
+            let updated = sqlx::query(&update_query)
+                .bind(&handle)
+                .bind(now_micros)
+                .bind(claim_until_micros)
+                .bind(MAX_DELIVERY_ATTEMPTS)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+            if updated == 1 {
+                let attempts: i32 = row.try_get("attempts")?;
+                wakeups.push(DueWakeup {
+                    handle,
+                    namespace: row.try_get("namespace")?,
+                    schedule_id: row.try_get("schedule_id")?,
+                    revision: row.try_get("revision")?,
+                    fire_at_micros: row.try_get("fire_at_micros")?,
+                    payload: row.try_get("payload")?,
+                    attempts: attempts + 1,
+                });
+            }
+        }
+        tx.commit().await?;
+        Ok(wakeups)
+    }
+
+    async fn deliver_wakeup(
+        &self,
+        client: &Client,
+        target_url: &str,
+        auth_token: Option<&str>,
+        wakeup: &DueWakeup,
+    ) -> Result<()> {
+        tracing::info!(
+            handle = %wakeup.handle,
+            namespace = %wakeup.namespace,
+            schedule_id = %wakeup.schedule_id,
+            revision = wakeup.revision,
+            fire_at_micros = wakeup.fire_at_micros,
+            target_url = %target_url,
+            attempts = wakeup.attempts,
+            "delivering local scheduler wakeup"
+        );
+        let mut request = client
+            .post(target_url)
+            .header("content-type", "application/json")
+            .body(wakeup.payload.clone());
+        if let Some(token) = auth_token {
+            request = request.header(SCHEDULER_AUTH_HEADER, token);
+        }
+        request.send().await?.error_for_status()?;
+        tracing::info!(
+            handle = %wakeup.handle,
+            namespace = %wakeup.namespace,
+            schedule_id = %wakeup.schedule_id,
+            revision = wakeup.revision,
+            fire_at_micros = wakeup.fire_at_micros,
+            "local scheduler wakeup HTTP delivery succeeded"
+        );
+        self.mark_delivered(&wakeup.handle).await
+    }
+
+    async fn mark_delivered(&self, handle: &str) -> Result<()> {
+        let query = format!(
+            "UPDATE {} SET delivered_at_micros = ?2, claim_until_micros = NULL WHERE handle = ?1",
+            self.table
+        );
+        sqlx::query(&query)
+            .bind(handle)
+            .bind(Utc::now().timestamp_micros())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn mark_delivery_failed(
+        &self,
+        handle: &str,
+        attempts: i32,
+        error_message: &str,
+    ) -> Result<()> {
+        if attempts >= MAX_DELIVERY_ATTEMPTS {
+            let query = format!(
+                "UPDATE {} SET canceled_at_micros = ?2, claim_until_micros = NULL, last_error = ?3 WHERE handle = ?1",
+                self.table
+            );
+            sqlx::query(&query)
+                .bind(handle)
+                .bind(Utc::now().timestamp_micros())
+                .bind(error_message)
+                .execute(&self.pool)
+                .await?;
+            return Ok(());
+        }
+        let backoff_seconds = compute_retry_delay_seconds(attempts);
+        let next_attempt_micros = Utc::now().timestamp_micros() + backoff_seconds * 1_000_000;
+        let query = format!(
+            "UPDATE {} SET claim_until_micros = ?2, last_error = ?3 WHERE handle = ?1",
+            self.table
+        );
+        sqlx::query(&query)
+            .bind(handle)
+            .bind(next_attempt_micros)
+            .bind(error_message)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+fn validate_identifier(value: &str) -> Result<()> {
+    if value.is_empty() || !value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        anyhow::bail!("invalid identifier: {}", value);
+    }
+    Ok(())
+}
+
+fn compute_retry_delay_seconds(attempts: i32) -> i64 {
+    let exponent = attempts.saturating_sub(1).clamp(0, 10) as u32;
+    (INITIAL_RETRY_DELAY_SECONDS * (1_i64 << exponent)).min(MAX_RETRY_DELAY_SECONDS)
+}
+
+#[async_trait::async_trait]
+impl SchedulerBackend for LocalSqliteSchedulerBackend {
+    async fn schedule(&self, req: ScheduleWakeupRequest) -> Result<ScheduledWakeup> {
+        let handle = uuid::Uuid::now_v7().to_string();
+        let query = format!(
+            "INSERT INTO {} (handle, namespace, schedule_id, revision, fire_at_micros, payload, created_at_micros)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            self.table
+        );
+        sqlx::query(&query)
+            .bind(&handle)
+            .bind(&req.namespace)
+            .bind(&req.schedule_id)
+            .bind(req.revision as i64)
+            .bind(req.fire_at.timestamp_micros())
+            .bind(&req.payload)
+            .bind(Utc::now().timestamp_micros())
+            .execute(&self.pool)
+            .await?;
+        Ok(ScheduledWakeup {
+            handle: Some(handle),
+            armed: true,
+        })
+    }
+
+    async fn cancel(&self, handle: &str) -> Result<()> {
+        let query = format!(
+            "UPDATE {} SET canceled_at_micros = ?2, claim_until_micros = NULL WHERE handle = ?1 AND delivered_at_micros IS NULL",
+            self.table
+        );
+        sqlx::query(&query)
+            .bind(handle)
+            .bind(Utc::now().timestamp_micros())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::kv::sqlite_url_for_path;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::sync::{oneshot, Mutex};
+
+    async fn init_test_backend() -> LocalSqliteSchedulerBackend {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("scheduler.db");
+        LocalSqliteSchedulerBackend::new(
+            &sqlite_url_for_path(&db_path),
+            Some("talon_scheduler_test".to_string()),
+            None,
+            None,
+            false,
+        )
+        .await
+        .unwrap()
+    }
+
+    async fn init_backend_with_options(
+        table: Option<String>,
+        runner_target_url: Option<String>,
+        auth_token: Option<String>,
+        runner_enabled: bool,
+    ) -> LocalSqliteSchedulerBackend {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("scheduler.db");
+        LocalSqliteSchedulerBackend::new(
+            &sqlite_url_for_path(&db_path),
+            table,
+            runner_target_url,
+            auth_token,
+            runner_enabled,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[derive(Clone, Default)]
+    struct ReceivedWakeup {
+        header: Option<String>,
+        body: Vec<u8>,
+    }
+
+    #[test]
+    fn validate_identifier_rejects_invalid_names_and_retry_delay_caps() {
+        assert!(validate_identifier("valid_table_01").is_ok());
+        assert!(validate_identifier("").is_err());
+        assert!(validate_identifier("bad-name").is_err());
+        assert!(validate_identifier("bad name").is_err());
+
+        assert_eq!(compute_retry_delay_seconds(0), 5);
+        assert_eq!(compute_retry_delay_seconds(1), 5);
+        assert_eq!(compute_retry_delay_seconds(2), 10);
+        assert_eq!(compute_retry_delay_seconds(3), 20);
+        assert_eq!(compute_retry_delay_seconds(20), 300);
+    }
+
+    #[tokio::test]
+    async fn schedule_claim_fail_cancel_and_deliver_round_trip() {
+        let backend = init_test_backend().await;
+
+        let scheduled = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "schedule-1".to_string(),
+                revision: 7,
+                fire_at: Utc::now() - chrono::Duration::seconds(1),
+                payload: br#"{"ok":true}"#.to_vec(),
+            })
+            .await
+            .unwrap();
+        let handle = scheduled.handle.unwrap();
+
+        let wakeups = backend.claim_due_wakeups(10).await.unwrap();
+        assert_eq!(wakeups.len(), 1);
+        assert_eq!(wakeups[0].handle, handle);
+        assert_eq!(wakeups[0].attempts, 1);
+
+        backend
+            .mark_delivery_failed(&handle, 1, "transient")
+            .await
+            .unwrap();
+        let failure_row = sqlx::query(&format!(
+            "SELECT last_error, claim_until_micros FROM {} WHERE handle = ?1",
+            backend.table
+        ))
+        .bind(&handle)
+        .fetch_one(&backend.pool)
+        .await
+        .unwrap();
+        let last_error: String = failure_row.try_get("last_error").unwrap();
+        let claim_until_micros: i64 = failure_row.try_get("claim_until_micros").unwrap();
+        assert_eq!(last_error, "transient");
+        assert!(claim_until_micros > Utc::now().timestamp_micros());
+
+        backend
+            .mark_delivery_failed(&handle, MAX_DELIVERY_ATTEMPTS, "permanent")
+            .await
+            .unwrap();
+        let canceled_row = sqlx::query(&format!(
+            "SELECT canceled_at_micros, claim_until_micros, last_error FROM {} WHERE handle = ?1",
+            backend.table
+        ))
+        .bind(&handle)
+        .fetch_one(&backend.pool)
+        .await
+        .unwrap();
+        let canceled_at: i64 = canceled_row.try_get("canceled_at_micros").unwrap();
+        let canceled_claim_until: Option<i64> = canceled_row.try_get("claim_until_micros").unwrap();
+        let canceled_error: String = canceled_row.try_get("last_error").unwrap();
+        assert!(canceled_at > 0);
+        assert!(canceled_claim_until.is_none());
+        assert_eq!(canceled_error, "permanent");
+    }
+
+    #[tokio::test]
+    async fn deliver_wakeup_surfaces_http_error_without_marking_delivered() {
+        let backend = init_test_backend().await;
+
+        let handle = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "error".to_string(),
+                revision: 11,
+                fire_at: Utc::now() - chrono::Duration::seconds(1),
+                payload: br#"{"error":true}"#.to_vec(),
+            })
+            .await
+            .unwrap()
+            .handle
+            .unwrap();
+        let wakeup = backend
+            .claim_due_wakeups(1)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|wakeup| wakeup.handle == handle)
+            .unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buffer = vec![0_u8; 4096];
+            let _ = socket.read(&mut buffer).await.unwrap();
+            socket
+                .write_all(b"HTTP/1.1 500 Internal Server Error\r\ncontent-length: 0\r\n\r\n")
+                .await
+                .unwrap();
+        });
+
+        let client = Client::builder().build().unwrap();
+        let err = backend
+            .deliver_wakeup(&client, &format!("http://{}/", addr), None, &wakeup)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("500"));
+        server.await.unwrap();
+
+        let row = sqlx::query(&format!(
+            "SELECT delivered_at_micros, attempts FROM {} WHERE handle = ?1",
+            backend.table
+        ))
+        .bind(&handle)
+        .fetch_one(&backend.pool)
+        .await
+        .unwrap();
+        let delivered_at: Option<i64> = row.try_get("delivered_at_micros").unwrap();
+        let attempts: i32 = row.try_get("attempts").unwrap();
+        assert!(delivered_at.is_none());
+        assert_eq!(attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn new_accepts_blank_runner_target_when_runner_disabled_and_rejects_bad_identifier() {
+        let backend = init_backend_with_options(
+            None,
+            Some("   ".to_string()),
+            Some("secret".to_string()),
+            false,
+        )
+        .await;
+        assert_eq!(backend.table, DEFAULT_TABLE);
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("scheduler.db");
+        let err = LocalSqliteSchedulerBackend::new(
+            &sqlite_url_for_path(&db_path),
+            Some("bad-table-name".to_string()),
+            None,
+            None,
+            false,
+        )
+        .await
+        .err()
+        .unwrap();
+        assert!(err.to_string().contains("invalid identifier"));
+    }
+
+    #[tokio::test]
+    async fn runner_enabled_delivers_due_wakeup_to_target() {
+        let received = Arc::new(Mutex::new(None::<ReceivedWakeup>));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let received_state = received.clone();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buffer = vec![0_u8; 4096];
+            let bytes_read = socket.read(&mut buffer).await.unwrap();
+            let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+            let expected_prefix = format!("{}:", SCHEDULER_AUTH_HEADER).to_ascii_lowercase();
+            let header = request.lines().find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                lower.strip_prefix(&expected_prefix).and_then(|_| {
+                    line.split_once(':')
+                        .map(|(_, value)| value.trim().to_string())
+                })
+            });
+            let body = request
+                .split("\r\n\r\n")
+                .nth(1)
+                .unwrap_or_default()
+                .as_bytes()
+                .to_vec();
+            *received_state.lock().await = Some(ReceivedWakeup { header, body });
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n")
+                .await
+                .unwrap();
+        });
+
+        let backend = init_backend_with_options(
+            Some("talon_scheduler_runner_test".to_string()),
+            Some(format!("http://{}/", addr)),
+            Some("runner-secret".to_string()),
+            true,
+        )
+        .await;
+
+        let scheduled = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "runner-schedule".to_string(),
+                revision: 12,
+                fire_at: Utc::now() - chrono::Duration::seconds(1),
+                payload: br#"{"runner":true}"#.to_vec(),
+            })
+            .await
+            .unwrap();
+        let handle = scheduled.handle.unwrap();
+
+        for _ in 0..40 {
+            if received.lock().await.is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        let captured = received.lock().await.clone().unwrap();
+        assert_eq!(captured.header.as_deref(), Some("runner-secret"));
+        assert_eq!(captured.body, br#"{"runner":true}"#.to_vec());
+        server.await.unwrap();
+
+        let row = sqlx::query(&format!(
+            "SELECT delivered_at_micros FROM {} WHERE handle = ?1",
+            backend.table
+        ))
+        .bind(&handle)
+        .fetch_one(&backend.pool)
+        .await
+        .unwrap();
+        let delivered_at: i64 = row.try_get("delivered_at_micros").unwrap();
+        assert!(delivered_at > 0);
+    }
+
+    #[tokio::test]
+    async fn claim_due_wakeups_skips_future_canceled_delivered_and_claimed_rows() {
+        let backend = init_test_backend().await;
+
+        let active = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "active".to_string(),
+                revision: 1,
+                fire_at: Utc::now() - chrono::Duration::seconds(1),
+                payload: br#"{"active":true}"#.to_vec(),
+            })
+            .await
+            .unwrap()
+            .handle
+            .unwrap();
+        let future = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "future".to_string(),
+                revision: 2,
+                fire_at: Utc::now() + chrono::Duration::seconds(60),
+                payload: br#"{"future":true}"#.to_vec(),
+            })
+            .await
+            .unwrap()
+            .handle
+            .unwrap();
+        let canceled = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "canceled".to_string(),
+                revision: 3,
+                fire_at: Utc::now() - chrono::Duration::seconds(1),
+                payload: br#"{"canceled":true}"#.to_vec(),
+            })
+            .await
+            .unwrap()
+            .handle
+            .unwrap();
+        let delivered = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "delivered".to_string(),
+                revision: 4,
+                fire_at: Utc::now() - chrono::Duration::seconds(1),
+                payload: br#"{"delivered":true}"#.to_vec(),
+            })
+            .await
+            .unwrap()
+            .handle
+            .unwrap();
+        let claimed = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "claimed".to_string(),
+                revision: 5,
+                fire_at: Utc::now() - chrono::Duration::seconds(1),
+                payload: br#"{"claimed":true}"#.to_vec(),
+            })
+            .await
+            .unwrap()
+            .handle
+            .unwrap();
+
+        backend.cancel(&canceled).await.unwrap();
+        backend.mark_delivered(&delivered).await.unwrap();
+        sqlx::query(&format!(
+            "UPDATE {} SET claim_until_micros = ?2 WHERE handle = ?1",
+            backend.table
+        ))
+        .bind(&claimed)
+        .bind(Utc::now().timestamp_micros() + 60_000_000)
+        .execute(&backend.pool)
+        .await
+        .unwrap();
+
+        let wakeups = backend.claim_due_wakeups(10).await.unwrap();
+        let handles: Vec<_> = wakeups.into_iter().map(|w| w.handle).collect();
+        assert_eq!(handles, vec![active]);
+
+        for skipped in [future, canceled, delivered, claimed] {
+            assert!(!handles.contains(&skipped));
+        }
+    }
+
+    #[tokio::test]
+    async fn claim_due_wakeups_honors_attempt_limit() {
+        let backend = init_test_backend().await;
+        let handle = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "exhausted".to_string(),
+                revision: 6,
+                fire_at: Utc::now() - chrono::Duration::seconds(1),
+                payload: br#"{"exhausted":true}"#.to_vec(),
+            })
+            .await
+            .unwrap()
+            .handle
+            .unwrap();
+
+        sqlx::query(&format!(
+            "UPDATE {} SET attempts = ?2 WHERE handle = ?1",
+            backend.table
+        ))
+        .bind(&handle)
+        .bind(MAX_DELIVERY_ATTEMPTS)
+        .execute(&backend.pool)
+        .await
+        .unwrap();
+
+        let wakeups = backend.claim_due_wakeups(10).await.unwrap();
+        assert!(wakeups.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deliver_wakeup_sends_auth_header_and_marks_delivered() {
+        let backend = init_test_backend().await;
+        let handle = backend
+            .schedule(ScheduleWakeupRequest {
+                namespace: "acme".to_string(),
+                schedule_id: "deliver".to_string(),
+                revision: 8,
+                fire_at: Utc::now() - chrono::Duration::seconds(1),
+                payload: br#"{"deliver":true}"#.to_vec(),
+            })
+            .await
+            .unwrap()
+            .handle
+            .unwrap();
+        let wakeup = backend
+            .claim_due_wakeups(1)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|wakeup| wakeup.handle == handle)
+            .unwrap();
+
+        let received = Arc::new(Mutex::new(None::<ReceivedWakeup>));
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let received_state = received.clone();
+        let server = tokio::spawn(async move {
+            tokio::select! {
+                _ = async {
+                    let (mut socket, _) = listener.accept().await.unwrap();
+                    let mut buffer = vec![0_u8; 4096];
+                    let bytes_read = socket.read(&mut buffer).await.unwrap();
+                    let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+                    let expected_prefix = format!("{}:", SCHEDULER_AUTH_HEADER).to_ascii_lowercase();
+                    let header = request.lines().find_map(|line| {
+                        let lower = line.to_ascii_lowercase();
+                        lower
+                            .strip_prefix(&expected_prefix)
+                            .and_then(|_| line.split_once(':').map(|(_, value)| value.trim().to_string()))
+                    });
+                    let body = request
+                        .split("\r\n\r\n")
+                        .nth(1)
+                        .unwrap_or_default()
+                        .as_bytes()
+                        .to_vec();
+                    *received_state.lock().await = Some(ReceivedWakeup { header, body });
+                    socket
+                        .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n")
+                        .await
+                        .unwrap();
+                } => {}
+                _ = shutdown_rx => {}
+            }
+        });
+
+        let client = Client::builder().build().unwrap();
+        backend
+            .deliver_wakeup(
+                &client,
+                &format!("http://{}/", addr),
+                Some("secret-token"),
+                &wakeup,
+            )
+            .await
+            .unwrap();
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+
+        let received = received.lock().await.clone().unwrap();
+        assert_eq!(received.header.as_deref(), Some("secret-token"));
+        assert_eq!(received.body, br#"{"deliver":true}"#.to_vec());
+
+        let delivered_row = sqlx::query(&format!(
+            "SELECT delivered_at_micros FROM {} WHERE handle = ?1",
+            backend.table
+        ))
+        .bind(&handle)
+        .fetch_one(&backend.pool)
+        .await
+        .unwrap();
+        let delivered_at: i64 = delivered_row.try_get("delivered_at_micros").unwrap();
+        assert!(delivered_at > 0);
+    }
+}

--- a/src/control/scheduler/local_sqlite.rs
+++ b/src/control/scheduler/local_sqlite.rs
@@ -10,6 +10,7 @@ use sqlx::{
     Row, SqlitePool,
 };
 use std::{str::FromStr, time::Duration};
+use tokio_util::sync::CancellationToken;
 use tracing::{error, warn};
 
 use super::{ScheduleWakeupRequest, ScheduledWakeup, SchedulerBackend, SCHEDULER_AUTH_HEADER};
@@ -28,6 +29,7 @@ const MAX_RETRY_DELAY_SECONDS: i64 = 300;
 pub struct LocalSqliteSchedulerBackend {
     pool: SqlitePool,
     table: String,
+    runner_shutdown: CancellationToken,
 }
 
 #[derive(Clone)]
@@ -60,6 +62,7 @@ impl LocalSqliteSchedulerBackend {
             .connect_with(options)
             .await?;
         let table = table.unwrap_or_else(|| DEFAULT_TABLE.to_string());
+        let runner_shutdown = CancellationToken::new();
         validate_identifier(&table)?;
         let create_stmt = format!(
             "CREATE TABLE IF NOT EXISTS {table} (
@@ -90,31 +93,50 @@ impl LocalSqliteSchedulerBackend {
             let Some(target_url) = runner_target_url.filter(|value| !value.trim().is_empty())
             else {
                 warn!("local_sqlite scheduler runner enabled without target URL; wakeups will not fire");
-                return Ok(Self { pool, table });
+                return Ok(Self {
+                    pool,
+                    table,
+                    runner_shutdown,
+                });
             };
             let runner = Self {
                 pool: pool.clone(),
                 table: table.clone(),
+                runner_shutdown: runner_shutdown.clone(),
             };
+            let shutdown = runner_shutdown.child_token();
             tokio::spawn(async move {
                 runner
                     .run_loop(
                         target_url,
                         auth_token.filter(|value| !value.trim().is_empty()),
+                        shutdown,
                     )
                     .await;
             });
         }
 
-        Ok(Self { pool, table })
+        Ok(Self {
+            pool,
+            table,
+            runner_shutdown,
+        })
     }
 
-    async fn run_loop(self, target_url: String, auth_token: Option<String>) {
+    async fn run_loop(
+        self,
+        target_url: String,
+        auth_token: Option<String>,
+        shutdown: CancellationToken,
+    ) {
         let client = Client::builder()
             .timeout(Duration::from_secs(DELIVERY_TIMEOUT_SECONDS))
             .build()
             .expect("failed to build local scheduler client");
         loop {
+            if shutdown.is_cancelled() {
+                return;
+            }
             let mut has_more = false;
             match self.claim_due_wakeups(MAX_CONCURRENT_DELIVERIES).await {
                 Ok(wakeups) => {
@@ -210,73 +232,61 @@ impl LocalSqliteSchedulerBackend {
                 }
             }
             if !has_more {
-                tokio::time::sleep(Duration::from_millis(POLL_INTERVAL_MILLIS)).await;
+                tokio::select! {
+                    _ = shutdown.cancelled() => return,
+                    _ = tokio::time::sleep(Duration::from_millis(POLL_INTERVAL_MILLIS)) => {}
+                }
             }
         }
     }
 
     async fn claim_due_wakeups(&self, limit: usize) -> Result<Vec<DueWakeup>> {
         let now_micros = Utc::now().timestamp_micros();
-        let select_query = format!(
-            "SELECT handle, namespace, schedule_id, revision, fire_at_micros, payload, attempts
-             FROM {table}
-             WHERE canceled_at_micros IS NULL
-               AND delivered_at_micros IS NULL
-               AND attempts < ?2
-               AND fire_at_micros <= ?1
-               AND (claim_until_micros IS NULL OR claim_until_micros < ?1)
-             ORDER BY fire_at_micros
-             LIMIT ?3",
-            table = self.table
-        );
-        let update_query = format!(
-            "UPDATE {table}
-             SET claimed_at_micros = ?2,
-                 claim_until_micros = ?3,
-                 attempts = attempts + 1
-             WHERE handle = ?1
-               AND canceled_at_micros IS NULL
-               AND delivered_at_micros IS NULL
-               AND attempts < ?4
-               AND fire_at_micros <= ?2
-               AND (claim_until_micros IS NULL OR claim_until_micros < ?2)",
+        let query = format!(
+            "WITH due AS (
+                SELECT handle
+                FROM {table}
+                WHERE canceled_at_micros IS NULL
+                  AND delivered_at_micros IS NULL
+                  AND attempts < ?2
+                  AND fire_at_micros <= ?1
+                  AND (claim_until_micros IS NULL OR claim_until_micros < ?1)
+                ORDER BY fire_at_micros
+                LIMIT ?3
+            )
+            UPDATE {table}
+            SET claimed_at_micros = ?1,
+                claim_until_micros = ?4,
+                attempts = attempts + 1
+            WHERE handle IN (SELECT handle FROM due)
+              AND canceled_at_micros IS NULL
+              AND delivered_at_micros IS NULL
+              AND attempts < ?2
+              AND fire_at_micros <= ?1
+              AND (claim_until_micros IS NULL OR claim_until_micros < ?1)
+            RETURNING handle, namespace, schedule_id, revision, fire_at_micros, payload, attempts",
             table = self.table
         );
         let claim_until_micros = now_micros + CLAIM_TIMEOUT_SECONDS * 1_000_000;
-
-        let mut tx = self.pool.begin().await?;
-        let rows = sqlx::query(&select_query)
+        let rows = sqlx::query(&query)
             .bind(now_micros)
             .bind(MAX_DELIVERY_ATTEMPTS)
             .bind(limit as i64)
-            .fetch_all(&mut *tx)
+            .bind(claim_until_micros)
+            .fetch_all(&self.pool)
             .await?;
-
         let mut wakeups = Vec::with_capacity(rows.len());
         for row in rows {
-            let handle: String = row.try_get("handle")?;
-            let updated = sqlx::query(&update_query)
-                .bind(&handle)
-                .bind(now_micros)
-                .bind(claim_until_micros)
-                .bind(MAX_DELIVERY_ATTEMPTS)
-                .execute(&mut *tx)
-                .await?
-                .rows_affected();
-            if updated == 1 {
-                let attempts: i32 = row.try_get("attempts")?;
-                wakeups.push(DueWakeup {
-                    handle,
-                    namespace: row.try_get("namespace")?,
-                    schedule_id: row.try_get("schedule_id")?,
-                    revision: row.try_get("revision")?,
-                    fire_at_micros: row.try_get("fire_at_micros")?,
-                    payload: row.try_get("payload")?,
-                    attempts: attempts + 1,
-                });
-            }
+            wakeups.push(DueWakeup {
+                handle: row.try_get("handle")?,
+                namespace: row.try_get("namespace")?,
+                schedule_id: row.try_get("schedule_id")?,
+                revision: row.try_get("revision")?,
+                fire_at_micros: row.try_get("fire_at_micros")?,
+                payload: row.try_get("payload")?,
+                attempts: row.try_get("attempts")?,
+            });
         }
-        tx.commit().await?;
         Ok(wakeups)
     }
 
@@ -405,6 +415,12 @@ impl SchedulerBackend for LocalSqliteSchedulerBackend {
             .execute(&self.pool)
             .await?;
         Ok(())
+    }
+}
+
+impl Drop for LocalSqliteSchedulerBackend {
+    fn drop(&mut self) {
+        self.runner_shutdown.cancel();
     }
 }
 
@@ -889,5 +905,22 @@ mod tests {
         .unwrap();
         let delivered_at: i64 = delivered_row.try_get("delivered_at_micros").unwrap();
         assert!(delivered_at > 0);
+    }
+
+    #[tokio::test]
+    async fn run_loop_exits_when_cancelled() {
+        let backend = init_test_backend().await;
+        let shutdown = CancellationToken::new();
+        let task = tokio::spawn(backend.run_loop(
+            "http://127.0.0.1:9/".to_string(),
+            None,
+            shutdown.child_token(),
+        ));
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap();
     }
 }

--- a/src/control/scheduler/local_sqlite.rs
+++ b/src/control/scheduler/local_sqlite.rs
@@ -481,7 +481,7 @@ mod tests {
     async fn init_test_backend() -> LocalSqliteSchedulerBackend {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("scheduler.db");
-        LocalSqliteSchedulerBackend::new(
+        let backend = LocalSqliteSchedulerBackend::new(
             &sqlite_url_for_path(&db_path),
             Some("talon_scheduler_test".to_string()),
             None,
@@ -489,7 +489,9 @@ mod tests {
             false,
         )
         .await
-        .unwrap()
+        .unwrap();
+        std::mem::forget(dir);
+        backend
     }
 
     async fn init_backend_with_options(
@@ -500,7 +502,7 @@ mod tests {
     ) -> LocalSqliteSchedulerBackend {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("scheduler.db");
-        LocalSqliteSchedulerBackend::new(
+        let backend = LocalSqliteSchedulerBackend::new(
             &sqlite_url_for_path(&db_path),
             table,
             runner_target_url,
@@ -508,7 +510,9 @@ mod tests {
             runner_enabled,
         )
         .await
-        .unwrap()
+        .unwrap();
+        std::mem::forget(dir);
+        backend
     }
 
     #[derive(Clone, Default)]

--- a/src/control/scheduler/local_sqlite.rs
+++ b/src/control/scheduler/local_sqlite.rs
@@ -24,11 +24,10 @@ const MAX_CONCURRENT_DELIVERIES: usize = 10;
 const MAX_DELIVERY_ATTEMPTS: i32 = 20;
 const INITIAL_RETRY_DELAY_SECONDS: i64 = 5;
 const MAX_RETRY_DELAY_SECONDS: i64 = 300;
+const MAX_POOL_CONNECTIONS: u32 = 5;
 
-#[derive(Clone)]
 pub struct LocalSqliteSchedulerBackend {
-    pool: SqlitePool,
-    table: String,
+    store: LocalSqliteSchedulerStore,
     runner_shutdown: CancellationToken,
 }
 
@@ -41,6 +40,12 @@ struct DueWakeup {
     fire_at_micros: i64,
     payload: Vec<u8>,
     attempts: i32,
+}
+
+#[derive(Clone)]
+struct LocalSqliteSchedulerStore {
+    pool: SqlitePool,
+    table: String,
 }
 
 impl LocalSqliteSchedulerBackend {
@@ -58,12 +63,13 @@ impl LocalSqliteSchedulerBackend {
             .busy_timeout(Duration::from_secs(5))
             .foreign_keys(true);
         let pool = SqlitePoolOptions::new()
-            .max_connections(1)
+            .max_connections(MAX_POOL_CONNECTIONS)
             .connect_with(options)
             .await?;
         let table = table.unwrap_or_else(|| DEFAULT_TABLE.to_string());
         let runner_shutdown = CancellationToken::new();
         validate_identifier(&table)?;
+        let store = LocalSqliteSchedulerStore { pool, table };
         let create_stmt = format!(
             "CREATE TABLE IF NOT EXISTS {table} (
                 handle TEXT PRIMARY KEY,
@@ -80,33 +86,28 @@ impl LocalSqliteSchedulerBackend {
                 last_error TEXT NULL,
                 created_at_micros INTEGER NOT NULL
             )",
-            table = table
+            table = store.table
         );
-        sqlx::query(&create_stmt).execute(&pool).await?;
+        sqlx::query(&create_stmt).execute(&store.pool).await?;
         let index_stmt = format!(
             "CREATE INDEX IF NOT EXISTS {table}_due_idx ON {table} (fire_at_micros) WHERE canceled_at_micros IS NULL AND delivered_at_micros IS NULL",
-            table = table
+            table = store.table
         );
-        sqlx::query(&index_stmt).execute(&pool).await?;
+        sqlx::query(&index_stmt).execute(&store.pool).await?;
 
         if runner_enabled {
             let Some(target_url) = runner_target_url.filter(|value| !value.trim().is_empty())
             else {
                 warn!("local_sqlite scheduler runner enabled without target URL; wakeups will not fire");
                 return Ok(Self {
-                    pool,
-                    table,
+                    store,
                     runner_shutdown,
                 });
             };
-            let runner = Self {
-                pool: pool.clone(),
-                table: table.clone(),
-                runner_shutdown: runner_shutdown.clone(),
-            };
+            let runner_store = store.clone();
             let shutdown = runner_shutdown.child_token();
             tokio::spawn(async move {
-                runner
+                runner_store
                     .run_loop(
                         target_url,
                         auth_token.filter(|value| !value.trim().is_empty()),
@@ -117,12 +118,48 @@ impl LocalSqliteSchedulerBackend {
         }
 
         Ok(Self {
-            pool,
-            table,
+            store,
             runner_shutdown,
         })
     }
 
+    #[cfg(test)]
+    async fn claim_due_wakeups(&self, limit: usize) -> Result<Vec<DueWakeup>> {
+        self.store.claim_due_wakeups(limit).await
+    }
+
+    #[cfg(test)]
+    async fn deliver_wakeup(
+        &self,
+        client: &Client,
+        target_url: &str,
+        auth_token: Option<&str>,
+        wakeup: &DueWakeup,
+    ) -> Result<()> {
+        self.store
+            .deliver_wakeup(client, target_url, auth_token, wakeup)
+            .await
+    }
+
+    #[cfg(test)]
+    async fn mark_delivered(&self, handle: &str) -> Result<()> {
+        self.store.mark_delivered(handle).await
+    }
+
+    #[cfg(test)]
+    async fn mark_delivery_failed(
+        &self,
+        handle: &str,
+        attempts: i32,
+        error_message: &str,
+    ) -> Result<()> {
+        self.store
+            .mark_delivery_failed(handle, attempts, error_message)
+            .await
+    }
+}
+
+impl LocalSqliteSchedulerStore {
     async fn run_loop(
         self,
         target_url: String,
@@ -150,7 +187,7 @@ impl LocalSqliteSchedulerBackend {
                     has_more = wakeups.len() == MAX_CONCURRENT_DELIVERIES;
                     let mut deliveries = FuturesUnordered::new();
                     for wakeup in wakeups {
-                        let backend = self.clone();
+                        let store = self.clone();
                         let client = client.clone();
                         let target_url = target_url.clone();
                         let auth_token = auth_token.clone();
@@ -163,7 +200,7 @@ impl LocalSqliteSchedulerBackend {
                             let attempts = wakeup.attempts;
                             let result = tokio::time::timeout(
                                 Duration::from_secs(DELIVERY_TIMEOUT_SECONDS + 5),
-                                backend.deliver_wakeup(
+                                store.deliver_wakeup(
                                     &client,
                                     &target_url,
                                     auth_token.as_deref(),
@@ -183,7 +220,7 @@ impl LocalSqliteSchedulerBackend {
                                 fire_at_micros,
                                 attempts,
                                 result,
-                                backend,
+                                store,
                             )
                         });
                     }
@@ -195,7 +232,7 @@ impl LocalSqliteSchedulerBackend {
                         fire_at_micros,
                         attempts,
                         result,
-                        backend,
+                        store,
                     )) = deliveries.next().await
                     {
                         if let Err(err) = result {
@@ -209,7 +246,7 @@ impl LocalSqliteSchedulerBackend {
                                 error = %err,
                                 "failed to deliver local scheduler wakeup"
                             );
-                            if let Err(mark_err) = backend
+                            if let Err(mark_err) = store
                                 .mark_delivery_failed(&handle, attempts, &err.to_string())
                                 .await
                             {
@@ -372,15 +409,7 @@ impl LocalSqliteSchedulerBackend {
             .await?;
         Ok(())
     }
-}
 
-fn compute_retry_delay_seconds(attempts: i32) -> i64 {
-    let exponent = attempts.saturating_sub(1).clamp(0, 10) as u32;
-    (INITIAL_RETRY_DELAY_SECONDS * (1_i64 << exponent)).min(MAX_RETRY_DELAY_SECONDS)
-}
-
-#[async_trait::async_trait]
-impl SchedulerBackend for LocalSqliteSchedulerBackend {
     async fn schedule(&self, req: ScheduleWakeupRequest) -> Result<ScheduledWakeup> {
         let handle = uuid::Uuid::now_v7().to_string();
         let query = format!(
@@ -415,6 +444,22 @@ impl SchedulerBackend for LocalSqliteSchedulerBackend {
             .execute(&self.pool)
             .await?;
         Ok(())
+    }
+}
+
+fn compute_retry_delay_seconds(attempts: i32) -> i64 {
+    let exponent = attempts.saturating_sub(1).clamp(0, 10) as u32;
+    (INITIAL_RETRY_DELAY_SECONDS * (1_i64 << exponent)).min(MAX_RETRY_DELAY_SECONDS)
+}
+
+#[async_trait::async_trait]
+impl SchedulerBackend for LocalSqliteSchedulerBackend {
+    async fn schedule(&self, req: ScheduleWakeupRequest) -> Result<ScheduledWakeup> {
+        self.store.schedule(req).await
+    }
+
+    async fn cancel(&self, handle: &str) -> Result<()> {
+        self.store.cancel(handle).await
     }
 }
 
@@ -513,10 +558,10 @@ mod tests {
             .unwrap();
         let failure_row = sqlx::query(&format!(
             "SELECT last_error, claim_until_micros FROM {} WHERE handle = ?1",
-            backend.table
+            backend.store.table
         ))
         .bind(&handle)
-        .fetch_one(&backend.pool)
+        .fetch_one(&backend.store.pool)
         .await
         .unwrap();
         let last_error: String = failure_row.try_get("last_error").unwrap();
@@ -530,10 +575,10 @@ mod tests {
             .unwrap();
         let canceled_row = sqlx::query(&format!(
             "SELECT canceled_at_micros, claim_until_micros, last_error FROM {} WHERE handle = ?1",
-            backend.table
+            backend.store.table
         ))
         .bind(&handle)
-        .fetch_one(&backend.pool)
+        .fetch_one(&backend.store.pool)
         .await
         .unwrap();
         let canceled_at: i64 = canceled_row.try_get("canceled_at_micros").unwrap();
@@ -590,10 +635,10 @@ mod tests {
 
         let row = sqlx::query(&format!(
             "SELECT delivered_at_micros, attempts FROM {} WHERE handle = ?1",
-            backend.table
+            backend.store.table
         ))
         .bind(&handle)
-        .fetch_one(&backend.pool)
+        .fetch_one(&backend.store.pool)
         .await
         .unwrap();
         let delivered_at: Option<i64> = row.try_get("delivered_at_micros").unwrap();
@@ -611,7 +656,7 @@ mod tests {
             false,
         )
         .await;
-        assert_eq!(backend.table, DEFAULT_TABLE);
+        assert_eq!(backend.store.table, DEFAULT_TABLE);
 
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("scheduler.db");
@@ -694,10 +739,10 @@ mod tests {
 
         let row = sqlx::query(&format!(
             "SELECT delivered_at_micros FROM {} WHERE handle = ?1",
-            backend.table
+            backend.store.table
         ))
         .bind(&handle)
-        .fetch_one(&backend.pool)
+        .fetch_one(&backend.store.pool)
         .await
         .unwrap();
         let delivered_at: i64 = row.try_get("delivered_at_micros").unwrap();
@@ -773,11 +818,11 @@ mod tests {
         backend.mark_delivered(&delivered).await.unwrap();
         sqlx::query(&format!(
             "UPDATE {} SET claim_until_micros = ?2 WHERE handle = ?1",
-            backend.table
+            backend.store.table
         ))
         .bind(&claimed)
         .bind(Utc::now().timestamp_micros() + 60_000_000)
-        .execute(&backend.pool)
+        .execute(&backend.store.pool)
         .await
         .unwrap();
 
@@ -808,11 +853,11 @@ mod tests {
 
         sqlx::query(&format!(
             "UPDATE {} SET attempts = ?2 WHERE handle = ?1",
-            backend.table
+            backend.store.table
         ))
         .bind(&handle)
         .bind(MAX_DELIVERY_ATTEMPTS)
-        .execute(&backend.pool)
+        .execute(&backend.store.pool)
         .await
         .unwrap();
 
@@ -897,10 +942,10 @@ mod tests {
 
         let delivered_row = sqlx::query(&format!(
             "SELECT delivered_at_micros FROM {} WHERE handle = ?1",
-            backend.table
+            backend.store.table
         ))
         .bind(&handle)
-        .fetch_one(&backend.pool)
+        .fetch_one(&backend.store.pool)
         .await
         .unwrap();
         let delivered_at: i64 = delivered_row.try_get("delivered_at_micros").unwrap();
@@ -908,16 +953,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_loop_exits_when_cancelled() {
+    async fn runner_stops_when_backend_is_dropped() {
         let backend = init_test_backend().await;
-        let shutdown = CancellationToken::new();
-        let task = tokio::spawn(backend.run_loop(
+        let shutdown = backend.runner_shutdown.child_token();
+        let task = tokio::spawn(backend.store.clone().run_loop(
             "http://127.0.0.1:9/".to_string(),
             None,
-            shutdown.child_token(),
+            shutdown,
         ));
 
-        shutdown.cancel();
+        drop(backend);
         tokio::time::timeout(Duration::from_secs(1), task)
             .await
             .unwrap()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import requests
 import sys
 import os
 from pathlib import Path
+import tempfile
 
 # Important: Add generated protos to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "generated")))
@@ -44,6 +45,46 @@ def get_binary_path(name):
             return resolved
 
     raise FileNotFoundError(f"Could not find binary {name}")
+
+
+def wait_for_gateway(host, port, attempts=20, delay_seconds=1):
+    import socket
+
+    for _ in range(attempts):
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return
+        except Exception:
+            time.sleep(delay_seconds)
+    raise RuntimeError(f"Talon server failed to start on port {port}")
+
+
+def start_talon_server_and_worker(env, grpc_port, worker_pull_mode=False):
+    server_bin = get_binary_path("talon_server")
+    worker_bin = get_binary_path("talon_worker")
+
+    server_proc = subprocess.Popen(
+        [server_bin],
+        env=env,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+    wait_for_gateway("127.0.0.1", grpc_port)
+    time.sleep(3)
+
+    worker_env = env.copy()
+    if worker_pull_mode:
+        worker_env["PULL_MODE"] = "1"
+
+    worker_proc = subprocess.Popen(
+        [worker_bin],
+        env=worker_env,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+    return server_proc, worker_proc
 
 @pytest.fixture(scope="session")
 def talon_infrastructure():
@@ -108,49 +149,11 @@ def talon_infrastructure():
             shutil.copy(config_src, config_dst)
             print("Copied talon.yaml to test execution root.")
 
-    server_bin = get_binary_path("talon_server")
-    worker_bin = get_binary_path("talon_worker")
-    
     print("\nStarting Talon server and worker...")
-    
-    server_proc = subprocess.Popen(
-        [server_bin],
-        env=env,
-        stdout=sys.stdout,
-        stderr=sys.stderr
-    )
-    
-    # Wait for gateway to be properly listening before starting worker 
-    # to avoid Postgres CREATE TABLE concurrent race condition.
-    # We use a raw socket to avoid initializing gRPC before python forks the worker_proc, 
-    # which causes gRPC C-Core to panic.
-    import socket
-    gateway_ready = False
-    for _ in range(20):
-        try:
-            with socket.create_connection(("127.0.0.1", test_grpc_port), timeout=1):
-                gateway_ready = True
-                break
-        except Exception:
-            time.sleep(1)
-            
-    if not gateway_ready:
-        server_proc.terminate()
-        postgres.stop()
-        pubsub.stop()
-        raise RuntimeError(f"Talon server failed to start on port {test_grpc_port}")
-        
-    time.sleep(3) # Hard wait for Postgres table creations to fully finalize
-    
-    print("\nStarting Talon worker now that server initialized DB...")
-    env_worker = env.copy()
-    env_worker["PULL_MODE"] = "1"
-    
-    worker_proc = subprocess.Popen(
-        [worker_bin],
-        env=env_worker, # PULL_MODE enabled
-        stdout=sys.stdout,
-        stderr=sys.stderr
+    server_proc, worker_proc = start_talon_server_and_worker(
+        env,
+        test_grpc_port,
+        worker_pull_mode=True,
     )
             
     yield
@@ -199,5 +202,82 @@ def test_grpc_port():
 def gateway_channel(talon_infrastructure, test_grpc_port):
     """Returns a connected gRPC channel to the Talon gateway."""
     channel = grpc.insecure_channel(f"127.0.0.1:{test_grpc_port}")
+    yield channel
+    channel.close()
+
+
+@pytest.fixture(scope="session")
+def talon_infrastructure_sqlite():
+    print("\nStarting SQLite + local_socket Talon stack...")
+    test_grpc_port = 50054
+    test_ui_port = 50055
+    worker_port = 18082
+
+    env = os.environ.copy()
+    env["RUST_LOG"] = "info"
+    env["NOVITA_API_KEY"] = "test-dummy-key"
+    env["GRPC_ADDR"] = f"127.0.0.1:{test_grpc_port}"
+    env["GATEWAY_UI_ADDR"] = f"127.0.0.1:{test_ui_port}"
+    env["PORT"] = str(worker_port)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="talon-sqlite-e2e-"))
+    data_dir = temp_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    config_path = temp_dir / "talon.e2e.sqlite.yaml"
+    config_path.write_text(
+        f"""
+providers:
+  mock:
+    type: openai_compatible
+    name: mock
+    base_url: "http://127.0.0.1:8000"
+    model: minimax/minimax-m2.7
+    api_key:
+      source: env
+      key: NOVITA_API_KEY
+server:
+  host: "127.0.0.1"
+  port: {test_ui_port}
+control_plane:
+  database:
+    driver: sqlite
+    data_dir: ./data
+  message_broker:
+    driver: local_socket
+""".strip()
+        + "\n"
+    )
+    env["TALON_CONFIG_PATH"] = str(config_path)
+
+    server_proc, worker_proc = start_talon_server_and_worker(
+        env,
+        test_grpc_port,
+        worker_pull_mode=True,
+    )
+
+    yield {
+        "grpc_port": test_grpc_port,
+        "ui_port": test_ui_port,
+        "worker_port": worker_port,
+        "config_path": str(config_path),
+        "data_dir": str(data_dir),
+    }
+
+    print("\nShutting down SQLite + local_socket Talon stack...")
+    server_proc.terminate()
+    worker_proc.terminate()
+    server_proc.wait()
+    worker_proc.wait()
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def sqlite_test_grpc_port():
+    return 50054
+
+
+@pytest.fixture
+def gateway_channel_sqlite(talon_infrastructure_sqlite, sqlite_test_grpc_port):
+    channel = grpc.insecure_channel(f"127.0.0.1:{sqlite_test_grpc_port}")
     yield channel
     channel.close()

--- a/tests/test_chat_sqlite.py
+++ b/tests/test_chat_sqlite.py
@@ -1,0 +1,184 @@
+import grpc
+import sys
+import os
+import threading
+import time
+
+# Important: Add generated protos to path so "proto.xxx" resolves locally and not to proto_plus
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "generated")))
+
+from proto.gateway_pb2_grpc import GatewayServiceStub
+from proto.gateway_pb2 import (
+    CreateAgentRequest,
+    CreateNamespaceRequest,
+    CreateSessionRequest,
+    GetSessionRequest,
+    SendMessageRequest,
+    StreamSessionStepsRequest,
+)
+from proto.manifests_pb2 import AgentDefinition, AgentSpec, Model
+
+STEP_TYPE_TOKEN = 1
+STEP_TYPE_REASONING = 6
+STEP_TYPE_USAGE = 7
+
+
+def ensure_namespace(stub, name):
+    try:
+        stub.CreateNamespace(CreateNamespaceRequest(name=name, recursive=True))
+    except grpc.RpcError as err:
+        if err.code() != grpc.StatusCode.ALREADY_EXISTS:
+            raise
+
+
+def test_single_turn_chat_sqlite_local_socket(gateway_channel_sqlite, mock_llm_server):
+    stub = GatewayServiceStub(gateway_channel_sqlite)
+
+    ensure_namespace(stub, "talon-sqlite-test")
+
+    agent = stub.CreateAgent(
+        CreateAgentRequest(
+            ns="talon-sqlite-test",
+            name="test-llm-agent",
+            definition=AgentDefinition(
+                custom_spec=AgentSpec(
+                    model_policy={
+                        "profiles": [
+                            {
+                                "name": "default",
+                                "model": Model(
+                                    provider="mock",
+                                    name="minimax-m2.7",
+                                    temperature=0.7,
+                                ),
+                            }
+                        ]
+                    },
+                    system_prompt="You are a helpful test assistant.",
+                )
+            ),
+        )
+    )
+    assert agent.agent == "test-llm-agent"
+
+    session = stub.CreateSession(
+        CreateSessionRequest(agent="test-llm-agent", ns="talon-sqlite-test")
+    )
+    session_id = session.session_id
+    assert session_id != ""
+
+    stub.SendMessage(
+        SendMessageRequest(
+            agent="test-llm-agent",
+            session_id=session_id,
+            ns="talon-sqlite-test",
+            message="What is the square root of 144?",
+        )
+    )
+
+    success = False
+    messages = []
+    for _ in range(30):
+        time.sleep(1)
+        res = stub.GetSession(
+            GetSessionRequest(
+                agent="test-llm-agent",
+                session_id=session_id,
+                ns="talon-sqlite-test",
+            )
+        )
+        messages = res.messages
+        if res.state == "IDLE" and len(messages) >= 2:
+            success = True
+            break
+
+    assert success, "Agent did not reply in time or failed to revert to IDLE"
+    agent_message = messages[-1]
+    assert agent_message.role == 2
+    assert "12" in agent_message.content
+
+
+def test_streaming_chat_sqlite_local_socket(gateway_channel_sqlite, mock_llm_server):
+    stub = GatewayServiceStub(gateway_channel_sqlite)
+
+    ensure_namespace(stub, "talon-sqlite-stream-test")
+
+    stub.CreateAgent(
+        CreateAgentRequest(
+            ns="talon-sqlite-stream-test",
+            name="stream-agent",
+            definition=AgentDefinition(
+                custom_spec=AgentSpec(
+                    model_policy={
+                        "profiles": [
+                            {
+                                "name": "default",
+                                "model": Model(
+                                    provider="mock",
+                                    name="minimax",
+                                    temperature=0.7,
+                                ),
+                            }
+                        ]
+                    },
+                    system_prompt="Stream me.",
+                )
+            ),
+        )
+    )
+
+    session = stub.CreateSession(
+        CreateSessionRequest(agent="stream-agent", ns="talon-sqlite-stream-test")
+    )
+    session_id = session.session_id
+
+    def send_msg():
+        time.sleep(2.0)
+        stub.SendMessage(
+            SendMessageRequest(
+                agent="stream-agent",
+                session_id=session_id,
+                ns="talon-sqlite-stream-test",
+                message="Stream test message",
+            )
+        )
+
+    sender = threading.Thread(target=send_msg)
+    sender.start()
+
+    stream_req = StreamSessionStepsRequest(
+        agent="stream-agent",
+        session_id=session_id,
+        ns="talon-sqlite-stream-test",
+    )
+    events = []
+    try:
+        saw_reasoning = False
+        saw_token = False
+        saw_usage = False
+        for idx, event in enumerate(stub.StreamSessionSteps(stream_req)):
+            events.append(event)
+            if event.step_type == STEP_TYPE_REASONING:
+                saw_reasoning = True
+            if event.step_type == STEP_TYPE_TOKEN:
+                saw_token = True
+            if event.step_type == STEP_TYPE_USAGE:
+                saw_usage = True
+            if saw_reasoning and saw_token and saw_usage:
+                break
+            if idx > 20:
+                break
+    except grpc.RpcError:
+        pass
+    sender.join()
+
+    assert len(events) >= 1
+    reasoning_events = [event for event in events if event.step_type == STEP_TYPE_REASONING]
+    token_events = [event for event in events if event.step_type == STEP_TYPE_TOKEN]
+    usage_events = [event for event in events if event.step_type == STEP_TYPE_USAGE]
+    assert len(reasoning_events) >= 1
+    assert len(token_events) >= 1
+    assert len(usage_events) >= 1
+    assert "Inspecting the request" in reasoning_events[0].content
+    streamed_text = "".join(event.content for event in token_events)
+    assert "received" in streamed_text


### PR DESCRIPTION
## What changed

This PR adds a SQLite-backed single-host control-plane path for Talon and wires a same-host Unix-socket broker for local gateway/worker coordination.

It includes:
- a split KV layer with separate Postgres and SQLite implementations
- SQLite control-plane database support
- a `local_sqlite` scheduler backend
- a `local_socket` message broker backend for same-host deployments
- worker pull-subscription support for `local_socket`
- config path resolution so relative `data_dir` values resolve from the config file directory
- updated local development and operations documentation, including the single-host wiki draft

## Why

The goal is to support a lightweight Talon deployment on a single machine without Postgres or Pub/Sub, while keeping the current browser flow workable through an Envoy edge.

The config path fix is included because the original local flow could mistakenly place SQLite artifacts under the process working directory instead of beside the config file.

## Validation

- `cargo test --offline --lib`
- `cargo test --offline --bin talon-worker`
