### PR TITLE
[codex] Clean up Cargo warnings

### DIFF
--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -280,7 +280,7 @@ impl LocalSocketPullSubscriptionBackend {
 #[async_trait::async_trait]
 impl PullSubscriptionBackend for GcpPullSubscriptionBackend {
     async fn ensure_topic(&self) -> Result<()> {
-        let mut topic = self.client.topic(&self.topic_name);
+        let topic = self.client.topic(&self.topic_name);
         if !topic.exists(None).await? {
             if let Err(err) = topic.create(None, None).await {
                 if !topic.exists(None).await? {
@@ -294,7 +294,7 @@ impl PullSubscriptionBackend for GcpPullSubscriptionBackend {
     async fn ensure_subscription(&self) -> Result<()> {
         use google_cloud_pubsub::subscription::SubscriptionConfig;
 
-        let mut subscription = self.client.subscription(&self.subscription_name);
+        let subscription = self.client.subscription(&self.subscription_name);
         if !subscription.exists(None).await? {
             let sub_config = SubscriptionConfig {
                 ack_deadline_seconds: 300,
@@ -318,7 +318,7 @@ impl PullSubscriptionBackend for GcpPullSubscriptionBackend {
         event_type: String,
         cancellation_token: CancellationToken,
     ) -> Result<()> {
-        let mut subscription = self.client.subscription(&self.subscription_name);
+        let subscription = self.client.subscription(&self.subscription_name);
         let receive_loop_cancellation = cancellation_token.clone();
         subscription
             .receive(

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -4,7 +4,6 @@
 use crate::config::proto;
 use anyhow::{anyhow, Result};
 use std::process::Command;
-use std::sync::Arc;
 
 pub use proto::Secret;
 

--- a/src/connectors/mcp.rs
+++ b/src/connectors/mcp.rs
@@ -9,7 +9,7 @@ use futures::{stream::BoxStream, StreamExt};
 use jsonwebtoken::{encode, EncodingKey, Header};
 use reqwest::header::ACCEPT;
 use rmcp::{
-    model::{CallToolRequestParam, Content, ResourceContents},
+    model::{CallToolRequestParams, Content, ResourceContents},
     model::{ClientJsonRpcMessage, ServerJsonRpcMessage},
     service::{RoleClient, RunningService, ServiceExt},
     transport::{
@@ -150,7 +150,7 @@ impl McpClient {
                 let result = service
                     .peer()
                     .call_tool(
-                        CallToolRequestParam::new(name.to_string()).with_arguments(
+                        CallToolRequestParams::new(name.to_string()).with_arguments(
                             arguments.unwrap_or_default(),
                         ),
                     )

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -10,7 +10,6 @@ pub mod pubsub;
 pub mod scheduler;
 pub mod topics;
 
-use serde::{de::DeserializeOwned, Serialize};
 use std::path::PathBuf;
 
 #[async_trait::async_trait]

--- a/src/control/pubsub.rs
+++ b/src/control/pubsub.rs
@@ -128,7 +128,7 @@ impl GcpPubSubPublisher {
             }
         }
 
-        let lock = self.initialized_topics.write().await;
+        let lock = self.initialized_topics.read().await;
         if lock.contains(&fq_topic) {
             return Ok(fq_topic);
         }

--- a/src/control/pubsub.rs
+++ b/src/control/pubsub.rs
@@ -128,7 +128,7 @@ impl GcpPubSubPublisher {
             }
         }
 
-        let mut lock = self.initialized_topics.write().await;
+        let lock = self.initialized_topics.write().await;
         if lock.contains(&fq_topic) {
             return Ok(fq_topic);
         }
@@ -164,7 +164,7 @@ impl Drop for SubscriptionGuard {
 #[async_trait::async_trait]
 impl PubSubBackend for GcpPubSubBackend {
     async fn ensure_topic(&self, fq_topic: &str) -> Result<()> {
-        let mut topic = self.client.topic(fq_topic);
+        let topic = self.client.topic(fq_topic);
         if !topic.exists(None).await? {
             if let Err(err) = topic.create(None, None).await {
                 if !topic.exists(None).await? {
@@ -211,7 +211,7 @@ impl PubSubBackend for GcpPubSubBackend {
             }),
             ..Default::default()
         };
-        let mut subscription = self.client.subscription(fq_sub);
+        let subscription = self.client.subscription(fq_sub);
         if !subscription.exists(None).await? {
             if let Err(err) = subscription.create(fq_topic, sub_config, None).await {
                 if !subscription.exists(None).await? {
@@ -245,7 +245,7 @@ impl PubSubBackend for GcpPubSubBackend {
     }
 
     async fn delete_subscription(&self, fq_sub: &str) -> Result<()> {
-        let mut sub = self.client.subscription(fq_sub);
+        let sub = self.client.subscription(fq_sub);
         sub.delete(None).await?;
         Ok(())
     }

--- a/src/control/scheduler/cloud_tasks.rs
+++ b/src/control/scheduler/cloud_tasks.rs
@@ -6,8 +6,7 @@ use anyhow::{anyhow, Context, Result};
 use base64::Engine as _;
 use chrono::{DateTime, Utc};
 use google_cloud_auth::credentials::{
-    AccessToken, AccessTokenCredentials, Builder as CredentialsBuilder, CacheableResource,
-    CredentialsProvider, EntityTag,
+    AccessTokenCredentials, Builder as CredentialsBuilder,
 };
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -272,7 +271,10 @@ mod tests {
     use axum::routing::{delete, post};
     use axum::{Json, Router};
     use chrono::TimeZone;
-    use google_cloud_auth::credentials::AccessTokenCredentialsProvider;
+    use google_cloud_auth::credentials::{
+        AccessToken, AccessTokenCredentialsProvider, CacheableResource, CredentialsProvider,
+        EntityTag,
+    };
     use std::sync::Arc;
     use tokio::net::TcpListener;
     use tokio::sync::Mutex;

--- a/src/gateway/rpc/knowledge.rs
+++ b/src/gateway/rpc/knowledge.rs
@@ -119,7 +119,7 @@ impl GrpcGatewayHandler {
 mod tests {
     use super::{decode_entry, list_namespace_knowledge};
     use crate::control::KeyValueStore;
-    use crate::gateway::rpc::{models, proto, GrpcGatewayHandler};
+    use crate::gateway::rpc::{proto, GrpcGatewayHandler};
     use crate::gateway::{server::Gateway, session_streams::SessionStreamHub};
     use async_trait::async_trait;
     use futures::stream;

--- a/src/gateway/rpc/namespaces.rs
+++ b/src/gateway/rpc/namespaces.rs
@@ -346,7 +346,7 @@ mod tests {
     use crate::gateway::{server::Gateway, session_streams::SessionStreamHub};
     use std::collections::HashMap;
     use std::sync::Arc;
-    use tokio::sync::{Mutex, RwLock};
+    use tokio::sync::Mutex;
 
     struct MockKvStore {
         store: Mutex<HashMap<String, Vec<u8>>>,


### PR DESCRIPTION
## What changed
Cleaned up the current Cargo compiler warnings across the workspace and test targets.

This removes unused imports, replaces the deprecated rmcp CallToolRequestParam alias with CallToolRequestParams, and drops unnecessary mut bindings in the Pub/Sub and worker code paths. It also keeps the test-only imports aligned so broader target compilation stays warning-free.

## Why
The workspace was building with avoidable compiler warnings, which obscured real diagnostics and left the build output noisy.

## Impact
Cargo workspace builds and all-target compile checks are now clean, which makes regressions easier to spot.

## Validation
- cargo build --workspace
- cargo test --workspace --all-targets --no-run