### PR TITLE
[codex] Improve README and ship CI binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,73 @@ jobs:
           load: false
           build-args: |
             NEXT_PUBLIC_GATEWAY_URL=http://localhost:18789
+
+  binary_artifacts:
+    name: Binary Artifacts
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - cargo
+      - runtime_image
+      - envoy_image
+      - ui
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: linux-x86_64
+          - os: macos-14
+            artifact_name: darwin-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends pkg-config libssl-dev protobuf-compiler
+
+      - name: Install macOS build dependencies
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+
+      - name: Build release binaries
+        run: cargo build --locked --release --bins
+
+      - name: Package binaries
+        run: |
+          ARTIFACT_DIR="dist/talon-${{ matrix.artifact_name }}"
+          mkdir -p "$ARTIFACT_DIR"
+          cp target/release/talon-server "$ARTIFACT_DIR"/
+          cp target/release/talon-worker "$ARTIFACT_DIR"/
+          cp target/release/talon-cli "$ARTIFACT_DIR"/
+          cp talon.yaml "$ARTIFACT_DIR"/
+          if [ "${RUNNER_OS}" = "macOS" ]; then
+            (
+              cd "$ARTIFACT_DIR"
+              shasum -a 256 talon-server talon-worker talon-cli talon.yaml > SHA256SUMS
+            )
+          else
+            (
+              cd "$ARTIFACT_DIR"
+              sha256sum talon-server talon-worker talon-cli talon.yaml > SHA256SUMS
+            )
+          fi
+          tar -C dist -czf "dist/talon-${{ matrix.artifact_name }}-${GITHUB_SHA}.tar.gz" "talon-${{ matrix.artifact_name }}"
+
+      - name: Upload binary artifact bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: talon-${{ matrix.artifact_name }}-${{ github.sha }}
+          path: |
+            dist/talon-${{ matrix.artifact_name }}-${{ github.sha }}.tar.gz
+            dist/talon-${{ matrix.artifact_name }}/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -1,23 +1,184 @@
 # Talon
 
-Talon is a Rust-based agent runtime and control plane with a gateway API, worker runtime, namespace-scoped resources, and an optional Next.js UI.
+Talon is an agent control plane and worker runtime. It gives you durable sessions, agent and template management, schedules, knowledge resources, MCP bindings, a gRPC/HTTP gateway, a worker process, and a browser UI for inspection.
 
-This repository is the open-source home for Talon runtime and UI code. It intentionally excludes Impala's private marketing site and internal deployment plumbing.
+This repository contains the Talon runtime, operator UI, manifests, protocol definitions, and docs.
 
-## Included
+## What ships in this repo
 
-- Rust runtime, worker, and CLI
-- Proto definitions
-- Resource manifests
-- UI under `ui/`
-- Dockerfiles for open-source validation
+- `talon-server`: gateway process exposing the canonical gRPC API plus the browser-oriented UI HTTP surface
+- `talon-worker`: worker runtime that consumes dispatch events and executes agent turns
+- `talon-cli`: admin CLI for applying manifests, inspecting resources, and managing knowledge
+- `ui/`: Next.js operator UI
+- `proto/`: gateway, config, manifest, event, and model contracts
+- `manifests/`: default resources plus end-to-end examples
+- `docs/`: concepts, tutorials, operations guides, and generated API reference
 
-## Not included
+## Runtime model
 
-- Internal production deploy configuration
-- `site/` marketing/docs site from the private monorepo
+Talon is split into a few explicit roles:
 
