### PR TITLE
[codex] Update CI actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Cargo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -45,13 +45,13 @@ jobs:
     name: Runtime Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build runtime image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: dockerfiles/oss-runtime.Dockerfile
@@ -62,7 +62,7 @@ jobs:
     name: Envoy Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install protobuf compiler
         run: |
@@ -79,10 +79,10 @@ jobs:
             proto/gateway.proto
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build envoy image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: dockerfiles/envoy-cloudrun.Dockerfile
@@ -93,15 +93,15 @@ jobs:
     name: UI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.17.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "pnpm"
@@ -116,10 +116,10 @@ jobs:
         run: pnpm build
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build UI image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: dockerfiles/oss-ui.Dockerfile


### PR DESCRIPTION
## Summary
- update GitHub-owned workflow actions to Node 24-backed major versions
- update Docker build actions to their Node 24-backed major versions
- update pnpm/action-setup to the Node 24-backed major version

## Why
GitHub Actions is warning that Node.js 20 actions are deprecated. The CI jobs still referenced action majors that bundle the Node 20 runtime, so GitHub annotates Cargo, Envoy Image, and UI runs.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow ok"'\n- git diff --check -- .github/workflows/ci.yml\n- confirmed updated action.yml files declare node24 for actions/checkout@v5, actions/setup-node@v6, pnpm/action-setup@v6, docker/setup-buildx-action@v4, and docker/build-push-action@v7\n\n## Notes\nSwatinem/rust-cache@v2 already declares node24, so it was left unchanged.