-## Local development
+- Gateway: accepts API calls, persists session state, and publishes work
+- Worker: consumes work, resolves models and tools, executes turns, and emits step events
+- Control plane: persistence, broker, and scheduler backing services
+- Edge/UI: Envoy plus the Next.js UI for browser access
+
+In the checked-in local stack, the control plane uses Postgres and a Pub/Sub emulator. For same-host development, Talon can also run directly against SQLite plus a local socket broker.
+
+## Repository layout
+
+```text
+src/                  Rust runtime, gateway, worker, control plane, CLI
+src/bin/              talon-server, talon-worker, talon-cli entrypoints
+ui/                   Next.js operator UI
+packages/copilot/     React client package for Talon-backed chat surfaces
+proto/                Protobuf service and schema definitions
+manifests/            Default and example namespace/agent resources
+dockerfiles/          Runtime, UI, and Envoy container builds
+docs/                 Product and operator documentation
+tests/                Python end-to-end tests
+```
+
+## Binaries
+
+Cargo builds three binaries:
+
+```bash
+cargo build --locked --bins
+```
+
+- `target/debug/talon-server`
+- `target/debug/talon-worker`
+- `target/debug/talon-cli`
+
+Release builds:
+
+```bash
+cargo build --locked --release --bins
+```
+
+## Quickstart
+
+### Prerequisites
+
+- Docker / Docker Compose
+- Rust toolchain
+- `protobuf-compiler`
+- at least one real provider API key in `.env`
+
+Create a local env file:
+
+```bash
+cp .env.example .env
+```
+
+Set at least one provider key. The checked-in local stack is wired to the `novita` provider in `talon.compose.yaml`, so the shortest path is:
+
+```bash
+NOVITA_API_KEY=your-real-api-key
+```
+
+### Start the full local stack
+
+```bash
+docker compose up --build -d
+```
+
+This starts:
+
+- gateway
+- worker
+- Postgres
+- Pub/Sub emulator
+- Envoy
+- UI
+- a manifest bootstrap step that applies `manifests/default_agent.yaml`
+
+Useful local endpoints:
+
+- UI: `http://localhost:3000`
+- Envoy edge: `http://localhost:18789`
+- native gRPC gateway: `http://localhost:50051`
+- gateway UI HTTP surface: `http://localhost:50052`
+
+The convenience wrapper in [`run.sh`](./run.sh) does the same startup and also loads provider keys from the macOS keychain when present.
+
+### Apply a namespace and agent
+
+```bash
+cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest apply -f manifests/examples/chatgpt-app/namespace.yaml
+cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest apply -f manifests/examples/chatgpt-app/support-docs-template.yaml
+cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest apply -f manifests/examples/chatgpt-app/support-docs-agent.yaml
+```
+
+### Send a browser-style session request
+
+```bash
+curl -sS http://localhost:18789/v1/ns/chatgpt-app/agents/support-docs/sessions \
+  -X POST \
+  -H 'content-type: application/json' \
+  -d '{"ns":"chatgpt-app","agent":"support-docs"}'
+```
+
+Use the returned `sessionId` against `/v1/ui/...` to drive a session, or inspect it in the UI.
+
+## Running without Docker
+
+For single-host development, Talon can run with:
+
+- SQLite for control-plane storage
+- `local_socket` for broker transport
+- host-native Envoy for the browser edge
+
+See [`docs/wiki/local-single-host-development.md`](./docs/wiki/local-single-host-development.md) for the full workflow. The short version is:
+
+1. build `talon-server`, `talon-worker`, and `talon-cli`
+2. point `TALON_CONFIG_PATH` at a config using `sqlite` and `local_socket`
+3. run the gateway and worker as local processes
+4. front them with Envoy for UI compatibility
+
+## Configuration
+
+Talon reads config from `TALON_CONFIG_PATH` or the default config loader. The checked-in [`talon.yaml`](./talon.yaml) and [`talon.compose.yaml`](./talon.compose.yaml) show the current supported shape:
+
+- provider definitions under `providers`
+- control-plane database driver and connection
+- message broker driver
+- optional scheduler configuration
+
+Common environment variables used by the runtime:
+
+- `TALON_CONFIG_PATH`
+- `POSTGRES_URL`
+- `GCP_PROJECT_ID`
+- `GRPC_ADDR`
+- `GATEWAY_UI_ADDR`
+- `PORT`
+- `PULL_MODE`
+- `TALON_SCHEDULER_DRIVER`
+- `TALON_LOCAL_SCHEDULER_TARGET_URL`
+- `TALON_LOCAL_SCHEDULER_RUNNER`
+- `GATEWAY_PASSWORD`, `GATEWAY_TOKEN`, or `GATEWAY_JWT_SECRET`
+
+## CLI
+
+`talon-cli` is the operator entry point for common admin flows:
+
+- `apply`
+- `render`
+- `get`
+- `delete`
+- `knowledge get|set|delete|sync`
+- `gen`
+
+Examples:
+
+```bash
+cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest get agent support-docs --namespace chatgpt-app
+cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest knowledge sync --namespace chatgpt-app --manifest manifests/examples/chatgpt-app/support-docs-template.yaml
+```
+
+## Development
 
 ### Rust
 
@@ -31,7 +192,7 @@ cargo test --locked
 
 ```bash
 cd ui
-pnpm install --no-frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm build
 ```
 
@@ -55,6 +216,33 @@ protoc -I. -Iproto -Ithird_party/googleapis \
 docker build -f dockerfiles/envoy-cloudrun.Dockerfile .
 ```
 
+## CI artifacts
+
+GitHub CI validates Cargo, runtime image, Envoy image, and UI builds. On pushes to `main`, CI also packages release binaries for:
+
+- Linux `x86_64`
+- macOS `arm64`
+
+Each workflow artifact bundle contains:
+
+- `talon-server`
+- `talon-worker`
+- `talon-cli`
+- `talon.yaml`
+- `SHA256SUMS`
+
+That artifact is intended for single-host runtime validation or downstream packaging. It is not a full deployment bundle by itself because Talon still expects a backing config and control-plane dependencies.
+
+## Documentation
+
+Start here:
+
+- [`docs/intro.md`](./docs/intro.md)
+- [`docs/getting-started/quickstart.md`](./docs/getting-started/quickstart.md)
+- [`docs/concepts/how-talon-works.md`](./docs/concepts/how-talon-works.md)
+- [`docs/operations/local-development.md`](./docs/operations/local-development.md)
+- [`docs/reference/index.md`](./docs/reference/index.md)
+
 ## License
 
-This repository is licensed under the GNU Affero General Public License v3.0. See `LICENSE`.
+Source files in this repository are marked `AGPL-3.0-only`. See [`SECURITY.md`](./SECURITY.md) and the repository licensing metadata for additional project policy.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Talon
 
-Talon is an agent control plane and worker runtime. It gives you durable sessions, agent and template management, schedules, knowledge resources, MCP bindings, a gRPC/HTTP gateway, a worker process, and a browser UI for inspection.
+Talon is the control plane for cloud native agents. It lets teams operate autonomous agent fleets with durable execution, declarative configuration, namespace isolation, and a browser-native fleet view.
 
-This repository contains the Talon runtime, operator UI, manifests, protocol definitions, and docs.
+Talon gives you the infrastructure long-lived agents were missing: a gateway API, worker runtime, persisted sessions, schedule wakeups, knowledge, MCP bindings, and Sightline for inspecting what is running.
 
 ## What ships in this repo
 
@@ -21,7 +21,9 @@ Talon is split into a few explicit roles:
 - Gateway: accepts API calls, persists session state, and publishes work
 - Worker: consumes work, resolves models and tools, executes turns, and emits step events
 - Control plane: persistence, broker, and scheduler backing services
-- Edge/UI: Envoy plus the Next.js UI for browser access
+- Edge/UI: Envoy plus Sightline, the browser-native fleet view for operators
+
+The important product behavior is durability. Threads survive crashes, deploys, and cold starts; schedules wake named agent workflows back up; and specs stay declarative as you iterate on prompts, tools, and policies.
 
 In the checked-in local stack, the control plane uses Postgres and a Pub/Sub emulator. For same-host development, Talon can also run directly against SQLite plus a local socket broker.
 
@@ -91,7 +93,7 @@ This starts:
 - Postgres
 - Pub/Sub emulator
 - Envoy
-- UI
+- Sightline UI
 - a manifest bootstrap step that applies `manifests/default_agent.yaml`
 
 Useful local endpoints:
@@ -110,6 +112,14 @@ cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest apply -f ma
 cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest apply -f manifests/examples/chatgpt-app/support-docs-template.yaml
 cargo run --bin talon-cli -- --gateway http://localhost:18789 --rest apply -f manifests/examples/chatgpt-app/support-docs-agent.yaml
 ```
+
+This is the core Talon loop in practice:
+
+- define declarative agent specs
+- bind tools and MCPs explicitly
+- run durable named sessions
+- wake work on schedule
+- reuse knowledge across agents
 
 ### Send a browser-style session request
 


### PR DESCRIPTION
## What changed
- rewrote the root README around the actual Talon runtime, local stack, binaries, configuration, and developer workflows
- added a `binary_artifacts` GitHub Actions job that runs on pushes to `main`
- packaged per-platform binary bundles for Linux x86_64 and macOS arm64, including checksums and `talon.yaml`

## Why
- the existing README was too thin to orient someone to the real runtime and local usage model
- CI validated builds but did not publish Talon binaries that could be downloaded from successful `main` runs
- artifact packaging needed a real OS matrix only for binary output, not for the existing image-validation jobs

## Impact
- contributors get a substantially better repository entry point
- successful `main` pushes now produce downloadable Talon binary artifacts
- the matrix is scoped to binary packaging, so Docker/image validation remains Linux-only and predictable

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow ok"'`
- `cargo build --locked --bins`
- `gh auth status`
