### PR TITLE
Refactor KV storage to structured resource keys

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,9 +34,7 @@ fn main() -> std::io::Result<()> {
         ".talon.models.Session",
         ".talon.models.SessionMessage",
     ];
-    let serde_derive_only_types = [
-        ".talon.manifests.PromptDelta",
-    ];
+    let serde_derive_only_types = [".talon.manifests.PromptDelta"];
 
     let mut builder = tonic_build::configure();
     for t in &serde_default_types {

--- a/docs/wiki/key-formats.md
+++ b/docs/wiki/key-formats.md
@@ -1,0 +1,99 @@
+# KV Storage Key Format
+
+Namespaces are organized in their own hierarchy. They are resources, but they are not listed as children in the ordinary resource hierarchy inside a namespace.
+
+## Canonical resources
+
+Most persisted Talon objects are resources inside an isolated namespace. Namespace names are defined in a colon-separated hierarchy, for example `Impala:Talon`.
+
+Each resource is referred to by a `<Type>/<Name>` pair. `Name` is the resource's stable Talon name in that context, not necessarily an opaque database ID. For example, agents use `Agent/<agent-name>`, while sessions and messages commonly use generated IDs as their names.
+
+Resource paths are nested by appending more pairs. Resource names are percent-encoded before serialization so `/` remains a structural separator:
+
+```text
+<Type>/<Name>/<Type>/<Name>
+```
+
+For example:
+
+```text
+Agent/hello-agent/Session/01KSNZ13X37KYK7TNWQH7C3XPG
+```
+
+## Key serialization format
+
+Stored keys use this shape:
+
+```text
+@Namespace/<namespace>/<ParentType>/<parent-name>/.../@/<ChildType>/<child-name>
+```
+
+For example:
+
+```text
+@Namespace/Impala:Talon/Agent/hello-agent/Session/01KSNZ13X37KYK7TNWQH7C3XPG/@/SessionMessage/01KSNZ1BAQ8GGHV75342GHSGE4
+```
+
+The segment before `/@/` identifies the namespace and parent resource path:
+
+```text
+@Namespace/Impala:Talon/Agent/hello-agent/Session/01KSNZ13X37KYK7TNWQH7C3XPG
+```
+
+The segment after `/@/` identifies the direct child resource stored at that key:
+
+```text
+SessionMessage/01KSNZ1BAQ8GGHV75342GHSGE4
+```
+
+Root-level resources in a namespace use the namespace itself as the parent path:
+
+```text
+@Namespace/Impala:Talon/@/Agent/hello-agent
+```
+
+## Listing behavior
+
+This format allows direct children of a resource to be listed with a single ordered-KV prefix scan. For example, this prefix lists sessions directly under the agent:
+
+```text
+@Namespace/Impala:Talon/Agent/hello-agent/@/
+```
+
+It does not include session messages, because messages are stored under the session parent path:
+
+```text
+@Namespace/Impala:Talon/Agent/hello-agent/Session/01KSNZ13X37KYK7TNWQH7C3XPG/@/SessionMessage/...
+```
+
+To recursively list all resources under an agent, query the parent path prefix:
+
+```text
+@Namespace/Impala:Talon/Agent/hello-agent/
+```
+
+The `/@/` separator is intentionally only placed immediately before the leaf resource. That keeps direct-child listing distinct from recursive descendant listing without requiring a second index.
+
+## Namespace hierarchy
+
+Namespace hierarchies are not represented in the ordinary resource hierarchy. A separate `NamespaceRef` resource defines each child namespace edge:
+
+```text
+@Namespace/Impala/@/NamespaceRef/Talon
+```
+
+This implies the existence of an `Impala:Talon` namespace.
+
+Root namespace edges are stored as system resources:
+
+```text
+@Namespace/Sys/@/NamespaceRef/Impala
+```
+
+## System namespace
+
+The special namespace `Sys` is reserved for system and global resources such as namespace metadata and MCP servers. For example, MCP server keys use:
+
+```text
+@Namespace/Sys/@/MCPServer/github
+```

--- a/docs/wiki/key-formats.md
+++ b/docs/wiki/key-formats.md
@@ -20,9 +20,31 @@ For example:
 Agent/hello-agent/Session/01KSNZ13X37KYK7TNWQH7C3XPG
 ```
 
-## Key serialization format
+## Structured storage columns
 
-Stored keys use this shape:
+The storage API passes a structured key instead of a pre-rendered string:
+
+```text
+namespace, parent_path, kind, name
+```
+
+SQL backends store those fields as separate text columns with the value as protobuf bytes:
+
+```sql
+PRIMARY KEY (namespace, parent_path, kind, name)
+```
+
+For Postgres this avoids prefix scans for direct children:
+
+```sql
+WHERE namespace = $1 AND parent_path = $2 AND kind = $3
+```
+
+For SQLite the same key is stored in a `WITHOUT ROWID` table so the primary-key B-tree is the table storage. This keeps sibling resources clustered by `namespace`, `parent_path`, `kind`, and `name`.
+
+## Canonical debug format
+
+The canonical string form is still used for debugging, documentation, and migrating older tables:
 
 ```text
 @Namespace/<namespace>/<ParentType>/<parent-name>/.../@/<ChildType>/<child-name>
@@ -54,25 +76,22 @@ Root-level resources in a namespace use the namespace itself as the parent path:
 
 ## Listing behavior
 
-This format allows direct children of a resource to be listed with a single ordered-KV prefix scan. For example, this prefix lists sessions directly under the agent:
+Direct children are listed by exact `namespace`, `parent_path`, and optional `kind`. For example, sessions directly under an agent use:
 
 ```text
-@Namespace/Impala:Talon/Agent/hello-agent/@/
+namespace = Impala:Talon
+parent_path = Agent/hello-agent
+kind = Session
 ```
 
 It does not include session messages, because messages are stored under the session parent path:
 
 ```text
-@Namespace/Impala:Talon/Agent/hello-agent/Session/01KSNZ13X37KYK7TNWQH7C3XPG/@/SessionMessage/...
+parent_path = Agent/hello-agent/Session/01KSNZ13X37KYK7TNWQH7C3XPG
+kind = SessionMessage
 ```
 
-To recursively list all resources under an agent, query the parent path prefix:
-
-```text
-@Namespace/Impala:Talon/Agent/hello-agent/
-```
-
-The `/@/` separator is intentionally only placed immediately before the leaf resource. That keeps direct-child listing distinct from recursive descendant listing without requiring a second index.
+Recursive operations walk direct children in application code. Talon does not maintain a second recursive index in the SQL storage layer.
 
 ## Namespace hierarchy
 

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -27,12 +27,17 @@ static_resources:
               cors:
                 allow_origin_string_match:
                 - exact: "https://ui.talon.orb.local"
+                - exact: "https://ui.tutorial.orb.local"
+                - safe_regex:
+                    google_re2: {}
+                    regex: "^https://ui\\.[^.]+\\.orb\\.local$"
                 - exact: "http://localhost:3000"
                 - exact: "http://127.0.0.1:3000"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms,authorization
                 max_age: "1728000"
                 expose_headers: grpc-status,grpc-message
+                allow_private_network_access: true
           http_filters:
           - name: envoy.filters.http.grpc_web
             typed_config:

--- a/proto/models.proto
+++ b/proto/models.proto
@@ -93,7 +93,7 @@ message Schedule {
 
 message Namespace {
   string name = 1;
-  string parent = 2; // e.g. "talon-system", "default:subs"
+  string parent = 2; // e.g. "Sys", "default:subs"
   bool is_deleted = 3; // GC Tombstone
   int64 deleted_at = 4;
   map<string, string> labels = 5;

--- a/src/agents/resolver.rs
+++ b/src/agents/resolver.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 
-use crate::control::{keys, ns, KeyValueStore, ProtoKeyValueStoreExt};
+use crate::control::{keys, KeyValueStore, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{
     manifests,
     protobuf_value::{value::Kind as ProtoValueKind, ListValue},
@@ -39,7 +39,7 @@ impl<'a> KvTemplateLoader<'a> {
 impl AgentTemplateLoader for KvTemplateLoader<'_> {
     async fn load_template(&self, name: &str) -> Result<Option<manifests::AgentTemplate>> {
         self.kv
-            .get_msg::<manifests::AgentTemplate>(ns::TALON_SYSTEM, &keys::agent_template(name))
+            .get_msg::<manifests::AgentTemplate>(&keys::agent_template(name))
             .await
     }
 }
@@ -292,10 +292,14 @@ fn validate_capabilities_policy(
             bail!("{path} capability names must be trimmed");
         }
         let capability = capability_trimmed;
-        for action in actions.values.iter().map(|value| match value.kind.as_ref() {
-            Some(ProtoValueKind::StringValue(action)) => Ok(action.as_str()),
-            _ => bail!("{path}['{capability}'] actions must be strings"),
-        }) {
+        for action in actions
+            .values
+            .iter()
+            .map(|value| match value.kind.as_ref() {
+                Some(ProtoValueKind::StringValue(action)) => Ok(action.as_str()),
+                _ => bail!("{path}['{capability}'] actions must be strings"),
+            })
+        {
             let action = action?;
             let action_trimmed = action.trim();
             if action_trimmed.is_empty() {
@@ -448,7 +452,7 @@ mod tests {
             kind: "AgentTemplate".to_string(),
             metadata: Some(manifests::ObjectMeta {
                 name: name.to_string(),
-                namespace: ns::TALON_SYSTEM.to_string(),
+                namespace: crate::control::ns::TALON_SYSTEM.to_string(),
                 labels: HashMap::new(),
                 annotations: HashMap::new(),
             }),
@@ -764,7 +768,9 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(missing_name.to_string().contains("template_name is required"));
+        assert!(missing_name
+            .to_string()
+            .contains("template_name is required"));
 
         let missing_definition = resolve_agent_definition_with_loader(
             &loader,
@@ -772,7 +778,9 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(missing_definition.to_string().contains("missing definition"));
+        assert!(missing_definition
+            .to_string()
+            .contains("missing definition"));
     }
 
     #[tokio::test]
@@ -789,7 +797,10 @@ mod tests {
                     capabilities: HashMap::new(),
                 })
             } else {
-                templated_definition(&format!("t{}", idx + 1), manifests::AgentSpecDelta::default())
+                templated_definition(
+                    &format!("t{}", idx + 1),
+                    manifests::AgentSpecDelta::default(),
+                )
             };
             templates.insert(name.clone(), template(&name, definition));
         }
@@ -852,7 +863,10 @@ mod tests {
 
         assert_eq!(spec.system_prompt, "Reset");
         assert_eq!(
-            spec.features.iter().map(|f| (f.name.as_str(), f.r#type.as_str())).collect::<Vec<_>>(),
+            spec.features
+                .iter()
+                .map(|f| (f.name.as_str(), f.r#type.as_str()))
+                .collect::<Vec<_>>(),
             vec![("search", "mcp"), ("plan", "builtin")]
         );
         assert_eq!(spec.mcp_server_refs, vec!["alt".to_string()]);
@@ -918,7 +932,9 @@ mod tests {
             capabilities: HashMap::new(),
         })
         .unwrap_err();
-        assert!(duplicate_mcp_ref.to_string().contains("Duplicate MCP server ref"));
+        assert!(duplicate_mcp_ref
+            .to_string()
+            .contains("Duplicate MCP server ref"));
     }
 
     #[test]
@@ -945,7 +961,9 @@ mod tests {
             "policy",
         )
         .unwrap_err();
-        assert!(duplicate_profile.to_string().contains("Duplicate model profile"));
+        assert!(duplicate_profile
+            .to_string()
+            .contains("Duplicate model profile"));
 
         let invalid_capability = validate_capabilities_policy(
             &HashMap::from([(
@@ -957,7 +975,9 @@ mod tests {
             "caps",
         )
         .unwrap_err();
-        assert!(invalid_capability.to_string().contains("unsupported action"));
+        assert!(invalid_capability
+            .to_string()
+            .contains("unsupported action"));
 
         let invalid_action_type = validate_capabilities_policy(
             &HashMap::from([(
@@ -971,7 +991,9 @@ mod tests {
             "caps",
         )
         .unwrap_err();
-        assert!(invalid_action_type.to_string().contains("actions must be strings"));
+        assert!(invalid_action_type
+            .to_string()
+            .contains("actions must be strings"));
 
         let untrimmed_action = validate_capabilities_policy(
             &HashMap::from([(
@@ -998,7 +1020,9 @@ mod tests {
             "model",
         )
         .unwrap_err();
-        assert!(missing_provider.to_string().contains(".provider is required"));
+        assert!(missing_provider
+            .to_string()
+            .contains(".provider is required"));
 
         let missing_name = validate_model(
             &manifests::Model {
@@ -1069,5 +1093,4 @@ mod tests {
             kind: Some(ProtoValueKind::StringValue(value.to_string())),
         }
     }
-
 }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1832,23 +1832,23 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: RwLock<HashMap<String, Vec<u8>>>,
+        data: RwLock<HashMap<keys::ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, k: &keys::ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.read().await.get(k).cloned())
         }
 
-        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data.write().await.insert(k.to_string(), v.to_vec());
+        async fn set(&self, k: &keys::ResourceKey, v: &[u8]) -> anyhow::Result<()> {
+            self.data.write().await.insert(k.clone(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            k: &str,
+            k: &keys::ResourceKey,
             old: Option<&[u8]>,
             new: &[u8],
         ) -> anyhow::Result<bool> {
@@ -1859,23 +1859,26 @@ mod tests {
                 _ => false,
             };
             if matches {
-                data.insert(k.to_string(), new.to_vec());
+                data.insert(k.clone(), new.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+        async fn delete(&self, k: &keys::ResourceKey) -> anyhow::Result<()> {
             self.data.write().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(
+            &self,
+            list: &keys::ResourceList,
+        ) -> anyhow::Result<Vec<keys::ResourceKey>> {
             let mut keys = self
                 .data
                 .read()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -12,8 +12,8 @@ use serde_json::json;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use talon::gateway::rpc::models;
 use talon::gateway::rpc::manifests::{Knowledge, KnowledgeSpec, ObjectMeta};
+use talon::gateway::rpc::models;
 use talon::gateway::rpc::proto::gateway_service_client::GatewayServiceClient;
 use talon::gateway::rpc::proto::{
     CreateAgentRequest, CreateAgentTemplateRequest, CreateMcpServerRequest,
@@ -343,7 +343,11 @@ fn agent_lookup_target(name: &str, namespace: Option<&String>) -> (String, Strin
     (final_ns, final_name)
 }
 
-fn rest_get_path(kind: &str, name: &str, namespace: Option<&String>) -> Result<(String, &'static str)> {
+fn rest_get_path(
+    kind: &str,
+    name: &str,
+    namespace: Option<&String>,
+) -> Result<(String, &'static str)> {
     match kind.to_lowercase().as_str() {
         "agenttemplate" | "templates" | "template" => Ok((
             format!("/v1/templates/{}", urlencoding::encode(name)),
@@ -439,9 +443,7 @@ fn rest_delete_path(kind: &str, name: &str, namespace: Option<&String>) -> Resul
                 urlencoding::encode(name)
             ))
         }
-        "namespace" | "namespaces" => {
-            Ok(format!("/v1/namespaces/{}", urlencoding::encode(name)))
-        }
+        "namespace" | "namespaces" => Ok(format!("/v1/namespaces/{}", urlencoding::encode(name))),
         "knowledge" | "knowledgeartifact" | "knowledgeartifacts" => {
             let ns = namespace
                 .as_ref()
@@ -752,11 +754,7 @@ async fn knowledge_list(cli: &Cli, namespace: &str) -> Result<Vec<Knowledge>> {
     }
 }
 
-async fn sync_knowledge_dir(
-    cli: &Cli,
-    namespace: &str,
-    dir: &str,
-) -> Result<(usize, Vec<String>)> {
+async fn sync_knowledge_dir(cli: &Cli, namespace: &str, dir: &str) -> Result<(usize, Vec<String>)> {
     let root = Path::new(dir);
     let files = collect_markdown_files(root)?;
     let existing: Vec<Knowledge> = knowledge_list(cli, namespace).await?;
@@ -954,7 +952,7 @@ fn build_rest_apply_plan(
                 .context("MCPServer missing metadata")?;
             if !meta.namespace.is_empty() {
                 anyhow::bail!(
-                    "MCPServer metadata.namespace is not supported; MCP servers are system resources in talon-system"
+                    "MCPServer metadata.namespace is not supported; MCP servers are system resources in Sys"
                 );
             }
             Ok(RestApplyPlan {
@@ -1070,15 +1068,16 @@ fn feature_ts_type(kind: &str) -> &'static str {
     }
 }
 
-fn sdk_method_for_template(template: &talon::gateway::rpc::manifests::AgentTemplate) -> Option<String> {
+fn sdk_method_for_template(
+    template: &talon::gateway::rpc::manifests::AgentTemplate,
+) -> Option<String> {
     let name = template.metadata.as_ref()?.name.clone();
     let method_name = format!("create{}", to_camel_case(&name));
     let mut args = Vec::new();
 
     if let Some(definition) = &template.definition {
-        if let Some(
-            talon::gateway::rpc::manifests::agent_definition::Source::CustomSpec(spec),
-        ) = definition.source.as_ref()
+        if let Some(talon::gateway::rpc::manifests::agent_definition::Source::CustomSpec(spec)) =
+            definition.source.as_ref()
         {
             for f in &spec.features {
                 let opt = if f.required { "" } else { "?" };
@@ -1225,7 +1224,7 @@ fn build_grpc_apply_plan(content: &str) -> Result<GrpcApplyPlan> {
                 .context("MCPServer missing metadata")?;
             if !meta.namespace.is_empty() {
                 anyhow::bail!(
-                    "MCPServer metadata.namespace is not supported; MCP servers are system resources in talon-system"
+                    "MCPServer metadata.namespace is not supported; MCP servers are system resources in Sys"
                 );
             }
             Ok(GrpcApplyPlan::McpServer {
@@ -1271,10 +1270,7 @@ async fn grpc_get_yaml(
                 .get_agent_template(GetAgentTemplateRequest { name: name.clone() })
                 .await
                 .with_context(|| format!("Failed to fetch AgentTemplate '{}'", name))?;
-            let template = resp
-                .into_inner()
-                .template
-                .context("Resource not found.")?;
+            let template = resp.into_inner().template.context("Resource not found.")?;
             talon::manifest::render_agent_template_yaml(&template)
         }
         GrpcGetTarget::Agent { ns, name } => {
@@ -1304,7 +1300,10 @@ async fn grpc_get_yaml(
                 })
                 .await
                 .with_context(|| format!("Failed to fetch Knowledge '{}/{}'", ns, name))?;
-            let knowledge = resp.into_inner().knowledge.context("Knowledge not found.")?;
+            let knowledge = resp
+                .into_inner()
+                .knowledge
+                .context("Knowledge not found.")?;
             talon::manifest::render_knowledge_yaml(&knowledge)
         }
         GrpcGetTarget::Schedule { ns, name } => {
@@ -1316,7 +1315,8 @@ async fn grpc_get_yaml(
                 .await
                 .with_context(|| format!("Failed to fetch Schedule '{}/{}'", ns, name))?;
             let schedule = resp.into_inner().schedule.context("Schedule not found.")?;
-            serde_yaml::to_string(&schedule_json(&schedule)).context("Failed to serialize Schedule YAML")
+            serde_yaml::to_string(&schedule_json(&schedule))
+                .context("Failed to serialize Schedule YAML")
         }
     }
 }
@@ -1357,7 +1357,10 @@ async fn grpc_delete_resource(
                 })
                 .await
                 .with_context(|| format!("Failed to delete Knowledge '{}/{}'", ns, name))?;
-            Ok(format!("✓ Knowledge '{}/{}' deleted successfully.", ns, name))
+            Ok(format!(
+                "✓ Knowledge '{}/{}' deleted successfully.",
+                ns, name
+            ))
         }
     }
 }
@@ -1441,7 +1444,10 @@ async fn grpc_apply_manifest(cli: &Cli, content: &str) -> Result<String> {
                 })
                 .await
                 .with_context(|| format!("Gateway rejected Knowledge '{}/{}'", ns, name))?;
-            Ok(format!("✓ Knowledge '{}/{}' applied successfully.", ns, name))
+            Ok(format!(
+                "✓ Knowledge '{}/{}' applied successfully.",
+                ns, name
+            ))
         }
     }
 }
@@ -1542,7 +1548,10 @@ async fn run_cli(cli: &Cli) -> Result<RunOutcome> {
                 } else {
                     false
                 };
-                println!("{}", rest_apply_manifest(&cli, &content, agent_exists).await?);
+                println!(
+                    "{}",
+                    rest_apply_manifest(&cli, &content, agent_exists).await?
+                );
                 return Ok(RunOutcome { exit_code: None });
             }
 
@@ -1572,10 +1581,16 @@ async fn run_cli(cli: &Cli) -> Result<RunOutcome> {
             namespace,
         } => {
             if cli.rest {
-                println!("{}", rest_get_yaml(&cli, kind, name, namespace.as_ref()).await?);
+                println!(
+                    "{}",
+                    rest_get_yaml(&cli, kind, name, namespace.as_ref()).await?
+                );
                 return Ok(RunOutcome { exit_code: None });
             }
-            println!("{}", grpc_get_yaml(&cli, kind, name, namespace.as_ref()).await?);
+            println!(
+                "{}",
+                grpc_get_yaml(&cli, kind, name, namespace.as_ref()).await?
+            );
         }
 
         Commands::Delete {
@@ -1735,15 +1750,17 @@ fn to_camel_case(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        agent_lookup_target, auth_interceptor, build_grpc_apply_plan, build_rest_apply_plan, build_knowledge,
-        canonicalize_manifest_path, collect_markdown_files, feature_ts_type, knowledge_delete,
-        grpc_apply_manifest, grpc_delete_resource, grpc_delete_target, grpc_get_target, grpc_get_yaml, knowledge_get, knowledge_list, knowledge_resource_name, knowledge_set,
-        manifest_json_payload, parse_raw_manifest, parse_vars, read_knowledge_content,
-        relative_knowledge_path, render_json_payload, render_manifest_file,
-        render_manifest_template, rest_apply_manifest, rest_client, rest_delete_path, rest_delete_resource, rest_get_path, rest_get_yaml,
-        rest_request_json, resolve_authorization_header, resolve_manifest_sources, run_cli, schedule_json, sync_knowledge_dir,
-        sdk_method_for_template, sdk_methods_from_dir, to_camel_case, Cli, Commands,
-        GrpcApplyPlan, GrpcDeleteTarget, GrpcGetTarget, KnowledgeCommands, RenderFormat,
+        agent_lookup_target, auth_interceptor, build_grpc_apply_plan, build_knowledge,
+        build_rest_apply_plan, canonicalize_manifest_path, collect_markdown_files, feature_ts_type,
+        grpc_apply_manifest, grpc_delete_resource, grpc_delete_target, grpc_get_target,
+        grpc_get_yaml, knowledge_delete, knowledge_get, knowledge_list, knowledge_resource_name,
+        knowledge_set, manifest_json_payload, parse_raw_manifest, parse_vars,
+        read_knowledge_content, relative_knowledge_path, render_json_payload, render_manifest_file,
+        render_manifest_template, resolve_authorization_header, resolve_manifest_sources,
+        rest_apply_manifest, rest_client, rest_delete_path, rest_delete_resource, rest_get_path,
+        rest_get_yaml, rest_request_json, run_cli, schedule_json, sdk_method_for_template,
+        sdk_methods_from_dir, sync_knowledge_dir, to_camel_case, Cli, Commands, GrpcApplyPlan,
+        GrpcDeleteTarget, GrpcGetTarget, KnowledgeCommands, RenderFormat,
     };
     use axum::{
         extract::{Path as AxumPath, State},
@@ -1756,23 +1773,23 @@ mod tests {
     use std::collections::HashMap;
     use std::fs;
     use std::net::SocketAddr;
-    use std::pin::Pin;
     use std::path::Path;
+    use std::pin::Pin;
     use std::sync::{Arc, Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::net::TcpListener;
     use tokio::sync::RwLock;
-    use tonic::transport::Server;
-    use tonic::service::Interceptor;
     use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::service::Interceptor;
+    use tonic::transport::Server;
 
-    use talon::control::{KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt};
     use talon::control::keys;
-    use talon::control::scheduler::SchedulerBackend;
     use talon::control::scheduler::NoopSchedulerBackend;
-    use talon::gateway::session_streams::SessionStreamHub;
+    use talon::control::scheduler::SchedulerBackend;
+    use talon::control::{KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt};
+    use talon::gateway::rpc::{models, proto, GrpcGatewayHandler};
     use talon::gateway::server::Gateway;
-    use talon::gateway::rpc::{GrpcGatewayHandler, models, proto};
+    use talon::gateway::session_streams::SessionStreamHub;
 
     fn env_mutex() -> &'static Mutex<()> {
         static MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
@@ -1815,62 +1832,50 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: RwLock<HashMap<(String, String), Vec<u8>>>,
+        data: RwLock<HashMap<String, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, ns: &str, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .read()
-                .await
-                .get(&(ns.to_string(), k.to_string()))
-                .cloned())
+        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.read().await.get(k).cloned())
         }
 
-        async fn set(&self, ns: &str, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .write()
-                .await
-                .insert((ns.to_string(), k.to_string()), v.to_vec());
+        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
+            self.data.write().await.insert(k.to_string(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            ns: &str,
             k: &str,
             old: Option<&[u8]>,
             new: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.write().await;
-            let key = (ns.to_string(), k.to_string());
-            let matches = match (data.get(&key), old) {
+            let matches = match (data.get(k), old) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(key, new.to_vec());
+                data.insert(k.to_string(), new.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, ns: &str, k: &str) -> anyhow::Result<()> {
-            self.data.write().await.remove(&(ns.to_string(), k.to_string()));
+        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+            self.data.write().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .read()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(p)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -1928,7 +1933,7 @@ mod tests {
             deleted_at: 0,
             labels: HashMap::new(),
         };
-        kv.set_msg("talon-system:ns", &format!("Namespace/{namespace}"), &value)
+        kv.set_msg(&keys::namespace_metadata(namespace), &value)
             .await
             .unwrap();
     }
@@ -2142,9 +2147,11 @@ mod tests {
         fs::write(temp_root.join("docs/nested/two.MD"), "two").unwrap();
         fs::write(temp_root.join("docs/skip.txt"), "skip").unwrap();
 
-        let relative =
-            relative_knowledge_path(&temp_root.join("docs"), &temp_root.join("docs/nested/two.MD"))
-                .unwrap();
+        let relative = relative_knowledge_path(
+            &temp_root.join("docs"),
+            &temp_root.join("docs/nested/two.MD"),
+        )
+        .unwrap();
         assert_eq!(relative, "nested/two.MD");
 
         let files = collect_markdown_files(&temp_root.join("docs")).unwrap();
@@ -2160,8 +2167,9 @@ mod tests {
         fs::create_dir_all(temp_root.join("docs")).unwrap();
         fs::write(temp_root.join("outside.md"), "outside").unwrap();
 
-        let outside = relative_knowledge_path(&temp_root.join("docs"), &temp_root.join("outside.md"))
-            .expect_err("outside file should fail");
+        let outside =
+            relative_knowledge_path(&temp_root.join("docs"), &temp_root.join("outside.md"))
+                .expect_err("outside file should fail");
         assert!(outside.to_string().contains("is not inside"));
 
         let empty = relative_knowledge_path(&temp_root.join("docs"), &temp_root.join("docs"))
@@ -2221,7 +2229,10 @@ mod tests {
         );
         assert_eq!(
             rest_get_path("schedule", "nightly sync", Some(&team)).unwrap(),
-            ("/v1/ns/team-a/schedules/nightly%20sync".to_string(), "schedule")
+            (
+                "/v1/ns/team-a/schedules/nightly%20sync".to_string(),
+                "schedule"
+            )
         );
         assert_eq!(
             rest_delete_path("namespace", "team/a", None).unwrap(),
@@ -2309,11 +2320,9 @@ mod tests {
         )
         .unwrap();
 
-        let rendered = render_manifest_file(
-            manifest_path.to_str().unwrap(),
-            &["ns=conic".to_string()],
-        )
-        .unwrap();
+        let rendered =
+            render_manifest_file(manifest_path.to_str().unwrap(), &["ns=conic".to_string()])
+                .unwrap();
         assert!(rendered.contains("namespace: conic"));
         assert!(rendered.contains("content: rendered"));
 
@@ -2572,7 +2581,8 @@ mod tests {
 
     #[test]
     fn resolve_manifest_sources_passes_through_non_knowledge_and_rejects_duplicate_sources() {
-        let namespace = "apiVersion: talon.impalasys.com/v1\nkind: Namespace\nmetadata:\n  name: conic\n";
+        let namespace =
+            "apiVersion: talon.impalasys.com/v1\nkind: Namespace\nmetadata:\n  name: conic\n";
         assert_eq!(
             resolve_manifest_sources("manifest.yaml", namespace).unwrap(),
             namespace
@@ -2583,7 +2593,9 @@ mod tests {
             "apiVersion: talon.impalasys.com/v1\nkind: Knowledge\nmetadata:\n  name: test\n  namespace: conic\nspec:\n  path: docs/test.md\n  content: inline\n  contentFromFile: docs/test.md\n",
         )
         .unwrap_err();
-        assert!(err.to_string().contains("only one of content or contentFromFile"));
+        assert!(err
+            .to_string()
+            .contains("only one of content or contentFromFile"));
     }
 
     #[test]
@@ -2592,15 +2604,15 @@ mod tests {
             "apiVersion: talon.impalasys.com/v1\nkind: UnknownThing\nmetadata:\n  name: test\n",
         )
         .unwrap_err();
-        assert!(unsupported.to_string().contains("Unsupported manifest kind"));
+        assert!(unsupported
+            .to_string()
+            .contains("Unsupported manifest kind"));
 
         let missing_namespace = manifest_json_payload(
             "apiVersion: talon.impalasys.com/v1\nkind: McpServerBinding\nmetadata:\n  name: github\nspec:\n  serverRef: github\n",
         )
         .unwrap_err();
-        assert!(missing_namespace
-            .to_string()
-            .contains("namespace"));
+        assert!(missing_namespace.to_string().contains("namespace"));
 
         let render_err = render_json_payload(
             "apiVersion: talon.impalasys.com/v1\nkind: UnknownThing\nmetadata:\n  name: test\n",
@@ -2748,7 +2760,9 @@ mod tests {
                             .unwrap()
                             .into_owned();
                         match state.store.lock().await.get(&decoded_name).cloned() {
-                            Some(knowledge) => (StatusCode::OK, Json(json!({ "knowledge": knowledge }))),
+                            Some(knowledge) => {
+                                (StatusCode::OK, Json(json!({ "knowledge": knowledge })))
+                            }
                             None => (StatusCode::NOT_FOUND, Json(json!({ "error": "missing" }))),
                         }
                     },
@@ -2774,7 +2788,10 @@ mod tests {
 
         let cli = rest_cli(format!("http://{addr}"));
         let path = "docs-test.md";
-        let missing = knowledge_get(&cli, "conic", path).await.unwrap_err().to_string();
+        let missing = knowledge_get(&cli, "conic", path)
+            .await
+            .unwrap_err()
+            .to_string();
         assert!(missing.contains("status=404 Not Found"));
 
         knowledge_set(&cli, "conic", path, "hello".to_string())
@@ -2849,7 +2866,9 @@ mod tests {
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].spec.as_ref().unwrap().path, "docs/grpc.md");
 
-        knowledge_delete(&cli, "conic", "docs/grpc.md").await.unwrap();
+        knowledge_delete(&cli, "conic", "docs/grpc.md")
+            .await
+            .unwrap();
         assert!(knowledge_get(&cli, "conic", "docs/grpc.md")
             .await
             .unwrap()
@@ -2877,14 +2896,9 @@ mod tests {
         assert!(yaml.contains("kind: Knowledge"));
         assert!(yaml.contains("content: grpc body"));
 
-        let deleted = grpc_delete_resource(
-            &cli,
-            "knowledge",
-            "docs/view.md",
-            Some(&namespace),
-        )
-        .await
-        .unwrap();
+        let deleted = grpc_delete_resource(&cli, "knowledge", "docs/view.md", Some(&namespace))
+            .await
+            .unwrap();
         assert!(deleted.contains("deleted successfully"));
         assert!(knowledge_get(&cli, "conic", "docs/view.md")
             .await
@@ -2908,7 +2922,9 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(knowledge_message.contains("Knowledge 'conic/docs/applied.md' applied successfully."));
+        assert!(
+            knowledge_message.contains("Knowledge 'conic/docs/applied.md' applied successfully.")
+        );
         let got = knowledge_get(&cli, "conic", "docs/applied.md")
             .await
             .unwrap()
@@ -2995,8 +3011,7 @@ mod tests {
         seed_namespace(&kv, "conic").await;
         let namespace = "conic".to_string();
         kv.set_msg(
-            &namespace,
-            &keys::schedule("nightly"),
+            &keys::schedule(&namespace, "nightly"),
             &models::Schedule {
                 name: "nightly".to_string(),
                 ns: namespace.clone(),
@@ -3357,14 +3372,10 @@ mod tests {
             .await
             .unwrap();
         assert!(knowledge_yaml.contains("content: rest body"));
-        let knowledge_deleted = rest_delete_resource(
-            &cli,
-            "knowledge",
-            "docs/rest.md",
-            Some(&namespace),
-        )
-        .await
-        .unwrap();
+        let knowledge_deleted =
+            rest_delete_resource(&cli, "knowledge", "docs/rest.md", Some(&namespace))
+                .await
+                .unwrap();
         assert!(knowledge_deleted.contains("deleted successfully"));
 
         let binding_message = rest_apply_manifest(
@@ -3482,7 +3493,10 @@ mod tests {
     #[tokio::test]
     async fn rest_helpers_surface_missing_fields_and_server_errors() {
         let app = Router::new()
-            .route("/v1/templates/:name", get(|| async { Json(json!({ "wrong": {} })) }))
+            .route(
+                "/v1/templates/:name",
+                get(|| async { Json(json!({ "wrong": {} })) }),
+            )
             .route(
                 "/v1/ns/:ns/agents/:name",
                 delete(|| async { (StatusCode::BAD_REQUEST, "cannot delete") }),

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -216,7 +216,7 @@ mod tests {
     use std::sync::Arc;
     use talon::config::Config;
     use talon::control::{
-        scheduler::NoopSchedulerBackend, ControlPlane, KeyValueStore, MessagePublisher,
+        keys, scheduler::NoopSchedulerBackend, ControlPlane, KeyValueStore, MessagePublisher,
     };
     use talon::gateway::auth::AuthConfig;
     use talon::gateway::auth::AuthMode;
@@ -296,41 +296,34 @@ mod tests {
     #[tokio::test]
     async fn mock_control_plane_helpers_cover_storage_and_pubsub_branches() {
         let kv = MockKvStore::default();
-        assert_eq!(kv.get("root/missing").await.unwrap(), None);
+        let missing = keys::agent("root", "missing");
+        let a = keys::agent("root", "a");
+        let b = keys::agent("root", "b");
+        let c = keys::agent("other", "c");
+        let new = keys::agent("root", "new");
+        let list = keys::agent_prefix("root");
+        assert_eq!(kv.get(&missing).await.unwrap(), None);
 
-        kv.set("root/agents/a", b"one").await.unwrap();
-        kv.set("root/agents/b", b"two").await.unwrap();
-        kv.set("other/agents/c", b"three").await.unwrap();
-        assert_eq!(
-            kv.get("root/agents/a").await.unwrap(),
-            Some(b"one".to_vec())
-        );
+        kv.set(&a, b"one").await.unwrap();
+        kv.set(&b, b"two").await.unwrap();
+        kv.set(&c, b"three").await.unwrap();
+        assert_eq!(kv.get(&a).await.unwrap(), Some(b"one".to_vec()));
 
+        assert!(kv.compare_and_swap(&new, None, b"created").await.unwrap());
         assert!(kv
-            .compare_and_swap("root/agents/new", None, b"created")
-            .await
-            .unwrap());
-        assert!(kv
-            .compare_and_swap("root/agents/a", Some(b"one"), b"updated")
+            .compare_and_swap(&a, Some(b"one"), b"updated")
             .await
             .unwrap());
         assert!(!kv
-            .compare_and_swap("root/agents/a", Some(b"wrong"), b"nope")
+            .compare_and_swap(&a, Some(b"wrong"), b"nope")
             .await
             .unwrap());
 
-        let keys = kv.list_keys("root/agents/").await.unwrap();
-        assert_eq!(
-            keys,
-            vec![
-                "root/agents/a".to_string(),
-                "root/agents/b".to_string(),
-                "root/agents/new".to_string(),
-            ]
-        );
+        let keys = kv.list_keys(&list).await.unwrap();
+        assert_eq!(keys, vec![a.clone(), b.clone(), new.clone()]);
 
-        kv.delete("root/agents/b").await.unwrap();
-        assert_eq!(kv.get("root/agents/b").await.unwrap(), None);
+        kv.delete(&b).await.unwrap();
+        assert_eq!(kv.get(&b).await.unwrap(), None);
 
         let pubsub = EmptyPubSub;
         pubsub.publish("topic", b"payload").await.unwrap();

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -296,41 +296,41 @@ mod tests {
     #[tokio::test]
     async fn mock_control_plane_helpers_cover_storage_and_pubsub_branches() {
         let kv = MockKvStore::default();
-        assert_eq!(kv.get("root", "missing").await.unwrap(), None);
+        assert_eq!(kv.get("root/missing").await.unwrap(), None);
 
-        kv.set("root", "agents/a", b"one").await.unwrap();
-        kv.set("root", "agents/b", b"two").await.unwrap();
-        kv.set("other", "agents/c", b"three").await.unwrap();
+        kv.set("root/agents/a", b"one").await.unwrap();
+        kv.set("root/agents/b", b"two").await.unwrap();
+        kv.set("other/agents/c", b"three").await.unwrap();
         assert_eq!(
-            kv.get("root", "agents/a").await.unwrap(),
+            kv.get("root/agents/a").await.unwrap(),
             Some(b"one".to_vec())
         );
 
         assert!(kv
-            .compare_and_swap("root", "agents/new", None, b"created")
+            .compare_and_swap("root/agents/new", None, b"created")
             .await
             .unwrap());
         assert!(kv
-            .compare_and_swap("root", "agents/a", Some(b"one"), b"updated")
+            .compare_and_swap("root/agents/a", Some(b"one"), b"updated")
             .await
             .unwrap());
         assert!(!kv
-            .compare_and_swap("root", "agents/a", Some(b"wrong"), b"nope")
+            .compare_and_swap("root/agents/a", Some(b"wrong"), b"nope")
             .await
             .unwrap());
 
-        let keys = kv.list_keys("root", "agents/").await.unwrap();
+        let keys = kv.list_keys("root/agents/").await.unwrap();
         assert_eq!(
             keys,
             vec![
-                "agents/a".to_string(),
-                "agents/b".to_string(),
-                "agents/new".to_string(),
+                "root/agents/a".to_string(),
+                "root/agents/b".to_string(),
+                "root/agents/new".to_string(),
             ]
         );
 
-        kv.delete("root", "agents/b").await.unwrap();
-        assert_eq!(kv.get("root", "agents/b").await.unwrap(), None);
+        kv.delete("root/agents/b").await.unwrap();
+        assert_eq!(kv.get("root/agents/b").await.unwrap(), None);
 
         let pubsub = EmptyPubSub;
         pubsub.publish("topic", b"payload").await.unwrap();

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -1074,41 +1074,41 @@ mod tests {
     #[tokio::test]
     async fn mock_control_plane_helpers_cover_storage_and_pubsub_branches() {
         let kv = MockKvStore::default();
-        assert_eq!(kv.get("root", "missing").await.unwrap(), None);
+        assert_eq!(kv.get("root/missing").await.unwrap(), None);
 
-        kv.set("root", "agents/a", b"one").await.unwrap();
-        kv.set("root", "agents/b", b"two").await.unwrap();
-        kv.set("other", "agents/c", b"three").await.unwrap();
+        kv.set("root/agents/a", b"one").await.unwrap();
+        kv.set("root/agents/b", b"two").await.unwrap();
+        kv.set("other/agents/c", b"three").await.unwrap();
         assert_eq!(
-            kv.get("root", "agents/a").await.unwrap(),
+            kv.get("root/agents/a").await.unwrap(),
             Some(b"one".to_vec())
         );
 
         assert!(kv
-            .compare_and_swap("root", "agents/new", None, b"created")
+            .compare_and_swap("root/agents/new", None, b"created")
             .await
             .unwrap());
         assert!(kv
-            .compare_and_swap("root", "agents/a", Some(b"one"), b"updated")
+            .compare_and_swap("root/agents/a", Some(b"one"), b"updated")
             .await
             .unwrap());
         assert!(!kv
-            .compare_and_swap("root", "agents/a", Some(b"wrong"), b"nope")
+            .compare_and_swap("root/agents/a", Some(b"wrong"), b"nope")
             .await
             .unwrap());
 
-        let keys = kv.list_keys("root", "agents/").await.unwrap();
+        let keys = kv.list_keys("root/agents/").await.unwrap();
         assert_eq!(
             keys,
             vec![
-                "agents/a".to_string(),
-                "agents/b".to_string(),
-                "agents/new".to_string(),
+                "root/agents/a".to_string(),
+                "root/agents/b".to_string(),
+                "root/agents/new".to_string(),
             ]
         );
 
-        kv.delete("root", "agents/b").await.unwrap();
-        assert_eq!(kv.get("root", "agents/b").await.unwrap(), None);
+        kv.delete("root/agents/b").await.unwrap();
+        assert_eq!(kv.get("root/agents/b").await.unwrap(), None);
 
         let pubsub = EmptyPubSub;
         pubsub.publish("topic", b"payload").await.unwrap();
@@ -1437,8 +1437,7 @@ mod tests {
     async fn schedule_fire_surfaces_wakeup_processing_failures() {
         let kv = Arc::new(MockKvStore::default());
         kv.set_msg(
-            "default",
-            &keys::schedule("nightly"),
+            &keys::schedule("default", "nightly"),
             &schedule_with_next_run(4, i64::MAX),
         )
         .await

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -1074,41 +1074,34 @@ mod tests {
     #[tokio::test]
     async fn mock_control_plane_helpers_cover_storage_and_pubsub_branches() {
         let kv = MockKvStore::default();
-        assert_eq!(kv.get("root/missing").await.unwrap(), None);
+        let missing = keys::agent("root", "missing");
+        let a = keys::agent("root", "a");
+        let b = keys::agent("root", "b");
+        let c = keys::agent("other", "c");
+        let new = keys::agent("root", "new");
+        let list = keys::agent_prefix("root");
+        assert_eq!(kv.get(&missing).await.unwrap(), None);
 
-        kv.set("root/agents/a", b"one").await.unwrap();
-        kv.set("root/agents/b", b"two").await.unwrap();
-        kv.set("other/agents/c", b"three").await.unwrap();
-        assert_eq!(
-            kv.get("root/agents/a").await.unwrap(),
-            Some(b"one".to_vec())
-        );
+        kv.set(&a, b"one").await.unwrap();
+        kv.set(&b, b"two").await.unwrap();
+        kv.set(&c, b"three").await.unwrap();
+        assert_eq!(kv.get(&a).await.unwrap(), Some(b"one".to_vec()));
 
+        assert!(kv.compare_and_swap(&new, None, b"created").await.unwrap());
         assert!(kv
-            .compare_and_swap("root/agents/new", None, b"created")
-            .await
-            .unwrap());
-        assert!(kv
-            .compare_and_swap("root/agents/a", Some(b"one"), b"updated")
+            .compare_and_swap(&a, Some(b"one"), b"updated")
             .await
             .unwrap());
         assert!(!kv
-            .compare_and_swap("root/agents/a", Some(b"wrong"), b"nope")
+            .compare_and_swap(&a, Some(b"wrong"), b"nope")
             .await
             .unwrap());
 
-        let keys = kv.list_keys("root/agents/").await.unwrap();
-        assert_eq!(
-            keys,
-            vec![
-                "root/agents/a".to_string(),
-                "root/agents/b".to_string(),
-                "root/agents/new".to_string(),
-            ]
-        );
+        let keys = kv.list_keys(&list).await.unwrap();
+        assert_eq!(keys, vec![a.clone(), b.clone(), new.clone()]);
 
-        kv.delete("root/agents/b").await.unwrap();
-        assert_eq!(kv.get("root/agents/b").await.unwrap(), None);
+        kv.delete(&b).await.unwrap();
+        assert_eq!(kv.get(&b).await.unwrap(), None);
 
         let pubsub = EmptyPubSub;
         pubsub.publish("topic", b"payload").await.unwrap();

--- a/src/connectors/mcp.rs
+++ b/src/connectors/mcp.rs
@@ -150,9 +150,8 @@ impl McpClient {
                 let result = service
                     .peer()
                     .call_tool(
-                        CallToolRequestParams::new(name.to_string()).with_arguments(
-                            arguments.unwrap_or_default(),
-                        ),
+                        CallToolRequestParams::new(name.to_string())
+                            .with_arguments(arguments.unwrap_or_default()),
                     )
                     .await?;
 

--- a/src/connectors/mcp_tests.rs
+++ b/src/connectors/mcp_tests.rs
@@ -4,8 +4,8 @@
 #[cfg(test)]
 mod tests {
     use crate::connectors::mcp::{
-        authorization_bearer_token, authorization_header, clear_broker_auth_cache_for_test,
-        call_tool_for_config, content_type_matches, format_tool_result,
+        authorization_bearer_token, authorization_header, call_tool_for_config,
+        clear_broker_auth_cache_for_test, content_type_matches, format_tool_result,
         invalidate_all_broker_auth_cache, invalidate_broker_auth_cache, list_tools_for_config,
         resolve_http_headers, validate_http_headers, AuthenticatedReqwestClient,
         McpAuthBrokerConfig, McpClient, McpConnectionConfig,
@@ -198,7 +198,10 @@ mod tests {
     #[test]
     fn test_format_tool_result_uses_text_when_structured_content_is_missing() {
         let result = format_tool_result(
-            &[Content::text("File content here"), Content::text("More text")],
+            &[
+                Content::text("File content here"),
+                Content::text("More text"),
+            ],
             None,
             json!([]),
         )
@@ -257,7 +260,10 @@ mod tests {
     fn test_format_tool_result_decodes_blob_and_serializes_non_text_blocks() {
         let result = format_tool_result(
             &[
-                Content::resource(ResourceContents::blob("SGVsbG8gYmxvYg==", "file:///blob.txt")),
+                Content::resource(ResourceContents::blob(
+                    "SGVsbG8gYmxvYg==",
+                    "file:///blob.txt",
+                )),
                 Content::image("ZmFrZQ==", "image/png"),
             ],
             None,
@@ -272,7 +278,8 @@ mod tests {
 
     #[test]
     fn test_format_tool_result_falls_back_to_pretty_printed_json() {
-        let result = format_tool_result(&[], None, json!({"ok": true, "items": [1, 2, 3]})).unwrap();
+        let result =
+            format_tool_result(&[], None, json!({"ok": true, "items": [1, 2, 3]})).unwrap();
         assert!(result.contains("\"ok\": true"));
         assert!(result.contains("\"items\": ["));
     }
@@ -396,10 +403,7 @@ mod tests {
                 transport: "http".to_string(),
                 target: "https://example.com/mcp".to_string(),
                 args: vec!["--flag".to_string()],
-                headers: HashMap::from([(
-                    "Authorization".to_string(),
-                    "Bearer token".to_string(),
-                )]),
+                headers: HashMap::from([("Authorization".to_string(), "Bearer token".to_string())]),
                 disabled: true,
             }),
         };
@@ -551,10 +555,7 @@ mod tests {
             transport: "http".to_string(),
             target: "https://api.githubcopilot.com/mcp/".to_string(),
             args: Vec::new(),
-            headers: HashMap::from([(
-                "Authorization".to_string(),
-                "Bearer static".to_string(),
-            )]),
+            headers: HashMap::from([("Authorization".to_string(), "Bearer static".to_string())]),
             disabled: false,
             namespace: Some("conic:wks:42".to_string()),
             binding_name: Some("github".to_string()),
@@ -740,11 +741,9 @@ mod tests {
             }),
         ))
         .await;
-        let invalid_json_addr = serve(Router::new().route(
-            "/broker",
-            post(|| async { (StatusCode::OK, "not-json") }),
-        ))
-        .await;
+        let invalid_json_addr =
+            serve(Router::new().route("/broker", post(|| async { (StatusCode::OK, "not-json") })))
+                .await;
         let empty_token_addr = serve(Router::new().route(
             "/broker",
             post(|| async {
@@ -800,7 +799,10 @@ mod tests {
             }),
             ..base_config.clone()
         };
-        let err = resolve_http_headers(&status_config).await.unwrap_err().to_string();
+        let err = resolve_http_headers(&status_config)
+            .await
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("returned 502 Bad Gateway"));
         assert!(err.contains("truncated"));
 
@@ -954,12 +956,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_authenticated_reqwest_client_get_stream_handles_method_not_allowed_and_bad_content_type()
-    {
+    async fn test_authenticated_reqwest_client_get_stream_handles_method_not_allowed_and_bad_content_type(
+    ) {
         let app = Router::new().route(
             "/mcp",
-            get(|| async { (StatusCode::OK, [(axum::http::header::CONTENT_TYPE, "text/plain")], "nope") })
-                .post(|| async { StatusCode::METHOD_NOT_ALLOWED }),
+            get(|| async {
+                (
+                    StatusCode::OK,
+                    [(axum::http::header::CONTENT_TYPE, "text/plain")],
+                    "nope",
+                )
+            })
+            .post(|| async { StatusCode::METHOD_NOT_ALLOWED }),
         );
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -985,17 +993,14 @@ mod tests {
             .post_message(uri, ping_message(), None, None, HashMap::new())
             .await
             .unwrap_err();
-        assert!(matches!(
-            method_not_allowed,
-            StreamableHttpError::Client(_)
-        ));
+        assert!(matches!(method_not_allowed, StreamableHttpError::Client(_)));
 
         server.abort();
     }
 
     #[tokio::test]
-    async fn test_authenticated_reqwest_client_get_stream_uses_custom_headers_last_event_id_and_auth_override()
-    {
+    async fn test_authenticated_reqwest_client_get_stream_uses_custom_headers_last_event_id_and_auth_override(
+    ) {
         let app = Router::new().route(
             "/mcp",
             get(|headers: HeaderMap| async move {
@@ -1056,8 +1061,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_authenticated_reqwest_client_get_stream_rejects_missing_content_type_and_method_not_allowed()
-    {
+    async fn test_authenticated_reqwest_client_get_stream_rejects_missing_content_type_and_method_not_allowed(
+    ) {
         let missing_content_type_app = Router::new().route(
             "/mcp",
             get(|| async {
@@ -1142,8 +1147,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_authenticated_reqwest_client_delete_session_honors_custom_headers_and_surfaces_errors()
-    {
+    async fn test_authenticated_reqwest_client_delete_session_honors_custom_headers_and_surfaces_errors(
+    ) {
         let app = Router::new().route(
             "/mcp",
             delete(|headers: HeaderMap| async move {
@@ -1215,7 +1220,10 @@ mod tests {
                 (
                     [
                         (axum::http::header::CONTENT_TYPE, "text/event-stream"),
-                        (axum::http::header::HeaderName::from_static("mcp-session-id"), "session-xyz"),
+                        (
+                            axum::http::header::HeaderName::from_static("mcp-session-id"),
+                            "session-xyz",
+                        ),
                     ],
                     "data: {\"jsonrpc\":\"2.0\",\"method\":\"ping\"}\n\n",
                 )
@@ -1258,7 +1266,10 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(matches!(json_response, StreamableHttpPostResponse::Json(_, _)));
+        assert!(matches!(
+            json_response,
+            StreamableHttpPostResponse::Json(_, _)
+        ));
 
         let sse_response = client
             .post_message(
@@ -1279,8 +1290,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_authenticated_reqwest_client_post_message_uses_headers_and_rejects_unexpected_content_type()
-    {
+    async fn test_authenticated_reqwest_client_post_message_uses_headers_and_rejects_unexpected_content_type(
+    ) {
         let app = Router::new().route(
             "/mcp",
             post(|headers: HeaderMap| async move {

--- a/src/control/keys.rs
+++ b/src/control/keys.rs
@@ -1,124 +1,285 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-/// Generates the standard KeyValue store path for an Agent
-/// e.g., "Agent/billing-bot-abc123"
-pub fn agent(id: &str) -> String {
-    format!("Agent/{}", id)
+use crate::control::ns;
+use anyhow::{anyhow, Result};
+
+const NS_PREFIX: &str = "@Namespace";
+const DIRECT_CHILD_SEP: &str = "@";
+
+fn enc(value: &str) -> String {
+    urlencoding::encode(value).into_owned()
 }
 
-/// Generates the standard KeyValue store path for an Agent Session
-/// e.g., "Agent/billing-bot-abc123/Session/XYZ"
-pub fn session(agent: &str, session_id: &str) -> String {
-    format!("Agent/{}/Session/{}", agent, session_id)
+fn dec(value: &str) -> Result<String> {
+    urlencoding::decode(value)
+        .map(|value| value.into_owned())
+        .map_err(|err| anyhow!("failed to decode key segment '{value}': {err}"))
 }
 
-/// Generates the standard KeyValue store path for searching an Agent's Sessions prefix
-pub fn session_prefix(agent: &str) -> String {
-    format!("Agent/{}/Session/", agent)
+fn pair(kind: &str, name: &str) -> String {
+    format!("{}/{}", kind, enc(name))
 }
 
-/// Generates the key for a single message inside a Session
-pub fn session_message(agent: &str, session_id: &str, message_id: &str) -> String {
-    format!(
-        "Agent/{}/Session/{}/Messages/{}",
-        agent, session_id, message_id
+fn path(pairs: &[(&str, &str)]) -> String {
+    pairs
+        .iter()
+        .map(|(kind, name)| pair(kind, name))
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn resource_key(
+    namespace: &str,
+    parent: &[(&str, &str)],
+    child_kind: &str,
+    child_name: &str,
+) -> String {
+    if parent.is_empty() {
+        format!(
+            "{}/{}/{}/{}",
+            NS_PREFIX,
+            namespace,
+            DIRECT_CHILD_SEP,
+            pair(child_kind, child_name)
+        )
+    } else {
+        format!(
+            "{}/{}/{}/{}/{}",
+            NS_PREFIX,
+            namespace,
+            path(parent),
+            DIRECT_CHILD_SEP,
+            pair(child_kind, child_name)
+        )
+    }
+}
+
+fn direct_child_prefix(
+    namespace: &str,
+    parent: &[(&str, &str)],
+    child_kind: Option<&str>,
+) -> String {
+    let base = if parent.is_empty() {
+        format!("{}/{}/{}/", NS_PREFIX, namespace, DIRECT_CHILD_SEP)
+    } else {
+        format!(
+            "{}/{}/{}/{}/",
+            NS_PREFIX,
+            namespace,
+            path(parent),
+            DIRECT_CHILD_SEP
+        )
+    };
+    match child_kind {
+        Some(kind) => format!("{base}{kind}/"),
+        None => base,
+    }
+}
+
+pub fn recursive_prefix(namespace: &str, parent: &[(&str, &str)]) -> String {
+    if parent.is_empty() {
+        format!("{}/{}/", NS_PREFIX, namespace)
+    } else {
+        format!("{}/{}/{}/", NS_PREFIX, namespace, path(parent))
+    }
+}
+
+pub fn direct_child_name(prefix: &str, key: &str) -> Option<String> {
+    let suffix = key.strip_prefix(prefix)?;
+    if suffix.is_empty() || suffix.contains('/') {
+        return None;
+    }
+    dec(suffix).ok()
+}
+
+pub fn namespace_metadata(name: &str) -> String {
+    resource_key(ns::TALON_SYSTEM, &[], "Namespace", name)
+}
+
+pub fn namespace_metadata_prefix() -> String {
+    direct_child_prefix(ns::TALON_SYSTEM, &[], Some("Namespace"))
+}
+
+pub fn namespace_ref(parent: Option<&str>, child_segment: &str) -> String {
+    let ref_namespace = parent.unwrap_or(ns::TALON_SYSTEM);
+    resource_key(ref_namespace, &[], "NamespaceRef", child_segment)
+}
+
+pub fn namespace_ref_prefix(parent: Option<&str>) -> String {
+    let ref_namespace = parent.unwrap_or(ns::TALON_SYSTEM);
+    direct_child_prefix(ref_namespace, &[], Some("NamespaceRef"))
+}
+
+pub fn agent(namespace: &str, id: &str) -> String {
+    resource_key(namespace, &[], "Agent", id)
+}
+
+pub fn agent_prefix(namespace: &str) -> String {
+    direct_child_prefix(namespace, &[], Some("Agent"))
+}
+
+pub fn session(namespace: &str, agent: &str, session_id: &str) -> String {
+    resource_key(namespace, &[("Agent", agent)], "Session", session_id)
+}
+
+pub fn session_prefix(namespace: &str, agent: &str) -> String {
+    direct_child_prefix(namespace, &[("Agent", agent)], Some("Session"))
+}
+
+pub fn session_message(namespace: &str, agent: &str, session_id: &str, message_id: &str) -> String {
+    resource_key(
+        namespace,
+        &[("Agent", agent), ("Session", session_id)],
+        "SessionMessage",
+        message_id,
     )
 }
 
-/// Generates the key prefix to list all messages safely sequentially sorted temporally
-pub fn session_message_prefix(agent: &str, session_id: &str) -> String {
-    format!("Agent/{}/Session/{}/Messages/", agent, session_id)
+pub fn session_message_prefix(namespace: &str, agent: &str, session_id: &str) -> String {
+    direct_child_prefix(
+        namespace,
+        &[("Agent", agent), ("Session", session_id)],
+        Some("SessionMessage"),
+    )
 }
 
-/// Generates the key for a single step inside a SessionMessage
 pub fn session_message_step(
+    namespace: &str,
     agent: &str,
     session_id: &str,
     message_id: &str,
     step_id: &str,
 ) -> String {
-    format!(
-        "Agent/{}/Session/{}/Messages/{}/Steps/{}",
-        agent, session_id, message_id, step_id
+    resource_key(
+        namespace,
+        &[
+            ("Agent", agent),
+            ("Session", session_id),
+            ("SessionMessage", message_id),
+        ],
+        "SessionStep",
+        step_id,
     )
 }
 
-/// Generates the key prefix to list all steps for a single message
-pub fn session_message_step_prefix(agent: &str, session_id: &str, message_id: &str) -> String {
-    format!(
-        "Agent/{}/Session/{}/Messages/{}/Steps/",
-        agent, session_id, message_id
+pub fn session_message_step_prefix(
+    namespace: &str,
+    agent: &str,
+    session_id: &str,
+    message_id: &str,
+) -> String {
+    direct_child_prefix(
+        namespace,
+        &[
+            ("Agent", agent),
+            ("Session", session_id),
+            ("SessionMessage", message_id),
+        ],
+        Some("SessionStep"),
     )
 }
 
-/// Generates the key for a schedule resource within a namespace.
-pub fn schedule(name: &str) -> String {
-    format!("Schedule/{}", name)
+pub fn schedule(namespace: &str, name: &str) -> String {
+    resource_key(namespace, &[], "Schedule", name)
 }
 
-/// Prefix used to list all schedule resources in a namespace.
-pub fn schedule_prefix() -> &'static str {
-    "Schedule/"
+pub fn schedule_prefix(namespace: &str) -> String {
+    direct_child_prefix(namespace, &[], Some("Schedule"))
 }
 
-/// Generates the standard KeyValue store path for an AgentTemplate
-/// e.g., "AgentTemplate/customer-service"
 pub fn agent_template(name: &str) -> String {
-    format!("AgentTemplate/{}", name)
+    resource_key(ns::TALON_SYSTEM, &[], "AgentTemplate", name)
 }
 
-/// Generates the key for an MCP server resource.
+pub fn agent_template_prefix() -> String {
+    direct_child_prefix(ns::TALON_SYSTEM, &[], Some("AgentTemplate"))
+}
+
 pub fn mcp_server(name: &str) -> String {
-    format!("McpServer/{}", name)
+    resource_key(ns::TALON_SYSTEM, &[], "MCPServer", name)
 }
 
-/// Generates the prefix used to list MCP server resources in a namespace.
-pub fn mcp_server_prefix() -> &'static str {
-    "McpServer/"
+pub fn mcp_server_prefix() -> String {
+    direct_child_prefix(ns::TALON_SYSTEM, &[], Some("MCPServer"))
 }
 
-/// Generates the key for an MCP server binding resource in a namespace.
-pub fn mcp_server_binding(name: &str) -> String {
-    format!("McpServerBinding/{}", name)
+pub fn mcp_server_binding(namespace: &str, name: &str) -> String {
+    resource_key(namespace, &[], "MCPServerBinding", name)
 }
 
-/// Generates the prefix used to list MCP server bindings in a namespace.
-pub fn mcp_server_binding_prefix() -> &'static str {
-    "McpServerBinding/"
+pub fn mcp_server_binding_prefix(namespace: &str) -> String {
+    direct_child_prefix(namespace, &[], Some("MCPServerBinding"))
 }
 
-/// Generates the key for a memory file in an agent's storage
-/// e.g. "Agent/seo-agent/Memory/goals.md"
-pub fn agent_memory(agent: &str, path: &str) -> String {
-    format!("Agent/{}/Memory/{}", agent, path)
+pub fn agent_memory(namespace: &str, agent: &str, path: &str) -> String {
+    resource_key(namespace, &[("Agent", agent)], "Memory", path)
 }
 
-/// Generates the key prefix to list all memory files for an agent
-/// e.g. "Agent/seo-agent/Memory/"
-pub fn agent_memory_prefix(agent: &str) -> String {
-    format!("Agent/{}/Memory/", agent)
+pub fn agent_memory_prefix(namespace: &str, agent: &str) -> String {
+    direct_child_prefix(namespace, &[("Agent", agent)], Some("Memory"))
 }
 
-/// Key for a KnowledgeBook artifact within a namespace.
-/// Usage: kv.get(ns, &keys::knowledge(path))
-/// e.g.   kv.get("acme-corp", &keys::knowledge("seo/best-practices.md"))
-///        => full logical path: acme-corp / Knowledge/seo/best-practices.md
-pub fn knowledge(path: &str) -> String {
-    format!("Knowledge/{}", path)
+pub fn knowledge(namespace: &str, path: &str) -> String {
+    resource_key(namespace, &[], "Knowledge", path)
 }
 
-/// Prefix to list all KnowledgeBook artifacts for a namespace.
-pub fn knowledge_prefix() -> &'static str {
-    "Knowledge/"
+pub fn knowledge_prefix(namespace: &str) -> String {
+    direct_child_prefix(namespace, &[], Some("Knowledge"))
 }
 
-/// Generates the key for a manifest-managed knowledge resource in a namespace.
-pub fn knowledge_resource(name: &str) -> String {
-    format!("KnowledgeResource/{}", name)
+pub fn knowledge_resource(namespace: &str, name: &str) -> String {
+    resource_key(namespace, &[], "KnowledgeResource", name)
 }
 
-/// Prefix used to list manifest-managed knowledge resources in a namespace.
-pub fn knowledge_resource_prefix() -> &'static str {
-    "KnowledgeResource/"
+pub fn knowledge_resource_prefix(namespace: &str) -> String {
+    direct_child_prefix(namespace, &[], Some("KnowledgeResource"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_keys_place_separator_before_leaf() {
+        assert_eq!(
+            agent("Impala:Talon", "hello-agent"),
+            "@Namespace/Impala:Talon/@/Agent/hello-agent"
+        );
+        assert_eq!(
+            session("Impala:Talon", "hello-agent", "session-id"),
+            "@Namespace/Impala:Talon/Agent/hello-agent/@/Session/session-id"
+        );
+        assert_eq!(
+            session_message("Impala:Talon", "hello-agent", "session-id", "message-id"),
+            "@Namespace/Impala:Talon/Agent/hello-agent/Session/session-id/@/SessionMessage/message-id"
+        );
+    }
+
+    #[test]
+    fn prefixes_distinguish_direct_and_recursive_listing() {
+        assert_eq!(
+            session_prefix("Impala:Talon", "hello-agent"),
+            "@Namespace/Impala:Talon/Agent/hello-agent/@/Session/"
+        );
+        assert_eq!(
+            recursive_prefix("Impala:Talon", &[("Agent", "hello-agent")]),
+            "@Namespace/Impala:Talon/Agent/hello-agent/"
+        );
+    }
+
+    #[test]
+    fn names_are_encoded_per_resource_segment() {
+        assert_eq!(
+            knowledge("quickstart", "docs/hello world.md"),
+            "@Namespace/quickstart/@/Knowledge/docs%2Fhello%20world.md"
+        );
+        assert_eq!(
+            direct_child_name(
+                &knowledge_prefix("quickstart"),
+                &knowledge("quickstart", "docs/hello world.md")
+            ),
+            Some("docs/hello world.md".to_string())
+        );
+    }
 }

--- a/src/control/keys.rs
+++ b/src/control/keys.rs
@@ -2,10 +2,184 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use crate::control::ns;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
+use std::fmt;
 
 const NS_PREFIX: &str = "@Namespace";
 const DIRECT_CHILD_SEP: &str = "@";
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ResourceSegment {
+    pub kind: String,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ResourceParent {
+    pub namespace: String,
+    pub parent_path: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ResourceKey {
+    pub namespace: String,
+    pub parent_path: String,
+    pub kind: String,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ResourceList {
+    pub parent: ResourceParent,
+    pub kind: Option<String>,
+}
+
+impl ResourceSegment {
+    pub fn new(kind: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            name: name.into(),
+        }
+    }
+}
+
+impl ResourceParent {
+    pub fn root(namespace: impl Into<String>) -> Self {
+        Self {
+            namespace: namespace.into(),
+            parent_path: String::new(),
+        }
+    }
+
+    pub fn child(&self, kind: &str, name: &str) -> Self {
+        let segment = pair(kind, name);
+        let parent_path = if self.parent_path.is_empty() {
+            segment
+        } else {
+            format!("{}/{}", self.parent_path, segment)
+        };
+        Self {
+            namespace: self.namespace.clone(),
+            parent_path,
+        }
+    }
+
+    pub fn list(&self, kind: Option<&str>) -> ResourceList {
+        ResourceList {
+            parent: self.clone(),
+            kind: kind.map(str::to_string),
+        }
+    }
+}
+
+impl ResourceKey {
+    pub fn new(namespace: &str, parent: &[(&str, &str)], kind: &str, name: &str) -> Self {
+        Self {
+            namespace: namespace.to_string(),
+            parent_path: path(parent),
+            kind: kind.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    pub fn as_parent(&self) -> ResourceParent {
+        ResourceParent {
+            namespace: self.namespace.clone(),
+            parent_path: if self.parent_path.is_empty() {
+                pair(&self.kind, &self.name)
+            } else {
+                format!("{}/{}", self.parent_path, pair(&self.kind, &self.name))
+            },
+        }
+    }
+
+    pub fn canonical(&self) -> String {
+        if self.parent_path.is_empty() {
+            format!(
+                "{}/{}/{}/{}",
+                NS_PREFIX,
+                self.namespace,
+                DIRECT_CHILD_SEP,
+                pair(&self.kind, &self.name)
+            )
+        } else {
+            format!(
+                "{}/{}/{}/{}/{}",
+                NS_PREFIX,
+                self.namespace,
+                self.parent_path,
+                DIRECT_CHILD_SEP,
+                pair(&self.kind, &self.name)
+            )
+        }
+    }
+
+    pub fn parse_canonical(key: &str) -> Result<Self> {
+        let rest = key
+            .strip_prefix(&format!("{NS_PREFIX}/"))
+            .ok_or_else(|| anyhow!("key does not start with {NS_PREFIX}: {key}"))?;
+        let (namespace, rest) = rest
+            .split_once('/')
+            .ok_or_else(|| anyhow!("key is missing namespace separator: {key}"))?;
+        let (parent_path, leaf) =
+            if let Some(leaf) = rest.strip_prefix(&format!("{DIRECT_CHILD_SEP}/")) {
+                ("", leaf)
+            } else {
+                let sep = format!("/{DIRECT_CHILD_SEP}/");
+                rest.split_once(&sep)
+                    .ok_or_else(|| anyhow!("key is missing direct-child separator: {key}"))?
+            };
+        let segments = parse_path(leaf)?;
+        if segments.len() != 1 {
+            bail!("key leaf must contain exactly one kind/name segment: {key}");
+        }
+        let leaf = &segments[0];
+        Ok(Self {
+            namespace: namespace.to_string(),
+            parent_path: parent_path.to_string(),
+            kind: leaf.kind.clone(),
+            name: leaf.name.clone(),
+        })
+    }
+}
+
+impl ResourceList {
+    pub fn matches(&self, key: &ResourceKey) -> bool {
+        key.namespace == self.parent.namespace
+            && key.parent_path == self.parent.parent_path
+            && self.kind.as_ref().map_or(true, |kind| key.kind == *kind)
+    }
+
+    pub fn canonical_prefix(&self) -> String {
+        let base = if self.parent.parent_path.is_empty() {
+            format!(
+                "{}/{}/{}/",
+                NS_PREFIX, self.parent.namespace, DIRECT_CHILD_SEP
+            )
+        } else {
+            format!(
+                "{}/{}/{}/{}/",
+                NS_PREFIX, self.parent.namespace, self.parent.parent_path, DIRECT_CHILD_SEP
+            )
+        };
+        match self.kind.as_deref() {
+            Some(kind) => format!("{base}{kind}/"),
+            None => base,
+        }
+    }
+}
+
+impl fmt::Display for ResourceKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.canonical())
+    }
+}
+
+impl fmt::Display for ResourceList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.canonical_prefix())
+    }
+}
 
 fn enc(value: &str) -> String {
     urlencoding::encode(value).into_owned()
@@ -29,105 +203,91 @@ fn path(pairs: &[(&str, &str)]) -> String {
         .join("/")
 }
 
+fn parse_path(path: &str) -> Result<Vec<ResourceSegment>> {
+    if path.is_empty() {
+        return Ok(Vec::new());
+    }
+    let parts = path.split('/').collect::<Vec<_>>();
+    let chunks = parts.chunks_exact(2);
+    if !chunks.remainder().is_empty() {
+        bail!("resource path must contain kind/name pairs: {path}");
+    }
+    chunks
+        .map(|chunk| Ok(ResourceSegment::new(chunk[0], dec(chunk[1])?)))
+        .collect()
+}
+
 fn resource_key(
     namespace: &str,
     parent: &[(&str, &str)],
     child_kind: &str,
     child_name: &str,
-) -> String {
-    if parent.is_empty() {
-        format!(
-            "{}/{}/{}/{}",
-            NS_PREFIX,
-            namespace,
-            DIRECT_CHILD_SEP,
-            pair(child_kind, child_name)
-        )
-    } else {
-        format!(
-            "{}/{}/{}/{}/{}",
-            NS_PREFIX,
-            namespace,
-            path(parent),
-            DIRECT_CHILD_SEP,
-            pair(child_kind, child_name)
-        )
-    }
+) -> ResourceKey {
+    ResourceKey::new(namespace, parent, child_kind, child_name)
 }
 
 fn direct_child_prefix(
     namespace: &str,
     parent: &[(&str, &str)],
     child_kind: Option<&str>,
-) -> String {
-    let base = if parent.is_empty() {
-        format!("{}/{}/{}/", NS_PREFIX, namespace, DIRECT_CHILD_SEP)
-    } else {
-        format!(
-            "{}/{}/{}/{}/",
-            NS_PREFIX,
-            namespace,
-            path(parent),
-            DIRECT_CHILD_SEP
-        )
-    };
-    match child_kind {
-        Some(kind) => format!("{base}{kind}/"),
-        None => base,
+) -> ResourceList {
+    ResourceList {
+        parent: ResourceParent {
+            namespace: namespace.to_string(),
+            parent_path: path(parent),
+        },
+        kind: child_kind.map(str::to_string),
     }
 }
 
-pub fn recursive_prefix(namespace: &str, parent: &[(&str, &str)]) -> String {
-    if parent.is_empty() {
-        format!("{}/{}/", NS_PREFIX, namespace)
-    } else {
-        format!("{}/{}/{}/", NS_PREFIX, namespace, path(parent))
-    }
+pub fn direct_child_name(prefix: &ResourceList, key: &ResourceKey) -> Option<String> {
+    prefix.matches(key).then(|| key.name.clone())
 }
 
-pub fn direct_child_name(prefix: &str, key: &str) -> Option<String> {
-    let suffix = key.strip_prefix(prefix)?;
-    if suffix.is_empty() || suffix.contains('/') {
-        return None;
-    }
-    dec(suffix).ok()
-}
-
-pub fn namespace_metadata(name: &str) -> String {
+pub fn namespace_metadata(name: &str) -> ResourceKey {
     resource_key(ns::TALON_SYSTEM, &[], "Namespace", name)
 }
 
-pub fn namespace_metadata_prefix() -> String {
+pub fn namespace_metadata_prefix() -> ResourceList {
     direct_child_prefix(ns::TALON_SYSTEM, &[], Some("Namespace"))
 }
 
-pub fn namespace_ref(parent: Option<&str>, child_segment: &str) -> String {
+pub fn namespace_ref(parent: Option<&str>, child_segment: &str) -> ResourceKey {
     let ref_namespace = parent.unwrap_or(ns::TALON_SYSTEM);
     resource_key(ref_namespace, &[], "NamespaceRef", child_segment)
 }
 
-pub fn namespace_ref_prefix(parent: Option<&str>) -> String {
+pub fn namespace_ref_prefix(parent: Option<&str>) -> ResourceList {
     let ref_namespace = parent.unwrap_or(ns::TALON_SYSTEM);
     direct_child_prefix(ref_namespace, &[], Some("NamespaceRef"))
 }
 
-pub fn agent(namespace: &str, id: &str) -> String {
+pub fn agent(namespace: &str, id: &str) -> ResourceKey {
     resource_key(namespace, &[], "Agent", id)
 }
 
-pub fn agent_prefix(namespace: &str) -> String {
+pub fn agent_prefix(namespace: &str) -> ResourceList {
     direct_child_prefix(namespace, &[], Some("Agent"))
 }
 
-pub fn session(namespace: &str, agent: &str, session_id: &str) -> String {
+pub fn session(namespace: &str, agent: &str, session_id: &str) -> ResourceKey {
     resource_key(namespace, &[("Agent", agent)], "Session", session_id)
 }
 
-pub fn session_prefix(namespace: &str, agent: &str) -> String {
+pub fn session_parent(namespace: &str, agent: &str, session_id: &str) -> ResourceParent {
+    session(namespace, agent, session_id).as_parent()
+}
+
+pub fn session_prefix(namespace: &str, agent: &str) -> ResourceList {
     direct_child_prefix(namespace, &[("Agent", agent)], Some("Session"))
 }
 
-pub fn session_message(namespace: &str, agent: &str, session_id: &str, message_id: &str) -> String {
+pub fn session_message(
+    namespace: &str,
+    agent: &str,
+    session_id: &str,
+    message_id: &str,
+) -> ResourceKey {
     resource_key(
         namespace,
         &[("Agent", agent), ("Session", session_id)],
@@ -136,7 +296,16 @@ pub fn session_message(namespace: &str, agent: &str, session_id: &str, message_i
     )
 }
 
-pub fn session_message_prefix(namespace: &str, agent: &str, session_id: &str) -> String {
+pub fn session_message_parent(
+    namespace: &str,
+    agent: &str,
+    session_id: &str,
+    message_id: &str,
+) -> ResourceParent {
+    session_message(namespace, agent, session_id, message_id).as_parent()
+}
+
+pub fn session_message_prefix(namespace: &str, agent: &str, session_id: &str) -> ResourceList {
     direct_child_prefix(
         namespace,
         &[("Agent", agent), ("Session", session_id)],
@@ -150,7 +319,7 @@ pub fn session_message_step(
     session_id: &str,
     message_id: &str,
     step_id: &str,
-) -> String {
+) -> ResourceKey {
     resource_key(
         namespace,
         &[
@@ -168,7 +337,7 @@ pub fn session_message_step_prefix(
     agent: &str,
     session_id: &str,
     message_id: &str,
-) -> String {
+) -> ResourceList {
     direct_child_prefix(
         namespace,
         &[
@@ -180,59 +349,59 @@ pub fn session_message_step_prefix(
     )
 }
 
-pub fn schedule(namespace: &str, name: &str) -> String {
+pub fn schedule(namespace: &str, name: &str) -> ResourceKey {
     resource_key(namespace, &[], "Schedule", name)
 }
 
-pub fn schedule_prefix(namespace: &str) -> String {
+pub fn schedule_prefix(namespace: &str) -> ResourceList {
     direct_child_prefix(namespace, &[], Some("Schedule"))
 }
 
-pub fn agent_template(name: &str) -> String {
+pub fn agent_template(name: &str) -> ResourceKey {
     resource_key(ns::TALON_SYSTEM, &[], "AgentTemplate", name)
 }
 
-pub fn agent_template_prefix() -> String {
+pub fn agent_template_prefix() -> ResourceList {
     direct_child_prefix(ns::TALON_SYSTEM, &[], Some("AgentTemplate"))
 }
 
-pub fn mcp_server(name: &str) -> String {
+pub fn mcp_server(name: &str) -> ResourceKey {
     resource_key(ns::TALON_SYSTEM, &[], "MCPServer", name)
 }
 
-pub fn mcp_server_prefix() -> String {
+pub fn mcp_server_prefix() -> ResourceList {
     direct_child_prefix(ns::TALON_SYSTEM, &[], Some("MCPServer"))
 }
 
-pub fn mcp_server_binding(namespace: &str, name: &str) -> String {
+pub fn mcp_server_binding(namespace: &str, name: &str) -> ResourceKey {
     resource_key(namespace, &[], "MCPServerBinding", name)
 }
 
-pub fn mcp_server_binding_prefix(namespace: &str) -> String {
+pub fn mcp_server_binding_prefix(namespace: &str) -> ResourceList {
     direct_child_prefix(namespace, &[], Some("MCPServerBinding"))
 }
 
-pub fn agent_memory(namespace: &str, agent: &str, path: &str) -> String {
+pub fn agent_memory(namespace: &str, agent: &str, path: &str) -> ResourceKey {
     resource_key(namespace, &[("Agent", agent)], "Memory", path)
 }
 
-pub fn agent_memory_prefix(namespace: &str, agent: &str) -> String {
+pub fn agent_memory_prefix(namespace: &str, agent: &str) -> ResourceList {
     direct_child_prefix(namespace, &[("Agent", agent)], Some("Memory"))
 }
 
-pub fn knowledge(namespace: &str, path: &str) -> String {
+pub fn knowledge(namespace: &str, path: &str) -> ResourceKey {
     resource_key(namespace, &[], "Knowledge", path)
 }
 
-pub fn knowledge_prefix(namespace: &str) -> String {
+pub fn knowledge_prefix(namespace: &str) -> ResourceList {
     direct_child_prefix(namespace, &[], Some("Knowledge"))
 }
 
-pub fn knowledge_resource(namespace: &str, name: &str) -> String {
+pub fn knowledge_resource(namespace: &str, name: &str) -> ResourceKey {
     resource_key(namespace, &[], "KnowledgeResource", name)
 }
 
-pub fn knowledge_resource_prefix(namespace: &str) -> String {
+pub fn knowledge_resource_prefix(namespace: &str) -> ResourceList {
     direct_child_prefix(namespace, &[], Some("KnowledgeResource"))
 }
 
@@ -243,15 +412,16 @@ mod tests {
     #[test]
     fn resource_keys_place_separator_before_leaf() {
         assert_eq!(
-            agent("Impala:Talon", "hello-agent"),
+            agent("Impala:Talon", "hello-agent").canonical(),
             "@Namespace/Impala:Talon/@/Agent/hello-agent"
         );
         assert_eq!(
-            session("Impala:Talon", "hello-agent", "session-id"),
+            session("Impala:Talon", "hello-agent", "session-id").canonical(),
             "@Namespace/Impala:Talon/Agent/hello-agent/@/Session/session-id"
         );
         assert_eq!(
-            session_message("Impala:Talon", "hello-agent", "session-id", "message-id"),
+            session_message("Impala:Talon", "hello-agent", "session-id", "message-id")
+                .canonical(),
             "@Namespace/Impala:Talon/Agent/hello-agent/Session/session-id/@/SessionMessage/message-id"
         );
     }
@@ -259,19 +429,21 @@ mod tests {
     #[test]
     fn prefixes_distinguish_direct_and_recursive_listing() {
         assert_eq!(
-            session_prefix("Impala:Talon", "hello-agent"),
+            session_prefix("Impala:Talon", "hello-agent").canonical_prefix(),
             "@Namespace/Impala:Talon/Agent/hello-agent/@/Session/"
         );
         assert_eq!(
-            recursive_prefix("Impala:Talon", &[("Agent", "hello-agent")]),
-            "@Namespace/Impala:Talon/Agent/hello-agent/"
+            session("Impala:Talon", "hello-agent", "session-id")
+                .as_parent()
+                .parent_path,
+            "Agent/hello-agent/Session/session-id"
         );
     }
 
     #[test]
     fn names_are_encoded_per_resource_segment() {
         assert_eq!(
-            knowledge("quickstart", "docs/hello world.md"),
+            knowledge("quickstart", "docs/hello world.md").canonical(),
             "@Namespace/quickstart/@/Knowledge/docs%2Fhello%20world.md"
         );
         assert_eq!(
@@ -280,6 +452,22 @@ mod tests {
                 &knowledge("quickstart", "docs/hello world.md")
             ),
             Some("docs/hello world.md".to_string())
+        );
+    }
+
+    #[test]
+    fn canonical_keys_parse_into_structured_columns() {
+        let key = ResourceKey::parse_canonical(
+            "@Namespace/quickstart/Agent/hello-agent/Session/s/@/SessionMessage/m%2F1",
+        )
+        .unwrap();
+        assert_eq!(key.namespace, "quickstart");
+        assert_eq!(key.parent_path, "Agent/hello-agent/Session/s");
+        assert_eq!(key.kind, "SessionMessage");
+        assert_eq!(key.name, "m/1");
+        assert_eq!(
+            key.canonical(),
+            "@Namespace/quickstart/Agent/hello-agent/Session/s/@/SessionMessage/m%2F1"
         );
     }
 }

--- a/src/control/kv/legacy.rs
+++ b/src/control/kv/legacy.rs
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use anyhow::{anyhow, Result};
+
+use crate::control::keys;
+
+pub(super) fn namespaced_key(namespace: &str, key: &str) -> Result<String> {
+    let namespace = match namespace {
+        "talon-system:ns" => "Sys:ns",
+        "talon-system:ns:internal" => "Sys:ns:internal",
+        namespace => namespace,
+    };
+
+    if namespace == "Sys:ns" {
+        let name = key
+            .strip_prefix("Namespace/")
+            .ok_or_else(|| anyhow!("unknown legacy namespace metadata key '{key}'"))?;
+        return Ok(keys::namespace_metadata(name));
+    }
+
+    if namespace == "Sys:ns:internal" {
+        let child = key
+            .strip_prefix("NamespaceRef/")
+            .ok_or_else(|| anyhow!("unknown legacy root namespace edge key '{key}'"))?;
+        return Ok(keys::namespace_ref(None, child));
+    }
+
+    if let Some(parent) = namespace.strip_suffix(":ns:internal") {
+        let full_child = key
+            .strip_prefix("NamespaceRef/")
+            .ok_or_else(|| anyhow!("unknown legacy namespace edge key '{key}'"))?;
+        let child = full_child.rsplit(':').next().unwrap_or(full_child);
+        return Ok(keys::namespace_ref(Some(parent), child));
+    }
+
+    let parts = key.split('/').collect::<Vec<_>>();
+    match parts.as_slice() {
+        ["Agent", agent_name] => Ok(keys::agent(namespace, agent_name)),
+        ["Agent", agent_name, "Session", session_id] => {
+            Ok(keys::session(namespace, agent_name, session_id))
+        }
+        ["Agent", agent_name, "Session", session_id, "Messages", message] => Ok(
+            keys::session_message(namespace, agent_name, session_id, message),
+        ),
+        ["Agent", agent_name, "Session", session_id, "Messages", message, "Steps", step] => Ok(
+            keys::session_message_step(namespace, agent_name, session_id, message, step),
+        ),
+        ["Schedule", name] => Ok(keys::schedule(namespace, name)),
+        ["AgentTemplate", name] => Ok(keys::agent_template(name)),
+        ["McpServer", name] => Ok(keys::mcp_server(name)),
+        ["McpServerBinding", name] => Ok(keys::mcp_server_binding(namespace, name)),
+        ["KnowledgeResource", name] => Ok(keys::knowledge_resource(namespace, name)),
+        ["Agent", agent, "Memory", rest @ ..] if !rest.is_empty() => {
+            Ok(keys::agent_memory(namespace, agent, &rest.join("/")))
+        }
+        ["Knowledge", rest @ ..] if !rest.is_empty() => {
+            Ok(keys::knowledge(namespace, &rest.join("/")))
+        }
+        _ => Err(anyhow!(
+            "unknown legacy key shape namespace='{namespace}' key='{key}'"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::namespaced_key;
+
+    #[test]
+    fn legacy_keys_convert_to_ordered_keys() {
+        assert_eq!(
+            namespaced_key("acme", "Agent/agent-1/Session/s1/Messages/m1").unwrap(),
+            crate::control::keys::session_message("acme", "agent-1", "s1", "m1")
+        );
+        assert_eq!(
+            namespaced_key("Sys:ns", "Namespace/acme:team").unwrap(),
+            crate::control::keys::namespace_metadata("acme:team")
+        );
+        assert_eq!(
+            namespaced_key("acme:ns:internal", "NamespaceRef/acme:team").unwrap(),
+            crate::control::keys::namespace_ref(Some("acme"), "team")
+        );
+        assert_eq!(
+            namespaced_key("talon-system:ns", "Namespace/quickstart").unwrap(),
+            crate::control::keys::namespace_metadata("quickstart")
+        );
+        assert_eq!(
+            namespaced_key("talon-system:ns:internal", "NamespaceRef/quickstart").unwrap(),
+            crate::control::keys::namespace_ref(None, "quickstart")
+        );
+    }
+}

--- a/src/control/kv/legacy.rs
+++ b/src/control/kv/legacy.rs
@@ -16,14 +16,14 @@ pub(super) fn namespaced_key(namespace: &str, key: &str) -> Result<String> {
         let name = key
             .strip_prefix("Namespace/")
             .ok_or_else(|| anyhow!("unknown legacy namespace metadata key '{key}'"))?;
-        return Ok(keys::namespace_metadata(name));
+        return Ok(keys::namespace_metadata(name).canonical());
     }
 
     if namespace == "Sys:ns:internal" {
         let child = key
             .strip_prefix("NamespaceRef/")
             .ok_or_else(|| anyhow!("unknown legacy root namespace edge key '{key}'"))?;
-        return Ok(keys::namespace_ref(None, child));
+        return Ok(keys::namespace_ref(None, child).canonical());
     }
 
     if let Some(parent) = namespace.strip_suffix(":ns:internal") {
@@ -31,31 +31,32 @@ pub(super) fn namespaced_key(namespace: &str, key: &str) -> Result<String> {
             .strip_prefix("NamespaceRef/")
             .ok_or_else(|| anyhow!("unknown legacy namespace edge key '{key}'"))?;
         let child = full_child.rsplit(':').next().unwrap_or(full_child);
-        return Ok(keys::namespace_ref(Some(parent), child));
+        return Ok(keys::namespace_ref(Some(parent), child).canonical());
     }
 
     let parts = key.split('/').collect::<Vec<_>>();
     match parts.as_slice() {
-        ["Agent", agent_name] => Ok(keys::agent(namespace, agent_name)),
+        ["Agent", agent_name] => Ok(keys::agent(namespace, agent_name).canonical()),
         ["Agent", agent_name, "Session", session_id] => {
-            Ok(keys::session(namespace, agent_name, session_id))
+            Ok(keys::session(namespace, agent_name, session_id).canonical())
         }
-        ["Agent", agent_name, "Session", session_id, "Messages", message] => Ok(
-            keys::session_message(namespace, agent_name, session_id, message),
-        ),
+        ["Agent", agent_name, "Session", session_id, "Messages", message] => {
+            Ok(keys::session_message(namespace, agent_name, session_id, message).canonical())
+        }
         ["Agent", agent_name, "Session", session_id, "Messages", message, "Steps", step] => Ok(
-            keys::session_message_step(namespace, agent_name, session_id, message, step),
+            keys::session_message_step(namespace, agent_name, session_id, message, step)
+                .canonical(),
         ),
-        ["Schedule", name] => Ok(keys::schedule(namespace, name)),
-        ["AgentTemplate", name] => Ok(keys::agent_template(name)),
-        ["McpServer", name] => Ok(keys::mcp_server(name)),
-        ["McpServerBinding", name] => Ok(keys::mcp_server_binding(namespace, name)),
-        ["KnowledgeResource", name] => Ok(keys::knowledge_resource(namespace, name)),
+        ["Schedule", name] => Ok(keys::schedule(namespace, name).canonical()),
+        ["AgentTemplate", name] => Ok(keys::agent_template(name).canonical()),
+        ["McpServer", name] => Ok(keys::mcp_server(name).canonical()),
+        ["McpServerBinding", name] => Ok(keys::mcp_server_binding(namespace, name).canonical()),
+        ["KnowledgeResource", name] => Ok(keys::knowledge_resource(namespace, name).canonical()),
         ["Agent", agent, "Memory", rest @ ..] if !rest.is_empty() => {
-            Ok(keys::agent_memory(namespace, agent, &rest.join("/")))
+            Ok(keys::agent_memory(namespace, agent, &rest.join("/")).canonical())
         }
         ["Knowledge", rest @ ..] if !rest.is_empty() => {
-            Ok(keys::knowledge(namespace, &rest.join("/")))
+            Ok(keys::knowledge(namespace, &rest.join("/")).canonical())
         }
         _ => Err(anyhow!(
             "unknown legacy key shape namespace='{namespace}' key='{key}'"
@@ -71,23 +72,23 @@ mod tests {
     fn legacy_keys_convert_to_ordered_keys() {
         assert_eq!(
             namespaced_key("acme", "Agent/agent-1/Session/s1/Messages/m1").unwrap(),
-            crate::control::keys::session_message("acme", "agent-1", "s1", "m1")
+            crate::control::keys::session_message("acme", "agent-1", "s1", "m1").canonical()
         );
         assert_eq!(
             namespaced_key("Sys:ns", "Namespace/acme:team").unwrap(),
-            crate::control::keys::namespace_metadata("acme:team")
+            crate::control::keys::namespace_metadata("acme:team").canonical()
         );
         assert_eq!(
             namespaced_key("acme:ns:internal", "NamespaceRef/acme:team").unwrap(),
-            crate::control::keys::namespace_ref(Some("acme"), "team")
+            crate::control::keys::namespace_ref(Some("acme"), "team").canonical()
         );
         assert_eq!(
             namespaced_key("talon-system:ns", "Namespace/quickstart").unwrap(),
-            crate::control::keys::namespace_metadata("quickstart")
+            crate::control::keys::namespace_metadata("quickstart").canonical()
         );
         assert_eq!(
             namespaced_key("talon-system:ns:internal", "NamespaceRef/quickstart").unwrap(),
-            crate::control::keys::namespace_ref(None, "quickstart")
+            crate::control::keys::namespace_ref(None, "quickstart").canonical()
         );
     }
 }

--- a/src/control/kv/mod.rs
+++ b/src/control/kv/mod.rs
@@ -1,11 +1,12 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
+mod legacy;
 mod postgres;
 mod shared;
 mod sqlite;
 
 pub use postgres::PostgresKvStore;
-pub(crate) use shared::validate_identifier;
 pub use shared::sqlite_url_for_path;
+pub(crate) use shared::validate_identifier;
 pub use sqlite::SqliteKvStore;

--- a/src/control/kv/postgres.rs
+++ b/src/control/kv/postgres.rs
@@ -11,10 +11,9 @@ fn create_table_statement(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
         "CREATE TABLE IF NOT EXISTS {} (
-                namespace VARCHAR(255) NOT NULL,
-                key VARCHAR(255) NOT NULL,
+                key TEXT NOT NULL,
                 value BYTEA NOT NULL,
-                PRIMARY KEY (namespace, key)
+                PRIMARY KEY (key)
             )",
         table
     )
@@ -22,7 +21,7 @@ fn create_table_statement(table: &str) -> String {
 
 fn get_query(table: &str) -> String {
     format!(
-        "SELECT value FROM {} WHERE namespace = $1 AND key = $2",
+        "SELECT value FROM {} WHERE key = $1",
         quoted_identifier(table)
     )
 }
@@ -30,8 +29,8 @@ fn get_query(table: &str) -> String {
 fn set_query(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
-        "INSERT INTO {} (namespace, key, value) VALUES ($1, $2, $3) 
-             ON CONFLICT (namespace, key) DO UPDATE SET value = $3",
+        "INSERT INTO {} (key, value) VALUES ($1, $2)
+             ON CONFLICT (key) DO UPDATE SET value = $2",
         table
     )
 }
@@ -41,35 +40,32 @@ fn compare_and_swap_query(table: &str, expected: bool) -> String {
     if expected {
         format!(
             "UPDATE {} SET value = $3
-                 WHERE namespace = $1 AND key = $2 AND value = $4",
+                 WHERE key = $1 AND value = $2",
             table
         )
     } else {
         format!(
-            "INSERT INTO {} (namespace, key, value) VALUES ($1, $2, $3)
-                 ON CONFLICT (namespace, key) DO NOTHING",
+            "INSERT INTO {} (key, value) VALUES ($1, $2)
+                 ON CONFLICT (key) DO NOTHING",
             table
         )
     }
 }
 
 fn delete_query(table: &str) -> String {
-    format!(
-        "DELETE FROM {} WHERE namespace = $1 AND key = $2",
-        quoted_identifier(table)
-    )
+    format!("DELETE FROM {} WHERE key = $1", quoted_identifier(table))
 }
 
 fn list_keys_query(table: &str) -> String {
     format!(
-        "SELECT key FROM {} WHERE namespace = $1 AND key LIKE $2 ESCAPE '\\'",
+        "SELECT key FROM {} WHERE key LIKE $1 ESCAPE '\\'",
         quoted_identifier(table)
     )
 }
 
 fn list_entries_query(table: &str) -> String {
     format!(
-        "SELECT key, value FROM {} WHERE namespace = $1 AND key LIKE $2 ESCAPE '\\'",
+        "SELECT key, value FROM {} WHERE key LIKE $1 ESCAPE '\\'",
         quoted_identifier(table)
     )
 }
@@ -77,11 +73,10 @@ fn list_entries_query(table: &str) -> String {
 fn list_keys_page_query(table: &str) -> String {
     format!(
         "SELECT key FROM {}
-         WHERE namespace = $1
-           AND key LIKE $2 ESCAPE '\\'
-           AND ($3 IS NULL OR key < $3)
+         WHERE key LIKE $1 ESCAPE '\\'
+           AND ($2 IS NULL OR key < $2)
          ORDER BY key DESC
-         LIMIT $4",
+         LIMIT $3",
         quoted_identifier(table)
     )
 }
@@ -89,20 +84,105 @@ fn list_keys_page_query(table: &str) -> String {
 fn list_entries_page_query(table: &str) -> String {
     format!(
         "SELECT key, value FROM {}
-         WHERE namespace = $1
-           AND key LIKE $2 ESCAPE '\\'
-           AND ($3 IS NULL OR key < $3)
+         WHERE key LIKE $1 ESCAPE '\\'
+           AND ($2 IS NULL OR key < $2)
          ORDER BY key DESC
-         LIMIT $4",
+         LIMIT $3",
         quoted_identifier(table)
     )
 }
 
 fn delete_prefix_query(table: &str) -> String {
     format!(
-        "DELETE FROM {} WHERE namespace = $1 AND key LIKE $2 ESCAPE '\\'",
+        "DELETE FROM {} WHERE key LIKE $1 ESCAPE '\\'",
         quoted_identifier(table)
     )
+}
+
+fn legacy_columns_query() -> &'static str {
+    "SELECT column_name FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = $1"
+}
+
+fn create_migration_table_statement(table: &str) -> String {
+    let table = quoted_identifier(table);
+    format!(
+        "CREATE TABLE {} (
+                key TEXT NOT NULL PRIMARY KEY,
+                value BYTEA NOT NULL
+            )",
+        table
+    )
+}
+
+fn rename_migration_index_statement(table: &str, migration_table: &str) -> String {
+    format!(
+        "ALTER INDEX IF EXISTS {} RENAME TO {}",
+        quoted_identifier(&format!("{migration_table}_pkey")),
+        quoted_identifier(&format!("{table}_pkey"))
+    )
+}
+
+async fn migrate_legacy_table(pool: &PgPool, table: &str) -> Result<()> {
+    let rows = sqlx::query(legacy_columns_query())
+        .bind(table)
+        .fetch_all(pool)
+        .await?;
+    let has_namespace = rows
+        .iter()
+        .filter_map(|row| row.try_get::<String, _>("column_name").ok())
+        .any(|column| column == "namespace");
+    if !has_namespace {
+        return Ok(());
+    }
+
+    let migration_table = format!("{table}_full_key_migration");
+    sqlx::query(&format!(
+        "DROP TABLE IF EXISTS {}",
+        quoted_identifier(&migration_table)
+    ))
+    .execute(pool)
+    .await?;
+    sqlx::query(&create_migration_table_statement(&migration_table))
+        .execute(pool)
+        .await?;
+
+    let old_rows = sqlx::query(&format!(
+        "SELECT namespace, key, value FROM {}",
+        quoted_identifier(table)
+    ))
+    .fetch_all(pool)
+    .await?;
+    let insert = format!(
+        "INSERT INTO {} (key, value) VALUES ($1, $2)
+         ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+        quoted_identifier(&migration_table)
+    );
+    for row in old_rows {
+        let namespace: String = row.try_get("namespace")?;
+        let old_key: String = row.try_get("key")?;
+        let value: Vec<u8> = row.try_get("value")?;
+        let new_key = super::legacy::namespaced_key(&namespace, &old_key)?;
+        sqlx::query(&insert)
+            .bind(new_key)
+            .bind(value)
+            .execute(pool)
+            .await?;
+    }
+
+    sqlx::query(&format!("DROP TABLE {}", quoted_identifier(table)))
+        .execute(pool)
+        .await?;
+    sqlx::query(&format!(
+        "ALTER TABLE {} RENAME TO {}",
+        quoted_identifier(&migration_table),
+        quoted_identifier(table)
+    ))
+    .execute(pool)
+    .await?;
+    sqlx::query(&rename_migration_index_statement(table, &migration_table))
+        .execute(pool)
+        .await?;
+    Ok(())
 }
 
 pub struct PostgresKvStore {
@@ -115,6 +195,7 @@ impl PostgresKvStore {
         validate_identifier(table)?;
         let pool = PgPool::connect(url).await?;
 
+        migrate_legacy_table(&pool, table).await?;
         let create_stmt = create_table_statement(table);
         sqlx::query(&create_stmt).execute(&pool).await?;
 
@@ -127,10 +208,9 @@ impl PostgresKvStore {
 
 #[async_trait::async_trait]
 impl KeyValueStore for PostgresKvStore {
-    async fn get(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
         let query = get_query(&self.table);
         let row = sqlx::query(&query)
-            .bind(namespace)
             .bind(key)
             .fetch_optional(&self.pool)
             .await?;
@@ -143,10 +223,9 @@ impl KeyValueStore for PostgresKvStore {
         }
     }
 
-    async fn set(&self, namespace: &str, key: &str, value: &[u8]) -> Result<()> {
+    async fn set(&self, key: &str, value: &[u8]) -> Result<()> {
         let query = set_query(&self.table);
         sqlx::query(&query)
-            .bind(namespace)
             .bind(key)
             .bind(value)
             .execute(&self.pool)
@@ -156,36 +235,31 @@ impl KeyValueStore for PostgresKvStore {
 
     async fn compare_and_swap(
         &self,
-        namespace: &str,
         key: &str,
         expected: Option<&[u8]>,
         value: &[u8],
     ) -> Result<bool> {
         let query = compare_and_swap_query(&self.table, expected.is_some());
 
-        let mut q = sqlx::query(&query).bind(namespace).bind(key).bind(value);
-        if let Some(expected) = expected {
-            q = q.bind(expected);
-        }
+        let q = if let Some(expected) = expected {
+            sqlx::query(&query).bind(key).bind(expected).bind(value)
+        } else {
+            sqlx::query(&query).bind(key).bind(value)
+        };
         let rows_affected = q.execute(&self.pool).await?.rows_affected();
         Ok(rows_affected == 1)
     }
 
-    async fn delete(&self, namespace: &str, key: &str) -> Result<()> {
+    async fn delete(&self, key: &str) -> Result<()> {
         let query = delete_query(&self.table);
-        sqlx::query(&query)
-            .bind(namespace)
-            .bind(key)
-            .execute(&self.pool)
-            .await?;
+        sqlx::query(&query).bind(key).execute(&self.pool).await?;
         Ok(())
     }
 
-    async fn list_keys(&self, namespace: &str, prefix: &str) -> Result<Vec<String>> {
+    async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
         let query = list_keys_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .fetch_all(&self.pool)
             .await?;
@@ -197,11 +271,10 @@ impl KeyValueStore for PostgresKvStore {
         Ok(keys)
     }
 
-    async fn list_entries(&self, namespace: &str, prefix: &str) -> Result<Vec<(String, Vec<u8>)>> {
+    async fn list_entries(&self, prefix: &str) -> Result<Vec<(String, Vec<u8>)>> {
         let query = list_entries_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .fetch_all(&self.pool)
             .await?;
@@ -215,7 +288,6 @@ impl KeyValueStore for PostgresKvStore {
 
     async fn list_keys_page(
         &self,
-        namespace: &str,
         prefix: &str,
         before_key: Option<&str>,
         limit: usize,
@@ -227,7 +299,6 @@ impl KeyValueStore for PostgresKvStore {
         let query = list_keys_page_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .bind(before_key)
             .bind(limit as i64)
@@ -243,7 +314,6 @@ impl KeyValueStore for PostgresKvStore {
 
     async fn list_entries_page(
         &self,
-        namespace: &str,
         prefix: &str,
         before_key: Option<&str>,
         limit: usize,
@@ -255,7 +325,6 @@ impl KeyValueStore for PostgresKvStore {
         let query = list_entries_page_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .bind(before_key)
             .bind(limit as i64)
@@ -269,11 +338,10 @@ impl KeyValueStore for PostgresKvStore {
         Ok(entries)
     }
 
-    async fn delete_prefix(&self, namespace: &str, prefix: &str) -> Result<()> {
+    async fn delete_prefix(&self, prefix: &str) -> Result<()> {
         let query = delete_prefix_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .execute(&self.pool)
             .await?;
@@ -286,7 +354,7 @@ mod tests {
     use super::{
         compare_and_swap_query, create_table_statement, delete_prefix_query, delete_query,
         get_query, list_entries_page_query, list_entries_query, list_keys_page_query,
-        list_keys_query, set_query, PostgresKvStore,
+        list_keys_query, rename_migration_index_statement, set_query, PostgresKvStore,
     };
     use crate::control::KeyValueStore;
     use crate::test_support::{docker_test_guard, PostgresContainer};
@@ -296,25 +364,46 @@ mod tests {
     fn sql_builders_use_expected_table_and_clauses() {
         let create = create_table_statement("talon_kv");
         assert!(create.contains("CREATE TABLE IF NOT EXISTS \"talon_kv\""));
-        assert!(create.contains("PRIMARY KEY (namespace, key)"));
+        assert!(create.contains("PRIMARY KEY (key)"));
 
         assert_eq!(
             get_query("talon_kv"),
-            "SELECT value FROM \"talon_kv\" WHERE namespace = $1 AND key = $2"
+            "SELECT value FROM \"talon_kv\" WHERE key = $1"
         );
-        assert!(set_query("talon_kv").contains("ON CONFLICT (namespace, key) DO UPDATE"));
-        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = $4"));
+        assert!(set_query("talon_kv").contains("ON CONFLICT (key) DO UPDATE"));
+        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = $2"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
         assert_eq!(
             delete_query("talon_kv"),
-            "DELETE FROM \"talon_kv\" WHERE namespace = $1 AND key = $2"
+            "DELETE FROM \"talon_kv\" WHERE key = $1"
         );
-        assert!(list_keys_query("talon_kv").contains("LIKE $2 ESCAPE '\\'"));
+        assert!(list_keys_query("talon_kv").contains("LIKE $1 ESCAPE '\\'"));
         assert!(list_keys_page_query("talon_kv").contains("ORDER BY key DESC"));
         assert!(list_entries_page_query("talon_kv").contains("SELECT key, value"));
         assert!(list_entries_page_query("talon_kv").contains("ORDER BY key DESC"));
         assert!(list_entries_query("talon_kv").contains("SELECT key, value"));
         assert!(delete_prefix_query("talon_kv").contains("DELETE FROM \"talon_kv\""));
+        assert_eq!(
+            rename_migration_index_statement("talon_kv", "talon_kv_full_key_migration"),
+            "ALTER INDEX IF EXISTS \"talon_kv_full_key_migration_pkey\" RENAME TO \"talon_kv_pkey\""
+        );
+    }
+
+    #[test]
+    fn postgres_legacy_migration_maps_old_system_namespace_names() {
+        assert_eq!(
+            super::super::legacy::namespaced_key("talon-system:ns", "Namespace/quickstart")
+                .unwrap(),
+            crate::control::keys::namespace_metadata("quickstart")
+        );
+        assert_eq!(
+            super::super::legacy::namespaced_key(
+                "talon-system:ns:internal",
+                "NamespaceRef/quickstart"
+            )
+            .unwrap(),
+            crate::control::keys::namespace_ref(None, "quickstart")
+        );
     }
 
     async fn init_test_store(database_url: &str) -> PostgresKvStore {
@@ -340,76 +429,64 @@ mod tests {
         let pg = PostgresContainer::start("talon-kv-pg");
         let store = init_test_store(&pg.database_url()).await;
 
-        assert!(store.get("ns", "missing").await.unwrap().is_none());
+        assert!(store.get("missing").await.unwrap().is_none());
 
-        store.set("ns", "prefix/a", b"one").await.unwrap();
-        store.set("ns", "prefix/b", b"two").await.unwrap();
-        store.set("ns", "other/c", b"three").await.unwrap();
-        assert_eq!(
-            store.get("ns", "prefix/a").await.unwrap(),
-            Some(b"one".to_vec())
-        );
+        store.set("prefix/a", b"one").await.unwrap();
+        store.set("prefix/b", b"two").await.unwrap();
+        store.set("other/c", b"three").await.unwrap();
+        assert_eq!(store.get("prefix/a").await.unwrap(), Some(b"one".to_vec()));
 
-        let mut keys = store.list_keys("ns", "prefix/").await.unwrap();
+        let mut keys = store.list_keys("prefix/").await.unwrap();
         keys.sort();
         assert_eq!(keys, vec!["prefix/a".to_string(), "prefix/b".to_string()]);
 
         assert_eq!(
-            store
-                .list_keys_page("ns", "prefix/", None, 10)
-                .await
-                .unwrap(),
+            store.list_keys_page("prefix/", None, 10).await.unwrap(),
             vec!["prefix/b".to_string(), "prefix/a".to_string()]
         );
         assert_eq!(
             store
-                .list_keys_page("ns", "prefix/", Some("prefix/b"), 10)
+                .list_keys_page("prefix/", Some("prefix/b"), 10)
                 .await
                 .unwrap(),
             vec!["prefix/a".to_string()]
         );
         assert_eq!(
-            store
-                .list_entries_page("ns", "prefix/", None, 10)
-                .await
-                .unwrap(),
+            store.list_entries_page("prefix/", None, 10).await.unwrap(),
             vec![
                 ("prefix/b".to_string(), b"two".to_vec()),
                 ("prefix/a".to_string(), b"one".to_vec())
             ]
         );
 
-        let mut entries = store.list_entries("ns", "prefix/").await.unwrap();
+        let mut entries = store.list_entries("prefix/").await.unwrap();
         entries.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(entries[0], ("prefix/a".to_string(), b"one".to_vec()));
         assert_eq!(entries[1], ("prefix/b".to_string(), b"two".to_vec()));
 
         assert!(store
-            .compare_and_swap("ns", "prefix/a", Some(b"one"), b"updated")
+            .compare_and_swap("prefix/a", Some(b"one"), b"updated")
             .await
             .unwrap());
         assert!(!store
-            .compare_and_swap("ns", "prefix/a", Some(b"wrong"), b"nope")
+            .compare_and_swap("prefix/a", Some(b"wrong"), b"nope")
             .await
             .unwrap());
         assert!(store
-            .compare_and_swap("ns", "new/key", None, b"created")
+            .compare_and_swap("new/key", None, b"created")
             .await
             .unwrap());
         assert!(!store
-            .compare_and_swap("ns", "new/key", None, b"duplicate")
+            .compare_and_swap("new/key", None, b"duplicate")
             .await
             .unwrap());
 
-        store.delete("ns", "new/key").await.unwrap();
-        assert!(store.get("ns", "new/key").await.unwrap().is_none());
+        store.delete("new/key").await.unwrap();
+        assert!(store.get("new/key").await.unwrap().is_none());
 
-        store.delete_prefix("ns", "prefix/").await.unwrap();
-        assert!(store.get("ns", "prefix/a").await.unwrap().is_none());
-        assert!(store.get("ns", "prefix/b").await.unwrap().is_none());
-        assert_eq!(
-            store.get("ns", "other/c").await.unwrap(),
-            Some(b"three".to_vec())
-        );
+        store.delete_prefix("prefix/").await.unwrap();
+        assert!(store.get("prefix/a").await.unwrap().is_none());
+        assert!(store.get("prefix/b").await.unwrap().is_none());
+        assert_eq!(store.get("other/c").await.unwrap(), Some(b"three".to_vec()));
     }
 }

--- a/src/control/kv/postgres.rs
+++ b/src/control/kv/postgres.rs
@@ -1,19 +1,25 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::control::KeyValueStore;
-use anyhow::Result;
-use sqlx::{PgPool, Row};
+use crate::control::{
+    keys::{ResourceKey, ResourceList},
+    KeyValueStore,
+};
+use anyhow::{bail, Result};
+use sqlx::{PgConnection, PgPool, Row};
 
-use super::shared::{like_prefix_pattern, quoted_identifier, validate_identifier};
+use super::shared::{quoted_identifier, validate_identifier};
 
 fn create_table_statement(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
         "CREATE TABLE IF NOT EXISTS {} (
-                key TEXT NOT NULL,
+                namespace TEXT NOT NULL,
+                parent_path TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                name TEXT NOT NULL,
                 value BYTEA NOT NULL,
-                PRIMARY KEY (key)
+                PRIMARY KEY (namespace, parent_path, kind, name)
             )",
         table
     )
@@ -21,7 +27,8 @@ fn create_table_statement(table: &str) -> String {
 
 fn get_query(table: &str) -> String {
     format!(
-        "SELECT value FROM {} WHERE key = $1",
+        "SELECT value FROM {}
+         WHERE namespace = $1 AND parent_path = $2 AND kind = $3 AND name = $4",
         quoted_identifier(table)
     )
 }
@@ -29,8 +36,10 @@ fn get_query(table: &str) -> String {
 fn set_query(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
-        "INSERT INTO {} (key, value) VALUES ($1, $2)
-             ON CONFLICT (key) DO UPDATE SET value = $2",
+        "INSERT INTO {} (namespace, parent_path, kind, name, value)
+             VALUES ($1, $2, $3, $4, $5)
+             ON CONFLICT (namespace, parent_path, kind, name)
+             DO UPDATE SET value = excluded.value",
         table
     )
 }
@@ -39,62 +48,66 @@ fn compare_and_swap_query(table: &str, expected: bool) -> String {
     let table = quoted_identifier(table);
     if expected {
         format!(
-            "UPDATE {} SET value = $3
-                 WHERE key = $1 AND value = $2",
+            "UPDATE {} SET value = $5
+             WHERE namespace = $1 AND parent_path = $2 AND kind = $3 AND name = $4 AND value = $6",
             table
         )
     } else {
         format!(
-            "INSERT INTO {} (key, value) VALUES ($1, $2)
-                 ON CONFLICT (key) DO NOTHING",
+            "INSERT INTO {} (namespace, parent_path, kind, name, value)
+             VALUES ($1, $2, $3, $4, $5)
+             ON CONFLICT (namespace, parent_path, kind, name) DO NOTHING",
             table
         )
     }
 }
 
 fn delete_query(table: &str) -> String {
-    format!("DELETE FROM {} WHERE key = $1", quoted_identifier(table))
-}
-
-fn list_keys_query(table: &str) -> String {
     format!(
-        "SELECT key FROM {} WHERE key LIKE $1 ESCAPE '\\'",
+        "DELETE FROM {}
+         WHERE namespace = $1 AND parent_path = $2 AND kind = $3 AND name = $4",
         quoted_identifier(table)
     )
 }
 
-fn list_entries_query(table: &str) -> String {
+fn list_keys_query(table: &str, has_kind: bool) -> String {
+    let kind_clause = if has_kind { "AND kind = $3" } else { "" };
     format!(
-        "SELECT key, value FROM {} WHERE key LIKE $1 ESCAPE '\\'",
+        "SELECT namespace, parent_path, kind, name FROM {}
+         WHERE namespace = $1 AND parent_path = $2 {kind_clause}
+         ORDER BY kind ASC, name ASC",
+        quoted_identifier(table)
+    )
+}
+
+fn list_entries_query(table: &str, has_kind: bool) -> String {
+    let kind_clause = if has_kind { "AND kind = $3" } else { "" };
+    format!(
+        "SELECT namespace, parent_path, kind, name, value FROM {}
+         WHERE namespace = $1 AND parent_path = $2 {kind_clause}
+         ORDER BY kind ASC, name ASC",
         quoted_identifier(table)
     )
 }
 
 fn list_keys_page_query(table: &str) -> String {
     format!(
-        "SELECT key FROM {}
-         WHERE key LIKE $1 ESCAPE '\\'
-           AND ($2 IS NULL OR key < $2)
-         ORDER BY key DESC
-         LIMIT $3",
+        "SELECT namespace, parent_path, kind, name FROM {}
+         WHERE namespace = $1 AND parent_path = $2 AND kind = $3
+           AND ($4 IS NULL OR name < $4)
+         ORDER BY name DESC
+         LIMIT $5",
         quoted_identifier(table)
     )
 }
 
 fn list_entries_page_query(table: &str) -> String {
     format!(
-        "SELECT key, value FROM {}
-         WHERE key LIKE $1 ESCAPE '\\'
-           AND ($2 IS NULL OR key < $2)
-         ORDER BY key DESC
-         LIMIT $3",
-        quoted_identifier(table)
-    )
-}
-
-fn delete_prefix_query(table: &str) -> String {
-    format!(
-        "DELETE FROM {} WHERE key LIKE $1 ESCAPE '\\'",
+        "SELECT namespace, parent_path, kind, name, value FROM {}
+         WHERE namespace = $1 AND parent_path = $2 AND kind = $3
+           AND ($4 IS NULL OR name < $4)
+         ORDER BY name DESC
+         LIMIT $5",
         quoted_identifier(table)
     )
 }
@@ -104,14 +117,7 @@ fn legacy_columns_query() -> &'static str {
 }
 
 fn create_migration_table_statement(table: &str) -> String {
-    let table = quoted_identifier(table);
-    format!(
-        "CREATE TABLE {} (
-                key TEXT NOT NULL PRIMARY KEY,
-                value BYTEA NOT NULL
-            )",
-        table
-    )
+    create_table_statement(table).replacen("CREATE TABLE IF NOT EXISTS", "CREATE TABLE", 1)
 }
 
 fn rename_migration_index_statement(table: &str, migration_table: &str) -> String {
@@ -122,65 +128,107 @@ fn rename_migration_index_statement(table: &str, migration_table: &str) -> Strin
     )
 }
 
-async fn migrate_legacy_table(pool: &PgPool, table: &str) -> Result<()> {
+fn key_from_row(row: &sqlx::postgres::PgRow) -> Result<ResourceKey> {
+    Ok(ResourceKey {
+        namespace: row.try_get("namespace")?,
+        parent_path: row.try_get("parent_path")?,
+        kind: row.try_get("kind")?,
+        name: row.try_get("name")?,
+    })
+}
+
+fn insert_query(table: &str) -> String {
+    format!(
+        "INSERT INTO {} (namespace, parent_path, kind, name, value)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (namespace, parent_path, kind, name)
+         DO UPDATE SET value = excluded.value",
+        quoted_identifier(table)
+    )
+}
+
+async fn migrate_legacy_table(conn: &mut PgConnection, table: &str) -> Result<()> {
     let rows = sqlx::query(legacy_columns_query())
         .bind(table)
-        .fetch_all(pool)
+        .fetch_all(&mut *conn)
         .await?;
-    let has_namespace = rows
+    let columns = rows
         .iter()
         .filter_map(|row| row.try_get::<String, _>("column_name").ok())
-        .any(|column| column == "namespace");
-    if !has_namespace {
+        .collect::<std::collections::HashSet<_>>();
+    let has_namespace = columns.contains("namespace");
+    let has_parent_path = columns.contains("parent_path");
+    let has_key = columns.contains("key");
+
+    if has_namespace && has_parent_path {
         return Ok(());
     }
+    if columns.is_empty() {
+        return Ok(());
+    }
+    if !has_key {
+        bail!("cannot migrate {table}: expected legacy key column");
+    }
 
-    let migration_table = format!("{table}_full_key_migration");
+    let migration_table = format!("{table}_structured_key_migration");
     sqlx::query(&format!(
         "DROP TABLE IF EXISTS {}",
         quoted_identifier(&migration_table)
     ))
-    .execute(pool)
+    .execute(&mut *conn)
     .await?;
     sqlx::query(&create_migration_table_statement(&migration_table))
-        .execute(pool)
+        .execute(&mut *conn)
         .await?;
 
-    let old_rows = sqlx::query(&format!(
-        "SELECT namespace, key, value FROM {}",
-        quoted_identifier(table)
-    ))
-    .fetch_all(pool)
-    .await?;
-    let insert = format!(
-        "INSERT INTO {} (key, value) VALUES ($1, $2)
-         ON CONFLICT (key) DO UPDATE SET value = excluded.value",
-        quoted_identifier(&migration_table)
-    );
+    let old_rows = if has_namespace {
+        sqlx::query(&format!(
+            "SELECT namespace, key, value FROM {}",
+            quoted_identifier(table)
+        ))
+        .fetch_all(&mut *conn)
+        .await?
+    } else {
+        sqlx::query(&format!(
+            "SELECT key, value FROM {}",
+            quoted_identifier(table)
+        ))
+        .fetch_all(&mut *conn)
+        .await?
+    };
+    let insert = insert_query(&migration_table);
     for row in old_rows {
-        let namespace: String = row.try_get("namespace")?;
         let old_key: String = row.try_get("key")?;
         let value: Vec<u8> = row.try_get("value")?;
-        let new_key = super::legacy::namespaced_key(&namespace, &old_key)?;
+        let key = if has_namespace {
+            let namespace: String = row.try_get("namespace")?;
+            let canonical = super::legacy::namespaced_key(&namespace, &old_key)?;
+            ResourceKey::parse_canonical(&canonical)?
+        } else {
+            ResourceKey::parse_canonical(&old_key)?
+        };
         sqlx::query(&insert)
-            .bind(new_key)
+            .bind(&key.namespace)
+            .bind(&key.parent_path)
+            .bind(&key.kind)
+            .bind(&key.name)
             .bind(value)
-            .execute(pool)
+            .execute(&mut *conn)
             .await?;
     }
 
     sqlx::query(&format!("DROP TABLE {}", quoted_identifier(table)))
-        .execute(pool)
+        .execute(&mut *conn)
         .await?;
     sqlx::query(&format!(
         "ALTER TABLE {} RENAME TO {}",
         quoted_identifier(&migration_table),
         quoted_identifier(table)
     ))
-    .execute(pool)
+    .execute(&mut *conn)
     .await?;
     sqlx::query(&rename_migration_index_statement(table, &migration_table))
-        .execute(pool)
+        .execute(&mut *conn)
         .await?;
     Ok(())
 }
@@ -195,9 +243,20 @@ impl PostgresKvStore {
         validate_identifier(table)?;
         let pool = PgPool::connect(url).await?;
 
-        migrate_legacy_table(&pool, table).await?;
+        let mut conn = pool.acquire().await?;
+        let lock_key = format!("talon_kv_store:{table}:schema");
+        sqlx::query("SELECT pg_advisory_lock(hashtext($1))")
+            .bind(&lock_key)
+            .execute(&mut *conn)
+            .await?;
+        migrate_legacy_table(&mut *conn, table).await?;
         let create_stmt = create_table_statement(table);
-        sqlx::query(&create_stmt).execute(&pool).await?;
+        sqlx::query(&create_stmt).execute(&mut *conn).await?;
+        sqlx::query("SELECT pg_advisory_unlock(hashtext($1))")
+            .bind(&lock_key)
+            .execute(&mut *conn)
+            .await?;
+        drop(conn);
 
         Ok(Self {
             pool,
@@ -208,10 +267,13 @@ impl PostgresKvStore {
 
 #[async_trait::async_trait]
 impl KeyValueStore for PostgresKvStore {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &ResourceKey) -> Result<Option<Vec<u8>>> {
         let query = get_query(&self.table);
         let row = sqlx::query(&query)
-            .bind(key)
+            .bind(&key.namespace)
+            .bind(&key.parent_path)
+            .bind(&key.kind)
+            .bind(&key.name)
             .fetch_optional(&self.pool)
             .await?;
 
@@ -223,10 +285,13 @@ impl KeyValueStore for PostgresKvStore {
         }
     }
 
-    async fn set(&self, key: &str, value: &[u8]) -> Result<()> {
+    async fn set(&self, key: &ResourceKey, value: &[u8]) -> Result<()> {
         let query = set_query(&self.table);
         sqlx::query(&query)
-            .bind(key)
+            .bind(&key.namespace)
+            .bind(&key.parent_path)
+            .bind(&key.kind)
+            .bind(&key.name)
             .bind(value)
             .execute(&self.pool)
             .await?;
@@ -235,128 +300,147 @@ impl KeyValueStore for PostgresKvStore {
 
     async fn compare_and_swap(
         &self,
-        key: &str,
+        key: &ResourceKey,
         expected: Option<&[u8]>,
         value: &[u8],
     ) -> Result<bool> {
         let query = compare_and_swap_query(&self.table, expected.is_some());
 
         let q = if let Some(expected) = expected {
-            sqlx::query(&query).bind(key).bind(expected).bind(value)
+            sqlx::query(&query)
+                .bind(&key.namespace)
+                .bind(&key.parent_path)
+                .bind(&key.kind)
+                .bind(&key.name)
+                .bind(value)
+                .bind(expected)
         } else {
-            sqlx::query(&query).bind(key).bind(value)
+            sqlx::query(&query)
+                .bind(&key.namespace)
+                .bind(&key.parent_path)
+                .bind(&key.kind)
+                .bind(&key.name)
+                .bind(value)
         };
         let rows_affected = q.execute(&self.pool).await?.rows_affected();
         Ok(rows_affected == 1)
     }
 
-    async fn delete(&self, key: &str) -> Result<()> {
+    async fn delete(&self, key: &ResourceKey) -> Result<()> {
         let query = delete_query(&self.table);
-        sqlx::query(&query).bind(key).execute(&self.pool).await?;
+        sqlx::query(&query)
+            .bind(&key.namespace)
+            .bind(&key.parent_path)
+            .bind(&key.kind)
+            .bind(&key.name)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 
-    async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
-        let query = list_keys_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
-        let rows = sqlx::query(&query)
-            .bind(prefix_pattern)
-            .fetch_all(&self.pool)
-            .await?;
+    async fn list_keys(&self, list: &ResourceList) -> Result<Vec<ResourceKey>> {
+        let query = list_keys_query(&self.table, list.kind.is_some());
+        let mut query = sqlx::query(&query)
+            .bind(&list.parent.namespace)
+            .bind(&list.parent.parent_path);
+        if let Some(kind) = &list.kind {
+            query = query.bind(kind);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
-        let mut keys = Vec::new();
+        let mut keys = Vec::with_capacity(rows.len());
         for row in rows {
-            keys.push(row.try_get("key")?);
+            keys.push(key_from_row(&row)?);
         }
         Ok(keys)
     }
 
-    async fn list_entries(&self, prefix: &str) -> Result<Vec<(String, Vec<u8>)>> {
-        let query = list_entries_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
-        let rows = sqlx::query(&query)
-            .bind(prefix_pattern)
-            .fetch_all(&self.pool)
-            .await?;
+    async fn list_entries(&self, list: &ResourceList) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let query = list_entries_query(&self.table, list.kind.is_some());
+        let mut query = sqlx::query(&query)
+            .bind(&list.parent.namespace)
+            .bind(&list.parent.parent_path);
+        if let Some(kind) = &list.kind {
+            query = query.bind(kind);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
         let mut entries = Vec::with_capacity(rows.len());
         for row in rows {
-            entries.push((row.try_get("key")?, row.try_get("value")?));
+            entries.push((key_from_row(&row)?, row.try_get("value")?));
         }
         Ok(entries)
     }
 
     async fn list_keys_page(
         &self,
-        prefix: &str,
-        before_key: Option<&str>,
+        list: &ResourceList,
+        before_name: Option<&str>,
         limit: usize,
-    ) -> Result<Vec<String>> {
+    ) -> Result<Vec<ResourceKey>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
+        let Some(kind) = &list.kind else {
+            bail!("paged resource listing requires an explicit resource kind");
+        };
 
         let query = list_keys_page_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(prefix_pattern)
-            .bind(before_key)
+            .bind(&list.parent.namespace)
+            .bind(&list.parent.parent_path)
+            .bind(kind)
+            .bind(before_name)
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await?;
 
         let mut keys = Vec::with_capacity(rows.len());
         for row in rows {
-            keys.push(row.try_get("key")?);
+            keys.push(key_from_row(&row)?);
         }
         Ok(keys)
     }
 
     async fn list_entries_page(
         &self,
-        prefix: &str,
-        before_key: Option<&str>,
+        list: &ResourceList,
+        before_name: Option<&str>,
         limit: usize,
-    ) -> Result<Vec<(String, Vec<u8>)>> {
+    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
+        let Some(kind) = &list.kind else {
+            bail!("paged resource listing requires an explicit resource kind");
+        };
 
         let query = list_entries_page_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(prefix_pattern)
-            .bind(before_key)
+            .bind(&list.parent.namespace)
+            .bind(&list.parent.parent_path)
+            .bind(kind)
+            .bind(before_name)
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await?;
 
         let mut entries = Vec::with_capacity(rows.len());
         for row in rows {
-            entries.push((row.try_get("key")?, row.try_get("value")?));
+            entries.push((key_from_row(&row)?, row.try_get("value")?));
         }
         Ok(entries)
-    }
-
-    async fn delete_prefix(&self, prefix: &str) -> Result<()> {
-        let query = delete_prefix_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
-        sqlx::query(&query)
-            .bind(prefix_pattern)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        compare_and_swap_query, create_table_statement, delete_prefix_query, delete_query,
-        get_query, list_entries_page_query, list_entries_query, list_keys_page_query,
-        list_keys_query, rename_migration_index_statement, set_query, PostgresKvStore,
+        compare_and_swap_query, create_table_statement, delete_query, get_query,
+        list_entries_page_query, list_entries_query, list_keys_page_query, list_keys_query,
+        rename_migration_index_statement, set_query, PostgresKvStore,
     };
-    use crate::control::KeyValueStore;
+    use crate::control::{keys, KeyValueStore};
     use crate::test_support::{docker_test_guard, PostgresContainer};
     use std::time::Duration;
 
@@ -364,28 +448,21 @@ mod tests {
     fn sql_builders_use_expected_table_and_clauses() {
         let create = create_table_statement("talon_kv");
         assert!(create.contains("CREATE TABLE IF NOT EXISTS \"talon_kv\""));
-        assert!(create.contains("PRIMARY KEY (key)"));
+        assert!(create.contains("PRIMARY KEY (namespace, parent_path, kind, name)"));
 
-        assert_eq!(
-            get_query("talon_kv"),
-            "SELECT value FROM \"talon_kv\" WHERE key = $1"
-        );
-        assert!(set_query("talon_kv").contains("ON CONFLICT (key) DO UPDATE"));
-        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = $2"));
+        assert!(get_query("talon_kv").contains("WHERE namespace = $1"));
+        assert!(set_query("talon_kv").contains("ON CONFLICT (namespace, parent_path, kind, name)"));
+        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = $6"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
+        assert!(delete_query("talon_kv").contains("WHERE namespace = $1"));
+        assert!(list_keys_query("talon_kv", true).contains("AND kind = $3"));
+        assert!(list_keys_page_query("talon_kv").contains("ORDER BY name DESC"));
+        assert!(list_entries_page_query("talon_kv")
+            .contains("SELECT namespace, parent_path, kind, name, value"));
+        assert!(list_entries_query("talon_kv", false).contains("ORDER BY kind ASC, name ASC"));
         assert_eq!(
-            delete_query("talon_kv"),
-            "DELETE FROM \"talon_kv\" WHERE key = $1"
-        );
-        assert!(list_keys_query("talon_kv").contains("LIKE $1 ESCAPE '\\'"));
-        assert!(list_keys_page_query("talon_kv").contains("ORDER BY key DESC"));
-        assert!(list_entries_page_query("talon_kv").contains("SELECT key, value"));
-        assert!(list_entries_page_query("talon_kv").contains("ORDER BY key DESC"));
-        assert!(list_entries_query("talon_kv").contains("SELECT key, value"));
-        assert!(delete_prefix_query("talon_kv").contains("DELETE FROM \"talon_kv\""));
-        assert_eq!(
-            rename_migration_index_statement("talon_kv", "talon_kv_full_key_migration"),
-            "ALTER INDEX IF EXISTS \"talon_kv_full_key_migration_pkey\" RENAME TO \"talon_kv_pkey\""
+            rename_migration_index_statement("talon_kv", "talon_kv_structured_key_migration"),
+            "ALTER INDEX IF EXISTS \"talon_kv_structured_key_migration_pkey\" RENAME TO \"talon_kv_pkey\""
         );
     }
 
@@ -394,7 +471,7 @@ mod tests {
         assert_eq!(
             super::super::legacy::namespaced_key("talon-system:ns", "Namespace/quickstart")
                 .unwrap(),
-            crate::control::keys::namespace_metadata("quickstart")
+            crate::control::keys::namespace_metadata("quickstart").canonical()
         );
         assert_eq!(
             super::super::legacy::namespaced_key(
@@ -402,7 +479,7 @@ mod tests {
                 "NamespaceRef/quickstart"
             )
             .unwrap(),
-            crate::control::keys::namespace_ref(None, "quickstart")
+            crate::control::keys::namespace_ref(None, "quickstart").canonical()
         );
     }
 
@@ -424,69 +501,71 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn postgres_kv_round_trip_compare_and_swap_and_prefix_ops() {
+    async fn postgres_kv_round_trip_compare_and_swap_and_direct_list_ops() {
         let _guard = docker_test_guard();
         let pg = PostgresContainer::start("talon-kv-pg");
         let store = init_test_store(&pg.database_url()).await;
 
-        assert!(store.get("missing").await.unwrap().is_none());
+        let missing = keys::session("quickstart", "hello-agent", "missing");
+        let a = keys::session("quickstart", "hello-agent", "a");
+        let b = keys::session("quickstart", "hello-agent", "b");
+        let other = keys::session("quickstart", "other-agent", "c");
+        let list = keys::session_prefix("quickstart", "hello-agent");
 
-        store.set("prefix/a", b"one").await.unwrap();
-        store.set("prefix/b", b"two").await.unwrap();
-        store.set("other/c", b"three").await.unwrap();
-        assert_eq!(store.get("prefix/a").await.unwrap(), Some(b"one".to_vec()));
+        assert!(store.get(&missing).await.unwrap().is_none());
 
-        let mut keys = store.list_keys("prefix/").await.unwrap();
-        keys.sort();
-        assert_eq!(keys, vec!["prefix/a".to_string(), "prefix/b".to_string()]);
+        store.set(&a, b"one").await.unwrap();
+        store.set(&b, b"two").await.unwrap();
+        store.set(&other, b"three").await.unwrap();
+        assert_eq!(store.get(&a).await.unwrap(), Some(b"one".to_vec()));
+
+        let mut listed = store.list_keys(&list).await.unwrap();
+        listed.sort_by(|left, right| left.name.cmp(&right.name));
+        assert_eq!(listed, vec![a.clone(), b.clone()]);
 
         assert_eq!(
-            store.list_keys_page("prefix/", None, 10).await.unwrap(),
-            vec!["prefix/b".to_string(), "prefix/a".to_string()]
+            store.list_keys_page(&list, None, 10).await.unwrap(),
+            vec![b.clone(), a.clone()]
         );
         assert_eq!(
-            store
-                .list_keys_page("prefix/", Some("prefix/b"), 10)
-                .await
-                .unwrap(),
-            vec!["prefix/a".to_string()]
+            store.list_keys_page(&list, Some("b"), 10).await.unwrap(),
+            vec![a.clone()]
         );
         assert_eq!(
-            store.list_entries_page("prefix/", None, 10).await.unwrap(),
-            vec![
-                ("prefix/b".to_string(), b"two".to_vec()),
-                ("prefix/a".to_string(), b"one".to_vec())
-            ]
+            store.list_entries_page(&list, None, 10).await.unwrap(),
+            vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 
-        let mut entries = store.list_entries("prefix/").await.unwrap();
-        entries.sort_by(|a, b| a.0.cmp(&b.0));
-        assert_eq!(entries[0], ("prefix/a".to_string(), b"one".to_vec()));
-        assert_eq!(entries[1], ("prefix/b".to_string(), b"two".to_vec()));
+        let mut entries = store.list_entries(&list).await.unwrap();
+        entries.sort_by(|left, right| left.0.name.cmp(&right.0.name));
+        assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
+        assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
 
         assert!(store
-            .compare_and_swap("prefix/a", Some(b"one"), b"updated")
+            .compare_and_swap(&a, Some(b"one"), b"updated")
             .await
             .unwrap());
         assert!(!store
-            .compare_and_swap("prefix/a", Some(b"wrong"), b"nope")
+            .compare_and_swap(&a, Some(b"wrong"), b"nope")
             .await
             .unwrap());
+        let new_key = keys::session("quickstart", "hello-agent", "new");
         assert!(store
-            .compare_and_swap("new/key", None, b"created")
+            .compare_and_swap(&new_key, None, b"created")
             .await
             .unwrap());
         assert!(!store
-            .compare_and_swap("new/key", None, b"duplicate")
+            .compare_and_swap(&new_key, None, b"duplicate")
             .await
             .unwrap());
 
-        store.delete("new/key").await.unwrap();
-        assert!(store.get("new/key").await.unwrap().is_none());
+        store.delete(&new_key).await.unwrap();
+        assert!(store.get(&new_key).await.unwrap().is_none());
 
-        store.delete_prefix("prefix/").await.unwrap();
-        assert!(store.get("prefix/a").await.unwrap().is_none());
-        assert!(store.get("prefix/b").await.unwrap().is_none());
-        assert_eq!(store.get("other/c").await.unwrap(), Some(b"three".to_vec()));
+        store.delete(&a).await.unwrap();
+        store.delete(&b).await.unwrap();
+        assert!(store.get(&a).await.unwrap().is_none());
+        assert!(store.get(&b).await.unwrap().is_none());
+        assert_eq!(store.get(&other).await.unwrap(), Some(b"three".to_vec()));
     }
 }

--- a/src/control/kv/shared.rs
+++ b/src/control/kv/shared.rs
@@ -125,39 +125,14 @@ pub(crate) fn quoted_identifier(table: &str) -> String {
     format!("\"{}\"", table)
 }
 
-pub(crate) fn like_prefix_pattern(prefix: &str) -> String {
-    let mut escaped = String::with_capacity(prefix.len() + 1);
-    for ch in prefix.chars() {
-        match ch {
-            '\\' | '%' | '_' => {
-                escaped.push('\\');
-                escaped.push(ch);
-            }
-            _ => escaped.push(ch),
-        }
-    }
-    escaped.push('%');
-    escaped
-}
-
 pub fn sqlite_url_for_path(path: &Path) -> String {
     format!("sqlite://{}", path.display())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{like_prefix_pattern, sqlite_url_for_path, validate_identifier};
+    use super::{sqlite_url_for_path, validate_identifier};
     use std::path::Path;
-
-    #[test]
-    fn like_prefix_pattern_appends_sql_wildcard() {
-        assert_eq!(like_prefix_pattern("Agent/test"), "Agent/test%");
-    }
-
-    #[test]
-    fn like_prefix_pattern_escapes_like_metacharacters() {
-        assert_eq!(like_prefix_pattern(r"Agent_%\path"), r"Agent\_\%\\path%");
-    }
 
     #[test]
     fn validate_identifier_rejects_invalid_table_names() {

--- a/src/control/kv/sqlite.rs
+++ b/src/control/kv/sqlite.rs
@@ -1,31 +1,38 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::control::KeyValueStore;
-use anyhow::Result;
+use crate::control::{
+    keys::{ResourceKey, ResourceList},
+    KeyValueStore,
+};
+use anyhow::{bail, Result};
 use sqlx::{
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
     Row, SqlitePool,
 };
 use std::{str::FromStr, time::Duration};
 
-use super::shared::{like_prefix_pattern, quoted_identifier, validate_identifier};
+use super::shared::{quoted_identifier, validate_identifier};
 
 fn create_table_statement(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
         "CREATE TABLE IF NOT EXISTS {} (
-                key TEXT NOT NULL,
+                namespace TEXT NOT NULL,
+                parent_path TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                name TEXT NOT NULL,
                 value BLOB NOT NULL,
-                PRIMARY KEY (key)
-            )",
+                PRIMARY KEY (namespace, parent_path, kind, name)
+            ) WITHOUT ROWID",
         table
     )
 }
 
 fn get_query(table: &str) -> String {
     format!(
-        "SELECT value FROM {} WHERE key = ?1",
+        "SELECT value FROM {}
+         WHERE namespace = ?1 AND parent_path = ?2 AND kind = ?3 AND name = ?4",
         quoted_identifier(table)
     )
 }
@@ -33,8 +40,10 @@ fn get_query(table: &str) -> String {
 fn set_query(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
-        "INSERT INTO {} (key, value) VALUES (?1, ?2)
-             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+        "INSERT INTO {} (namespace, parent_path, kind, name, value)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT (namespace, parent_path, kind, name)
+             DO UPDATE SET value = excluded.value",
         table
     )
 }
@@ -43,64 +52,81 @@ fn compare_and_swap_query(table: &str, expected: bool) -> String {
     let table = quoted_identifier(table);
     if expected {
         format!(
-            "UPDATE {} SET value = ?3
-                 WHERE key = ?1 AND value = ?2",
+            "UPDATE {} SET value = ?5
+             WHERE namespace = ?1 AND parent_path = ?2 AND kind = ?3 AND name = ?4 AND value = ?6",
             table
         )
     } else {
         format!(
-            "INSERT INTO {} (key, value) VALUES (?1, ?2)
-                 ON CONFLICT (key) DO NOTHING",
+            "INSERT INTO {} (namespace, parent_path, kind, name, value)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT (namespace, parent_path, kind, name) DO NOTHING",
             table
         )
     }
 }
 
 fn delete_query(table: &str) -> String {
-    format!("DELETE FROM {} WHERE key = ?1", quoted_identifier(table))
-}
-
-fn list_keys_query(table: &str) -> String {
     format!(
-        "SELECT key FROM {} WHERE key LIKE ?1 ESCAPE '\\'",
+        "DELETE FROM {}
+         WHERE namespace = ?1 AND parent_path = ?2 AND kind = ?3 AND name = ?4",
         quoted_identifier(table)
     )
 }
 
-fn list_entries_query(table: &str) -> String {
+fn list_keys_query(table: &str, has_kind: bool) -> String {
+    let kind_clause = if has_kind { "AND kind = ?3" } else { "" };
     format!(
-        "SELECT key, value FROM {} WHERE key LIKE ?1 ESCAPE '\\'",
+        "SELECT namespace, parent_path, kind, name FROM {}
+         WHERE namespace = ?1 AND parent_path = ?2 {kind_clause}
+         ORDER BY kind ASC, name ASC",
+        quoted_identifier(table)
+    )
+}
+
+fn list_entries_query(table: &str, has_kind: bool) -> String {
+    let kind_clause = if has_kind { "AND kind = ?3" } else { "" };
+    format!(
+        "SELECT namespace, parent_path, kind, name, value FROM {}
+         WHERE namespace = ?1 AND parent_path = ?2 {kind_clause}
+         ORDER BY kind ASC, name ASC",
         quoted_identifier(table)
     )
 }
 
 fn list_keys_page_query(table: &str) -> String {
     format!(
-        "SELECT key FROM {}
-         WHERE key LIKE ?1 ESCAPE '\\'
-           AND (?2 IS NULL OR key < ?2)
-         ORDER BY key DESC
-         LIMIT ?3",
+        "SELECT namespace, parent_path, kind, name FROM {}
+         WHERE namespace = ?1 AND parent_path = ?2 AND kind = ?3
+           AND (?4 IS NULL OR name < ?4)
+         ORDER BY name DESC
+         LIMIT ?5",
         quoted_identifier(table)
     )
 }
 
 fn list_entries_page_query(table: &str) -> String {
     format!(
-        "SELECT key, value FROM {}
-         WHERE key LIKE ?1 ESCAPE '\\'
-           AND (?2 IS NULL OR key < ?2)
-         ORDER BY key DESC
-         LIMIT ?3",
+        "SELECT namespace, parent_path, kind, name, value FROM {}
+         WHERE namespace = ?1 AND parent_path = ?2 AND kind = ?3
+           AND (?4 IS NULL OR name < ?4)
+         ORDER BY name DESC
+         LIMIT ?5",
         quoted_identifier(table)
     )
 }
 
-fn delete_prefix_query(table: &str) -> String {
-    format!(
-        "DELETE FROM {} WHERE key LIKE ?1 ESCAPE '\\'",
-        quoted_identifier(table)
-    )
+fn create_migration_table_statement(table: &str) -> String {
+    create_table_statement(table).replacen("CREATE TABLE IF NOT EXISTS", "CREATE TABLE", 1)
+}
+
+fn key_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<ResourceKey> {
+    Ok(ResourceKey {
+        namespace: row.try_get("namespace")?,
+        parent_path: row.try_get("parent_path")?,
+        kind: row.try_get("kind")?,
+        name: row.try_get("name")?,
+    })
 }
 
 pub struct SqliteKvStore {
@@ -128,40 +154,67 @@ async fn migrate_legacy_table(pool: &SqlitePool, table: &str) -> Result<()> {
     let columns = sqlx::query(&format!("PRAGMA table_info({})", quoted_identifier(table)))
         .fetch_all(pool)
         .await?;
-    let has_namespace = columns
+    let columns = columns
         .iter()
         .filter_map(|row| row.try_get::<String, _>("name").ok())
-        .any(|column| column == "namespace");
-    if !has_namespace {
+        .collect::<std::collections::HashSet<_>>();
+    let has_namespace = columns.contains("namespace");
+    let has_parent_path = columns.contains("parent_path");
+    let has_key = columns.contains("key");
+
+    if has_namespace && has_parent_path {
         return Ok(());
+    }
+    if columns.is_empty() {
+        return Ok(());
+    }
+    if !has_key {
+        bail!("cannot migrate {table}: expected legacy key column");
     }
 
     let mut tx = pool.begin().await?;
-    let old_rows = sqlx::query(&format!(
-        "SELECT namespace, key, value FROM {}",
-        quoted_identifier(table)
-    ))
-    .fetch_all(&mut *tx)
-    .await?;
+    let old_rows = if has_namespace {
+        sqlx::query(&format!(
+            "SELECT namespace, key, value FROM {}",
+            quoted_identifier(table)
+        ))
+        .fetch_all(&mut *tx)
+        .await?
+    } else {
+        sqlx::query(&format!(
+            "SELECT key, value FROM {}",
+            quoted_identifier(table)
+        ))
+        .fetch_all(&mut *tx)
+        .await?
+    };
     let mut converted_rows = Vec::with_capacity(old_rows.len());
     for row in old_rows {
-        let namespace: String = row.try_get("namespace")?;
         let old_key: String = row.try_get("key")?;
         let value: Vec<u8> = row.try_get("value")?;
-        let new_key = super::legacy::namespaced_key(&namespace, &old_key)?;
-        converted_rows.push((new_key, value));
+        let key = if has_namespace {
+            let namespace: String = row.try_get("namespace")?;
+            let canonical = super::legacy::namespaced_key(&namespace, &old_key)?;
+            ResourceKey::parse_canonical(&canonical)?
+        } else {
+            ResourceKey::parse_canonical(&old_key)?
+        };
+        converted_rows.push((key, value));
     }
 
     sqlx::query(&format!("DROP TABLE {}", quoted_identifier(table)))
         .execute(&mut *tx)
         .await?;
-    sqlx::query(&create_table_statement(table))
+    sqlx::query(&create_migration_table_statement(table))
         .execute(&mut *tx)
         .await?;
     let insert = set_query(table);
     for (key, value) in converted_rows {
         sqlx::query(&insert)
-            .bind(key)
+            .bind(&key.namespace)
+            .bind(&key.parent_path)
+            .bind(&key.kind)
+            .bind(&key.name)
             .bind(value)
             .execute(&mut *tx)
             .await?;
@@ -185,10 +238,13 @@ async fn sqlite_pool(url: &str) -> Result<SqlitePool> {
 
 #[async_trait::async_trait]
 impl KeyValueStore for SqliteKvStore {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &ResourceKey) -> Result<Option<Vec<u8>>> {
         let query = get_query(&self.table);
         let row = sqlx::query(&query)
-            .bind(key)
+            .bind(&key.namespace)
+            .bind(&key.parent_path)
+            .bind(&key.kind)
+            .bind(&key.name)
             .fetch_optional(&self.pool)
             .await?;
 
@@ -200,10 +256,13 @@ impl KeyValueStore for SqliteKvStore {
         }
     }
 
-    async fn set(&self, key: &str, value: &[u8]) -> Result<()> {
+    async fn set(&self, key: &ResourceKey, value: &[u8]) -> Result<()> {
         let query = set_query(&self.table);
         sqlx::query(&query)
-            .bind(key)
+            .bind(&key.namespace)
+            .bind(&key.parent_path)
+            .bind(&key.kind)
+            .bind(&key.name)
             .bind(value)
             .execute(&self.pool)
             .await?;
@@ -212,128 +271,147 @@ impl KeyValueStore for SqliteKvStore {
 
     async fn compare_and_swap(
         &self,
-        key: &str,
+        key: &ResourceKey,
         expected: Option<&[u8]>,
         value: &[u8],
     ) -> Result<bool> {
         let query = compare_and_swap_query(&self.table, expected.is_some());
         let q = if let Some(expected) = expected {
-            sqlx::query(&query).bind(key).bind(expected).bind(value)
+            sqlx::query(&query)
+                .bind(&key.namespace)
+                .bind(&key.parent_path)
+                .bind(&key.kind)
+                .bind(&key.name)
+                .bind(value)
+                .bind(expected)
         } else {
-            sqlx::query(&query).bind(key).bind(value)
+            sqlx::query(&query)
+                .bind(&key.namespace)
+                .bind(&key.parent_path)
+                .bind(&key.kind)
+                .bind(&key.name)
+                .bind(value)
         };
         let rows_affected = q.execute(&self.pool).await?.rows_affected();
         Ok(rows_affected == 1)
     }
 
-    async fn delete(&self, key: &str) -> Result<()> {
+    async fn delete(&self, key: &ResourceKey) -> Result<()> {
         let query = delete_query(&self.table);
-        sqlx::query(&query).bind(key).execute(&self.pool).await?;
+        sqlx::query(&query)
+            .bind(&key.namespace)
+            .bind(&key.parent_path)
+            .bind(&key.kind)
+            .bind(&key.name)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 
-    async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
-        let query = list_keys_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
-        let rows = sqlx::query(&query)
-            .bind(prefix_pattern)
-            .fetch_all(&self.pool)
-            .await?;
+    async fn list_keys(&self, list: &ResourceList) -> Result<Vec<ResourceKey>> {
+        let query = list_keys_query(&self.table, list.kind.is_some());
+        let mut query = sqlx::query(&query)
+            .bind(&list.parent.namespace)
+            .bind(&list.parent.parent_path);
+        if let Some(kind) = &list.kind {
+            query = query.bind(kind);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
-        let mut keys = Vec::new();
+        let mut keys = Vec::with_capacity(rows.len());
         for row in rows {
-            keys.push(row.try_get("key")?);
+            keys.push(key_from_row(&row)?);
         }
         Ok(keys)
     }
 
-    async fn list_entries(&self, prefix: &str) -> Result<Vec<(String, Vec<u8>)>> {
-        let query = list_entries_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
-        let rows = sqlx::query(&query)
-            .bind(prefix_pattern)
-            .fetch_all(&self.pool)
-            .await?;
+    async fn list_entries(&self, list: &ResourceList) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let query = list_entries_query(&self.table, list.kind.is_some());
+        let mut query = sqlx::query(&query)
+            .bind(&list.parent.namespace)
+            .bind(&list.parent.parent_path);
+        if let Some(kind) = &list.kind {
+            query = query.bind(kind);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
 
         let mut entries = Vec::with_capacity(rows.len());
         for row in rows {
-            entries.push((row.try_get("key")?, row.try_get("value")?));
+            entries.push((key_from_row(&row)?, row.try_get("value")?));
         }
         Ok(entries)
     }
 
     async fn list_keys_page(
         &self,
-        prefix: &str,
-        before_key: Option<&str>,
+        list: &ResourceList,
+        before_name: Option<&str>,
         limit: usize,
-    ) -> Result<Vec<String>> {
+    ) -> Result<Vec<ResourceKey>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
+        let Some(kind) = &list.kind else {
+            bail!("paged resource listing requires an explicit resource kind");
+        };
 
         let query = list_keys_page_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(prefix_pattern)
-            .bind(before_key)
+            .bind(&list.parent.namespace)
+            .bind(&list.parent.parent_path)
+            .bind(kind)
+            .bind(before_name)
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await?;
 
         let mut keys = Vec::with_capacity(rows.len());
         for row in rows {
-            keys.push(row.try_get("key")?);
+            keys.push(key_from_row(&row)?);
         }
         Ok(keys)
     }
 
     async fn list_entries_page(
         &self,
-        prefix: &str,
-        before_key: Option<&str>,
+        list: &ResourceList,
+        before_name: Option<&str>,
         limit: usize,
-    ) -> Result<Vec<(String, Vec<u8>)>> {
+    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
+        let Some(kind) = &list.kind else {
+            bail!("paged resource listing requires an explicit resource kind");
+        };
 
         let query = list_entries_page_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(prefix_pattern)
-            .bind(before_key)
+            .bind(&list.parent.namespace)
+            .bind(&list.parent.parent_path)
+            .bind(kind)
+            .bind(before_name)
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await?;
 
         let mut entries = Vec::with_capacity(rows.len());
         for row in rows {
-            entries.push((row.try_get("key")?, row.try_get("value")?));
+            entries.push((key_from_row(&row)?, row.try_get("value")?));
         }
         Ok(entries)
-    }
-
-    async fn delete_prefix(&self, prefix: &str) -> Result<()> {
-        let query = delete_prefix_query(&self.table);
-        let prefix_pattern = like_prefix_pattern(prefix);
-        sqlx::query(&query)
-            .bind(prefix_pattern)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        compare_and_swap_query, create_table_statement, delete_prefix_query, delete_query,
-        get_query, list_entries_page_query, list_entries_query, list_keys_page_query,
-        list_keys_query, set_query, sqlite_pool, SqliteKvStore,
+        compare_and_swap_query, create_table_statement, delete_query, get_query,
+        list_entries_page_query, list_entries_query, list_keys_page_query, list_keys_query,
+        set_query, sqlite_pool, SqliteKvStore,
     };
     use crate::control::kv::sqlite_url_for_path;
-    use crate::control::KeyValueStore;
+    use crate::control::{keys, KeyValueStore};
     use tempfile::tempdir;
 
     #[test]
@@ -341,24 +419,18 @@ mod tests {
         let create = create_table_statement("talon_kv");
         assert!(create.contains("CREATE TABLE IF NOT EXISTS \"talon_kv\""));
         assert!(create.contains("value BLOB NOT NULL"));
+        assert!(create.contains("WITHOUT ROWID"));
 
-        assert_eq!(
-            get_query("talon_kv"),
-            "SELECT value FROM \"talon_kv\" WHERE key = ?1"
-        );
+        assert!(get_query("talon_kv").contains("WHERE namespace = ?1"));
         assert!(set_query("talon_kv").contains("excluded.value"));
-        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = ?2"));
+        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = ?6"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
-        assert_eq!(
-            delete_query("talon_kv"),
-            "DELETE FROM \"talon_kv\" WHERE key = ?1"
-        );
-        assert!(list_keys_query("talon_kv").contains("LIKE ?1 ESCAPE '\\'"));
-        assert!(list_keys_page_query("talon_kv").contains("ORDER BY key DESC"));
-        assert!(list_entries_page_query("talon_kv").contains("SELECT key, value"));
-        assert!(list_entries_page_query("talon_kv").contains("ORDER BY key DESC"));
-        assert!(list_entries_query("talon_kv").contains("SELECT key, value"));
-        assert!(delete_prefix_query("talon_kv").contains("DELETE FROM \"talon_kv\""));
+        assert!(delete_query("talon_kv").contains("WHERE namespace = ?1"));
+        assert!(list_keys_query("talon_kv", true).contains("AND kind = ?3"));
+        assert!(list_keys_page_query("talon_kv").contains("ORDER BY name DESC"));
+        assert!(list_entries_page_query("talon_kv")
+            .contains("SELECT namespace, parent_path, kind, name, value"));
+        assert!(list_entries_query("talon_kv", false).contains("ORDER BY kind ASC, name ASC"));
     }
 
     #[test]
@@ -366,7 +438,7 @@ mod tests {
         assert_eq!(
             super::super::legacy::namespaced_key("talon-system:ns", "Namespace/quickstart")
                 .unwrap(),
-            crate::control::keys::namespace_metadata("quickstart")
+            crate::control::keys::namespace_metadata("quickstart").canonical()
         );
         assert_eq!(
             super::super::legacy::namespaced_key(
@@ -374,7 +446,7 @@ mod tests {
                 "NamespaceRef/quickstart"
             )
             .unwrap(),
-            crate::control::keys::namespace_ref(None, "quickstart")
+            crate::control::keys::namespace_ref(None, "quickstart").canonical()
         );
     }
 
@@ -438,71 +510,73 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sqlite_kv_round_trip_compare_and_swap_and_prefix_ops() {
+    async fn sqlite_kv_round_trip_compare_and_swap_and_direct_list_ops() {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("talon-kv.db");
         let store = SqliteKvStore::new(&sqlite_url_for_path(&db_path), "talon_kv_store_test")
             .await
             .unwrap();
 
-        assert!(store.get("missing").await.unwrap().is_none());
+        let missing = keys::session("quickstart", "hello-agent", "missing");
+        let a = keys::session("quickstart", "hello-agent", "a");
+        let b = keys::session("quickstart", "hello-agent", "b");
+        let other = keys::session("quickstart", "other-agent", "c");
+        let list = keys::session_prefix("quickstart", "hello-agent");
 
-        store.set("prefix/a", b"one").await.unwrap();
-        store.set("prefix/b", b"two").await.unwrap();
-        store.set("other/c", b"three").await.unwrap();
-        assert_eq!(store.get("prefix/a").await.unwrap(), Some(b"one".to_vec()));
+        assert!(store.get(&missing).await.unwrap().is_none());
 
-        let mut keys = store.list_keys("prefix/").await.unwrap();
-        keys.sort();
-        assert_eq!(keys, vec!["prefix/a".to_string(), "prefix/b".to_string()]);
+        store.set(&a, b"one").await.unwrap();
+        store.set(&b, b"two").await.unwrap();
+        store.set(&other, b"three").await.unwrap();
+        assert_eq!(store.get(&a).await.unwrap(), Some(b"one".to_vec()));
+
+        let mut listed = store.list_keys(&list).await.unwrap();
+        listed.sort_by(|left, right| left.name.cmp(&right.name));
+        assert_eq!(listed, vec![a.clone(), b.clone()]);
 
         assert_eq!(
-            store.list_keys_page("prefix/", None, 10).await.unwrap(),
-            vec!["prefix/b".to_string(), "prefix/a".to_string()]
+            store.list_keys_page(&list, None, 10).await.unwrap(),
+            vec![b.clone(), a.clone()]
         );
         assert_eq!(
-            store
-                .list_keys_page("prefix/", Some("prefix/b"), 10)
-                .await
-                .unwrap(),
-            vec!["prefix/a".to_string()]
+            store.list_keys_page(&list, Some("b"), 10).await.unwrap(),
+            vec![a.clone()]
         );
         assert_eq!(
-            store.list_entries_page("prefix/", None, 10).await.unwrap(),
-            vec![
-                ("prefix/b".to_string(), b"two".to_vec()),
-                ("prefix/a".to_string(), b"one".to_vec())
-            ]
+            store.list_entries_page(&list, None, 10).await.unwrap(),
+            vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 
-        let mut entries = store.list_entries("prefix/").await.unwrap();
-        entries.sort_by(|a, b| a.0.cmp(&b.0));
-        assert_eq!(entries[0], ("prefix/a".to_string(), b"one".to_vec()));
-        assert_eq!(entries[1], ("prefix/b".to_string(), b"two".to_vec()));
+        let mut entries = store.list_entries(&list).await.unwrap();
+        entries.sort_by(|left, right| left.0.name.cmp(&right.0.name));
+        assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
+        assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
 
         assert!(store
-            .compare_and_swap("prefix/a", Some(b"one"), b"updated")
+            .compare_and_swap(&a, Some(b"one"), b"updated")
             .await
             .unwrap());
         assert!(!store
-            .compare_and_swap("prefix/a", Some(b"wrong"), b"nope")
+            .compare_and_swap(&a, Some(b"wrong"), b"nope")
             .await
             .unwrap());
+        let new_key = keys::session("quickstart", "hello-agent", "new");
         assert!(store
-            .compare_and_swap("new/key", None, b"created")
+            .compare_and_swap(&new_key, None, b"created")
             .await
             .unwrap());
         assert!(!store
-            .compare_and_swap("new/key", None, b"duplicate")
+            .compare_and_swap(&new_key, None, b"duplicate")
             .await
             .unwrap());
 
-        store.delete("new/key").await.unwrap();
-        assert!(store.get("new/key").await.unwrap().is_none());
+        store.delete(&new_key).await.unwrap();
+        assert!(store.get(&new_key).await.unwrap().is_none());
 
-        store.delete_prefix("prefix/").await.unwrap();
-        assert!(store.get("prefix/a").await.unwrap().is_none());
-        assert!(store.get("prefix/b").await.unwrap().is_none());
-        assert_eq!(store.get("other/c").await.unwrap(), Some(b"three".to_vec()));
+        store.delete(&a).await.unwrap();
+        store.delete(&b).await.unwrap();
+        assert!(store.get(&a).await.unwrap().is_none());
+        assert!(store.get(&b).await.unwrap().is_none());
+        assert_eq!(store.get(&other).await.unwrap(), Some(b"three".to_vec()));
     }
 }

--- a/src/control/kv/sqlite.rs
+++ b/src/control/kv/sqlite.rs
@@ -15,10 +15,9 @@ fn create_table_statement(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
         "CREATE TABLE IF NOT EXISTS {} (
-                namespace TEXT NOT NULL,
                 key TEXT NOT NULL,
                 value BLOB NOT NULL,
-                PRIMARY KEY (namespace, key)
+                PRIMARY KEY (key)
             )",
         table
     )
@@ -26,7 +25,7 @@ fn create_table_statement(table: &str) -> String {
 
 fn get_query(table: &str) -> String {
     format!(
-        "SELECT value FROM {} WHERE namespace = ?1 AND key = ?2",
+        "SELECT value FROM {} WHERE key = ?1",
         quoted_identifier(table)
     )
 }
@@ -34,8 +33,8 @@ fn get_query(table: &str) -> String {
 fn set_query(table: &str) -> String {
     let table = quoted_identifier(table);
     format!(
-        "INSERT INTO {} (namespace, key, value) VALUES (?1, ?2, ?3)
-             ON CONFLICT (namespace, key) DO UPDATE SET value = excluded.value",
+        "INSERT INTO {} (key, value) VALUES (?1, ?2)
+             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
         table
     )
 }
@@ -45,35 +44,32 @@ fn compare_and_swap_query(table: &str, expected: bool) -> String {
     if expected {
         format!(
             "UPDATE {} SET value = ?3
-                 WHERE namespace = ?1 AND key = ?2 AND value = ?4",
+                 WHERE key = ?1 AND value = ?2",
             table
         )
     } else {
         format!(
-            "INSERT INTO {} (namespace, key, value) VALUES (?1, ?2, ?3)
-                 ON CONFLICT (namespace, key) DO NOTHING",
+            "INSERT INTO {} (key, value) VALUES (?1, ?2)
+                 ON CONFLICT (key) DO NOTHING",
             table
         )
     }
 }
 
 fn delete_query(table: &str) -> String {
-    format!(
-        "DELETE FROM {} WHERE namespace = ?1 AND key = ?2",
-        quoted_identifier(table)
-    )
+    format!("DELETE FROM {} WHERE key = ?1", quoted_identifier(table))
 }
 
 fn list_keys_query(table: &str) -> String {
     format!(
-        "SELECT key FROM {} WHERE namespace = ?1 AND key LIKE ?2 ESCAPE '\\'",
+        "SELECT key FROM {} WHERE key LIKE ?1 ESCAPE '\\'",
         quoted_identifier(table)
     )
 }
 
 fn list_entries_query(table: &str) -> String {
     format!(
-        "SELECT key, value FROM {} WHERE namespace = ?1 AND key LIKE ?2 ESCAPE '\\'",
+        "SELECT key, value FROM {} WHERE key LIKE ?1 ESCAPE '\\'",
         quoted_identifier(table)
     )
 }
@@ -81,11 +77,10 @@ fn list_entries_query(table: &str) -> String {
 fn list_keys_page_query(table: &str) -> String {
     format!(
         "SELECT key FROM {}
-         WHERE namespace = ?1
-           AND key LIKE ?2 ESCAPE '\\'
-           AND (?3 IS NULL OR key < ?3)
+         WHERE key LIKE ?1 ESCAPE '\\'
+           AND (?2 IS NULL OR key < ?2)
          ORDER BY key DESC
-         LIMIT ?4",
+         LIMIT ?3",
         quoted_identifier(table)
     )
 }
@@ -93,18 +88,17 @@ fn list_keys_page_query(table: &str) -> String {
 fn list_entries_page_query(table: &str) -> String {
     format!(
         "SELECT key, value FROM {}
-         WHERE namespace = ?1
-           AND key LIKE ?2 ESCAPE '\\'
-           AND (?3 IS NULL OR key < ?3)
+         WHERE key LIKE ?1 ESCAPE '\\'
+           AND (?2 IS NULL OR key < ?2)
          ORDER BY key DESC
-         LIMIT ?4",
+         LIMIT ?3",
         quoted_identifier(table)
     )
 }
 
 fn delete_prefix_query(table: &str) -> String {
     format!(
-        "DELETE FROM {} WHERE namespace = ?1 AND key LIKE ?2 ESCAPE '\\'",
+        "DELETE FROM {} WHERE key LIKE ?1 ESCAPE '\\'",
         quoted_identifier(table)
     )
 }
@@ -119,6 +113,7 @@ impl SqliteKvStore {
         validate_identifier(table)?;
         let pool = sqlite_pool(url).await?;
 
+        migrate_legacy_table(&pool, table).await?;
         let create_stmt = create_table_statement(table);
         sqlx::query(&create_stmt).execute(&pool).await?;
 
@@ -127,6 +122,52 @@ impl SqliteKvStore {
             table: table.to_string(),
         })
     }
+}
+
+async fn migrate_legacy_table(pool: &SqlitePool, table: &str) -> Result<()> {
+    let columns = sqlx::query(&format!("PRAGMA table_info({})", quoted_identifier(table)))
+        .fetch_all(pool)
+        .await?;
+    let has_namespace = columns
+        .iter()
+        .filter_map(|row| row.try_get::<String, _>("name").ok())
+        .any(|column| column == "namespace");
+    if !has_namespace {
+        return Ok(());
+    }
+
+    let mut tx = pool.begin().await?;
+    let old_rows = sqlx::query(&format!(
+        "SELECT namespace, key, value FROM {}",
+        quoted_identifier(table)
+    ))
+    .fetch_all(&mut *tx)
+    .await?;
+    let mut converted_rows = Vec::with_capacity(old_rows.len());
+    for row in old_rows {
+        let namespace: String = row.try_get("namespace")?;
+        let old_key: String = row.try_get("key")?;
+        let value: Vec<u8> = row.try_get("value")?;
+        let new_key = super::legacy::namespaced_key(&namespace, &old_key)?;
+        converted_rows.push((new_key, value));
+    }
+
+    sqlx::query(&format!("DROP TABLE {}", quoted_identifier(table)))
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(&create_table_statement(table))
+        .execute(&mut *tx)
+        .await?;
+    let insert = set_query(table);
+    for (key, value) in converted_rows {
+        sqlx::query(&insert)
+            .bind(key)
+            .bind(value)
+            .execute(&mut *tx)
+            .await?;
+    }
+    tx.commit().await?;
+    Ok(())
 }
 
 async fn sqlite_pool(url: &str) -> Result<SqlitePool> {
@@ -144,10 +185,9 @@ async fn sqlite_pool(url: &str) -> Result<SqlitePool> {
 
 #[async_trait::async_trait]
 impl KeyValueStore for SqliteKvStore {
-    async fn get(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
         let query = get_query(&self.table);
         let row = sqlx::query(&query)
-            .bind(namespace)
             .bind(key)
             .fetch_optional(&self.pool)
             .await?;
@@ -160,10 +200,9 @@ impl KeyValueStore for SqliteKvStore {
         }
     }
 
-    async fn set(&self, namespace: &str, key: &str, value: &[u8]) -> Result<()> {
+    async fn set(&self, key: &str, value: &[u8]) -> Result<()> {
         let query = set_query(&self.table);
         sqlx::query(&query)
-            .bind(namespace)
             .bind(key)
             .bind(value)
             .execute(&self.pool)
@@ -173,35 +212,30 @@ impl KeyValueStore for SqliteKvStore {
 
     async fn compare_and_swap(
         &self,
-        namespace: &str,
         key: &str,
         expected: Option<&[u8]>,
         value: &[u8],
     ) -> Result<bool> {
         let query = compare_and_swap_query(&self.table, expected.is_some());
-        let mut q = sqlx::query(&query).bind(namespace).bind(key).bind(value);
-        if let Some(expected) = expected {
-            q = q.bind(expected);
-        }
+        let q = if let Some(expected) = expected {
+            sqlx::query(&query).bind(key).bind(expected).bind(value)
+        } else {
+            sqlx::query(&query).bind(key).bind(value)
+        };
         let rows_affected = q.execute(&self.pool).await?.rows_affected();
         Ok(rows_affected == 1)
     }
 
-    async fn delete(&self, namespace: &str, key: &str) -> Result<()> {
+    async fn delete(&self, key: &str) -> Result<()> {
         let query = delete_query(&self.table);
-        sqlx::query(&query)
-            .bind(namespace)
-            .bind(key)
-            .execute(&self.pool)
-            .await?;
+        sqlx::query(&query).bind(key).execute(&self.pool).await?;
         Ok(())
     }
 
-    async fn list_keys(&self, namespace: &str, prefix: &str) -> Result<Vec<String>> {
+    async fn list_keys(&self, prefix: &str) -> Result<Vec<String>> {
         let query = list_keys_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .fetch_all(&self.pool)
             .await?;
@@ -213,11 +247,10 @@ impl KeyValueStore for SqliteKvStore {
         Ok(keys)
     }
 
-    async fn list_entries(&self, namespace: &str, prefix: &str) -> Result<Vec<(String, Vec<u8>)>> {
+    async fn list_entries(&self, prefix: &str) -> Result<Vec<(String, Vec<u8>)>> {
         let query = list_entries_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .fetch_all(&self.pool)
             .await?;
@@ -231,7 +264,6 @@ impl KeyValueStore for SqliteKvStore {
 
     async fn list_keys_page(
         &self,
-        namespace: &str,
         prefix: &str,
         before_key: Option<&str>,
         limit: usize,
@@ -243,7 +275,6 @@ impl KeyValueStore for SqliteKvStore {
         let query = list_keys_page_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .bind(before_key)
             .bind(limit as i64)
@@ -259,7 +290,6 @@ impl KeyValueStore for SqliteKvStore {
 
     async fn list_entries_page(
         &self,
-        namespace: &str,
         prefix: &str,
         before_key: Option<&str>,
         limit: usize,
@@ -271,7 +301,6 @@ impl KeyValueStore for SqliteKvStore {
         let query = list_entries_page_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         let rows = sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .bind(before_key)
             .bind(limit as i64)
@@ -285,11 +314,10 @@ impl KeyValueStore for SqliteKvStore {
         Ok(entries)
     }
 
-    async fn delete_prefix(&self, namespace: &str, prefix: &str) -> Result<()> {
+    async fn delete_prefix(&self, prefix: &str) -> Result<()> {
         let query = delete_prefix_query(&self.table);
         let prefix_pattern = like_prefix_pattern(prefix);
         sqlx::query(&query)
-            .bind(namespace)
             .bind(prefix_pattern)
             .execute(&self.pool)
             .await?;
@@ -302,7 +330,7 @@ mod tests {
     use super::{
         compare_and_swap_query, create_table_statement, delete_prefix_query, delete_query,
         get_query, list_entries_page_query, list_entries_query, list_keys_page_query,
-        list_keys_query, set_query, SqliteKvStore,
+        list_keys_query, set_query, sqlite_pool, SqliteKvStore,
     };
     use crate::control::kv::sqlite_url_for_path;
     use crate::control::KeyValueStore;
@@ -316,21 +344,97 @@ mod tests {
 
         assert_eq!(
             get_query("talon_kv"),
-            "SELECT value FROM \"talon_kv\" WHERE namespace = ?1 AND key = ?2"
+            "SELECT value FROM \"talon_kv\" WHERE key = ?1"
         );
         assert!(set_query("talon_kv").contains("excluded.value"));
-        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = ?4"));
+        assert!(compare_and_swap_query("talon_kv", true).contains("AND value = ?2"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
         assert_eq!(
             delete_query("talon_kv"),
-            "DELETE FROM \"talon_kv\" WHERE namespace = ?1 AND key = ?2"
+            "DELETE FROM \"talon_kv\" WHERE key = ?1"
         );
-        assert!(list_keys_query("talon_kv").contains("LIKE ?2 ESCAPE '\\'"));
+        assert!(list_keys_query("talon_kv").contains("LIKE ?1 ESCAPE '\\'"));
         assert!(list_keys_page_query("talon_kv").contains("ORDER BY key DESC"));
         assert!(list_entries_page_query("talon_kv").contains("SELECT key, value"));
         assert!(list_entries_page_query("talon_kv").contains("ORDER BY key DESC"));
         assert!(list_entries_query("talon_kv").contains("SELECT key, value"));
         assert!(delete_prefix_query("talon_kv").contains("DELETE FROM \"talon_kv\""));
+    }
+
+    #[test]
+    fn sqlite_legacy_migration_maps_old_system_namespace_names() {
+        assert_eq!(
+            super::super::legacy::namespaced_key("talon-system:ns", "Namespace/quickstart")
+                .unwrap(),
+            crate::control::keys::namespace_metadata("quickstart")
+        );
+        assert_eq!(
+            super::super::legacy::namespaced_key(
+                "talon-system:ns:internal",
+                "NamespaceRef/quickstart"
+            )
+            .unwrap(),
+            crate::control::keys::namespace_ref(None, "quickstart")
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_migrates_old_system_namespace_rows() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("talon-kv-legacy.db");
+        let url = sqlite_url_for_path(&db_path);
+        let setup_pool = sqlite_pool(&url).await.unwrap();
+        sqlx::query(
+            "CREATE TABLE talon_kv_store_test (
+                namespace TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value BLOB NOT NULL,
+                PRIMARY KEY (namespace, key)
+            )",
+        )
+        .execute(&setup_pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO talon_kv_store_test (namespace, key, value)
+             VALUES (?1, ?2, ?3)",
+        )
+        .bind("talon-system:ns")
+        .bind("Namespace/quickstart")
+        .bind(b"meta".to_vec())
+        .execute(&setup_pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO talon_kv_store_test (namespace, key, value)
+             VALUES (?1, ?2, ?3)",
+        )
+        .bind("talon-system:ns:internal")
+        .bind("NamespaceRef/quickstart")
+        .bind(b"edge".to_vec())
+        .execute(&setup_pool)
+        .await
+        .unwrap();
+        setup_pool.close().await;
+
+        let store = SqliteKvStore::new(&url, "talon_kv_store_test")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .get(&crate::control::keys::namespace_metadata("quickstart"))
+                .await
+                .unwrap(),
+            Some(b"meta".to_vec())
+        );
+        assert_eq!(
+            store
+                .get(&crate::control::keys::namespace_ref(None, "quickstart"))
+                .await
+                .unwrap(),
+            Some(b"edge".to_vec())
+        );
     }
 
     #[tokio::test]
@@ -341,76 +445,64 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(store.get("ns", "missing").await.unwrap().is_none());
+        assert!(store.get("missing").await.unwrap().is_none());
 
-        store.set("ns", "prefix/a", b"one").await.unwrap();
-        store.set("ns", "prefix/b", b"two").await.unwrap();
-        store.set("ns", "other/c", b"three").await.unwrap();
-        assert_eq!(
-            store.get("ns", "prefix/a").await.unwrap(),
-            Some(b"one".to_vec())
-        );
+        store.set("prefix/a", b"one").await.unwrap();
+        store.set("prefix/b", b"two").await.unwrap();
+        store.set("other/c", b"three").await.unwrap();
+        assert_eq!(store.get("prefix/a").await.unwrap(), Some(b"one".to_vec()));
 
-        let mut keys = store.list_keys("ns", "prefix/").await.unwrap();
+        let mut keys = store.list_keys("prefix/").await.unwrap();
         keys.sort();
         assert_eq!(keys, vec!["prefix/a".to_string(), "prefix/b".to_string()]);
 
         assert_eq!(
-            store
-                .list_keys_page("ns", "prefix/", None, 10)
-                .await
-                .unwrap(),
+            store.list_keys_page("prefix/", None, 10).await.unwrap(),
             vec!["prefix/b".to_string(), "prefix/a".to_string()]
         );
         assert_eq!(
             store
-                .list_keys_page("ns", "prefix/", Some("prefix/b"), 10)
+                .list_keys_page("prefix/", Some("prefix/b"), 10)
                 .await
                 .unwrap(),
             vec!["prefix/a".to_string()]
         );
         assert_eq!(
-            store
-                .list_entries_page("ns", "prefix/", None, 10)
-                .await
-                .unwrap(),
+            store.list_entries_page("prefix/", None, 10).await.unwrap(),
             vec![
                 ("prefix/b".to_string(), b"two".to_vec()),
                 ("prefix/a".to_string(), b"one".to_vec())
             ]
         );
 
-        let mut entries = store.list_entries("ns", "prefix/").await.unwrap();
+        let mut entries = store.list_entries("prefix/").await.unwrap();
         entries.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(entries[0], ("prefix/a".to_string(), b"one".to_vec()));
         assert_eq!(entries[1], ("prefix/b".to_string(), b"two".to_vec()));
 
         assert!(store
-            .compare_and_swap("ns", "prefix/a", Some(b"one"), b"updated")
+            .compare_and_swap("prefix/a", Some(b"one"), b"updated")
             .await
             .unwrap());
         assert!(!store
-            .compare_and_swap("ns", "prefix/a", Some(b"wrong"), b"nope")
+            .compare_and_swap("prefix/a", Some(b"wrong"), b"nope")
             .await
             .unwrap());
         assert!(store
-            .compare_and_swap("ns", "new/key", None, b"created")
+            .compare_and_swap("new/key", None, b"created")
             .await
             .unwrap());
         assert!(!store
-            .compare_and_swap("ns", "new/key", None, b"duplicate")
+            .compare_and_swap("new/key", None, b"duplicate")
             .await
             .unwrap());
 
-        store.delete("ns", "new/key").await.unwrap();
-        assert!(store.get("ns", "new/key").await.unwrap().is_none());
+        store.delete("new/key").await.unwrap();
+        assert!(store.get("new/key").await.unwrap().is_none());
 
-        store.delete_prefix("ns", "prefix/").await.unwrap();
-        assert!(store.get("ns", "prefix/a").await.unwrap().is_none());
-        assert!(store.get("ns", "prefix/b").await.unwrap().is_none());
-        assert_eq!(
-            store.get("ns", "other/c").await.unwrap(),
-            Some(b"three".to_vec())
-        );
+        store.delete_prefix("prefix/").await.unwrap();
+        assert!(store.get("prefix/a").await.unwrap().is_none());
+        assert!(store.get("prefix/b").await.unwrap().is_none());
+        assert_eq!(store.get("other/c").await.unwrap(), Some(b"three".to_vec()));
     }
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -12,32 +12,34 @@ pub mod topics;
 
 use std::path::PathBuf;
 
+use keys::{ResourceKey, ResourceList};
+
 pub fn page_keys_desc(
-    mut keys: Vec<String>,
-    before_key: Option<&str>,
+    mut keys: Vec<ResourceKey>,
+    before_name: Option<&str>,
     limit: usize,
-) -> Vec<String> {
+) -> Vec<ResourceKey> {
     if limit == 0 {
         return Vec::new();
     }
 
-    keys.retain(|key| before_key.map_or(true, |cursor| key.as_str() < cursor));
-    keys.sort_by(|left, right| right.cmp(left));
+    keys.retain(|key| before_name.map_or(true, |cursor| key.name.as_str() < cursor));
+    keys.sort_by(|left, right| right.name.cmp(&left.name));
     keys.truncate(limit);
     keys
 }
 
 pub fn page_entries_desc(
-    mut entries: Vec<(String, Vec<u8>)>,
-    before_key: Option<&str>,
+    mut entries: Vec<(ResourceKey, Vec<u8>)>,
+    before_name: Option<&str>,
     limit: usize,
-) -> Vec<(String, Vec<u8>)> {
+) -> Vec<(ResourceKey, Vec<u8>)> {
     if limit == 0 {
         return Vec::new();
     }
 
-    entries.retain(|(key, _)| before_key.map_or(true, |cursor| key.as_str() < cursor));
-    entries.sort_by(|left, right| right.0.cmp(&left.0));
+    entries.retain(|(key, _)| before_name.map_or(true, |cursor| key.name.as_str() < cursor));
+    entries.sort_by(|left, right| right.0.name.cmp(&left.0.name));
     entries.truncate(limit);
     entries
 }
@@ -45,58 +47,61 @@ pub fn page_entries_desc(
 #[async_trait::async_trait]
 pub trait KeyValueStore: Send + Sync {
     /// Retrieve a raw byte sequence from the store
-    async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>>;
+    async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>>;
 
     /// Store a raw byte sequence into the store
-    async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()>;
+    async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()>;
 
     /// Atomically replace the current value when it matches the expected value.
     async fn compare_and_swap(
         &self,
-        key: &str,
+        key: &ResourceKey,
         expected: Option<&[u8]>,
         value: &[u8],
     ) -> anyhow::Result<bool>;
 
     /// Delete a key.
-    async fn delete(&self, key: &str) -> anyhow::Result<()>;
+    async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()>;
 
-    /// List all keys with a given prefix.
-    async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>>;
+    /// List direct children matching a resource parent and optional kind.
+    async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>>;
 
-    /// List keys in a namespace with a given prefix, ordered by key descending.
+    /// List direct children, ordered by resource name descending.
     ///
-    /// `before_key` is an exclusive full-key cursor. Production backends should
-    /// override this with a storage-level page read. The default implementation
-    /// fails rather than silently materializing an unbounded prefix.
+    /// `before_name` is an exclusive resource-name cursor. Production backends
+    /// should override this with a storage-level page read. The default
+    /// implementation fails rather than silently materializing an unbounded list.
     async fn list_keys_page(
         &self,
-        prefix: &str,
-        before_key: Option<&str>,
+        list: &ResourceList,
+        before_name: Option<&str>,
         limit: usize,
-    ) -> anyhow::Result<Vec<String>> {
-        let _ = (prefix, before_key, limit);
+    ) -> anyhow::Result<Vec<ResourceKey>> {
+        let _ = (list, before_name, limit);
         anyhow::bail!("list_keys_page is not implemented for this KeyValueStore")
     }
 
-    /// List key/value pairs in a namespace with a given prefix, ordered by key descending.
+    /// List direct child key/value pairs, ordered by resource name descending.
     ///
-    /// `before_key` is an exclusive full-key cursor. Production backends should
-    /// override this with a storage-level page read. The default implementation
-    /// fails rather than silently materializing an unbounded prefix.
+    /// `before_name` is an exclusive resource-name cursor. Production backends
+    /// should override this with a storage-level page read. The default
+    /// implementation fails rather than silently materializing an unbounded list.
     async fn list_entries_page(
         &self,
-        prefix: &str,
-        before_key: Option<&str>,
+        list: &ResourceList,
+        before_name: Option<&str>,
         limit: usize,
-    ) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
-        let _ = (prefix, before_key, limit);
+    ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let _ = (list, before_name, limit);
         anyhow::bail!("list_entries_page is not implemented for this KeyValueStore")
     }
 
-    /// List all key/value pairs with a given prefix.
-    async fn list_entries(&self, prefix: &str) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
-        let keys = self.list_keys(prefix).await?;
+    /// List all matching direct child key/value pairs.
+    async fn list_entries(
+        &self,
+        list: &ResourceList,
+    ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let keys = self.list_keys(list).await?;
         let mut entries = Vec::with_capacity(keys.len());
         for key in keys {
             if let Some(value) = self.get(&key).await? {
@@ -105,33 +110,38 @@ pub trait KeyValueStore: Send + Sync {
         }
         Ok(entries)
     }
-
-    /// Delete all keys with a given prefix.
-    async fn delete_prefix(&self, prefix: &str) -> anyhow::Result<()> {
-        let keys = self.list_keys(prefix).await?;
-        for key in keys {
-            self.delete(&key).await?;
-        }
-        Ok(())
-    }
 }
 
 #[async_trait::async_trait]
 pub trait ProtoKeyValueStoreExt {
-    async fn get_msg<M: prost::Message + Default>(&self, key: &str) -> anyhow::Result<Option<M>>;
-    async fn set_msg<M: prost::Message + Sync>(&self, key: &str, msg: &M) -> anyhow::Result<()>;
+    async fn get_msg<M: prost::Message + Default>(
+        &self,
+        key: &ResourceKey,
+    ) -> anyhow::Result<Option<M>>;
+    async fn set_msg<M: prost::Message + Sync>(
+        &self,
+        key: &ResourceKey,
+        msg: &M,
+    ) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]
 impl<T: KeyValueStore + ?Sized> ProtoKeyValueStoreExt for T {
-    async fn get_msg<M: prost::Message + Default>(&self, key: &str) -> anyhow::Result<Option<M>> {
+    async fn get_msg<M: prost::Message + Default>(
+        &self,
+        key: &ResourceKey,
+    ) -> anyhow::Result<Option<M>> {
         match self.get(key).await? {
             Some(bytes) => Ok(Some(M::decode(bytes.as_slice())?)),
             None => Ok(None),
         }
     }
 
-    async fn set_msg<M: prost::Message + Sync>(&self, key: &str, msg: &M) -> anyhow::Result<()> {
+    async fn set_msg<M: prost::Message + Sync>(
+        &self,
+        key: &ResourceKey,
+        msg: &M,
+    ) -> anyhow::Result<()> {
         self.set(key, &msg.encode_to_vec()).await
     }
 }
@@ -410,6 +420,7 @@ mod tests {
     };
     use crate::config::proto;
     use crate::config::proto::{scheduler_callback_auth_config, scheduler_config, secret};
+    use crate::control::keys;
     use crate::gateway::rpc::models;
     use crate::test_support::MockKvStore;
     use std::collections::HashMap;
@@ -579,20 +590,25 @@ mod tests {
     #[tokio::test]
     async fn key_value_store_default_helpers_and_proto_round_trip_work() {
         let kv = MockKvStore::default();
-        kv.set("prefix/a", b"one").await.unwrap();
-        kv.set("prefix/b", b"two").await.unwrap();
-        kv.set("other/c", b"three").await.unwrap();
+        let a = keys::session("ns", "agent", "a");
+        let b = keys::session("ns", "agent", "b");
+        let other = keys::session("ns", "other", "c");
+        let list = keys::session_prefix("ns", "agent");
+        kv.set(&a, b"one").await.unwrap();
+        kv.set(&b, b"two").await.unwrap();
+        kv.set(&other, b"three").await.unwrap();
 
-        let mut entries = kv.list_entries("prefix/").await.unwrap();
-        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        let mut entries = kv.list_entries(&list).await.unwrap();
+        entries.sort_by(|a, b| a.0.name.cmp(&b.0.name));
         assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0], ("prefix/a".to_string(), b"one".to_vec()));
-        assert_eq!(entries[1], ("prefix/b".to_string(), b"two".to_vec()));
+        assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
+        assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
 
-        kv.delete_prefix("prefix/").await.unwrap();
-        assert!(kv.get("prefix/a").await.unwrap().is_none());
-        assert!(kv.get("prefix/b").await.unwrap().is_none());
-        assert_eq!(kv.get("other/c").await.unwrap(), Some(b"three".to_vec()));
+        kv.delete(&a).await.unwrap();
+        kv.delete(&b).await.unwrap();
+        assert!(kv.get(&a).await.unwrap().is_none());
+        assert!(kv.get(&b).await.unwrap().is_none());
+        assert_eq!(kv.get(&other).await.unwrap(), Some(b"three".to_vec()));
 
         let session = models::Session {
             id: "session-1".to_string(),
@@ -604,16 +620,17 @@ mod tests {
             metadata: HashMap::new(),
             labels: HashMap::from([("env".to_string(), "test".to_string())]),
         };
-        kv.set_msg("session/key", &session).await.unwrap();
+        let session_key = keys::session("ns", "agent", "session-1");
+        kv.set_msg(&session_key, &session).await.unwrap();
         let loaded = kv
-            .get_msg::<models::Session>("session/key")
+            .get_msg::<models::Session>(&session_key)
             .await
             .unwrap()
             .expect("session should decode");
         assert_eq!(loaded.id, "session-1");
         assert_eq!(loaded.labels.get("env").map(String::as_str), Some("test"));
         assert!(kv
-            .get_msg::<models::Session>("missing")
+            .get_msg::<models::Session>(&keys::session("ns", "agent", "missing"))
             .await
             .unwrap()
             .is_none());

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -45,25 +45,24 @@ pub fn page_entries_desc(
 #[async_trait::async_trait]
 pub trait KeyValueStore: Send + Sync {
     /// Retrieve a raw byte sequence from the store
-    async fn get(&self, namespace: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>>;
+    async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>>;
 
     /// Store a raw byte sequence into the store
-    async fn set(&self, namespace: &str, key: &str, value: &[u8]) -> anyhow::Result<()>;
+    async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()>;
 
     /// Atomically replace the current value when it matches the expected value.
     async fn compare_and_swap(
         &self,
-        namespace: &str,
         key: &str,
         expected: Option<&[u8]>,
         value: &[u8],
     ) -> anyhow::Result<bool>;
 
-    /// Delete a key from the namespace
-    async fn delete(&self, namespace: &str, key: &str) -> anyhow::Result<()>;
+    /// Delete a key.
+    async fn delete(&self, key: &str) -> anyhow::Result<()>;
 
-    /// List all keys in a namespace with a given prefix
-    async fn list_keys(&self, namespace: &str, prefix: &str) -> anyhow::Result<Vec<String>>;
+    /// List all keys with a given prefix.
+    async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>>;
 
     /// List keys in a namespace with a given prefix, ordered by key descending.
     ///
@@ -72,12 +71,11 @@ pub trait KeyValueStore: Send + Sync {
     /// fails rather than silently materializing an unbounded prefix.
     async fn list_keys_page(
         &self,
-        namespace: &str,
         prefix: &str,
         before_key: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<String>> {
-        let _ = (namespace, prefix, before_key, limit);
+        let _ = (prefix, before_key, limit);
         anyhow::bail!("list_keys_page is not implemented for this KeyValueStore")
     }
 
@@ -88,36 +86,31 @@ pub trait KeyValueStore: Send + Sync {
     /// fails rather than silently materializing an unbounded prefix.
     async fn list_entries_page(
         &self,
-        namespace: &str,
         prefix: &str,
         before_key: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
-        let _ = (namespace, prefix, before_key, limit);
+        let _ = (prefix, before_key, limit);
         anyhow::bail!("list_entries_page is not implemented for this KeyValueStore")
     }
 
-    /// List all key/value pairs in a namespace with a given prefix.
-    async fn list_entries(
-        &self,
-        namespace: &str,
-        prefix: &str,
-    ) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
-        let keys = self.list_keys(namespace, prefix).await?;
+    /// List all key/value pairs with a given prefix.
+    async fn list_entries(&self, prefix: &str) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
+        let keys = self.list_keys(prefix).await?;
         let mut entries = Vec::with_capacity(keys.len());
         for key in keys {
-            if let Some(value) = self.get(namespace, &key).await? {
+            if let Some(value) = self.get(&key).await? {
                 entries.push((key, value));
             }
         }
         Ok(entries)
     }
 
-    /// Delete all keys in a namespace with a given prefix.
-    async fn delete_prefix(&self, namespace: &str, prefix: &str) -> anyhow::Result<()> {
-        let keys = self.list_keys(namespace, prefix).await?;
+    /// Delete all keys with a given prefix.
+    async fn delete_prefix(&self, prefix: &str) -> anyhow::Result<()> {
+        let keys = self.list_keys(prefix).await?;
         for key in keys {
-            self.delete(namespace, &key).await?;
+            self.delete(&key).await?;
         }
         Ok(())
     }
@@ -125,39 +118,21 @@ pub trait KeyValueStore: Send + Sync {
 
 #[async_trait::async_trait]
 pub trait ProtoKeyValueStoreExt {
-    async fn get_msg<M: prost::Message + Default>(
-        &self,
-        namespace: &str,
-        key: &str,
-    ) -> anyhow::Result<Option<M>>;
-    async fn set_msg<M: prost::Message + Sync>(
-        &self,
-        namespace: &str,
-        key: &str,
-        msg: &M,
-    ) -> anyhow::Result<()>;
+    async fn get_msg<M: prost::Message + Default>(&self, key: &str) -> anyhow::Result<Option<M>>;
+    async fn set_msg<M: prost::Message + Sync>(&self, key: &str, msg: &M) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]
 impl<T: KeyValueStore + ?Sized> ProtoKeyValueStoreExt for T {
-    async fn get_msg<M: prost::Message + Default>(
-        &self,
-        namespace: &str,
-        key: &str,
-    ) -> anyhow::Result<Option<M>> {
-        match self.get(namespace, key).await? {
+    async fn get_msg<M: prost::Message + Default>(&self, key: &str) -> anyhow::Result<Option<M>> {
+        match self.get(key).await? {
             Some(bytes) => Ok(Some(M::decode(bytes.as_slice())?)),
             None => Ok(None),
         }
     }
 
-    async fn set_msg<M: prost::Message + Sync>(
-        &self,
-        namespace: &str,
-        key: &str,
-        msg: &M,
-    ) -> anyhow::Result<()> {
-        self.set(namespace, key, &msg.encode_to_vec()).await
+    async fn set_msg<M: prost::Message + Sync>(&self, key: &str, msg: &M) -> anyhow::Result<()> {
+        self.set(key, &msg.encode_to_vec()).await
     }
 }
 
@@ -604,23 +579,20 @@ mod tests {
     #[tokio::test]
     async fn key_value_store_default_helpers_and_proto_round_trip_work() {
         let kv = MockKvStore::default();
-        kv.set("ns", "prefix/a", b"one").await.unwrap();
-        kv.set("ns", "prefix/b", b"two").await.unwrap();
-        kv.set("ns", "other/c", b"three").await.unwrap();
+        kv.set("prefix/a", b"one").await.unwrap();
+        kv.set("prefix/b", b"two").await.unwrap();
+        kv.set("other/c", b"three").await.unwrap();
 
-        let mut entries = kv.list_entries("ns", "prefix/").await.unwrap();
+        let mut entries = kv.list_entries("prefix/").await.unwrap();
         entries.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0], ("prefix/a".to_string(), b"one".to_vec()));
         assert_eq!(entries[1], ("prefix/b".to_string(), b"two".to_vec()));
 
-        kv.delete_prefix("ns", "prefix/").await.unwrap();
-        assert!(kv.get("ns", "prefix/a").await.unwrap().is_none());
-        assert!(kv.get("ns", "prefix/b").await.unwrap().is_none());
-        assert_eq!(
-            kv.get("ns", "other/c").await.unwrap(),
-            Some(b"three".to_vec())
-        );
+        kv.delete_prefix("prefix/").await.unwrap();
+        assert!(kv.get("prefix/a").await.unwrap().is_none());
+        assert!(kv.get("prefix/b").await.unwrap().is_none());
+        assert_eq!(kv.get("other/c").await.unwrap(), Some(b"three".to_vec()));
 
         let session = models::Session {
             id: "session-1".to_string(),
@@ -632,16 +604,16 @@ mod tests {
             metadata: HashMap::new(),
             labels: HashMap::from([("env".to_string(), "test".to_string())]),
         };
-        kv.set_msg("ns", "session/key", &session).await.unwrap();
+        kv.set_msg("session/key", &session).await.unwrap();
         let loaded = kv
-            .get_msg::<models::Session>("ns", "session/key")
+            .get_msg::<models::Session>("session/key")
             .await
             .unwrap()
             .expect("session should decode");
         assert_eq!(loaded.id, "session-1");
         assert_eq!(loaded.labels.get("env").map(String::as_str), Some("test"));
         assert!(kv
-            .get_msg::<models::Session>("ns", "missing")
+            .get_msg::<models::Session>("missing")
             .await
             .unwrap()
             .is_none());

--- a/src/control/ns.rs
+++ b/src/control/ns.rs
@@ -5,7 +5,7 @@
 /// Similar to Kubernetes' `kube-system`, this namespace is strictly for
 /// internal platform logic, template artifacts, and manifests that are globally accessible
 /// but shouldn't collide with dynamic tenant/workspace namespaces.
-pub const TALON_SYSTEM: &str = "talon-system";
+pub const TALON_SYSTEM: &str = "Sys";
 
 /// Standard domain prefix.
 /// In Kubernetes, while namespaces are short (e.g. `kube-system`), domains are

--- a/src/control/scheduler/cloud_tasks.rs
+++ b/src/control/scheduler/cloud_tasks.rs
@@ -5,9 +5,7 @@ use crate::config::{proto::CloudTasksSchedulerConfig, SecretExt};
 use anyhow::{anyhow, Context, Result};
 use base64::Engine as _;
 use chrono::{DateTime, Utc};
-use google_cloud_auth::credentials::{
-    AccessTokenCredentials, Builder as CredentialsBuilder,
-};
+use google_cloud_auth::credentials::{AccessTokenCredentials, Builder as CredentialsBuilder};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 

--- a/src/control/scheduler/local_postgres.rs
+++ b/src/control/scheduler/local_postgres.rs
@@ -78,7 +78,8 @@ impl LocalPostgresSchedulerBackend {
         sqlx::query(&index_stmt).execute(&pool).await?;
 
         if runner_enabled {
-            let Some(target_url) = runner_target_url.filter(|value| !value.trim().is_empty()) else {
+            let Some(target_url) = runner_target_url.filter(|value| !value.trim().is_empty())
+            else {
                 warn!("local_postgres scheduler runner enabled without target URL; wakeups will not fire");
                 return Ok(Self { pool, table });
             };
@@ -88,7 +89,10 @@ impl LocalPostgresSchedulerBackend {
             };
             tokio::spawn(async move {
                 runner
-                    .run_loop(target_url, auth_token.filter(|value| !value.trim().is_empty()))
+                    .run_loop(
+                        target_url,
+                        auth_token.filter(|value| !value.trim().is_empty()),
+                    )
                     .await;
             });
         }
@@ -140,10 +144,7 @@ impl LocalPostgresSchedulerBackend {
                             )
                             .await
                             .map_err(|_| {
-                                anyhow!(
-                                    "timed out delivering scheduler wakeup to {}",
-                                    target_url
-                                )
+                                anyhow!("timed out delivering scheduler wakeup to {}", target_url)
                             })
                             .and_then(|result| result);
                             (
@@ -339,11 +340,7 @@ impl LocalPostgresSchedulerBackend {
 }
 
 fn validate_identifier(value: &str) -> Result<()> {
-    if value.is_empty()
-        || !value
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
-    {
+    if value.is_empty() || !value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
         anyhow::bail!("invalid identifier: {}", value);
     }
     Ok(())
@@ -536,8 +533,7 @@ mod tests {
         .await
         .expect("canceled row should load");
         let canceled_at: i64 = canceled_row.try_get("canceled_at_micros").unwrap();
-        let canceled_claim_until: Option<i64> =
-            canceled_row.try_get("claim_until_micros").unwrap();
+        let canceled_claim_until: Option<i64> = canceled_row.try_get("claim_until_micros").unwrap();
         let canceled_error: String = canceled_row.try_get("last_error").unwrap();
         assert!(canceled_at > 0);
         assert!(canceled_claim_until.is_none());
@@ -614,7 +610,11 @@ mod tests {
         let _ = shutdown_tx.send(());
         server.await.expect("server task should finish");
 
-        let received = received.lock().await.clone().expect("request should be captured");
+        let received = received
+            .lock()
+            .await
+            .clone()
+            .expect("request should be captured");
         assert_eq!(received.header.as_deref(), Some("secret-token"));
         assert_eq!(received.body, br#"{"deliver":true}"#.to_vec());
 
@@ -640,7 +640,10 @@ mod tests {
             .await
             .expect("cancel schedule should succeed");
         let cancel_handle = scheduled_cancel.handle.expect("cancel handle");
-        backend.cancel(&cancel_handle).await.expect("cancel should succeed");
+        backend
+            .cancel(&cancel_handle)
+            .await
+            .expect("cancel should succeed");
         let cancel_row = sqlx::query(&format!(
             "SELECT canceled_at_micros FROM {} WHERE handle = $1",
             backend.table
@@ -720,7 +723,10 @@ mod tests {
             .handle
             .expect("claimed handle");
 
-        backend.cancel(&canceled).await.expect("cancel should succeed");
+        backend
+            .cancel(&canceled)
+            .await
+            .expect("cancel should succeed");
         backend
             .mark_delivered(&delivered)
             .await
@@ -856,9 +862,10 @@ mod tests {
             let expected_prefix = format!("{}:", SCHEDULER_AUTH_HEADER).to_ascii_lowercase();
             let header = request.lines().find_map(|line| {
                 let lower = line.to_ascii_lowercase();
-                lower
-                    .strip_prefix(&expected_prefix)
-                    .and_then(|_| line.split_once(':').map(|(_, value)| value.trim().to_string()))
+                lower.strip_prefix(&expected_prefix).and_then(|_| {
+                    line.split_once(':')
+                        .map(|(_, value)| value.trim().to_string())
+                })
             });
             let body = request
                 .split("\r\n\r\n")

--- a/src/control/scheduler/noop.rs
+++ b/src/control/scheduler/noop.rs
@@ -38,6 +38,9 @@ mod tests {
             .await
             .expect("schedule should succeed");
         assert_eq!(wakeup, ScheduledWakeup::default());
-        backend.cancel("ignored-handle").await.expect("cancel should succeed");
+        backend
+            .cancel("ignored-handle")
+            .await
+            .expect("cancel should succeed");
     }
 }

--- a/src/core/context_budget.rs
+++ b/src/core/context_budget.rs
@@ -218,9 +218,11 @@ fn segment_history(history: &[LoopMessage], budget: ContextBudget) -> Vec<Histor
         let message = &history[index];
 
         if message.role == "tool" {
-            segments.push(HistorySegment::Message(
-                tool_segment_summary(None, std::slice::from_ref(message), budget),
-            ));
+            segments.push(HistorySegment::Message(tool_segment_summary(
+                None,
+                std::slice::from_ref(message),
+                budget,
+            )));
             index += 1;
             continue;
         }
@@ -303,7 +305,10 @@ fn tool_segment_summary(
     let mut parts = Vec::new();
     if let Some(assistant) = assistant {
         if !assistant.content.trim().is_empty() {
-            parts.push(truncate_middle(&assistant.content, budget.max_message_chars / 2));
+            parts.push(truncate_middle(
+                &assistant.content,
+                budget.max_message_chars / 2,
+            ));
         }
         if let Some(tool_calls) = &assistant.tool_calls {
             let names = tool_calls
@@ -319,8 +324,7 @@ fn tool_segment_summary(
         }
     } else {
         parts.push(
-            "[Prior orphaned tool result omitted to preserve a valid tool transcript.]"
-                .to_string(),
+            "[Prior orphaned tool result omitted to preserve a valid tool transcript.]".to_string(),
         );
     }
 
@@ -699,9 +703,10 @@ mod tests {
 
         assert!(tool_history_is_consistent(&compacted));
         assert!(!compacted.iter().any(|message| message.role == "tool"));
-        assert!(!compacted
-            .iter()
-            .any(|message| message.tool_calls.as_ref().is_some_and(|calls| !calls.is_empty())));
+        assert!(!compacted.iter().any(|message| message
+            .tool_calls
+            .as_ref()
+            .is_some_and(|calls| !calls.is_empty())));
         assert!(compacted.iter().any(|message| {
             message.content.contains("valid tool transcript")
                 || message.content.contains("earlier messages omitted")
@@ -766,7 +771,9 @@ mod tests {
             "non-tool message exceeded max_message_chars"
         );
         assert!(
-            compacted.iter().any(|message| message.content.contains("omitted")),
+            compacted
+                .iter()
+                .any(|message| message.content.contains("omitted")),
             "expected older replay history to be omitted for this downloaded session"
         );
         assert!(

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -478,6 +478,7 @@ mod tests {
         LoopMessage,
     };
     use crate::config::Config;
+    use crate::control::keys::{ResourceKey, ResourceList};
     use crate::control::scheduler::{ScheduleWakeupRequest, ScheduledWakeup, SchedulerBackend};
     use crate::control::{ControlPlane, KeyValueStore, MessagePublisher};
     use crate::core::ContextBudget;
@@ -508,24 +509,24 @@ mod tests {
 
     #[async_trait]
     impl KeyValueStore for NoopKv {
-        async fn get(&self, _key: &str) -> Result<Option<Vec<u8>>> {
+        async fn get(&self, _key: &ResourceKey) -> Result<Option<Vec<u8>>> {
             Ok(None)
         }
-        async fn set(&self, _key: &str, _value: &[u8]) -> Result<()> {
+        async fn set(&self, _key: &ResourceKey, _value: &[u8]) -> Result<()> {
             Ok(())
         }
         async fn compare_and_swap(
             &self,
-            _key: &str,
+            _key: &ResourceKey,
             _expected: Option<&[u8]>,
             _value: &[u8],
         ) -> Result<bool> {
             Ok(true)
         }
-        async fn delete(&self, _key: &str) -> Result<()> {
+        async fn delete(&self, _key: &ResourceKey) -> Result<()> {
             Ok(())
         }
-        async fn list_keys(&self, _prefix: &str) -> Result<Vec<String>> {
+        async fn list_keys(&self, _list: &ResourceList) -> Result<Vec<ResourceKey>> {
             Ok(Vec::new())
         }
     }

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -9,16 +9,16 @@ use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::info_span;
 use tokio_util::sync::CancellationToken;
+use tracing::info_span;
 
 use crate::config::Config;
 use crate::connectors::mcp::{call_tool_for_config, McpConnectionConfig};
-use crate::core::context_budget::{compact_history_for_llm, tool_result_preview};
 use crate::control::ControlPlane;
+use crate::core::context_budget::{compact_history_for_llm, tool_result_preview};
 use crate::knowledge::KnowledgeBook;
-use crate::llm::{ChatMessage, ChatRequest, ChatStreamEvent, ChatUsage, LlmProvider, ToolCall};
 use crate::llm::resolver::resolve_model_profile;
+use crate::llm::{ChatMessage, ChatRequest, ChatStreamEvent, ChatUsage, LlmProvider, ToolCall};
 use crate::skills::registry::ToolRegistry;
 
 const DEFAULT_EXECUTION_TURN_LIMIT: usize = 25;
@@ -508,25 +508,24 @@ mod tests {
 
     #[async_trait]
     impl KeyValueStore for NoopKv {
-        async fn get(&self, _namespace: &str, _key: &str) -> Result<Option<Vec<u8>>> {
+        async fn get(&self, _key: &str) -> Result<Option<Vec<u8>>> {
             Ok(None)
         }
-        async fn set(&self, _namespace: &str, _key: &str, _value: &[u8]) -> Result<()> {
+        async fn set(&self, _key: &str, _value: &[u8]) -> Result<()> {
             Ok(())
         }
         async fn compare_and_swap(
             &self,
-            _namespace: &str,
             _key: &str,
             _expected: Option<&[u8]>,
             _value: &[u8],
         ) -> Result<bool> {
             Ok(true)
         }
-        async fn delete(&self, _namespace: &str, _key: &str) -> Result<()> {
+        async fn delete(&self, _key: &str) -> Result<()> {
             Ok(())
         }
-        async fn list_keys(&self, _namespace: &str, _prefix: &str) -> Result<Vec<String>> {
+        async fn list_keys(&self, _prefix: &str) -> Result<Vec<String>> {
             Ok(Vec::new())
         }
     }
@@ -661,10 +660,7 @@ mod tests {
             Ok(vec![0.0; 8])
         }
 
-        async fn chat_completion(
-            &self,
-            request: ChatRequest,
-        ) -> Result<ChatResponse> {
+        async fn chat_completion(&self, request: ChatRequest) -> Result<ChatResponse> {
             self.seen_messages
                 .lock()
                 .unwrap()
@@ -708,10 +704,7 @@ mod tests {
             Ok(vec![0.0; 8])
         }
 
-        async fn chat_completion(
-            &self,
-            _request: ChatRequest,
-        ) -> Result<ChatResponse> {
+        async fn chat_completion(&self, _request: ChatRequest) -> Result<ChatResponse> {
             unreachable!("stream_chat_completion is used in this test");
         }
 
@@ -830,7 +823,10 @@ mod tests {
                 && message.content
                     == "I'm talking about the blogs link in the footer and the blogs pages"
         }));
-        let tool_message = messages.iter().find(|message| message.role == "tool").unwrap();
+        let tool_message = messages
+            .iter()
+            .find(|message| message.role == "tool")
+            .unwrap();
         assert!(tool_message.content.len() <= ContextBudget::default().max_tool_result_chars);
         assert!(
             tool_message.content.contains("chars omitted")
@@ -923,23 +919,23 @@ mod tests {
             Ok(vec![0.0; 8])
         }
 
-        async fn chat_completion(
-            &self,
-            _request: ChatRequest,
-        ) -> Result<ChatResponse> {
+        async fn chat_completion(&self, _request: ChatRequest) -> Result<ChatResponse> {
             unreachable!("stream_chat_completion is used in this test");
         }
 
         async fn stream_chat_completion(&self, _request: ChatRequest) -> Result<ChatStream> {
-            Ok(Box::pin(futures::stream::unfold(0usize, |state| async move {
-                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-                let token = match state {
-                    0 => "Hello",
-                    1 => " world",
-                    _ => " trailing",
-                };
-                Some((Ok(ChatStreamEvent::TextDelta(token.to_string())), state + 1))
-            })))
+            Ok(Box::pin(futures::stream::unfold(
+                0usize,
+                |state| async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                    let token = match state {
+                        0 => "Hello",
+                        1 => " world",
+                        _ => " trailing",
+                    };
+                    Some((Ok(ChatStreamEvent::TextDelta(token.to_string())), state + 1))
+                },
+            )))
         }
 
         async fn completion(&self, prompt: &str) -> Result<String> {
@@ -999,7 +995,10 @@ mod tests {
             .await
             .expect("write user");
 
-        let assembled = ContextAssembler::new(dir.path()).assemble().await.expect("assemble");
+        let assembled = ContextAssembler::new(dir.path())
+            .assemble()
+            .await
+            .expect("assemble");
         assert!(assembled.contains("soul body"));
         assert!(assembled.contains("user body"));
         assert!(assembled.contains("(No AGENTS.md provided)"));
@@ -1073,7 +1072,10 @@ mod tests {
         assert!(get.contains("[conic:wks:13:notes/plan.md]"));
 
         let search = executor
-            .execute_tool(crate::knowledge::KNOWLEDGE_SEARCH_TOOL, r#"{"query":"plan"}"#)
+            .execute_tool(
+                crate::knowledge::KNOWLEDGE_SEARCH_TOOL,
+                r#"{"query":"plan"}"#,
+            )
             .await
             .expect("knowledge search");
         assert!(search.contains("remember the plan"));

--- a/src/gateway/rpc/agents.rs
+++ b/src/gateway/rpc/agents.rs
@@ -43,7 +43,9 @@ impl GrpcGatewayHandler {
         };
 
         if !validate_k8s_name(&agent) {
-            return Err(tonic::Status::invalid_argument("Agent name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character."));
+            return Err(tonic::Status::invalid_argument(
+                "Agent name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character.",
+            ));
         }
         if req.ns.is_empty() {
             return Err(tonic::Status::invalid_argument(
@@ -51,11 +53,11 @@ impl GrpcGatewayHandler {
             ));
         }
 
-        let meta_key = format!("Namespace/{}", req.ns);
+        let meta_key = keys::namespace_metadata(&req.ns);
         let ns_check = self
             .gateway
             .kv
-            .get_msg::<models::Namespace>("talon-system:ns", &meta_key)
+            .get_msg::<models::Namespace>(&meta_key)
             .await;
         match ns_check {
             Ok(Some(ns_record)) if !ns_record.is_deleted => {
@@ -65,19 +67,19 @@ impl GrpcGatewayHandler {
                 return Err(tonic::Status::failed_precondition(format!(
                     "Namespace '{}' is deleted.",
                     req.ns
-                )))
+                )));
             }
             Ok(None) => {
                 return Err(tonic::Status::failed_precondition(format!(
                     "Namespace '{}' does not exist.",
                     req.ns
-                )))
+                )));
             }
             Err(e) => {
                 return Err(tonic::Status::internal(format!(
                     "Database error checking namespace '{}': {}",
                     req.ns, e
-                )))
+                )));
             }
         }
 
@@ -99,11 +101,11 @@ impl GrpcGatewayHandler {
             labels: req.labels.clone(),
         };
 
-        let agent_db_key = keys::agent(&agent);
+        let agent_db_key = keys::agent(&req.ns, &agent);
 
         self.gateway
             .kv
-            .set_msg(&req.ns, &agent_db_key, &agent_model)
+            .set_msg(&agent_db_key, &agent_model)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to save agent state: {}", e)))?;
 
@@ -133,12 +135,12 @@ impl GrpcGatewayHandler {
         crate::require_auth!(self, req, &req.get_ref().ns, &req.get_ref().name);
         let req = req.into_inner();
 
-        let agent_db_key = keys::agent(&req.name);
+        let agent_db_key = keys::agent(&req.ns, &req.name);
 
         let agent = self
             .gateway
             .kv
-            .get_msg::<models::Agent>(&req.ns, &agent_db_key)
+            .get_msg::<models::Agent>(&agent_db_key)
             .await
             .map_err(|e| tonic::Status::internal(format!("Database error: {}", e)))?
             .ok_or_else(|| {
@@ -160,11 +162,11 @@ impl GrpcGatewayHandler {
         crate::require_auth!(self, req, &req.get_ref().ns, &req.get_ref().agent);
         let req = req.into_inner();
 
-        let agent_db_key = keys::agent(&req.agent);
+        let agent_db_key = keys::agent(&req.ns, &req.agent);
         let mut agent = self
             .gateway
             .kv
-            .get_msg::<models::Agent>(&req.ns, &agent_db_key)
+            .get_msg::<models::Agent>(&agent_db_key)
             .await
             .map_err(|e| tonic::Status::internal(format!("Database error: {}", e)))?
             .ok_or_else(|| {
@@ -190,7 +192,7 @@ impl GrpcGatewayHandler {
 
         self.gateway
             .kv
-            .set_msg(&req.ns, &agent_db_key, &agent)
+            .set_msg(&agent_db_key, &agent)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to update agent state: {}", e)))?;
 
@@ -221,25 +223,18 @@ impl GrpcGatewayHandler {
         crate::require_auth!(self, req, &req.get_ref().ns);
         let req = req.into_inner();
 
-        let prefix = "Agent/";
+        let prefix = keys::agent_prefix(&req.ns);
 
         let keys = self
             .gateway
             .kv
-            .list_keys(&req.ns, prefix)
+            .list_keys(&prefix)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to list agents: {}", e)))?;
 
         let agents: Vec<String> = keys
             .into_iter()
-            .filter_map(|k| {
-                let stripped = k.strip_prefix(prefix).unwrap_or(&k);
-                if stripped.contains('/') {
-                    None // Skip nested resources like Agent/test/Session/default
-                } else {
-                    Some(stripped.to_string())
-                }
-            })
+            .filter_map(|k| keys::direct_child_name(&prefix, &k))
             .collect();
 
         Ok(tonic::Response::new(proto::ListAgentsResponse { agents }))

--- a/src/gateway/rpc/crud_tests.rs
+++ b/src/gateway/rpc/crud_tests.rs
@@ -3,22 +3,18 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::test_support::{MockKvStore, RecordingPubSub};
     use crate::control::{
-        events, keys, ns, scheduler::NoopSchedulerBackend, topics,
-        KeyValueStore, ProtoKeyValueStoreExt,
+        events, keys, ns, scheduler::NoopSchedulerBackend, topics, KeyValueStore,
+        ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{manifests, models, proto, GrpcGatewayHandler};
     use crate::gateway::server::Gateway;
+    use crate::test_support::{MockKvStore, RecordingPubSub};
     use prost::Message;
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    fn setup_handler() -> (
-        GrpcGatewayHandler,
-        Arc<MockKvStore>,
-        Arc<RecordingPubSub>,
-    ) {
+    fn setup_handler() -> (GrpcGatewayHandler, Arc<MockKvStore>, Arc<RecordingPubSub>) {
         let kv = Arc::new(MockKvStore::default());
         let pubsub = Arc::new(RecordingPubSub::default());
         let gateway = Arc::new(Gateway::new(
@@ -32,8 +28,7 @@ mod tests {
 
     async fn seed_namespace(kv: &Arc<MockKvStore>, namespace: &str) {
         kv.set_msg(
-            "talon-system:ns",
-            &format!("Namespace/{namespace}"),
+            &keys::namespace_metadata(namespace),
             &models::Namespace {
                 name: namespace.to_string(),
                 parent: String::new(),
@@ -137,7 +132,7 @@ mod tests {
         assert_eq!(create.agent, "agent-1");
 
         let stored = kv
-            .get_msg::<models::Agent>("acme", &keys::agent("agent-1"))
+            .get_msg::<models::Agent>(&keys::agent("acme", "agent-1"))
             .await
             .expect("agent lookup should succeed")
             .expect("agent should be persisted");
@@ -228,8 +223,7 @@ mod tests {
         assert_eq!(empty_namespace.code(), tonic::Code::InvalidArgument);
 
         kv.set_msg(
-            "talon-system:ns",
-            "Namespace/deleted",
+            &keys::namespace_metadata("deleted"),
             &models::Namespace {
                 name: "deleted".to_string(),
                 parent: String::new(),
@@ -289,8 +283,7 @@ mod tests {
         assert_eq!(missing_modify.code(), tonic::Code::NotFound);
 
         kv.set_msg(
-            "acme",
-            &keys::agent("agent-1"),
+            &keys::agent("acme", "agent-1"),
             &models::Agent {
                 name: "agent-1".to_string(),
                 ns: "acme".to_string(),
@@ -302,7 +295,7 @@ mod tests {
         )
         .await
         .unwrap();
-        kv.set("acme", "Agent/agent-1/Session/test", b"nested")
+        kv.set(&keys::session("acme", "agent-1", "test"), b"nested")
             .await
             .unwrap();
 
@@ -318,7 +311,7 @@ mod tests {
 
     #[tokio::test]
     async fn template_crud_applies_defaults_and_validates_namespace() {
-        let (handler, _, _) = setup_handler();
+        let (handler, kv, _) = setup_handler();
 
         let created = handler
             .handle_create_agent_template(tonic::Request::new(proto::CreateAgentTemplateRequest {
@@ -344,6 +337,45 @@ mod tests {
             .expect("template list should succeed")
             .into_inner();
         assert_eq!(listed.templates.len(), 1);
+
+        let legacy_created = handler
+            .handle_create_agent_template(tonic::Request::new(proto::CreateAgentTemplateRequest {
+                template: Some(agent_template("legacy-researcher", "talon-system")),
+            }))
+            .await
+            .expect("legacy template namespace should be accepted")
+            .into_inner();
+        assert_eq!(
+            legacy_created
+                .template
+                .as_ref()
+                .and_then(|template| template.metadata.as_ref())
+                .map(|meta| meta.namespace.as_str()),
+            Some(ns::TALON_SYSTEM)
+        );
+
+        kv.set_msg(
+            &keys::agent_template("legacy-stored"),
+            &agent_template("legacy-stored", "talon-system"),
+        )
+        .await
+        .expect("legacy stored template should seed");
+
+        let legacy_fetched = handler
+            .handle_get_agent_template(tonic::Request::new(proto::GetAgentTemplateRequest {
+                name: "legacy-stored".to_string(),
+            }))
+            .await
+            .expect("legacy stored template should fetch")
+            .into_inner();
+        assert_eq!(
+            legacy_fetched
+                .template
+                .as_ref()
+                .and_then(|template| template.metadata.as_ref())
+                .map(|meta| meta.namespace.as_str()),
+            Some(ns::TALON_SYSTEM)
+        );
 
         let fetched = handler
             .handle_get_agent_template(tonic::Request::new(proto::GetAgentTemplateRequest {

--- a/src/gateway/rpc/knowledge.rs
+++ b/src/gateway/rpc/knowledge.rs
@@ -32,7 +32,7 @@ async fn list_namespace_knowledge(
         })?;
 
         for key in keys {
-            let path = keys::direct_child_name(&prefix, &key).unwrap_or(key.clone());
+            let path = keys::direct_child_name(&prefix, &key).unwrap_or_else(|| key.name.clone());
             if !seen_paths.insert(path.clone()) {
                 continue;
             }
@@ -118,7 +118,7 @@ impl GrpcGatewayHandler {
 #[cfg(test)]
 mod tests {
     use super::{decode_entry, list_namespace_knowledge};
-    use crate::control::keys;
+    use crate::control::keys::{self, ResourceKey, ResourceList};
     use crate::control::KeyValueStore;
     use crate::gateway::rpc::{proto, GrpcGatewayHandler};
     use crate::gateway::{server::Gateway, session_streams::SessionStreamHub};
@@ -131,23 +131,23 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<String, Vec<u8>>>,
+        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, k: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data.lock().await.insert(k.to_string(), v.to_vec());
+        async fn set(&self, k: &ResourceKey, v: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(k.clone(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            k: &str,
+            k: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
@@ -159,23 +159,23 @@ mod tests {
                 _ => false,
             };
             if matches {
-                data.insert(k.to_string(), value.to_vec());
+                data.insert(k.clone(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+        async fn delete(&self, k: &ResourceKey) -> anyhow::Result<()> {
             self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)

--- a/src/gateway/rpc/knowledge.rs
+++ b/src/gateway/rpc/knowledge.rs
@@ -22,21 +22,21 @@ async fn list_namespace_knowledge(
     kv: Arc<dyn crate::control::KeyValueStore>,
     namespace: &str,
 ) -> std::result::Result<Vec<models::Knowledge>, tonic::Status> {
-    let prefix = keys::knowledge_prefix();
     let mut modules = Vec::new();
     let mut seen_paths = HashSet::new();
 
     for candidate_ns in ns::ancestry(namespace) {
-        let keys = kv.list_keys(&candidate_ns, prefix).await.map_err(|e| {
+        let prefix = keys::knowledge_prefix(&candidate_ns);
+        let keys = kv.list_keys(&prefix).await.map_err(|e| {
             tonic::Status::internal(format!("Failed to list knowledge artifacts: {}", e))
         })?;
 
         for key in keys {
-            let path = key.strip_prefix(prefix).unwrap_or(&key).to_string();
+            let path = keys::direct_child_name(&prefix, &key).unwrap_or(key.clone());
             if !seen_paths.insert(path.clone()) {
                 continue;
             }
-            if let Some(bytes) = kv.get(&candidate_ns, &key).await.unwrap_or(None) {
+            if let Some(bytes) = kv.get(&key).await.unwrap_or(None) {
                 let entry = decode_entry(&candidate_ns, &path, &bytes);
                 modules.push(models::Knowledge {
                     namespace: entry.namespace,
@@ -118,6 +118,7 @@ impl GrpcGatewayHandler {
 #[cfg(test)]
 mod tests {
     use super::{decode_entry, list_namespace_knowledge};
+    use crate::control::keys;
     use crate::control::KeyValueStore;
     use crate::gateway::rpc::{proto, GrpcGatewayHandler};
     use crate::gateway::{server::Gateway, session_streams::SessionStreamHub};
@@ -130,63 +131,51 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+        data: Mutex<HashMap<String, Vec<u8>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, ns: &str, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(ns.to_string(), k.to_string()))
-                .cloned())
+        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, ns: &str, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .insert((ns.to_string(), k.to_string()), v.to_vec());
+        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(k.to_string(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            ns: &str,
             k: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let key = (ns.to_string(), k.to_string());
-            let current = data.get(&key).cloned();
+            let current = data.get(k).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(key, value.to_vec());
+                data.insert(k.to_string(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, ns: &str, k: &str) -> anyhow::Result<()> {
-            self.data.lock().await.remove(&(ns.to_string(), k.to_string()));
+        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+            self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(p)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -258,22 +247,19 @@ mod tests {
             updated_at: 3,
         };
         kv.set(
-            "acme",
-            "Knowledge/guide.md",
+            &keys::knowledge("acme", "guide.md"),
             &serde_json::to_vec(&root_entry).unwrap(),
         )
         .await
         .unwrap();
         kv.set(
-            "acme:child",
-            "Knowledge/guide.md",
+            &keys::knowledge("acme:child", "guide.md"),
             &serde_json::to_vec(&child_entry).unwrap(),
         )
         .await
         .unwrap();
         kv.set(
-            "acme",
-            "Knowledge/shared.md",
+            &keys::knowledge("acme", "shared.md"),
             &serde_json::to_vec(&unique_entry).unwrap(),
         )
         .await
@@ -281,8 +267,12 @@ mod tests {
 
         let modules = list_namespace_knowledge(kv, "acme:child").await.unwrap();
         assert_eq!(modules.len(), 2);
-        assert!(modules.iter().any(|m| m.path == "guide.md" && m.content == "child guide"));
-        assert!(modules.iter().any(|m| m.path == "shared.md" && m.content == "shared root"));
+        assert!(modules
+            .iter()
+            .any(|m| m.path == "guide.md" && m.content == "child guide"));
+        assert!(modules
+            .iter()
+            .any(|m| m.path == "shared.md" && m.content == "shared root"));
     }
 
     #[tokio::test]
@@ -309,8 +299,7 @@ mod tests {
             updated_at: 7,
         };
         kv.set(
-            "acme",
-            "Knowledge/guide.md",
+            &keys::knowledge("acme", "guide.md"),
             &serde_json::to_vec(&entry).unwrap(),
         )
         .await

--- a/src/gateway/rpc/knowledge_resources.rs
+++ b/src/gateway/rpc/knowledge_resources.rs
@@ -246,7 +246,7 @@ impl GrpcGatewayHandler {
 #[cfg(test)]
 mod tests {
     use super::hydrate_knowledge_manifest;
-    use crate::control::keys;
+    use crate::control::keys::{self, ResourceKey, ResourceList};
     use crate::control::{KeyValueStore, ProtoKeyValueStoreExt};
     use crate::gateway::rpc::{manifests, proto, GrpcGatewayHandler};
     use crate::gateway::{server::Gateway, session_streams::SessionStreamHub};
@@ -259,23 +259,23 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<String, Vec<u8>>>,
+        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, k: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data.lock().await.insert(k.to_string(), v.to_vec());
+        async fn set(&self, k: &ResourceKey, v: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(k.clone(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            k: &str,
+            k: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
@@ -287,23 +287,23 @@ mod tests {
                 _ => false,
             };
             if matches {
-                data.insert(k.to_string(), value.to_vec());
+                data.insert(k.clone(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+        async fn delete(&self, k: &ResourceKey) -> anyhow::Result<()> {
             self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)

--- a/src/gateway/rpc/knowledge_resources.rs
+++ b/src/gateway/rpc/knowledge_resources.rs
@@ -13,9 +13,9 @@ async fn hydrate_knowledge_manifest(
     let Some(spec) = knowledge.spec.as_mut() else {
         return Ok(knowledge);
     };
-    let path_key = keys::knowledge(&spec.path);
+    let path_key = keys::knowledge(namespace, &spec.path);
     if let Some(bytes) = kv
-        .get(namespace, &path_key)
+        .get(&path_key)
         .await
         .map_err(|e| tonic::Status::internal(format!("Failed to read knowledge artifact: {}", e)))?
     {
@@ -69,10 +69,10 @@ impl GrpcGatewayHandler {
                 "Knowledge spec.path is required",
             ));
         }
-        let path_key = keys::knowledge(&spec.path);
+        let path_key = keys::knowledge(&req.ns, &spec.path);
 
         if let Some(existing_bytes) =
-            self.gateway.kv.get(&req.ns, &path_key).await.map_err(|e| {
+            self.gateway.kv.get(&path_key).await.map_err(|e| {
                 tonic::Status::internal(format!("Failed to read knowledge path: {}", e))
             })?
         {
@@ -89,11 +89,11 @@ impl GrpcGatewayHandler {
             }
         }
 
-        let resource_key = keys::knowledge_resource(&meta.name);
+        let resource_key = keys::knowledge_resource(&req.ns, &meta.name);
         if let Some(existing) = self
             .gateway
             .kv
-            .get_msg::<manifests::Knowledge>(&req.ns, &resource_key)
+            .get_msg::<manifests::Knowledge>(&resource_key)
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to read knowledge resource: {}", e))
@@ -101,17 +101,13 @@ impl GrpcGatewayHandler {
         {
             if let Some(existing_spec) = existing.spec {
                 if existing_spec.path != spec.path && !existing_spec.path.is_empty() {
-                    let old_key = keys::knowledge(&existing_spec.path);
-                    self.gateway
-                        .kv
-                        .delete(&req.ns, &old_key)
-                        .await
-                        .map_err(|e| {
-                            tonic::Status::internal(format!(
-                                "Failed to delete previous knowledge artifact: {}",
-                                e
-                            ))
-                        })?;
+                    let old_key = keys::knowledge(&req.ns, &existing_spec.path);
+                    self.gateway.kv.delete(&old_key).await.map_err(|e| {
+                        tonic::Status::internal(format!(
+                            "Failed to delete previous knowledge artifact: {}",
+                            e
+                        ))
+                    })?;
                 }
             }
         }
@@ -131,12 +127,12 @@ impl GrpcGatewayHandler {
         })?;
         self.gateway
             .kv
-            .set(&req.ns, &path_key, &bytes)
+            .set(&path_key, &bytes)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to write knowledge: {}", e)))?;
         self.gateway
             .kv
-            .set_msg(&req.ns, &resource_key, &knowledge)
+            .set_msg(&resource_key, &knowledge)
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to write knowledge resource: {}", e))
@@ -154,11 +150,11 @@ impl GrpcGatewayHandler {
     {
         crate::require_auth!(self, req, &req.get_ref().ns);
         let req = req.into_inner();
-        let key = keys::knowledge_resource(&req.name);
+        let key = keys::knowledge_resource(&req.ns, &req.name);
         let knowledge = self
             .gateway
             .kv
-            .get_msg::<manifests::Knowledge>(&req.ns, &key)
+            .get_msg::<manifests::Knowledge>(&key)
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to read knowledge resource: {}", e))
@@ -184,7 +180,7 @@ impl GrpcGatewayHandler {
         for key in self
             .gateway
             .kv
-            .list_keys(&req.ns, keys::knowledge_resource_prefix())
+            .list_keys(&keys::knowledge_resource_prefix(&req.ns))
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to list knowledge resources: {}", e))
@@ -193,7 +189,7 @@ impl GrpcGatewayHandler {
             if let Some(entry) = self
                 .gateway
                 .kv
-                .get_msg::<manifests::Knowledge>(&req.ns, &key)
+                .get_msg::<manifests::Knowledge>(&key)
                 .await
                 .map_err(|e| {
                     tonic::Status::internal(format!("Failed to fetch knowledge resource: {}", e))
@@ -215,11 +211,11 @@ impl GrpcGatewayHandler {
     {
         crate::require_auth!(self, req, &req.get_ref().ns);
         let req = req.into_inner();
-        let resource_key = keys::knowledge_resource(&req.name);
+        let resource_key = keys::knowledge_resource(&req.ns, &req.name);
         let Some(knowledge) = self
             .gateway
             .kv
-            .get_msg::<manifests::Knowledge>(&req.ns, &resource_key)
+            .get_msg::<manifests::Knowledge>(&resource_key)
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to read knowledge resource: {}", e))
@@ -231,19 +227,15 @@ impl GrpcGatewayHandler {
         if let Some(spec) = knowledge.spec {
             self.gateway
                 .kv
-                .delete(&req.ns, &keys::knowledge(&spec.path))
+                .delete(&keys::knowledge(&req.ns, &spec.path))
                 .await
                 .map_err(|e| {
                     tonic::Status::internal(format!("Failed to delete knowledge: {}", e))
                 })?;
         }
-        self.gateway
-            .kv
-            .delete(&req.ns, &resource_key)
-            .await
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to delete knowledge resource: {}", e))
-            })?;
+        self.gateway.kv.delete(&resource_key).await.map_err(|e| {
+            tonic::Status::internal(format!("Failed to delete knowledge resource: {}", e))
+        })?;
 
         Ok(tonic::Response::new(
             proto::DeleteNamespaceKnowledgeResponse { success: true },
@@ -254,6 +246,7 @@ impl GrpcGatewayHandler {
 #[cfg(test)]
 mod tests {
     use super::hydrate_knowledge_manifest;
+    use crate::control::keys;
     use crate::control::{KeyValueStore, ProtoKeyValueStoreExt};
     use crate::gateway::rpc::{manifests, proto, GrpcGatewayHandler};
     use crate::gateway::{server::Gateway, session_streams::SessionStreamHub};
@@ -266,63 +259,51 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+        data: Mutex<HashMap<String, Vec<u8>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, ns: &str, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(ns.to_string(), k.to_string()))
-                .cloned())
+        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, ns: &str, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .insert((ns.to_string(), k.to_string()), v.to_vec());
+        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(k.to_string(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            ns: &str,
             k: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let key = (ns.to_string(), k.to_string());
-            let current = data.get(&key).cloned();
+            let current = data.get(k).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(key, value.to_vec());
+                data.insert(k.to_string(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, ns: &str, k: &str) -> anyhow::Result<()> {
-            self.data.lock().await.remove(&(ns.to_string(), k.to_string()));
+        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+            self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(p)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -391,8 +372,7 @@ mod tests {
             updated_at: 1,
         };
         kv.set(
-            "acme",
-            "Knowledge/guide.md",
+            &keys::knowledge("acme", "guide.md"),
             &serde_json::to_vec(&entry).unwrap(),
         )
         .await
@@ -415,8 +395,7 @@ mod tests {
     async fn create_namespace_knowledge_rejects_path_claim_conflicts() {
         let kv = Arc::new(MockKvStore::default());
         kv.set(
-            "acme",
-            "Knowledge/guide.md",
+            &keys::knowledge("acme", "guide.md"),
             &serde_json::to_vec(&crate::knowledge::KnowledgeEntry {
                 namespace: "acme".to_string(),
                 name: "other".to_string(),
@@ -446,15 +425,13 @@ mod tests {
     async fn create_namespace_knowledge_replaces_old_path_for_same_resource() {
         let kv = Arc::new(MockKvStore::default());
         kv.set_msg(
-            "acme",
-            "KnowledgeResource/guide",
+            &keys::knowledge_resource("acme", "guide"),
             &manifest("guide", "acme", "old.md", "old content"),
         )
         .await
         .unwrap();
         kv.set(
-            "acme",
-            "Knowledge/old.md",
+            &keys::knowledge("acme", "old.md"),
             &serde_json::to_vec(&crate::knowledge::KnowledgeEntry {
                 namespace: "acme".to_string(),
                 name: "guide".to_string(),
@@ -487,8 +464,16 @@ mod tests {
                 .map(|spec| spec.path.as_str()),
             Some("new.md")
         );
-        assert!(kv.get("acme", "Knowledge/old.md").await.unwrap().is_none());
-        assert!(kv.get("acme", "Knowledge/new.md").await.unwrap().is_some());
+        assert!(kv
+            .get(&keys::knowledge("acme", "old.md"))
+            .await
+            .unwrap()
+            .is_none());
+        assert!(kv
+            .get(&keys::knowledge("acme", "new.md"))
+            .await
+            .unwrap()
+            .is_some());
     }
 
     #[tokio::test]

--- a/src/gateway/rpc/mcp_bindings.rs
+++ b/src/gateway/rpc/mcp_bindings.rs
@@ -62,7 +62,7 @@ impl GrpcGatewayHandler {
         let server = self
             .gateway
             .kv
-            .get_msg::<manifests::McpServer>(crate::control::ns::TALON_SYSTEM, &server_key)
+            .get_msg::<manifests::McpServer>(&server_key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?
             .ok_or_else(|| tonic::Status::failed_precondition("Referenced MCPServer not found"))?;
@@ -132,11 +132,11 @@ impl GrpcGatewayHandler {
             ));
         }
 
-        let key = keys::mcp_server_binding(&binding_name);
+        let key = keys::mcp_server_binding(&msg.ns, &binding_name);
         let action = if self
             .gateway
             .kv
-            .get_msg::<manifests::McpServerBinding>(&msg.ns, &key)
+            .get_msg::<manifests::McpServerBinding>(&key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?
             .is_some()
@@ -148,7 +148,7 @@ impl GrpcGatewayHandler {
 
         self.gateway
             .kv
-            .set_msg(&msg.ns, &key, &binding)
+            .set_msg(&key, &binding)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
@@ -182,12 +182,12 @@ impl GrpcGatewayHandler {
         if msg.name.is_empty() {
             return Err(tonic::Status::invalid_argument("name is required"));
         }
-        let key = keys::mcp_server_binding(&msg.name);
+        let key = keys::mcp_server_binding(&msg.ns, &msg.name);
 
         let binding = self
             .gateway
             .kv
-            .get_msg::<manifests::McpServerBinding>(&msg.ns, &key)
+            .get_msg::<manifests::McpServerBinding>(&key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?
             .ok_or_else(|| tonic::Status::not_found("McpServerBinding not found"))?;
@@ -210,7 +210,7 @@ impl GrpcGatewayHandler {
         let keys = self
             .gateway
             .kv
-            .list_keys(&msg.ns, keys::mcp_server_binding_prefix())
+            .list_keys(&keys::mcp_server_binding_prefix(&msg.ns))
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
@@ -219,7 +219,7 @@ impl GrpcGatewayHandler {
             if let Some(binding) = self
                 .gateway
                 .kv
-                .get_msg::<manifests::McpServerBinding>(&msg.ns, &key)
+                .get_msg::<manifests::McpServerBinding>(&key)
                 .await
                 .map_err(|e| tonic::Status::internal(e.to_string()))?
             {
@@ -244,12 +244,12 @@ impl GrpcGatewayHandler {
         if msg.name.is_empty() {
             return Err(tonic::Status::invalid_argument("name is required"));
         }
-        let key = keys::mcp_server_binding(&msg.name);
+        let key = keys::mcp_server_binding(&msg.ns, &msg.name);
 
         if self
             .gateway
             .kv
-            .get_msg::<manifests::McpServerBinding>(&msg.ns, &key)
+            .get_msg::<manifests::McpServerBinding>(&key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?
             .is_none()
@@ -259,7 +259,7 @@ impl GrpcGatewayHandler {
 
         self.gateway
             .kv
-            .delete(&msg.ns, &key)
+            .delete(&key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 

--- a/src/gateway/rpc/mcp_servers.rs
+++ b/src/gateway/rpc/mcp_servers.rs
@@ -34,7 +34,7 @@ impl GrpcGatewayHandler {
         }
         if !meta.namespace.is_empty() {
             return Err(tonic::Status::invalid_argument(
-                "MCPServer metadata.namespace is not supported; MCP servers are stored in talon-system",
+                "MCPServer metadata.namespace is not supported; MCP servers are stored in Sys",
             ));
         }
 
@@ -58,7 +58,7 @@ impl GrpcGatewayHandler {
         let action = if self
             .gateway
             .kv
-            .get_msg::<manifests::McpServer>(ns::TALON_SYSTEM, &key)
+            .get_msg::<manifests::McpServer>(&key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?
             .is_some()
@@ -69,7 +69,7 @@ impl GrpcGatewayHandler {
         };
         self.gateway
             .kv
-            .set_msg(ns::TALON_SYSTEM, &key, &server)
+            .set_msg(&key, &server)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
@@ -102,7 +102,7 @@ impl GrpcGatewayHandler {
         let server = self
             .gateway
             .kv
-            .get_msg::<manifests::McpServer>(ns::TALON_SYSTEM, &key)
+            .get_msg::<manifests::McpServer>(&key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?
             .ok_or_else(|| tonic::Status::not_found("MCPServer not found"))?;
@@ -121,7 +121,7 @@ impl GrpcGatewayHandler {
         let keys = self
             .gateway
             .kv
-            .list_keys(ns::TALON_SYSTEM, keys::mcp_server_prefix())
+            .list_keys(&keys::mcp_server_prefix())
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
@@ -130,7 +130,7 @@ impl GrpcGatewayHandler {
             if let Some(server) = self
                 .gateway
                 .kv
-                .get_msg::<manifests::McpServer>(ns::TALON_SYSTEM, &key)
+                .get_msg::<manifests::McpServer>(&key)
                 .await
                 .map_err(|e| tonic::Status::internal(e.to_string()))?
             {
@@ -154,7 +154,7 @@ impl GrpcGatewayHandler {
         if self
             .gateway
             .kv
-            .get_msg::<manifests::McpServer>(ns::TALON_SYSTEM, &key)
+            .get_msg::<manifests::McpServer>(&key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?
             .is_none()
@@ -164,7 +164,7 @@ impl GrpcGatewayHandler {
 
         self.gateway
             .kv
-            .delete(ns::TALON_SYSTEM, &key)
+            .delete(&key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 

--- a/src/gateway/rpc/namespaces.rs
+++ b/src/gateway/rpc/namespaces.rs
@@ -317,14 +317,18 @@ impl GrpcGatewayHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::control::{scheduler::NoopSchedulerBackend, KeyValueStore, MessagePublisher};
+    use crate::control::{
+        keys::{ResourceKey, ResourceList},
+        scheduler::NoopSchedulerBackend,
+        KeyValueStore, MessagePublisher,
+    };
     use crate::gateway::{server::Gateway, session_streams::SessionStreamHub};
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
 
     struct MockKvStore {
-        store: Mutex<HashMap<String, Vec<u8>>>,
+        store: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     impl MockKvStore {
@@ -337,20 +341,20 @@ mod tests {
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             let map = self.store.lock().await;
             Ok(map.get(key).cloned())
         }
 
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
-            map.insert(key.to_string(), value.to_vec());
+            map.insert(key.clone(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            key: &str,
+            key: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
@@ -364,22 +368,22 @@ mod tests {
             if !matches {
                 return Ok(false);
             }
-            map.insert(key.to_string(), value.to_vec());
+            map.insert(key.clone(), value.to_vec());
             Ok(true)
         }
 
-        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
             map.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let map = self.store.lock().await;
             let mut results = Vec::new();
             for k in map.keys() {
-                if k.starts_with(prefix) {
-                    results.push(k.to_string());
+                if list.matches(k) {
+                    results.push(k.clone());
                 }
             }
             Ok(results)

--- a/src/gateway/rpc/namespaces.rs
+++ b/src/gateway/rpc/namespaces.rs
@@ -1,13 +1,10 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::control::ns;
 use crate::control::ProtoKeyValueStoreExt;
+use crate::control::{keys, ns};
 use crate::gateway::rpc::{models, proto, GrpcGatewayHandler};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-const META_NS: &str = "talon-system:ns";
-const ROOT_EDGE_NS: &str = "talon-system:ns:internal";
 
 impl GrpcGatewayHandler {
     pub async fn handle_create_namespace(
@@ -38,18 +35,18 @@ impl GrpcGatewayHandler {
 
         // Namespace creation is idempotent for active namespaces so bootstrap and
         // reconcile flows can safely backfill labels without failing on re-create.
-        let meta_key = format!("Namespace/{}", name);
+        let meta_key = keys::namespace_metadata(&name);
         if let Ok(Some(mut existing_ns)) = self
             .gateway
             .kv
-            .get_msg::<models::Namespace>(META_NS, &meta_key)
+            .get_msg::<models::Namespace>(&meta_key)
             .await
         {
             if !existing_ns.is_deleted {
                 existing_ns.labels.extend(req.labels.clone());
                 self.gateway
                     .kv
-                    .set_msg(META_NS, &meta_key, &existing_ns)
+                    .set_msg(&meta_key, &existing_ns)
                     .await
                     .map_err(|e| {
                         tonic::Status::internal(format!(
@@ -92,11 +89,11 @@ impl GrpcGatewayHandler {
                     current_parent = format!("{}:{}", current_parent, part);
                 }
 
-                let check_key = format!("Namespace/{}", current_parent);
+                let check_key = keys::namespace_metadata(&current_parent);
                 if self
                     .gateway
                     .kv
-                    .get_msg::<models::Namespace>(META_NS, &check_key)
+                    .get_msg::<models::Namespace>(&check_key)
                     .await
                     .unwrap_or(None)
                     .is_none()
@@ -119,45 +116,37 @@ impl GrpcGatewayHandler {
                         labels: std::collections::HashMap::new(),
                     };
 
-                    if let Some(ref gp) = grandparent {
-                        let edge_ns = format!("{}:ns:internal", gp);
-                        let edge_key = format!("NamespaceRef/{}", current_parent);
-                        let _ = self
-                            .gateway
-                            .kv
-                            .set(&edge_ns, &edge_key, current_parent.as_bytes())
-                            .await;
-                    } else {
-                        let edge_key = format!("NamespaceRef/{}", current_parent);
-                        let _ = self
-                            .gateway
-                            .kv
-                            .set(ROOT_EDGE_NS, &edge_key, current_parent.as_bytes())
-                            .await;
-                    }
+                    let child_segment =
+                        current_parent.rsplit(':').next().unwrap_or(&current_parent);
+                    let edge_key = keys::namespace_ref(grandparent.as_deref(), child_segment);
+                    let _ = self
+                        .gateway
+                        .kv
+                        .set(&edge_key, current_parent.as_bytes())
+                        .await;
 
-                    let _ = self.gateway.kv.set_msg(META_NS, &check_key, &p_ns).await;
+                    let _ = self.gateway.kv.set_msg(&check_key, &p_ns).await;
                 }
             }
         }
 
         // If it has a parent, insert an edge reference under the parent
         if let Some(ref p) = parent {
-            let edge_ns = format!("{}:ns:internal", p);
-            let edge_key = format!("NamespaceRef/{}", name);
+            let child_segment = name.rsplit(':').next().unwrap_or(&name);
+            let edge_key = keys::namespace_ref(Some(p), child_segment);
             self.gateway
                 .kv
-                .set(&edge_ns, &edge_key, name.as_bytes())
+                .set(&edge_key, name.as_bytes())
                 .await
                 .map_err(|e| {
                     tonic::Status::internal(format!("Failed to write edge reference: {}", e))
                 })?;
         } else {
             // Root namespace edge reference
-            let edge_key = format!("NamespaceRef/{}", name);
+            let edge_key = keys::namespace_ref(None, &name);
             self.gateway
                 .kv
-                .set(ROOT_EDGE_NS, &edge_key, name.as_bytes())
+                .set(&edge_key, name.as_bytes())
                 .await
                 .map_err(|e| {
                     tonic::Status::internal(format!("Failed to write root edge reference: {}", e))
@@ -165,14 +154,10 @@ impl GrpcGatewayHandler {
         }
 
         // Save the metadata node
-        let meta_key = format!("Namespace/{}", name);
-        self.gateway
-            .kv
-            .set_msg(META_NS, &meta_key, &ns)
-            .await
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to write namespace metadata: {}", e))
-            })?;
+        let meta_key = keys::namespace_metadata(&name);
+        self.gateway.kv.set_msg(&meta_key, &ns).await.map_err(|e| {
+            tonic::Status::internal(format!("Failed to write namespace metadata: {}", e))
+        })?;
 
         Ok(tonic::Response::new(proto::NamespaceResponse {
             name: ns.name,
@@ -196,12 +181,12 @@ impl GrpcGatewayHandler {
 
         let name = req.name;
 
-        let meta_key = format!("Namespace/{}", name);
+        let meta_key = keys::namespace_metadata(&name);
 
         let ns = self
             .gateway
             .kv
-            .get_msg::<models::Namespace>(META_NS, &meta_key)
+            .get_msg::<models::Namespace>(&meta_key)
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to read namespace metadata: {}", e))
@@ -230,12 +215,12 @@ impl GrpcGatewayHandler {
 
         let name = req.name;
 
-        let meta_key = format!("Namespace/{}", name);
+        let meta_key = keys::namespace_metadata(&name);
 
         let mut ns = self
             .gateway
             .kv
-            .get_msg::<models::Namespace>(META_NS, &meta_key)
+            .get_msg::<models::Namespace>(&meta_key)
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to read namespace metadata: {}", e))
@@ -254,13 +239,9 @@ impl GrpcGatewayHandler {
             .unwrap()
             .as_secs() as i64;
 
-        self.gateway
-            .kv
-            .set_msg(META_NS, &meta_key, &ns)
-            .await
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to write namespace metadata: {}", e))
-            })?;
+        self.gateway.kv.set_msg(&meta_key, &ns).await.map_err(|e| {
+            tonic::Status::internal(format!("Failed to write namespace metadata: {}", e))
+        })?;
 
         Ok(tonic::Response::new(proto::NamespaceResponse {
             name: ns.name,
@@ -285,24 +266,18 @@ impl GrpcGatewayHandler {
         let mut namespace_names = Vec::new();
 
         let parent = req.parent.unwrap_or_default();
-        let edge_ns = if parent.is_empty() {
-            ROOT_EDGE_NS.to_string()
-        } else {
-            format!("{}:ns:internal", parent)
-        };
+        let edge_prefix =
+            keys::namespace_ref_prefix((!parent.is_empty()).then_some(parent.as_str()));
 
-        let keys = self
-            .gateway
-            .kv
-            .list_keys(&edge_ns, "NamespaceRef/")
-            .await
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to list namespace references: {}", e))
-            })?;
+        let keys = self.gateway.kv.list_keys(&edge_prefix).await.map_err(|e| {
+            tonic::Status::internal(format!("Failed to list namespace references: {}", e))
+        })?;
 
         for k in keys {
-            if let Some(stripped) = k.strip_prefix("NamespaceRef/") {
-                namespace_names.push(stripped.to_string());
+            if let Ok(Some(bytes)) = self.gateway.kv.get(&k).await {
+                if let Ok(name) = String::from_utf8(bytes) {
+                    namespace_names.push(name);
+                }
             }
         }
 
@@ -310,11 +285,11 @@ impl GrpcGatewayHandler {
         let mut namespaces = Vec::new();
 
         for name in namespace_names {
-            let meta_key = format!("Namespace/{}", name);
+            let meta_key = keys::namespace_metadata(&name);
             if let Ok(Some(ns)) = self
                 .gateway
                 .kv
-                .get_msg::<models::Namespace>(META_NS, &meta_key)
+                .get_msg::<models::Namespace>(&meta_key)
                 .await
             {
                 if !ns.is_deleted {
@@ -358,35 +333,29 @@ mod tests {
                 store: Mutex::new(HashMap::new()),
             }
         }
-
-        fn make_key(ns: &str, k: &str) -> String {
-            format!("{}/{}", ns, k)
-        }
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, namespace: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
             let map = self.store.lock().await;
-            Ok(map.get(&Self::make_key(namespace, key)).cloned())
+            Ok(map.get(key).cloned())
         }
 
-        async fn set(&self, namespace: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
-            map.insert(Self::make_key(namespace, key), value.to_vec());
+            map.insert(key.to_string(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            namespace: &str,
             key: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut map = self.store.lock().await;
-            let full_key = Self::make_key(namespace, key);
-            let current = map.get(&full_key).cloned();
+            let current = map.get(key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
@@ -395,26 +364,22 @@ mod tests {
             if !matches {
                 return Ok(false);
             }
-            map.insert(full_key, value.to_vec());
+            map.insert(key.to_string(), value.to_vec());
             Ok(true)
         }
 
-        async fn delete(&self, namespace: &str, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
-            map.remove(&Self::make_key(namespace, key));
+            map.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, namespace: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
             let map = self.store.lock().await;
-            let ns_prefix = format!("{}/{}", namespace, prefix);
-            let ns_root = format!("{}/", namespace);
-
             let mut results = Vec::new();
             for k in map.keys() {
-                if k.starts_with(&ns_prefix) {
-                    let stripped = k.strip_prefix(&ns_root).unwrap();
-                    results.push(stripped.to_string());
+                if k.starts_with(prefix) {
+                    results.push(k.to_string());
                 }
             }
             Ok(results)
@@ -562,7 +527,10 @@ mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(recreated.labels.get("env").map(String::as_str), Some("dev"));
-        assert_eq!(recreated.labels.get("owner").map(String::as_str), Some("ops"));
+        assert_eq!(
+            recreated.labels.get("owner").map(String::as_str),
+            Some("ops")
+        );
 
         let fetched = handler
             .handle_get_namespace(tonic::Request::new(proto::GetNamespaceRequest {

--- a/src/gateway/rpc/schedules.rs
+++ b/src/gateway/rpc/schedules.rs
@@ -24,7 +24,7 @@ impl GrpcGatewayHandler {
         if self
             .gateway
             .kv
-            .get_msg::<models::Schedule>(&req.ns, &keys::schedule(&schedule.name))
+            .get_msg::<models::Schedule>(&keys::schedule(&req.ns, &schedule.name))
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("failed to check schedule existence: {}", e))
@@ -62,7 +62,7 @@ impl GrpcGatewayHandler {
         let schedule = self
             .gateway
             .kv
-            .get_msg::<models::Schedule>(&req.ns, &keys::schedule(&req.name))
+            .get_msg::<models::Schedule>(&keys::schedule(&req.ns, &req.name))
             .await
             .map_err(|e| tonic::Status::internal(format!("failed to load schedule: {}", e)))?
             .ok_or_else(|| tonic::Status::not_found("schedule not found"))?;
@@ -82,7 +82,7 @@ impl GrpcGatewayHandler {
         let existing = self
             .gateway
             .kv
-            .get_msg::<models::Schedule>(&req.ns, &keys::schedule(&req.name))
+            .get_msg::<models::Schedule>(&keys::schedule(&req.ns, &req.name))
             .await
             .map_err(|e| tonic::Status::internal(format!("failed to load schedule: {}", e)))?
             .ok_or_else(|| tonic::Status::not_found("schedule not found"))?;
@@ -126,24 +126,16 @@ impl GrpcGatewayHandler {
         let mut keys = self
             .gateway
             .kv
-            .list_keys(&req.ns, keys::schedule_prefix())
+            .list_keys(&keys::schedule_prefix(&req.ns))
             .await
             .map_err(|e| tonic::Status::internal(format!("failed to list schedules: {}", e)))?;
         keys.sort();
 
-        let schedule_keys = keys
-            .into_iter()
-            .filter(|key| {
-                let stripped = key.strip_prefix(keys::schedule_prefix()).unwrap_or(key);
-                !stripped.contains('/')
-            })
-            .collect::<Vec<_>>();
+        let schedule_keys = keys;
         let kv = self.gateway.kv.clone();
-        let namespace = req.ns.clone();
         let fetched = stream::iter(schedule_keys.into_iter().map(move |key| {
             let kv = kv.clone();
-            let namespace = namespace.clone();
-            async move { kv.get_msg::<models::Schedule>(&namespace, &key).await }
+            async move { kv.get_msg::<models::Schedule>(&key).await }
         }))
         .buffer_unordered(32)
         .collect::<Vec<_>>()
@@ -169,11 +161,11 @@ impl GrpcGatewayHandler {
     ) -> std::result::Result<tonic::Response<proto::DeleteScheduleResponse>, tonic::Status> {
         crate::require_auth!(self, req, &req.get_ref().ns);
         let req = req.into_inner();
-        let key = keys::schedule(&req.name);
+        let key = keys::schedule(&req.ns, &req.name);
         if let Some(schedule) = self
             .gateway
             .kv
-            .get_msg::<models::Schedule>(&req.ns, &key)
+            .get_msg::<models::Schedule>(&key)
             .await
             .map_err(|e| tonic::Status::internal(format!("failed to load schedule: {}", e)))?
         {
@@ -186,7 +178,7 @@ impl GrpcGatewayHandler {
 
         self.gateway
             .kv
-            .delete(&req.ns, &key)
+            .delete(&key)
             .await
             .map_err(|e| tonic::Status::internal(format!("failed to delete schedule: {}", e)))?;
 

--- a/src/gateway/rpc/sessions.rs
+++ b/src/gateway/rpc/sessions.rs
@@ -4,7 +4,7 @@
 use super::{models, proto, GrpcGatewayHandler};
 use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{events, keys};
+use crate::control::{events, keys, keys::ResourceParent, KeyValueStore};
 use crate::scheduling;
 use futures::future::try_join_all;
 use prost::Message;
@@ -13,6 +13,19 @@ const LARGE_SESSION_PAYLOAD_WARNING_BYTES: usize = 128 * 1024;
 const DEFAULT_SESSION_MESSAGES_PAGE_SIZE: usize = 50;
 const MAX_SESSION_MESSAGES_PAGE_SIZE: usize = 200;
 const SESSION_MESSAGE_KEY_SCAN_BATCH_SIZE: usize = 512;
+
+async fn delete_descendants(kv: &dyn KeyValueStore, parent: ResourceParent) -> anyhow::Result<()> {
+    let mut stack = vec![parent];
+    while let Some(parent) = stack.pop() {
+        let list = parent.list(None);
+        let children = kv.list_keys(&list).await?;
+        for child in children {
+            stack.push(child.as_parent());
+            kv.delete(&child).await?;
+        }
+    }
+    Ok(())
+}
 
 fn requested_limit(limit: i32) -> Option<usize> {
     match limit {
@@ -153,7 +166,7 @@ impl GrpcGatewayHandler {
         let mut messages = Vec::new();
         if message_limit != Some(0) {
             let msg_keys = if let Some(limit) = message_limit {
-                let mut page_before_key: Option<String> = None;
+                let mut page_before_name: Option<String> = None;
                 let mut keys = Vec::with_capacity(limit);
                 while keys.len() < limit {
                     let page = self
@@ -161,7 +174,7 @@ impl GrpcGatewayHandler {
                         .kv
                         .list_keys_page(
                             &msg_prefix,
-                            page_before_key.as_deref(),
+                            page_before_name.as_deref(),
                             SESSION_MESSAGE_KEY_SCAN_BATCH_SIZE,
                         )
                         .await
@@ -182,7 +195,7 @@ impl GrpcGatewayHandler {
                     if page.is_empty() {
                         break;
                     }
-                    page_before_key = page.last().cloned();
+                    page_before_name = page.last().map(|key| key.name.clone());
                     for key in page {
                         keys.push(key);
                         if keys.len() >= limit {
@@ -418,18 +431,16 @@ impl GrpcGatewayHandler {
             })?
             .ok_or_else(|| tonic::Status::not_found("Session not found"))?;
 
-        let before_key = req
+        let before_name = req
             .before_message_id
             .as_deref()
             .filter(|before_message_id| !before_message_id.is_empty())
-            .map(|before_message_id| {
-                keys::session_message(&req.ns, &req.agent, &req.session_id, before_message_id)
-            });
+            .map(str::to_string);
 
         // Fetch one extra message so the response can expose has_more and an
         // exclusive before_message_id cursor without requiring a separate count.
         let target_message_count = page_size + 1;
-        let mut scan_before_key = before_key;
+        let mut scan_before_name = before_name;
         let mut items = Vec::with_capacity(target_message_count);
 
         while items.len() < target_message_count {
@@ -438,7 +449,7 @@ impl GrpcGatewayHandler {
                 .kv
                 .list_entries_page(
                     &msg_prefix,
-                    scan_before_key.as_deref(),
+                    scan_before_name.as_deref(),
                     SESSION_MESSAGE_KEY_SCAN_BATCH_SIZE,
                 )
                 .await
@@ -452,7 +463,7 @@ impl GrpcGatewayHandler {
 
             // Continue from the last key returned, regardless of whether it was
             // a message key, a step key, or another nested descendant.
-            scan_before_key = entries.last().map(|(key, _)| key.clone());
+            scan_before_name = entries.last().map(|(key, _)| key.name.clone());
 
             let remaining = target_message_count.saturating_sub(items.len());
             let mut page_messages = Vec::with_capacity(remaining);
@@ -618,18 +629,15 @@ impl GrpcGatewayHandler {
         let req = req.into_inner();
 
         let session_db_key = keys::session(&req.ns, &req.agent, &req.session_id);
-        let message_prefix = keys::recursive_prefix(
-            &req.ns,
-            &[("Agent", &req.agent), ("Session", &req.session_id)],
-        );
 
-        self.gateway
-            .kv
-            .delete_prefix(&message_prefix)
-            .await
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to delete session descendants: {}", e))
-            })?;
+        delete_descendants(
+            self.gateway.kv.as_ref(),
+            keys::session_parent(&req.ns, &req.agent, &req.session_id),
+        )
+        .await
+        .map_err(|e| {
+            tonic::Status::internal(format!("Failed to delete session descendants: {}", e))
+        })?;
 
         self.gateway
             .kv

--- a/src/gateway/rpc/sessions.rs
+++ b/src/gateway/rpc/sessions.rs
@@ -6,8 +6,8 @@ use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;
 use crate::control::{events, keys};
 use crate::scheduling;
+use futures::future::try_join_all;
 use prost::Message;
-use std::collections::HashMap;
 
 const LARGE_SESSION_PAYLOAD_WARNING_BYTES: usize = 128 * 1024;
 const DEFAULT_SESSION_MESSAGES_PAGE_SIZE: usize = 50;
@@ -36,20 +36,6 @@ fn validated_page_size(page_size: i32) -> std::result::Result<usize, tonic::Stat
     Ok(page_size.min(MAX_SESSION_MESSAGES_PAGE_SIZE))
 }
 
-fn direct_message_id<'a>(prefix: &str, key: &'a str) -> Option<&'a str> {
-    let suffix = key.strip_prefix(prefix)?;
-    (!suffix.is_empty() && !suffix.contains('/')).then_some(suffix)
-}
-
-fn step_message_id<'a>(prefix: &str, key: &'a str) -> Option<&'a str> {
-    let suffix = key.strip_prefix(prefix)?;
-    let (message_id, step_id) = suffix.split_once("/Steps/")?;
-    if message_id.is_empty() || step_id.is_empty() {
-        return None;
-    }
-    Some(message_id)
-}
-
 impl GrpcGatewayHandler {
     pub async fn handle_create_session(
         &self,
@@ -59,11 +45,11 @@ impl GrpcGatewayHandler {
         let req = req.into_inner();
 
         // 1. Verify agent exists in namespace
-        let agent_db_key = keys::agent(&req.agent);
+        let agent_db_key = keys::agent(&req.ns, &req.agent);
         let agent_exists = self
             .gateway
             .kv
-            .get_msg::<models::Agent>(&req.ns, &agent_db_key)
+            .get_msg::<models::Agent>(&agent_db_key)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to verify agent: {}", e)))?;
 
@@ -88,11 +74,11 @@ impl GrpcGatewayHandler {
             labels: req.labels.clone(),
         };
 
-        let session_db_key = keys::session(&req.agent, &session_id);
+        let session_db_key = keys::session(&req.ns, &req.agent, &session_id);
 
         self.gateway
             .kv
-            .set_msg(&req.ns, &session_db_key, &session)
+            .set_msg(&session_db_key, &session)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to save session state: {}", e)))?;
 
@@ -134,13 +120,13 @@ impl GrpcGatewayHandler {
         let message_limit = requested_limit(req.message_limit);
         let step_limit = requested_limit(req.step_limit);
 
-        let session_db_key = keys::session(&req.agent, &req.session_id);
-        let msg_prefix = keys::session_message_prefix(&req.agent, &req.session_id);
+        let session_db_key = keys::session(&req.ns, &req.agent, &req.session_id);
+        let msg_prefix = keys::session_message_prefix(&req.ns, &req.agent, &req.session_id);
 
         let session = self
             .gateway
             .kv
-            .get_msg::<models::Session>(&req.ns, &session_db_key)
+            .get_msg::<models::Session>(&session_db_key)
             .await
             .map_err(|e| {
                 tracing::error!(
@@ -174,7 +160,6 @@ impl GrpcGatewayHandler {
                         .gateway
                         .kv
                         .list_keys_page(
-                            &req.ns,
                             &msg_prefix,
                             page_before_key.as_deref(),
                             SESSION_MESSAGE_KEY_SCAN_BATCH_SIZE,
@@ -189,54 +174,37 @@ impl GrpcGatewayHandler {
                                 error = %e,
                                 "failed to page session message keys"
                             );
-                            tonic::Status::internal(format!("Failed to list session messages: {}", e))
+                            tonic::Status::internal(format!(
+                                "Failed to list session messages: {}",
+                                e
+                            ))
                         })?;
                     if page.is_empty() {
                         break;
                     }
                     page_before_key = page.last().cloned();
                     for key in page {
-                        if direct_message_id(&msg_prefix, &key).is_some() {
-                            keys.push(key);
-                            if keys.len() >= limit {
-                                break;
-                            }
+                        keys.push(key);
+                        if keys.len() >= limit {
+                            break;
                         }
                     }
                 }
                 keys.sort();
                 keys
             } else {
-                let mut keys = self
-                    .gateway
-                    .kv
-                    .list_keys(&req.ns, &msg_prefix)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(
-                            ns = %req.ns,
-                            agent = %req.agent,
-                            session_id = %req.session_id,
-                            prefix = %msg_prefix,
-                            error = %e,
-                            "failed to list session messages"
-                        );
-                        tonic::Status::internal(format!("Failed to list session messages: {}", e))
-                    })?;
+                let mut keys = self.gateway.kv.list_keys(&msg_prefix).await.map_err(|e| {
+                    tracing::error!(
+                        ns = %req.ns,
+                        agent = %req.agent,
+                        session_id = %req.session_id,
+                        prefix = %msg_prefix,
+                        error = %e,
+                        "failed to list session messages"
+                    );
+                    tonic::Status::internal(format!("Failed to list session messages: {}", e))
+                })?;
                 keys.sort();
-                keys.retain(|key| {
-                    let nested = key.strip_prefix(&msg_prefix).unwrap_or(key).contains('/');
-                    if nested {
-                        tracing::debug!(
-                            ns = %req.ns,
-                            agent = %req.agent,
-                            session_id = %req.session_id,
-                            key = %key,
-                            "skipping nested message key while loading session"
-                        );
-                    }
-                    !nested
-                });
                 keys
             };
             tracing::info!(
@@ -248,7 +216,7 @@ impl GrpcGatewayHandler {
             );
 
             for key in &msg_keys {
-                match self.gateway.kv.get(&req.ns, key).await {
+                match self.gateway.kv.get(key).await {
                     Ok(Some(bytes)) => {
                         let payload_bytes = bytes.len();
                         if payload_bytes > LARGE_SESSION_PAYLOAD_WARNING_BYTES {
@@ -313,25 +281,24 @@ impl GrpcGatewayHandler {
             if remaining_steps == 0 {
                 break;
             }
-            let step_prefix =
-                keys::session_message_step_prefix(&req.agent, &req.session_id, &message.id);
-            let mut step_keys = self
-                .gateway
-                .kv
-                .list_keys(&req.ns, &step_prefix)
-                .await
-                .map_err(|e| {
-                    tracing::error!(
-                        ns = %req.ns,
-                        agent = %req.agent,
-                        session_id = %req.session_id,
-                        message_id = %message.id,
-                        prefix = %step_prefix,
-                        error = %e,
-                        "failed to list session steps"
-                    );
-                    tonic::Status::internal(format!("Failed to list session steps: {}", e))
-                })?;
+            let step_prefix = keys::session_message_step_prefix(
+                &req.ns,
+                &req.agent,
+                &req.session_id,
+                &message.id,
+            );
+            let mut step_keys = self.gateway.kv.list_keys(&step_prefix).await.map_err(|e| {
+                tracing::error!(
+                    ns = %req.ns,
+                    agent = %req.agent,
+                    session_id = %req.session_id,
+                    message_id = %message.id,
+                    prefix = %step_prefix,
+                    error = %e,
+                    "failed to list session steps"
+                );
+                tonic::Status::internal(format!("Failed to list session steps: {}", e))
+            })?;
             step_keys.sort();
             tracing::info!(
                 ns = %req.ns,
@@ -347,7 +314,7 @@ impl GrpcGatewayHandler {
                 if remaining_steps == 0 {
                     break;
                 }
-                match self.gateway.kv.get(&req.ns, &key).await {
+                match self.gateway.kv.get(&key).await {
                     Ok(Some(bytes)) => {
                         let payload_bytes = bytes.len();
                         if payload_bytes > LARGE_SESSION_PAYLOAD_WARNING_BYTES {
@@ -438,13 +405,13 @@ impl GrpcGatewayHandler {
         );
         let req = req.into_inner();
         let page_size = validated_page_size(req.page_size)?;
-        let session_db_key = keys::session(&req.agent, &req.session_id);
-        let msg_prefix = keys::session_message_prefix(&req.agent, &req.session_id);
+        let session_db_key = keys::session(&req.ns, &req.agent, &req.session_id);
+        let msg_prefix = keys::session_message_prefix(&req.ns, &req.agent, &req.session_id);
 
         let session = self
             .gateway
             .kv
-            .get_msg::<models::Session>(&req.ns, &session_db_key)
+            .get_msg::<models::Session>(&session_db_key)
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to fetch session metadata: {}", e))
@@ -456,7 +423,7 @@ impl GrpcGatewayHandler {
             .as_deref()
             .filter(|before_message_id| !before_message_id.is_empty())
             .map(|before_message_id| {
-                keys::session_message(&req.agent, &req.session_id, before_message_id)
+                keys::session_message(&req.ns, &req.agent, &req.session_id, before_message_id)
             });
 
         // Fetch one extra message so the response can expose has_more and an
@@ -464,19 +431,12 @@ impl GrpcGatewayHandler {
         let target_message_count = page_size + 1;
         let mut scan_before_key = before_key;
         let mut items = Vec::with_capacity(target_message_count);
-        let mut steps_by_message: HashMap<String, Vec<(String, events::SessionStepEvent)>> =
-            HashMap::new();
 
         while items.len() < target_message_count {
-            // Message and step records share the Messages/ prefix. In reverse
-            // key order, Steps/{step_id} keys appear before their parent
-            // message key, so a single key-page scan can buffer steps and then
-            // attach them when the message record is encountered.
             let entries = self
                 .gateway
                 .kv
                 .list_entries_page(
-                    &req.ns,
                     &msg_prefix,
                     scan_before_key.as_deref(),
                     SESSION_MESSAGE_KEY_SCAN_BATCH_SIZE,
@@ -494,48 +454,13 @@ impl GrpcGatewayHandler {
             // a message key, a step key, or another nested descendant.
             scan_before_key = entries.last().map(|(key, _)| key.clone());
 
+            let remaining = target_message_count.saturating_sub(items.len());
+            let mut page_messages = Vec::with_capacity(remaining);
             for (key, bytes) in entries {
+                if page_messages.len() >= remaining {
+                    break;
+                }
                 let payload_bytes = bytes.len();
-                // Handle step keys first; the rest of this loop is for direct
-                // message records.
-                if let Some(message_id) = step_message_id(&msg_prefix, &key).map(str::to_owned) {
-                    if payload_bytes > LARGE_SESSION_PAYLOAD_WARNING_BYTES {
-                        tracing::warn!(
-                            ns = %req.ns,
-                            agent = %req.agent,
-                            session_id = %req.session_id,
-                            key = %key,
-                            payload_bytes,
-                            "session step payload is unusually large"
-                        );
-                    }
-
-                    match events::SessionStepEvent::decode(bytes.as_slice()) {
-                        Ok(step) => {
-                            steps_by_message
-                                .entry(message_id)
-                                .or_default()
-                                .push((key, step));
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                ns = %req.ns,
-                                agent = %req.agent,
-                                session_id = %req.session_id,
-                                key = %key,
-                                payload_bytes,
-                                error = %e,
-                                "failed to decode session step"
-                            );
-                        }
-                    }
-                    continue;
-                }
-
-                if direct_message_id(&msg_prefix, &key).is_none() {
-                    continue;
-                }
-
                 if payload_bytes > LARGE_SESSION_PAYLOAD_WARNING_BYTES {
                     tracing::warn!(
                         ns = %req.ns,
@@ -563,20 +488,46 @@ impl GrpcGatewayHandler {
                     }
                 };
 
-                let mut steps = steps_by_message.remove(&message.id).unwrap_or_default();
-                // The outer scan runs newest-first, but steps should remain in
-                // their natural per-message order.
-                steps.sort_by(|left, right| left.0.cmp(&right.0));
-
-                items.push(proto::ListSessionMessagesResponseItem {
-                    steps: steps.into_iter().map(|(_, step)| step).collect(),
-                    message: Some(message),
-                });
-
-                if items.len() >= target_message_count {
-                    break;
-                }
+                page_messages.push(message);
             }
+
+            let step_fetches = page_messages.into_iter().map(|message| {
+                let kv = self.gateway.kv.clone();
+                let ns = req.ns.clone();
+                let agent = req.agent.clone();
+                let session_id = req.session_id.clone();
+                async move {
+                    let step_prefix =
+                        keys::session_message_step_prefix(&ns, &agent, &session_id, &message.id);
+                    let mut step_entries = kv.list_entries(&step_prefix).await.map_err(|e| {
+                        tonic::Status::internal(format!("Failed to list session steps: {}", e))
+                    })?;
+                    step_entries.sort_by(|left, right| left.0.cmp(&right.0));
+                    let steps = step_entries
+                        .into_iter()
+                        .filter_map(|(step_key, step_bytes)| {
+                            events::SessionStepEvent::decode(step_bytes.as_slice())
+                                .map_err(|e| {
+                                    tracing::error!(
+                                        ns = %ns,
+                                        agent = %agent,
+                                        session_id = %session_id,
+                                        key = %step_key,
+                                        error = %e,
+                                        "failed to decode session step"
+                                    );
+                                })
+                                .ok()
+                        })
+                        .collect();
+
+                    Ok::<_, tonic::Status>(proto::ListSessionMessagesResponseItem {
+                        steps,
+                        message: Some(message),
+                    })
+                }
+            });
+            items.extend(try_join_all(step_fetches).await?);
         }
 
         let has_more = items.len() > page_size;
@@ -611,29 +562,25 @@ impl GrpcGatewayHandler {
         crate::require_auth!(self, req, &req.get_ref().ns, &req.get_ref().agent);
         let req = req.into_inner();
 
-        let session_prefix = keys::session_prefix(&req.agent);
+        let session_prefix = keys::session_prefix(&req.ns, &req.agent);
 
         let keys = self
             .gateway
             .kv
-            .list_keys(&req.ns, &session_prefix)
+            .list_keys(&session_prefix)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to list sessions: {}", e)))?;
 
         let mut session_ids = Vec::new();
         let mut sessions = Vec::new();
-        // keys format is "Agent/{agent}/Session/{session_id}"
-        // list_keys returns ALL sub-keys too (e.g. messages), filter those out
         for key in keys {
-            let stripped = key.strip_prefix(&session_prefix).unwrap_or(&key);
-            if !stripped.contains('/') {
-                let session_id = stripped.to_string();
+            if let Some(session_id) = keys::direct_child_name(&session_prefix, &key) {
                 session_ids.push(session_id.clone());
 
                 let session = self
                     .gateway
                     .kv
-                    .get_msg::<models::Session>(&req.ns, &key)
+                    .get_msg::<models::Session>(&key)
                     .await
                     .map_err(|e| {
                         tonic::Status::internal(format!("Failed to fetch session metadata: {}", e))
@@ -670,12 +617,15 @@ impl GrpcGatewayHandler {
         );
         let req = req.into_inner();
 
-        let session_db_key = keys::session(&req.agent, &req.session_id);
-        let message_prefix = keys::session_message_prefix(&req.agent, &req.session_id);
+        let session_db_key = keys::session(&req.ns, &req.agent, &req.session_id);
+        let message_prefix = keys::recursive_prefix(
+            &req.ns,
+            &[("Agent", &req.agent), ("Session", &req.session_id)],
+        );
 
         self.gateway
             .kv
-            .delete_prefix(&req.ns, &message_prefix)
+            .delete_prefix(&message_prefix)
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to delete session descendants: {}", e))
@@ -683,7 +633,7 @@ impl GrpcGatewayHandler {
 
         self.gateway
             .kv
-            .delete(&req.ns, &session_db_key)
+            .delete(&session_db_key)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to delete session: {}", e)))?;
 
@@ -771,11 +721,11 @@ impl GrpcGatewayHandler {
         );
         let req = req.into_inner();
 
-        let session_db_key = keys::session(&req.agent, &req.session_id);
+        let session_db_key = keys::session(&req.ns, &req.agent, &req.session_id);
         let session = self
             .gateway
             .kv
-            .get_msg::<models::Session>(&req.ns, &session_db_key)
+            .get_msg::<models::Session>(&session_db_key)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to fetch session: {}", e)))?;
 

--- a/src/gateway/rpc/sessions_tests.rs
+++ b/src/gateway/rpc/sessions_tests.rs
@@ -47,7 +47,7 @@ mod tests {
 
     #[derive(Default)]
     struct FailingKvStore {
-        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+        data: Mutex<HashMap<String, Vec<u8>>>,
         fail_list_prefix: Option<String>,
         fail_get_key: Option<String>,
         fail_set_prefix: Option<String>,
@@ -57,19 +57,14 @@ mod tests {
 
     #[async_trait::async_trait]
     impl KeyValueStore for FailingKvStore {
-        async fn get(&self, ns: &str, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
             if self.fail_get_key.as_deref() == Some(k) {
                 anyhow::bail!("get failed for {}", k);
             }
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(ns.to_string(), k.to_string()))
-                .cloned())
+            Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, ns: &str, k: &str, v: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
             if self
                 .fail_set_prefix
                 .as_deref()
@@ -77,46 +72,38 @@ mod tests {
             {
                 anyhow::bail!("set failed for {}", k);
             }
-            self.data
-                .lock()
-                .await
-                .insert((ns.to_string(), k.to_string()), v.to_vec());
+            self.data.lock().await.insert(k.to_string(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            ns: &str,
             k: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let key = (ns.to_string(), k.to_string());
-            let current = data.get(&key).cloned();
+            let current = data.get(k).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(key, value.to_vec());
+                data.insert(k.to_string(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, ns: &str, k: &str) -> anyhow::Result<()> {
+        async fn delete(&self, k: &str) -> anyhow::Result<()> {
             if self.fail_delete_key.as_deref() == Some(k) {
                 anyhow::bail!("delete failed for {}", k);
             }
-            self.data
-                .lock()
-                .await
-                .remove(&(ns.to_string(), k.to_string()));
+            self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
             if self
                 .fail_list_prefix
                 .as_deref()
@@ -130,9 +117,7 @@ mod tests {
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(p)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.extend(self.extra_list_keys.iter().cloned());
             keys.sort();
@@ -141,13 +126,12 @@ mod tests {
 
         async fn list_keys_page(
             &self,
-            ns: &str,
             prefix: &str,
             before_key: Option<&str>,
             limit: usize,
         ) -> anyhow::Result<Vec<String>> {
             Ok(crate::control::page_keys_desc(
-                self.list_keys(ns, prefix).await?,
+                self.list_keys(prefix).await?,
                 before_key,
                 limit,
             ))
@@ -155,13 +139,12 @@ mod tests {
 
         async fn list_entries_page(
             &self,
-            ns: &str,
             prefix: &str,
             before_key: Option<&str>,
             limit: usize,
         ) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
             Ok(crate::control::page_entries_desc(
-                self.list_entries(ns, prefix).await?,
+                self.list_entries(prefix).await?,
                 before_key,
                 limit,
             ))
@@ -220,8 +203,7 @@ mod tests {
 
     async fn seed_agent(kv: &Arc<MockKvStore>, ns: &str, name: &str) {
         kv.set_msg(
-            ns,
-            &keys::agent(name),
+            &keys::agent(ns, name),
             &models::Agent {
                 name: name.to_string(),
                 ns: ns.to_string(),
@@ -268,10 +250,11 @@ mod tests {
         assert_eq!(response.labels.get("team").map(String::as_str), Some("ops"));
 
         let stored = kv
-            .get_msg::<models::Session>(
+            .get_msg::<models::Session>(&keys::session(
                 "default",
-                &keys::session("test-agent", &response.session_id),
-            )
+                "test-agent",
+                &response.session_id,
+            ))
             .await
             .unwrap()
             .expect("session should be stored");
@@ -310,10 +293,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_session_surfaces_save_failure() {
-        let session_key_prefix = keys::session("test-agent", "");
+        let session_key_prefix = keys::session_prefix("default", "test-agent");
         let kv = Arc::new(FailingKvStore {
             data: Mutex::new(HashMap::from([(
-                ("default".to_string(), keys::agent("test-agent")),
+                keys::agent("default", "test-agent"),
                 models::Agent {
                     name: "test-agent".to_string(),
                     ns: "default".to_string(),
@@ -362,8 +345,7 @@ mod tests {
         let message_id = "msg-1";
 
         kv.set_msg(
-            ns,
-            &keys::session(agent, session_id),
+            &keys::session(ns, agent, session_id),
             &models::Session {
                 id: session_id.to_string(),
                 agent: agent.to_string(),
@@ -379,8 +361,7 @@ mod tests {
         .unwrap();
 
         kv.set_msg(
-            ns,
-            &keys::session_message(agent, session_id, message_id),
+            &keys::session_message(ns, agent, session_id, message_id),
             &models::SessionMessage {
                 id: message_id.to_string(),
                 role: 2,
@@ -393,25 +374,22 @@ mod tests {
         .unwrap();
 
         kv.set(
-            ns,
             &format!(
                 "{}/nested",
-                keys::session_message(agent, session_id, message_id)
+                keys::session_message(ns, agent, session_id, message_id)
             ),
             b"should-be-ignored",
         )
         .await
         .unwrap();
         kv.set(
-            ns,
-            &keys::session_message(agent, session_id, "msg-invalid"),
+            &keys::session_message(ns, agent, session_id, "msg-invalid"),
             b"not-protobuf",
         )
         .await
         .unwrap();
         kv.set(
-            ns,
-            &keys::session_message_step(agent, session_id, message_id, "step-valid"),
+            &keys::session_message_step(ns, agent, session_id, message_id, "step-valid"),
             &SessionStepEvent {
                 session_id: session_id.to_string(),
                 step_type: StepType::Token as i32,
@@ -428,8 +406,7 @@ mod tests {
         .await
         .unwrap();
         kv.set(
-            ns,
-            &keys::session_message_step(agent, session_id, message_id, "step-invalid"),
+            &keys::session_message_step(ns, agent, session_id, message_id, "step-invalid"),
             b"not-step",
         )
         .await
@@ -460,10 +437,7 @@ mod tests {
     async fn test_get_session_negative_limits_return_metadata_without_listing_history() {
         let kv = Arc::new(FailingKvStore {
             data: Mutex::new(HashMap::from([(
-                (
-                    "default".to_string(),
-                    keys::session("test-agent", "session-1"),
-                ),
+                keys::session("default", "test-agent", "session-1"),
                 models::Session {
                     id: "session-1".to_string(),
                     agent: "test-agent".to_string(),
@@ -476,7 +450,11 @@ mod tests {
                 }
                 .encode_to_vec(),
             )])),
-            fail_list_prefix: Some(keys::session_message_prefix("test-agent", "session-1")),
+            fail_list_prefix: Some(keys::session_message_prefix(
+                "default",
+                "test-agent",
+                "session-1",
+            )),
             fail_get_key: None,
             fail_set_prefix: None,
             fail_delete_key: None,
@@ -522,10 +500,7 @@ mod tests {
 
         let kv = Arc::new(FailingKvStore {
             data: Mutex::new(HashMap::from([(
-                (
-                    "default".to_string(),
-                    keys::session("test-agent", "session-1"),
-                ),
+                keys::session("default", "test-agent", "session-1"),
                 models::Session {
                     id: "session-1".to_string(),
                     agent: "test-agent".to_string(),
@@ -538,7 +513,11 @@ mod tests {
                 }
                 .encode_to_vec(),
             )])),
-            fail_list_prefix: Some(keys::session_message_prefix("test-agent", "session-1")),
+            fail_list_prefix: Some(keys::session_message_prefix(
+                "default",
+                "test-agent",
+                "session-1",
+            )),
             fail_get_key: None,
             fail_set_prefix: None,
             fail_delete_key: None,
@@ -565,10 +544,7 @@ mod tests {
         let kv = Arc::new(FailingKvStore {
             data: Mutex::new(HashMap::from([
                 (
-                    (
-                        "default".to_string(),
-                        keys::session("test-agent", "session-1"),
-                    ),
+                    keys::session("default", "test-agent", "session-1"),
                     models::Session {
                         id: "session-1".to_string(),
                         agent: "test-agent".to_string(),
@@ -582,10 +558,7 @@ mod tests {
                     .encode_to_vec(),
                 ),
                 (
-                    (
-                        "default".to_string(),
-                        keys::session_message("test-agent", "session-1", "msg-1"),
-                    ),
+                    keys::session_message("default", "test-agent", "session-1", "msg-1"),
                     models::SessionMessage {
                         id: "msg-1".to_string(),
                         role: 1,
@@ -597,6 +570,7 @@ mod tests {
                 ),
             ])),
             fail_list_prefix: Some(keys::session_message_step_prefix(
+                "default",
                 "test-agent",
                 "session-1",
                 "msg-1",
@@ -631,8 +605,7 @@ mod tests {
         let handler = setup_mock_gateway_handler(kv.clone(), Arc::new(RecordingPubSub::default()));
 
         kv.set_msg(
-            ns,
-            &keys::session(agent, session_id),
+            &keys::session(ns, agent, session_id),
             &models::Session {
                 id: session_id.to_string(),
                 agent: agent.to_string(),
@@ -650,8 +623,7 @@ mod tests {
         for index in 1..=3 {
             let message_id = format!("msg-{index}");
             kv.set_msg(
-                ns,
-                &keys::session_message(agent, session_id, &message_id),
+                &keys::session_message(ns, agent, session_id, &message_id),
                 &models::SessionMessage {
                     id: message_id.clone(),
                     role: 2,
@@ -665,8 +637,8 @@ mod tests {
 
             for step_index in 1..=2 {
                 kv.set(
-                    ns,
                     &keys::session_message_step(
+                        ns,
                         agent,
                         session_id,
                         &message_id,
@@ -729,8 +701,7 @@ mod tests {
         let handler = setup_mock_gateway_handler(kv.clone(), Arc::new(RecordingPubSub::default()));
 
         kv.set_msg(
-            ns,
-            &keys::session(agent, session_id),
+            &keys::session(ns, agent, session_id),
             &models::Session {
                 id: session_id.to_string(),
                 agent: agent.to_string(),
@@ -748,8 +719,7 @@ mod tests {
         for index in 1..=3 {
             let message_id = format!("019f0000-0000-7000-8000-00000000000{index}");
             kv.set_msg(
-                ns,
-                &keys::session_message(agent, session_id, &message_id),
+                &keys::session_message(ns, agent, session_id, &message_id),
                 &models::SessionMessage {
                     id: message_id.clone(),
                     role: if index == 2 { 1 } else { 2 },
@@ -762,8 +732,7 @@ mod tests {
             .unwrap();
 
             kv.set(
-                ns,
-                &keys::session_message_step(agent, session_id, &message_id, "000001"),
+                &keys::session_message_step(ns, agent, session_id, &message_id, "000001"),
                 &SessionStepEvent {
                     session_id: session_id.to_string(),
                     step_type: StepType::Token as i32,
@@ -885,8 +854,7 @@ mod tests {
         let handler = setup_mock_gateway_handler(kv.clone(), Arc::new(RecordingPubSub::default()));
 
         kv.set_msg(
-            ns,
-            &keys::session(agent, session_id),
+            &keys::session(ns, agent, session_id),
             &models::Session {
                 id: session_id.to_string(),
                 agent: agent.to_string(),
@@ -904,8 +872,7 @@ mod tests {
         for index in 1..=3 {
             let message_id = format!("019f0000-0000-7000-8000-00000000000{index}");
             kv.set_msg(
-                ns,
-                &keys::session_message(agent, session_id, &message_id),
+                &keys::session_message(ns, agent, session_id, &message_id),
                 &models::SessionMessage {
                     id: message_id,
                     role: models::MessageRole::RoleAssistant as i32,
@@ -921,8 +888,8 @@ mod tests {
         let newest_message_id = "019f0000-0000-7000-8000-000000000003";
         for index in 0..700 {
             kv.set(
-                ns,
                 &keys::session_message_step(
+                    ns,
                     agent,
                     session_id,
                     newest_message_id,
@@ -978,8 +945,7 @@ mod tests {
         let handler = setup_mock_gateway_handler(kv.clone(), Arc::new(RecordingPubSub::default()));
 
         kv.set_msg(
-            "default",
-            &keys::session("test-agent", "session-1"),
+            &keys::session("default", "test-agent", "session-1"),
             &models::Session {
                 id: "session-1".to_string(),
                 agent: "test-agent".to_string(),
@@ -1039,8 +1005,7 @@ mod tests {
         assert_eq!(not_found.code(), tonic::Code::NotFound);
 
         kv.set_msg(
-            "default",
-            &keys::session("test-agent", "busy-session"),
+            &keys::session("default", "test-agent", "busy-session"),
             &models::Session {
                 id: "busy-session".to_string(),
                 agent: "test-agent".to_string(),
@@ -1068,8 +1033,7 @@ mod tests {
         assert_eq!(busy.code(), tonic::Code::ResourceExhausted);
 
         kv.set_msg(
-            "default",
-            &keys::session("test-agent", "idle-session"),
+            &keys::session("default", "test-agent", "idle-session"),
             &models::Session {
                 id: "idle-session".to_string(),
                 agent: "test-agent".to_string(),
@@ -1098,10 +1062,11 @@ mod tests {
         assert_eq!(sent.session_id, "idle-session");
 
         let stored_message_keys = kv
-            .list_keys(
+            .list_keys(&keys::session_message_prefix(
                 "default",
-                &keys::session_message_prefix("test-agent", "idle-session"),
-            )
+                "test-agent",
+                "idle-session",
+            ))
             .await
             .unwrap();
         assert_eq!(stored_message_keys.len(), 1);
@@ -1197,15 +1162,14 @@ mod tests {
             labels: HashMap::new(),
         };
 
-        kv.set_msg(ns, &keys::session(agent, &older_session.id), &older_session)
+        kv.set_msg(&keys::session(ns, agent, &older_session.id), &older_session)
             .await
             .unwrap();
-        kv.set_msg(ns, &keys::session(agent, &newer_session.id), &newer_session)
+        kv.set_msg(&keys::session(ns, agent, &newer_session.id), &newer_session)
             .await
             .unwrap();
         kv.set(
-            ns,
-            &keys::session_message(agent, &newer_session.id, "msg-1"),
+            &keys::session_message(ns, agent, &newer_session.id, "msg-1"),
             b"nested-message-should-be-skipped",
         )
         .await
@@ -1235,7 +1199,7 @@ mod tests {
         let handler = setup_gateway_handler_with(
             Arc::new(FailingKvStore {
                 data: Mutex::new(HashMap::new()),
-                fail_list_prefix: Some(keys::session_prefix("test-agent")),
+                fail_list_prefix: Some(keys::session_prefix("default", "test-agent")),
                 fail_get_key: None,
                 fail_set_prefix: None,
                 fail_delete_key: None,
@@ -1256,18 +1220,12 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::Internal);
         assert!(err.message().contains("Failed to list sessions"));
 
-        let session_key = keys::session("test-agent", "session-1");
+        let session_key = keys::session("default", "test-agent", "session-1");
         let kv = Arc::new(FailingKvStore {
             data: Mutex::new(HashMap::from([
+                (session_key.clone(), b"ignored".to_vec()),
                 (
-                    ("default".to_string(), session_key.clone()),
-                    b"ignored".to_vec(),
-                ),
-                (
-                    (
-                        "default".to_string(),
-                        keys::session("test-agent", "session-2"),
-                    ),
+                    keys::session("default", "test-agent", "session-2"),
                     models::Session {
                         id: "session-2".to_string(),
                         agent: "test-agent".to_string(),
@@ -1310,7 +1268,7 @@ mod tests {
             fail_get_key: None,
             fail_set_prefix: None,
             fail_delete_key: None,
-            extra_list_keys: vec![keys::session("test-agent", "session-ghost")],
+            extra_list_keys: vec![keys::session("default", "test-agent", "session-ghost")],
         });
         let handler = setup_gateway_handler_with(
             kv,
@@ -1373,19 +1331,17 @@ mod tests {
             payload_json: "{}".to_string(),
         };
 
-        kv.set_msg(ns, &keys::session(agent, session_id), &session)
+        kv.set_msg(&keys::session(ns, agent, session_id), &session)
             .await
             .unwrap();
         kv.set_msg(
-            ns,
-            &keys::session_message(agent, session_id, message_id),
+            &keys::session_message(ns, agent, session_id, message_id),
             &message,
         )
         .await
         .unwrap();
         kv.set_msg(
-            ns,
-            &keys::session_message_step(agent, session_id, message_id, step_id),
+            &keys::session_message_step(ns, agent, session_id, message_id, step_id),
             &step,
         )
         .await
@@ -1403,25 +1359,24 @@ mod tests {
 
         assert!(response.success);
         assert!(kv
-            .get(ns, &keys::session(agent, session_id))
+            .get(&keys::session(ns, agent, session_id))
             .await
             .unwrap()
             .is_none());
         assert!(kv
-            .get(ns, &keys::session_message(agent, session_id, message_id))
+            .get(&keys::session_message(ns, agent, session_id, message_id))
             .await
             .unwrap()
             .is_none());
         assert!(kv
-            .get(
-                ns,
-                &keys::session_message_step(agent, session_id, message_id, step_id)
-            )
+            .get(&keys::session_message_step(
+                ns, agent, session_id, message_id, step_id
+            ))
             .await
             .unwrap()
             .is_none());
         assert!(kv
-            .list_keys(ns, &keys::session_message_prefix(agent, session_id))
+            .list_keys(&keys::session_message_prefix(ns, agent, session_id))
             .await
             .unwrap()
             .is_empty());
@@ -1435,7 +1390,10 @@ mod tests {
     async fn test_delete_session_surfaces_delete_and_publish_failures() {
         let kv = Arc::new(FailingKvStore {
             data: Mutex::new(HashMap::new()),
-            fail_list_prefix: Some(keys::session_message_prefix("test-agent", "session-1")),
+            fail_list_prefix: Some(keys::recursive_prefix(
+                "default",
+                &[("Agent", "test-agent"), ("Session", "session-1")],
+            )),
             fail_get_key: None,
             fail_set_prefix: None,
             fail_delete_key: None,
@@ -1464,8 +1422,7 @@ mod tests {
 
         let kv = Arc::new(MockKvStore::default());
         kv.set_msg(
-            "default",
-            &keys::session("test-agent", "session-1"),
+            &keys::session("default", "test-agent", "session-1"),
             &models::Session {
                 id: "session-1".to_string(),
                 agent: "test-agent".to_string(),
@@ -1503,7 +1460,7 @@ mod tests {
             fail_list_prefix: None,
             fail_get_key: None,
             fail_set_prefix: None,
-            fail_delete_key: Some(keys::session("test-agent", "session-1")),
+            fail_delete_key: Some(keys::session("default", "test-agent", "session-1")),
             extra_list_keys: Vec::new(),
         });
         let handler = setup_gateway_handler_with(
@@ -1544,7 +1501,7 @@ mod tests {
             metadata: HashMap::new(),
             labels: HashMap::new(),
         };
-        kv.set_msg(ns, &keys::session(agent, session_id), &session)
+        kv.set_msg(&keys::session(ns, agent, session_id), &session)
             .await
             .unwrap();
 
@@ -1598,8 +1555,7 @@ mod tests {
     async fn test_stop_session_generation_surfaces_publish_failure() {
         let kv = Arc::new(MockKvStore::default());
         kv.set_msg(
-            "default",
-            &keys::session("test-agent", "session-1"),
+            &keys::session("default", "test-agent", "session-1"),
             &models::Session {
                 id: "session-1".to_string(),
                 agent: "test-agent".to_string(),

--- a/src/gateway/rpc/sessions_tests.rs
+++ b/src/gateway/rpc/sessions_tests.rs
@@ -5,7 +5,7 @@
 mod tests {
     use crate::control::{
         events::{SessionStepEvent, StepType},
-        keys,
+        keys::{self, ResourceKey, ResourceList},
         scheduler::NoopSchedulerBackend,
         topics, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
@@ -47,38 +47,38 @@ mod tests {
 
     #[derive(Default)]
     struct FailingKvStore {
-        data: Mutex<HashMap<String, Vec<u8>>>,
-        fail_list_prefix: Option<String>,
-        fail_get_key: Option<String>,
+        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
+        fail_list_prefix: Option<ResourceList>,
+        fail_get_key: Option<ResourceKey>,
         fail_set_prefix: Option<String>,
-        fail_delete_key: Option<String>,
-        extra_list_keys: Vec<String>,
+        fail_delete_key: Option<ResourceKey>,
+        extra_list_keys: Vec<ResourceKey>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for FailingKvStore {
-        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            if self.fail_get_key.as_deref() == Some(k) {
+        async fn get(&self, k: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
+            if self.fail_get_key.as_ref() == Some(k) {
                 anyhow::bail!("get failed for {}", k);
             }
             Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, k: &ResourceKey, v: &[u8]) -> anyhow::Result<()> {
             if self
                 .fail_set_prefix
                 .as_deref()
-                .is_some_and(|prefix| k.starts_with(prefix))
+                .is_some_and(|prefix| k.canonical().starts_with(prefix))
             {
                 anyhow::bail!("set failed for {}", k);
             }
-            self.data.lock().await.insert(k.to_string(), v.to_vec());
+            self.data.lock().await.insert(k.clone(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            k: &str,
+            k: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
@@ -90,26 +90,26 @@ mod tests {
                 _ => false,
             };
             if matches {
-                data.insert(k.to_string(), value.to_vec());
+                data.insert(k.clone(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, k: &str) -> anyhow::Result<()> {
-            if self.fail_delete_key.as_deref() == Some(k) {
+        async fn delete(&self, k: &ResourceKey) -> anyhow::Result<()> {
+            if self.fail_delete_key.as_ref() == Some(k) {
                 anyhow::bail!("delete failed for {}", k);
             }
             self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             if self
                 .fail_list_prefix
-                .as_deref()
-                .is_some_and(|prefix| p.starts_with(prefix))
+                .as_ref()
+                .is_some_and(|fail_list| fail_list == list)
             {
-                anyhow::bail!("list failed for {}", p);
+                anyhow::bail!("list failed for {}", list);
             }
 
             let mut keys = self
@@ -117,7 +117,7 @@ mod tests {
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.extend(self.extra_list_keys.iter().cloned());
             keys.sort();
@@ -126,12 +126,12 @@ mod tests {
 
         async fn list_keys_page(
             &self,
-            prefix: &str,
+            list: &ResourceList,
             before_key: Option<&str>,
             limit: usize,
-        ) -> anyhow::Result<Vec<String>> {
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(crate::control::page_keys_desc(
-                self.list_keys(prefix).await?,
+                self.list_keys(list).await?,
                 before_key,
                 limit,
             ))
@@ -139,12 +139,12 @@ mod tests {
 
         async fn list_entries_page(
             &self,
-            prefix: &str,
+            list: &ResourceList,
             before_key: Option<&str>,
             limit: usize,
-        ) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
+        ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
             Ok(crate::control::page_entries_desc(
-                self.list_entries(prefix).await?,
+                self.list_entries(list).await?,
                 before_key,
                 limit,
             ))
@@ -293,7 +293,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_session_surfaces_save_failure() {
-        let session_key_prefix = keys::session_prefix("default", "test-agent");
+        let session_key_prefix = keys::session_prefix("default", "test-agent").canonical_prefix();
         let kv = Arc::new(FailingKvStore {
             data: Mutex::new(HashMap::from([(
                 keys::agent("default", "test-agent"),
@@ -373,15 +373,6 @@ mod tests {
         .await
         .unwrap();
 
-        kv.set(
-            &format!(
-                "{}/nested",
-                keys::session_message(ns, agent, session_id, message_id)
-            ),
-            b"should-be-ignored",
-        )
-        .await
-        .unwrap();
         kv.set(
             &keys::session_message(ns, agent, session_id, "msg-invalid"),
             b"not-protobuf",
@@ -1390,10 +1381,9 @@ mod tests {
     async fn test_delete_session_surfaces_delete_and_publish_failures() {
         let kv = Arc::new(FailingKvStore {
             data: Mutex::new(HashMap::new()),
-            fail_list_prefix: Some(keys::recursive_prefix(
-                "default",
-                &[("Agent", "test-agent"), ("Session", "session-1")],
-            )),
+            fail_list_prefix: Some(
+                keys::session_parent("default", "test-agent", "session-1").list(None),
+            ),
             fail_get_key: None,
             fail_set_prefix: None,
             fail_delete_key: None,

--- a/src/gateway/rpc/templates.rs
+++ b/src/gateway/rpc/templates.rs
@@ -7,6 +7,16 @@ use super::GrpcGatewayHandler;
 use crate::control::{keys, ns};
 use anyhow::Result;
 
+const LEGACY_SYSTEM_NAMESPACE: &str = "talon-system";
+
+fn normalize_agent_template_namespace(template: &mut manifests::AgentTemplate) {
+    if let Some(meta) = template.metadata.as_mut() {
+        if meta.namespace.is_empty() || meta.namespace == LEGACY_SYSTEM_NAMESPACE {
+            meta.namespace = ns::TALON_SYSTEM.to_string();
+        }
+    }
+}
+
 impl GrpcGatewayHandler {
     pub async fn handle_create_agent_template(
         &self,
@@ -41,11 +51,12 @@ impl GrpcGatewayHandler {
             template.kind = "AgentTemplate".to_string();
         }
         if let Some(meta) = template.metadata.as_mut() {
-            if meta.namespace.is_empty() {
+            if meta.namespace.is_empty() || meta.namespace == LEGACY_SYSTEM_NAMESPACE {
                 meta.namespace = ns::TALON_SYSTEM.to_string();
             } else if meta.namespace != ns::TALON_SYSTEM {
                 return Err(tonic::Status::invalid_argument(format!(
-                    "AgentTemplate metadata.namespace must be empty or '{}'",
+                    "AgentTemplate metadata.namespace must be empty, '{}', or '{}'",
+                    LEGACY_SYSTEM_NAMESPACE,
                     ns::TALON_SYSTEM
                 )));
             }
@@ -58,7 +69,7 @@ impl GrpcGatewayHandler {
         use crate::control::ProtoKeyValueStoreExt;
         self.gateway
             .kv
-            .set_msg(ns::TALON_SYSTEM, &key, &template)
+            .set_msg(&key, &template)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
@@ -76,12 +87,13 @@ impl GrpcGatewayHandler {
         let key = keys::agent_template(&msg.name);
 
         use crate::control::ProtoKeyValueStoreExt;
-        if let Ok(Some(template)) = self
+        if let Ok(Some(mut template)) = self
             .gateway
             .kv
-            .get_msg::<manifests::AgentTemplate>(ns::TALON_SYSTEM, &key)
+            .get_msg::<manifests::AgentTemplate>(&key)
             .await
         {
+            normalize_agent_template_namespace(&mut template);
             Ok(tonic::Response::new(proto::AgentTemplateResponse {
                 template: Some(template),
             }))
@@ -96,23 +108,24 @@ impl GrpcGatewayHandler {
     ) -> Result<tonic::Response<proto::ListAgentTemplatesResponse>, tonic::Status> {
         crate::require_auth!(self, _req, ns::TALON_SYSTEM);
 
-        let prefix = "AgentTemplate/";
+        let prefix = keys::agent_template_prefix();
         let keys = self
             .gateway
             .kv
-            .list_keys(ns::TALON_SYSTEM, prefix)
+            .list_keys(&prefix)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
         use crate::control::ProtoKeyValueStoreExt;
         let mut templates = Vec::new();
         for key in keys {
-            if let Ok(Some(template)) = self
+            if let Ok(Some(mut template)) = self
                 .gateway
                 .kv
-                .get_msg::<manifests::AgentTemplate>(ns::TALON_SYSTEM, &key)
+                .get_msg::<manifests::AgentTemplate>(&key)
                 .await
             {
+                normalize_agent_template_namespace(&mut template);
                 templates.push(template);
             }
         }
@@ -134,12 +147,12 @@ impl GrpcGatewayHandler {
         if let Ok(Some(_)) = self
             .gateway
             .kv
-            .get_msg::<manifests::AgentTemplate>(ns::TALON_SYSTEM, &key)
+            .get_msg::<manifests::AgentTemplate>(&key)
             .await
         {
             self.gateway
                 .kv
-                .delete(ns::TALON_SYSTEM, &key)
+                .delete(&key)
                 .await
                 .map_err(|e| tonic::Status::internal(e.to_string()))?;
             Ok(tonic::Response::new(proto::DeleteAgentTemplateResponse {

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -119,7 +119,11 @@ impl Gateway {
 #[cfg(test)]
 mod tests {
     use super::Gateway;
-    use crate::control::{scheduler::NoopSchedulerBackend, KeyValueStore, MessagePublisher};
+    use crate::control::{
+        keys::{ResourceKey, ResourceList},
+        scheduler::NoopSchedulerBackend,
+        KeyValueStore, MessagePublisher,
+    };
     use crate::gateway::auth::AuthConfig;
     use axum::body::Body;
     use axum::http::{Method, Request, StatusCode};
@@ -134,52 +138,51 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<String, Vec<u8>>>,
+        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, k: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data.lock().await.insert(k.to_string(), v.to_vec());
+        async fn set(&self, k: &ResourceKey, v: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(k.clone(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            k: &str,
+            k: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let key = k.to_string();
-            let current = data.get(&key).cloned();
+            let current = data.get(k).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(key, value.to_vec());
+                data.insert(k.clone(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+        async fn delete(&self, k: &ResourceKey) -> anyhow::Result<()> {
             self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -119,8 +119,8 @@ impl Gateway {
 #[cfg(test)]
 mod tests {
     use super::Gateway;
-    use crate::gateway::auth::AuthConfig;
     use crate::control::{scheduler::NoopSchedulerBackend, KeyValueStore, MessagePublisher};
+    use crate::gateway::auth::AuthConfig;
     use axum::body::Body;
     use axum::http::{Method, Request, StatusCode};
     use futures::stream;
@@ -134,37 +134,28 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+        data: Mutex<HashMap<String, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, ns: &str, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(ns.to_string(), k.to_string()))
-                .cloned())
+        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, ns: &str, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .insert((ns.to_string(), k.to_string()), v.to_vec());
+        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(k.to_string(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            ns: &str,
             k: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let key = (ns.to_string(), k.to_string());
+            let key = k.to_string();
             let current = data.get(&key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
@@ -177,23 +168,18 @@ mod tests {
             Ok(matches)
         }
 
-        async fn delete(&self, ns: &str, k: &str) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .remove(&(ns.to_string(), k.to_string()));
+        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+            self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(p)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)

--- a/src/gateway/session_streams.rs
+++ b/src/gateway/session_streams.rs
@@ -97,11 +97,7 @@ impl SessionStreamHub {
         Ok(rx)
     }
 
-    async fn ensure_shard_task(
-        &self,
-        shard: usize,
-        state: Arc<Shard>,
-    ) -> anyhow::Result<()> {
+    async fn ensure_shard_task(&self, shard: usize, state: Arc<Shard>) -> anyhow::Result<()> {
         let topic = topics::session_step_topic_for_shard(shard as u32);
         loop {
             let should_subscribe = {

--- a/src/gateway/ui.rs
+++ b/src/gateway/ui.rs
@@ -553,10 +553,10 @@ pub async fn delete_chat(
 #[cfg(test)]
 mod tests {
     use super::{
-        data_stream_line, delete_chat, extract_tool_step_payload, fetch_session_metadata,
-        get_chat, last_message_text, latest_assistant_message_text, latest_tool_step_payload,
-        map_status, ndjson_line, post_chat, step_dedup_key, tonic_request, ChatRequestBody,
-        SessionPath, UiMessage, UiPart,
+        data_stream_line, delete_chat, extract_tool_step_payload, fetch_session_metadata, get_chat,
+        last_message_text, latest_assistant_message_text, latest_tool_step_payload, map_status,
+        ndjson_line, post_chat, step_dedup_key, tonic_request, ChatRequestBody, SessionPath,
+        UiMessage, UiPart,
     };
     use crate::control::events::{SessionControlEvent, SessionStepEvent, StepType};
     use crate::control::{
@@ -579,37 +579,28 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+        data: Mutex<HashMap<String, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, ns: &str, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(ns.to_string(), k.to_string()))
-                .cloned())
+        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, ns: &str, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .insert((ns.to_string(), k.to_string()), v.to_vec());
+        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(k.to_string(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            ns: &str,
             k: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let key = (ns.to_string(), k.to_string());
+            let key = k.to_string();
             let current = data.get(&key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
@@ -622,23 +613,18 @@ mod tests {
             Ok(matches)
         }
 
-        async fn delete(&self, ns: &str, k: &str) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .remove(&(ns.to_string(), k.to_string()));
+        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+            self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(p)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -646,13 +632,12 @@ mod tests {
 
         async fn list_keys_page(
             &self,
-            ns: &str,
             prefix: &str,
             before_key: Option<&str>,
             limit: usize,
         ) -> anyhow::Result<Vec<String>> {
             Ok(crate::control::page_keys_desc(
-                self.list_keys(ns, prefix).await?,
+                self.list_keys(prefix).await?,
                 before_key,
                 limit,
             ))
@@ -979,8 +964,7 @@ mod tests {
     async fn fetch_session_reads_seeded_session_state() {
         let kv = Arc::new(MockKvStore::default());
         kv.set_msg(
-            "default",
-            &keys::session("agent", "session-1"),
+            &keys::session("default", "agent", "session-1"),
             &models::Session {
                 id: "session-1".to_string(),
                 agent: "agent".to_string(),
@@ -995,8 +979,7 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "default",
-            &keys::session_message("agent", "session-1", "msg-1"),
+            &keys::session_message("default", "agent", "session-1", "msg-1"),
             &models::SessionMessage {
                 id: "msg-1".to_string(),
                 role: models::MessageRole::RoleAssistant as i32,
@@ -1008,8 +991,7 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "default",
-            &keys::session_message_step("agent", "session-1", "msg-1", "step-1"),
+            &keys::session_message_step("default", "agent", "session-1", "msg-1", "step-1"),
             &SessionStepEvent {
                 session_id: "session-1".to_string(),
                 step_type: StepType::Token as i32,
@@ -1117,8 +1099,7 @@ mod tests {
         let session_id = "session-error";
         let kv = Arc::new(MockKvStore::default());
         kv.set_msg(
-            "default",
-            &keys::session("agent", session_id),
+            &keys::session("default", "agent", session_id),
             &models::Session {
                 id: session_id.to_string(),
                 agent: "agent".to_string(),
@@ -1266,8 +1247,7 @@ mod tests {
     async fn delete_chat_stops_generation_and_returns_no_content() {
         let kv = Arc::new(MockKvStore::default());
         kv.set_msg(
-            "default",
-            &keys::session("agent", "session-1"),
+            &keys::session("default", "agent", "session-1"),
             &models::Session {
                 id: "session-1".to_string(),
                 agent: "agent".to_string(),

--- a/src/gateway/ui.rs
+++ b/src/gateway/ui.rs
@@ -560,8 +560,9 @@ mod tests {
     };
     use crate::control::events::{SessionControlEvent, SessionStepEvent, StepType};
     use crate::control::{
-        keys, scheduler::NoopSchedulerBackend, topics, KeyValueStore, MessagePublisher,
-        ProtoKeyValueStoreExt,
+        keys::{self, ResourceKey, ResourceList},
+        scheduler::NoopSchedulerBackend,
+        topics, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{models, proto};
     use crate::gateway::{server::Gateway, session_streams::SessionStreamHub};
@@ -579,52 +580,51 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<String, Vec<u8>>>,
+        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, k: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.lock().await.get(k).cloned())
         }
 
-        async fn set(&self, k: &str, v: &[u8]) -> anyhow::Result<()> {
-            self.data.lock().await.insert(k.to_string(), v.to_vec());
+        async fn set(&self, k: &ResourceKey, v: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(k.clone(), v.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            k: &str,
+            k: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let key = k.to_string();
-            let current = data.get(&key).cloned();
+            let current = data.get(k).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(key, value.to_vec());
+                data.insert(k.clone(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, k: &str) -> anyhow::Result<()> {
+        async fn delete(&self, k: &ResourceKey) -> anyhow::Result<()> {
             self.data.lock().await.remove(k);
             Ok(())
         }
 
-        async fn list_keys(&self, p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(p).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -632,12 +632,12 @@ mod tests {
 
         async fn list_keys_page(
             &self,
-            prefix: &str,
+            list: &ResourceList,
             before_key: Option<&str>,
             limit: usize,
-        ) -> anyhow::Result<Vec<String>> {
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(crate::control::page_keys_desc(
-                self.list_keys(prefix).await?,
+                self.list_keys(list).await?,
                 before_key,
                 limit,
             ))

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -455,7 +455,10 @@ mod tests {
         execute_tool, KnowledgeBook, KnowledgeEntry, KvKnowledgeBook, KNOWLEDGE_GET_TOOL,
         KNOWLEDGE_LIST_TOOL, KNOWLEDGE_SEARCH_TOOL, KNOWLEDGE_WRITE_TOOL,
     };
-    use crate::control::KeyValueStore;
+    use crate::control::{
+        keys::{ResourceKey, ResourceList},
+        KeyValueStore,
+    };
     use async_trait::async_trait;
     use serde_json::json;
     use std::collections::HashMap;
@@ -463,7 +466,7 @@ mod tests {
     use tokio::sync::Mutex;
 
     struct MockKvStore {
-        store: Mutex<HashMap<String, Vec<u8>>>,
+        store: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[tokio::test]
@@ -538,20 +541,20 @@ mod tests {
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             let map = self.store.lock().await;
             Ok(map.get(key).cloned())
         }
 
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
-            map.insert(key.to_string(), value.to_vec());
+            map.insert(key.clone(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            key: &str,
+            key: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
@@ -565,22 +568,22 @@ mod tests {
             if !matches {
                 return Ok(false);
             }
-            map.insert(key.to_string(), value.to_vec());
+            map.insert(key.clone(), value.to_vec());
             Ok(true)
         }
 
-        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
             map.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let map = self.store.lock().await;
             let mut results = Vec::new();
             for key in map.keys() {
-                if key.starts_with(prefix) {
-                    results.push(key.to_string());
+                if list.matches(key) {
+                    results.push(key.clone());
                 }
             }
             Ok(results)

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -162,10 +162,7 @@ pub async fn execute_tool(
         }
         KNOWLEDGE_LIST_TOOL => {
             let path_prefix = args["path"].as_str().unwrap_or("");
-            let local_only = args
-                .get("local")
-                .and_then(Value::as_bool)
-                .unwrap_or(true);
+            let local_only = args.get("local").and_then(Value::as_bool).unwrap_or(true);
             let recursive = args
                 .get("recursive")
                 .and_then(Value::as_bool)
@@ -181,7 +178,11 @@ pub async fn execute_tool(
             if entries.is_empty() {
                 Ok(Some(format!(
                     "KnowledgeBook: no artifacts found under '{}'.",
-                    if path_prefix.is_empty() { "/" } else { path_prefix }
+                    if path_prefix.is_empty() {
+                        "/"
+                    } else {
+                        path_prefix
+                    }
                 )))
             } else {
                 Ok(Some(serde_json::to_string_pretty(&json!({
@@ -222,20 +223,21 @@ impl KvKnowledgeBook {
     }
 
     async fn find_entry(&self, ns: &str, path: &str) -> Result<Option<KnowledgeEntry>> {
-        let key = crate::control::keys::knowledge(path);
-        if let Some(bytes) = self.kv.get(ns, &key).await? {
+        let key = crate::control::keys::knowledge(ns, path);
+        if let Some(bytes) = self.kv.get(&key).await? {
             return Ok(Some(Self::normalize_entry(ns, path, &bytes)));
         }
 
-        let prefix = crate::control::keys::knowledge_prefix();
+        let prefix = crate::control::keys::knowledge_prefix(ns);
         let path_lower = path.to_lowercase();
         let matches = self
             .kv
-            .list_keys(ns, prefix)
+            .list_keys(&prefix)
             .await?
             .into_iter()
             .filter(|candidate| {
-                let artifact_path = candidate.strip_prefix(prefix).unwrap_or(candidate);
+                let artifact_path =
+                    crate::control::keys::direct_child_name(&prefix, candidate).unwrap_or_default();
                 let artifact_lower = artifact_path.to_lowercase();
                 artifact_lower == path_lower
                     || artifact_lower.ends_with(&format!("/{}", path_lower))
@@ -246,11 +248,12 @@ impl KvKnowledgeBook {
             return Ok(None);
         }
 
-        let Some(bytes) = self.kv.get(ns, &matches[0]).await? else {
+        let Some(bytes) = self.kv.get(&matches[0]).await? else {
             return Ok(None);
         };
-        let artifact_path = matches[0].strip_prefix(prefix).unwrap_or(&matches[0]);
-        Ok(Some(Self::normalize_entry(ns, artifact_path, &bytes)))
+        let artifact_path =
+            crate::control::keys::direct_child_name(&prefix, &matches[0]).unwrap_or_default();
+        Ok(Some(Self::normalize_entry(ns, &artifact_path, &bytes)))
     }
 
     fn normalize_list_prefix(path_prefix: &str) -> String {
@@ -290,7 +293,7 @@ impl KnowledgeBook for KvKnowledgeBook {
     }
 
     async fn write(&self, ns: &str, path: &str, content: &str) -> Result<()> {
-        let key = crate::control::keys::knowledge(path);
+        let key = crate::control::keys::knowledge(ns, path);
         let entry = KnowledgeEntry {
             namespace: ns.to_string(),
             name: path.to_string(),
@@ -302,26 +305,24 @@ impl KnowledgeBook for KvKnowledgeBook {
                 .as_secs() as i64,
         };
         let bytes = serde_json::to_vec(&entry)?;
-        self.kv.set(ns, &key, &bytes).await?;
+        self.kv.set(&key, &bytes).await?;
         Ok(())
     }
 
     async fn search(&self, ns: &str, query: &str, limit: usize) -> Result<Vec<KnowledgeResult>> {
-        let prefix = crate::control::keys::knowledge_prefix();
         let query_lower = query.to_lowercase();
         let mut scored_results: Vec<(i32, usize, KnowledgeResult)> = Vec::new();
         let mut seen_paths = std::collections::HashSet::new();
 
         for (depth, candidate_ns) in crate::control::ns::ancestry(ns).into_iter().enumerate() {
-            let keys = self.kv.list_keys(&candidate_ns, prefix).await?;
+            let prefix = crate::control::keys::knowledge_prefix(&candidate_ns);
+            let keys = self.kv.list_keys(&prefix).await?;
 
             for key in keys {
-                if let Some(bytes) = self.kv.get(&candidate_ns, &key).await.unwrap_or(None) {
-                    let entry = Self::normalize_entry(
-                        &candidate_ns,
-                        key.strip_prefix(prefix).unwrap_or(&key),
-                        &bytes,
-                    );
+                if let Some(bytes) = self.kv.get(&key).await.unwrap_or(None) {
+                    let artifact_path =
+                        crate::control::keys::direct_child_name(&prefix, &key).unwrap_or_default();
+                    let entry = Self::normalize_entry(&candidate_ns, &artifact_path, &bytes);
                     let path = entry.path();
                     if !seen_paths.insert(path.clone()) {
                         continue;
@@ -392,7 +393,6 @@ impl KnowledgeBook for KvKnowledgeBook {
         recursive: bool,
         limit: usize,
     ) -> Result<Vec<KnowledgeListEntry>> {
-        let prefix = crate::control::keys::knowledge_prefix();
         let normalized_prefix = Self::normalize_list_prefix(path_prefix);
         let mut entries = Vec::new();
         let mut seen_paths = std::collections::HashSet::new();
@@ -404,21 +404,23 @@ impl KnowledgeBook for KvKnowledgeBook {
         };
 
         for candidate_ns in namespaces {
-            let mut keys = self.kv.list_keys(&candidate_ns, prefix).await?;
+            let prefix = crate::control::keys::knowledge_prefix(&candidate_ns);
+            let mut keys = self.kv.list_keys(&prefix).await?;
             keys.sort();
 
             for key in keys {
-                let artifact_path = key.strip_prefix(prefix).unwrap_or(&key);
-                if !Self::entry_matches_prefix(artifact_path, &normalized_prefix, recursive) {
+                let artifact_path =
+                    crate::control::keys::direct_child_name(&prefix, &key).unwrap_or_default();
+                if !Self::entry_matches_prefix(&artifact_path, &normalized_prefix, recursive) {
                     continue;
                 }
                 if !seen_paths.insert(artifact_path.to_string()) {
                     continue;
                 }
-                let Some(bytes) = self.kv.get(&candidate_ns, &key).await? else {
+                let Some(bytes) = self.kv.get(&key).await? else {
                     continue;
                 };
-                let entry = Self::normalize_entry(&candidate_ns, artifact_path, &bytes);
+                let entry = Self::normalize_entry(&candidate_ns, &artifact_path, &bytes);
                 let namespace = entry.namespace.clone();
                 let path = entry.path();
                 entries.push(KnowledgeListEntry {
@@ -450,8 +452,8 @@ impl KnowledgeEntry {
 #[cfg(test)]
 mod tests {
     use super::{
-        execute_tool, KnowledgeBook, KnowledgeEntry, KvKnowledgeBook,
-        KNOWLEDGE_GET_TOOL, KNOWLEDGE_LIST_TOOL, KNOWLEDGE_SEARCH_TOOL, KNOWLEDGE_WRITE_TOOL,
+        execute_tool, KnowledgeBook, KnowledgeEntry, KvKnowledgeBook, KNOWLEDGE_GET_TOOL,
+        KNOWLEDGE_LIST_TOOL, KNOWLEDGE_SEARCH_TOOL, KNOWLEDGE_WRITE_TOOL,
     };
     use crate::control::KeyValueStore;
     use async_trait::async_trait;
@@ -481,9 +483,12 @@ mod tests {
                 content: content.to_string(),
                 updated_at: 7,
             };
-            kv.set(ns, &format!("Knowledge/{}", path), &serde_json::to_vec(&entry).unwrap())
-                .await
-                .unwrap();
+            kv.set(
+                &crate::control::keys::knowledge(ns, path),
+                &serde_json::to_vec(&entry).unwrap(),
+            )
+            .await
+            .unwrap();
         }
 
         let non_recursive = book
@@ -501,7 +506,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(recursive.len(), 3);
-        let recursive_paths = recursive.into_iter().map(|entry| entry.path).collect::<Vec<_>>();
+        let recursive_paths = recursive
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect::<Vec<_>>();
         assert_eq!(
             recursive_paths,
             vec![
@@ -526,35 +534,29 @@ mod tests {
                 store: Mutex::new(HashMap::new()),
             }
         }
-
-        fn make_key(ns: &str, key: &str) -> String {
-            format!("{}/{}", ns, key)
-        }
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, namespace: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
             let map = self.store.lock().await;
-            Ok(map.get(&Self::make_key(namespace, key)).cloned())
+            Ok(map.get(key).cloned())
         }
 
-        async fn set(&self, namespace: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
-            map.insert(Self::make_key(namespace, key), value.to_vec());
+            map.insert(key.to_string(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            namespace: &str,
             key: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut map = self.store.lock().await;
-            let full_key = Self::make_key(namespace, key);
-            let current = map.get(&full_key).cloned();
+            let current = map.get(key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
@@ -563,24 +565,22 @@ mod tests {
             if !matches {
                 return Ok(false);
             }
-            map.insert(full_key, value.to_vec());
+            map.insert(key.to_string(), value.to_vec());
             Ok(true)
         }
 
-        async fn delete(&self, namespace: &str, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
-            map.remove(&Self::make_key(namespace, key));
+            map.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, namespace: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
             let map = self.store.lock().await;
-            let ns_prefix = format!("{}/{}", namespace, prefix);
-            let ns_root = format!("{}/", namespace);
             let mut results = Vec::new();
             for key in map.keys() {
-                if key.starts_with(&ns_prefix) {
-                    results.push(key.strip_prefix(&ns_root).unwrap().to_string());
+                if key.starts_with(prefix) {
+                    results.push(key.to_string());
                 }
             }
             Ok(results)
@@ -600,9 +600,12 @@ mod tests {
             updated_at: 0,
         };
         let bytes = serde_json::to_vec(&entry).unwrap();
-        kv.set("conic", "Knowledge/unicode.md", &bytes)
-            .await
-            .unwrap();
+        kv.set(
+            &crate::control::keys::knowledge("conic", "unicode.md"),
+            &bytes,
+        )
+        .await
+        .unwrap();
 
         let results = book.search("conic", "café", 5).await.unwrap();
 
@@ -624,9 +627,12 @@ mod tests {
             updated_at: 0,
         };
         let bytes = serde_json::to_vec(&entry).unwrap();
-        kv.set("conic", "Knowledge/playbooks/aeo.md", &bytes)
-            .await
-            .unwrap();
+        kv.set(
+            &crate::control::keys::knowledge("conic", "playbooks/aeo.md"),
+            &bytes,
+        )
+        .await
+        .unwrap();
 
         let result = book.get("conic:wks:13", "playbooks/aeo.md").await.unwrap();
         let result = result.expect("expected inherited knowledge");
@@ -651,9 +657,12 @@ mod tests {
                 updated_at: 0,
             };
             let bytes = serde_json::to_vec(&entry).unwrap();
-            kv.set(ns, "Knowledge/playbooks/framework.md", &bytes)
-                .await
-                .unwrap();
+            kv.set(
+                &crate::control::keys::knowledge(ns, "playbooks/framework.md"),
+                &bytes,
+            )
+            .await
+            .unwrap();
         }
 
         let results = book.search("conic:wks:13", "framework", 5).await.unwrap();
@@ -666,17 +675,23 @@ mod tests {
         let kv = Arc::new(MockKvStore::new());
         let book = KvKnowledgeBook::new(kv.clone());
 
-        kv.set("conic", "Knowledge/notes/Plan.md", b"plain text body")
-            .await
-            .unwrap();
+        kv.set(
+            &crate::control::keys::knowledge("conic", "notes/Plan.md"),
+            b"plain text body",
+        )
+        .await
+        .unwrap();
         let resolved = book.find_entry("conic", "plan.md").await.unwrap().unwrap();
         assert_eq!(resolved.namespace, "conic");
         assert_eq!(resolved.path(), "notes/Plan.md");
         assert_eq!(resolved.content, "plain text body");
 
-        kv.set("conic", "Knowledge/other/Plan.md", b"another body")
-            .await
-            .unwrap();
+        kv.set(
+            &crate::control::keys::knowledge("conic", "other/Plan.md"),
+            b"another body",
+        )
+        .await
+        .unwrap();
         let ambiguous = book.find_entry("conic", "plan.md").await.unwrap();
         assert!(ambiguous.is_none());
     }
@@ -700,8 +715,7 @@ mod tests {
                 updated_at: 0,
             };
             kv.set(
-                "conic",
-                &format!("Knowledge/{}", path),
+                &crate::control::keys::knowledge("conic", path),
                 &serde_json::to_vec(&entry).unwrap(),
             )
             .await
@@ -729,7 +743,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(wrote.as_deref(), Some("KnowledgeBook: wrote artifact 'goals.md'."));
+        assert_eq!(
+            wrote.as_deref(),
+            Some("KnowledgeBook: wrote artifact 'goals.md'.")
+        );
 
         let got = execute_tool(
             &book,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub use crate::knowledge::{KnowledgeBook, KvKnowledgeBook};
 pub use crate::security::encryption::SecurityProvider;
 
 pub mod test_support {
+    use crate::control::keys::{ResourceKey, ResourceList};
     use crate::control::{KeyValueStore, MessagePublisher};
     use futures::stream;
     use std::collections::HashMap;
@@ -45,7 +46,7 @@ pub mod test_support {
 
     #[derive(Default)]
     pub struct MockKvStore {
-        data: AsyncMutex<HashMap<String, Vec<u8>>>,
+        data: AsyncMutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     impl MockKvStore {
@@ -56,21 +57,18 @@ pub mod test_support {
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .insert(key.to_string(), value.to_vec());
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(key.clone(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            key: &str,
+            key: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
@@ -82,23 +80,23 @@ pub mod test_support {
                 _ => false,
             };
             if matches {
-                data.insert(key.to_string(), value.to_vec());
+                data.insert(key.clone(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
             self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -106,26 +104,26 @@ pub mod test_support {
 
         async fn list_keys_page(
             &self,
-            prefix: &str,
-            before_key: Option<&str>,
+            list: &ResourceList,
+            before_name: Option<&str>,
             limit: usize,
-        ) -> anyhow::Result<Vec<String>> {
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(crate::control::page_keys_desc(
-                self.list_keys(prefix).await?,
-                before_key,
+                self.list_keys(list).await?,
+                before_name,
                 limit,
             ))
         }
 
         async fn list_entries_page(
             &self,
-            prefix: &str,
-            before_key: Option<&str>,
+            list: &ResourceList,
+            before_name: Option<&str>,
             limit: usize,
-        ) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
+        ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
             Ok(crate::control::page_entries_desc(
-                self.list_entries(prefix).await?,
-                before_key,
+                self.list_entries(list).await?,
+                before_name,
                 limit,
             ))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub mod test_support {
 
     #[derive(Default)]
     pub struct MockKvStore {
-        data: AsyncMutex<HashMap<(String, String), Vec<u8>>>,
+        data: AsyncMutex<HashMap<String, Vec<u8>>>,
     }
 
     impl MockKvStore {
@@ -56,61 +56,49 @@ pub mod test_support {
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, namespace: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(namespace.to_string(), key.to_string()))
-                .cloned())
+        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, namespace: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             self.data
                 .lock()
                 .await
-                .insert((namespace.to_string(), key.to_string()), value.to_vec());
+                .insert(key.to_string(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            namespace: &str,
             key: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let storage_key = (namespace.to_string(), key.to_string());
-            let current = data.get(&storage_key).cloned();
+            let current = data.get(key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(storage_key, value.to_vec());
+                data.insert(key.to_string(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, namespace: &str, key: &str) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .remove(&(namespace.to_string(), key.to_string()));
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+            self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, namespace: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(ns, key)| {
-                    (ns == namespace && key.starts_with(prefix)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -118,13 +106,12 @@ pub mod test_support {
 
         async fn list_keys_page(
             &self,
-            namespace: &str,
             prefix: &str,
             before_key: Option<&str>,
             limit: usize,
         ) -> anyhow::Result<Vec<String>> {
             Ok(crate::control::page_keys_desc(
-                self.list_keys(namespace, prefix).await?,
+                self.list_keys(prefix).await?,
                 before_key,
                 limit,
             ))
@@ -132,13 +119,12 @@ pub mod test_support {
 
         async fn list_entries_page(
             &self,
-            namespace: &str,
             prefix: &str,
             before_key: Option<&str>,
             limit: usize,
         ) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
             Ok(crate::control::page_entries_desc(
-                self.list_entries(namespace, prefix).await?,
+                self.list_entries(prefix).await?,
                 before_key,
                 limit,
             ))

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -1,10 +1,10 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
+use crate::gateway::rpc::manifests;
 use crate::llm::provider::{
     ChatMessage, ChatRequest, ChatResponse, ChatStream, ChatStreamEvent, ChatUsage, LlmProvider,
 };
-use crate::gateway::rpc::manifests;
 use crate::memory::Embedding;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -82,10 +82,7 @@ impl LlmProvider for AnthropicProvider {
         Err(anyhow!("Anthropic does not natively support embeddings. Use an OpenAI-compatible provider for embeddings."))
     }
 
-    async fn chat_completion(
-        &self,
-        request: ChatRequest,
-    ) -> Result<ChatResponse> {
+    async fn chat_completion(&self, request: ChatRequest) -> Result<ChatResponse> {
         // TODO: Translate OpenAI-format tool definitions to Anthropic's tool schema
         // and include them in the payload when _tools is non-empty.
         let url = self.messages_url();
@@ -238,18 +235,16 @@ impl LlmProvider for AnthropicProvider {
     }
 
     async fn completion(&self, prompt: &str) -> Result<String> {
-        self.chat_completion(
-            ChatRequest {
-                messages: vec![ChatMessage {
-                    role: "user".to_string(),
-                    content: prompt.to_string(),
-                    tool_calls: None,
-                    tool_call_id: None,
-                }],
-                tools: vec![],
-                thinking: None,
-            },
-        )
+        self.chat_completion(ChatRequest {
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: prompt.to_string(),
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            tools: vec![],
+            thinking: None,
+        })
         .await
         .map(|r| r.content)
     }
@@ -288,8 +283,8 @@ fn extract_usage(result: &serde_json::Value) -> Option<ChatUsage> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{routing::post, Json, Router};
     use crate::gateway::rpc::manifests::ThinkingConfig;
+    use axum::{routing::post, Json, Router};
     use serde_json::json;
     use tokio::net::TcpListener;
 

--- a/src/llm/failover.rs
+++ b/src/llm/failover.rs
@@ -76,10 +76,7 @@ impl LlmProvider for FailoverProvider {
         .await
     }
 
-    async fn chat_completion(
-        &self,
-        request: ChatRequest,
-    ) -> Result<ChatResponse> {
+    async fn chat_completion(&self, request: ChatRequest) -> Result<ChatResponse> {
         self.with_failover(|p| {
             let request = request.clone();
             async move { p.chat_completion(request).await }
@@ -118,10 +115,7 @@ mod tests {
         async fn generate_embedding(&self, _text: &str) -> Result<Embedding> {
             Err(anyhow!("Always fails"))
         }
-        async fn chat_completion(
-            &self,
-            _request: ChatRequest,
-        ) -> Result<ChatResponse> {
+        async fn chat_completion(&self, _request: ChatRequest) -> Result<ChatResponse> {
             Err(anyhow!("Always fails"))
         }
         async fn stream_chat_completion(&self, _request: ChatRequest) -> Result<ChatStream> {
@@ -202,10 +196,7 @@ mod tests {
             }
         }
 
-        async fn chat_completion(
-            &self,
-            _request: ChatRequest,
-        ) -> Result<ChatResponse> {
+        async fn chat_completion(&self, _request: ChatRequest) -> Result<ChatResponse> {
             let call = self.chat_calls.fetch_add(1, Ordering::SeqCst);
             if call < self.fail_until {
                 Err(anyhow!("chat fail {}", call + 1))

--- a/src/llm/mock.rs
+++ b/src/llm/mock.rs
@@ -14,10 +14,7 @@ impl LlmProvider for MockLlmProvider {
         Ok(vec![0.0; 768])
     }
 
-    async fn chat_completion(
-        &self,
-        request: ChatRequest,
-    ) -> Result<ChatResponse> {
+    async fn chat_completion(&self, request: ChatRequest) -> Result<ChatResponse> {
         Ok(ChatResponse {
             content: format!("Mock response to {} messages", request.messages.len()),
             tool_calls: vec![],

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -90,15 +90,14 @@ impl OpenAiCompatibleProvider {
     }
 
     fn supports_stream_options_retry(&self, stream: bool, err_text: &str) -> bool {
-        stream
-            && {
-                let lower = err_text.to_ascii_lowercase();
-                lower.contains("stream_options")
-                    || lower.contains("include_usage")
-                    || lower.contains("unknown field")
-                    || lower.contains("unknown parameter")
-                    || lower.contains("unexpected field")
-            }
+        stream && {
+            let lower = err_text.to_ascii_lowercase();
+            lower.contains("stream_options")
+                || lower.contains("include_usage")
+                || lower.contains("unknown field")
+                || lower.contains("unknown parameter")
+                || lower.contains("unexpected field")
+        }
     }
 
     fn debug_requests_enabled() -> bool {
@@ -284,7 +283,11 @@ impl OpenAiCompatibleProvider {
                 payload["tool_choice"] = serde_json::json!("auto");
             }
 
-            if let Some(thinking) = request.thinking.as_ref().filter(|thinking| thinking.enabled) {
+            if let Some(thinking) = request
+                .thinking
+                .as_ref()
+                .filter(|thinking| thinking.enabled)
+            {
                 if !thinking.effort.trim().is_empty() {
                     payload["reasoning_effort"] = serde_json::json!(thinking.effort);
                 }
@@ -475,10 +478,7 @@ impl LlmProvider for OpenAiCompatibleProvider {
         Ok(vec![0.0; 768])
     }
 
-    async fn chat_completion(
-        &self,
-        request: ChatRequest,
-    ) -> Result<ChatResponse> {
+    async fn chat_completion(&self, request: ChatRequest) -> Result<ChatResponse> {
         use crate::llm::provider::ToolCall;
 
         let resp = self.send_chat_request(request, false).await?;
@@ -595,18 +595,16 @@ impl LlmProvider for OpenAiCompatibleProvider {
     }
 
     async fn completion(&self, prompt: &str) -> Result<String> {
-        self.chat_completion(
-            ChatRequest {
-                messages: vec![ChatMessage {
-                    role: "user".to_string(),
-                    content: prompt.to_string(),
-                    tool_calls: None,
-                    tool_call_id: None,
-                }],
-                tools: vec![],
-                thinking: None,
-            },
-        )
+        self.chat_completion(ChatRequest {
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: prompt.to_string(),
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            tools: vec![],
+            thinking: None,
+        })
         .await
         .map(|r| r.content)
     }
@@ -646,8 +644,8 @@ fn extract_usage(value: &serde_json::Value) -> Option<ChatUsage> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{extract::State, routing::post, Json, Router};
     use crate::gateway::rpc::manifests::ThinkingConfig;
+    use axum::{extract::State, routing::post, Json, Router};
     use std::{
         net::SocketAddr,
         sync::{

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -84,10 +84,7 @@ pub trait LlmProvider: Send + Sync {
     /// `tools` should be structured as provider-agnostic `Tool` objects.
     /// The provider implementation is responsible for formatting these into
     /// the provider's specific tool/function schema format.
-    async fn chat_completion(
-        &self,
-        request: ChatRequest,
-    ) -> Result<ChatResponse>;
+    async fn chat_completion(&self, request: ChatRequest) -> Result<ChatResponse>;
 
     async fn stream_chat_completion(&self, request: ChatRequest) -> Result<ChatStream>;
     async fn completion(&self, prompt: &str) -> Result<String>;

--- a/src/llm/resolver.rs
+++ b/src/llm/resolver.rs
@@ -4,21 +4,24 @@
 use anyhow::{anyhow, Context, Result};
 use std::sync::Arc;
 
-use crate::config::Config;
 use crate::config::secrets::SecretExt;
+use crate::config::Config;
 use crate::gateway::rpc::manifests::{self, AgentSpec};
 use crate::llm::LlmProvider;
 
-pub fn resolve_model_profile(
-    policy: Option<&manifests::ModelPolicy>,
-) -> Option<&manifests::Model> {
+pub fn resolve_model_profile(policy: Option<&manifests::ModelPolicy>) -> Option<&manifests::Model> {
     policy
         .and_then(|policy| {
             policy
                 .profiles
                 .iter()
                 .find(|profile| profile.name == "default")
-                .or_else(|| policy.profiles.iter().find(|profile| profile.model.is_some()))
+                .or_else(|| {
+                    policy
+                        .profiles
+                        .iter()
+                        .find(|profile| profile.model.is_some())
+                })
         })
         .and_then(|profile| profile.model.as_ref())
 }
@@ -119,12 +122,10 @@ pub async fn resolve_llm(
                 api_key, base_url, model,
             )))
         }
-        Some(crate::config::proto::llm_provider_config::Config::Google(_)) => {
-            Err(anyhow!(
-                "LLM provider '{}' uses Google config, which is not supported by this runtime yet",
-                provider_name
-            ))
-        }
+        Some(crate::config::proto::llm_provider_config::Config::Google(_)) => Err(anyhow!(
+            "LLM provider '{}' uses Google config, which is not supported by this runtime yet",
+            provider_name
+        )),
         None => Err(anyhow!(
             "LLM provider '{}' has no config; refusing to fall back to a mock provider",
             provider_name
@@ -220,10 +221,9 @@ mod tests {
             Ok(_) => panic!("expected provider config error"),
             Err(err) => err,
         };
-        assert!(
-            err.to_string()
-                .contains("refusing to fall back to a mock provider")
-        );
+        assert!(err
+            .to_string()
+            .contains("refusing to fall back to a mock provider"));
     }
 
     #[tokio::test]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -732,7 +732,8 @@ impl CapabilitiesPolicyDeltaManifest {
 
     fn from_proto(delta: &manifests::CapabilitiesPolicyDelta) -> Self {
         Self {
-            replace: (!delta.replace.is_empty()).then(|| capabilities_policy_from_proto(&delta.replace)),
+            replace: (!delta.replace.is_empty())
+                .then(|| capabilities_policy_from_proto(&delta.replace)),
         }
     }
 }
@@ -1034,7 +1035,9 @@ definition:
         )
         .expect("template manifest should parse");
 
-        let definition = template.definition.expect("template definition should exist");
+        let definition = template
+            .definition
+            .expect("template definition should exist");
         match definition.source.expect("template source should exist") {
             manifests::agent_definition::Source::Templated(templated) => {
                 assert_eq!(templated.template_name, "base");
@@ -1194,11 +1197,9 @@ spec:
                         delta: Some(manifests::AgentSpecDelta {
                             model_policy: None,
                             system_prompt: Some(manifests::PromptDelta {
-                                operation: Some(
-                                    manifests::prompt_delta::Operation::Append(
-                                        " extra".to_string(),
-                                    ),
-                                ),
+                                operation: Some(manifests::prompt_delta::Operation::Append(
+                                    " extra".to_string(),
+                                )),
                             }),
                             features: None,
                             mcp_server_refs: None,
@@ -1330,7 +1331,9 @@ spec:
 "#,
         )
         .expect_err("wrong kind should fail");
-        assert!(wrong_server.to_string().contains("Expected kind 'McpServer'"));
+        assert!(wrong_server
+            .to_string()
+            .contains("Expected kind 'McpServer'"));
 
         let wrong_binding = parse_mcp_server_binding(
             r#"
@@ -1360,7 +1363,9 @@ spec:
 "#,
         )
         .expect_err("wrong kind should fail");
-        assert!(wrong_knowledge.to_string().contains("Expected kind 'Knowledge'"));
+        assert!(wrong_knowledge
+            .to_string()
+            .contains("Expected kind 'Knowledge'"));
 
         let missing_definition = parse_agent_template(
             r#"
@@ -1549,8 +1554,9 @@ definition: {}
         assert!(templated.delta.mcp_server_refs.is_none());
         assert!(templated.delta.capabilities.is_none());
 
-        let yaml_err = AgentDefinitionYaml::from_proto(&manifests::AgentDefinition { source: None })
-            .unwrap_err();
+        let yaml_err =
+            AgentDefinitionYaml::from_proto(&manifests::AgentDefinition { source: None })
+                .unwrap_err();
         assert!(yaml_err.to_string().contains("missing source"));
 
         let profile = ModelProfileManifest::from_proto(&manifests::ModelProfile {
@@ -1586,14 +1592,16 @@ definition: {}
         assert!(prepend.append.is_none());
 
         let append = PromptDeltaManifest::from_proto(&manifests::PromptDelta {
-            operation: Some(manifests::prompt_delta::Operation::Append("after".to_string())),
+            operation: Some(manifests::prompt_delta::Operation::Append(
+                "after".to_string(),
+            )),
         });
         assert_eq!(append.append.as_deref(), Some("after"));
         assert!(append.replace.is_none());
         assert!(append.prepend.is_none());
 
-        let replace = CapabilitiesPolicyDeltaManifest::from_proto(
-            &manifests::CapabilitiesPolicyDelta {
+        let replace =
+            CapabilitiesPolicyDeltaManifest::from_proto(&manifests::CapabilitiesPolicyDelta {
                 replace: HashMap::from([(
                     "tools".to_string(),
                     ListValue {
@@ -1607,8 +1615,7 @@ definition: {}
                         ],
                     },
                 )]),
-            },
-        );
+            });
         assert_eq!(
             replace.replace,
             Some(HashMap::from([(
@@ -1617,11 +1624,10 @@ definition: {}
             )]))
         );
 
-        let empty = CapabilitiesPolicyDeltaManifest::from_proto(
-            &manifests::CapabilitiesPolicyDelta {
+        let empty =
+            CapabilitiesPolicyDeltaManifest::from_proto(&manifests::CapabilitiesPolicyDelta {
                 replace: HashMap::new(),
-            },
-        );
+            });
         assert!(empty.replace.is_none());
     }
 }

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -70,8 +70,8 @@ impl MemoryStore for KvMemoryStore {
 
     async fn save_memory(&self, ns: &str, agent: &str, path: &str, content: &str) -> Result<()> {
         // Unify with the Gateway's layout structure defined by 'keys::agent_memory'
-        let key = format!("Agent/{}/Memory/{}", agent, path);
-        self.kv.set(ns, &key, content.as_bytes()).await?;
+        let key = crate::control::keys::agent_memory(ns, agent, path);
+        self.kv.set(&key, content.as_bytes()).await?;
         Ok(())
     }
 }

--- a/src/native_tools.rs
+++ b/src/native_tools.rs
@@ -127,15 +127,11 @@ pub async fn execute_tool(
             let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(100) as usize;
             let mut entries = cp
                 .kv
-                .list_entries(namespace, keys::schedule_prefix())
+                .list_entries(&keys::schedule_prefix(namespace))
                 .await?;
             entries.sort_by(|a, b| a.0.cmp(&b.0));
             let mut schedules = Vec::new();
-            for (key, value) in entries {
-                let stripped = key.strip_prefix(keys::schedule_prefix()).unwrap_or(&key);
-                if stripped.contains('/') {
-                    continue;
-                }
+            for (_key, value) in entries {
                 let schedule = models::Schedule::decode(value.as_slice())?;
                 let spec_model = schedule.spec.as_ref();
                 let matches_agent = agent
@@ -170,7 +166,7 @@ pub async fn execute_tool(
             let schedule_name = req_str(args, "name")?;
             let schedule = cp
                 .kv
-                .get_msg::<models::Schedule>(namespace, &keys::schedule(schedule_name))
+                .get_msg::<models::Schedule>(&keys::schedule(namespace, schedule_name))
                 .await?
                 .ok_or_else(|| anyhow!("schedule '{}' not found", schedule_name))?;
             Ok(Some(serde_json::to_string_pretty(&json!({
@@ -192,7 +188,7 @@ pub async fn execute_tool(
             let schedule_name = req_str(args, "name")?;
             let existing = cp
                 .kv
-                .get_msg::<models::Schedule>(namespace, &keys::schedule(schedule_name))
+                .get_msg::<models::Schedule>(&keys::schedule(namespace, schedule_name))
                 .await?
                 .ok_or_else(|| anyhow!("schedule '{}' not found", schedule_name))?;
             let schedule =
@@ -206,15 +202,15 @@ pub async fn execute_tool(
             require_capability(spec, "schedules", "delete")?;
             let namespace = opt_str(args, "namespace").unwrap_or(current_namespace);
             let schedule_name = req_str(args, "name")?;
-            let key = keys::schedule(schedule_name);
-            if let Some(schedule) = cp.kv.get_msg::<models::Schedule>(namespace, &key).await? {
+            let key = keys::schedule(namespace, schedule_name);
+            if let Some(schedule) = cp.kv.get_msg::<models::Schedule>(&key).await? {
                 if let Some(handle) = schedule.status.and_then(|status| status.backend_handle) {
                     if let Err(error) = cp.scheduler.cancel(&handle).await {
                         tracing::warn!(handle = %handle, error = %error, "failed to cancel schedule handle");
                     }
                 }
             }
-            cp.kv.delete(namespace, &key).await?;
+            cp.kv.delete(&key).await?;
             Ok(Some(serde_json::to_string_pretty(
                 &json!({ "success": true }),
             )?))
@@ -472,8 +468,7 @@ mod tests {
 
     async fn seed_agent(kv: &MockKvStore, ns: &str, name: &str) {
         kv.set_msg(
-            ns,
-            &keys::agent(name),
+            &keys::agent(ns, name),
             &models::Agent {
                 name: name.to_string(),
                 ns: ns.to_string(),
@@ -611,7 +606,7 @@ mod tests {
         .unwrap();
         assert!(deleted.contains("\"success\": true"));
         assert!(kv
-            .get_msg::<models::Schedule>("conic:test", &keys::schedule("nightly"))
+            .get_msg::<models::Schedule>(&keys::schedule("conic:test", "nightly"))
             .await
             .unwrap()
             .is_none());

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -358,13 +358,7 @@ pub async fn arm_schedule(
     let detail = format!("next run at {}", fire_at.to_rfc3339());
     let outcome = if backend_armed { "armed" } else { "pending" }.to_string();
     let _ = status;
-    append_schedule_event(
-        schedule,
-        Utc::now(),
-        "arm",
-        outcome,
-        detail,
-    );
+    append_schedule_event(schedule, Utc::now(), "arm", outcome, detail);
     Ok(())
 }
 
@@ -391,7 +385,7 @@ fn duration_from_env(name: &str, default_seconds: i64) -> i64 {
 }
 
 pub async fn persist_schedule(kv: &dyn KeyValueStore, schedule: &models::Schedule) -> Result<()> {
-    kv.set_msg(&schedule.ns, &keys::schedule(&schedule.name), schedule)
+    kv.set_msg(&keys::schedule(&schedule.ns, &schedule.name), schedule)
         .await
 }
 
@@ -400,7 +394,7 @@ pub async fn load_schedule(
     ns: &str,
     name: &str,
 ) -> Result<Option<models::Schedule>> {
-    kv.get_msg(ns, &keys::schedule(name)).await
+    kv.get_msg(&keys::schedule(ns, name)).await
 }
 
 pub async fn dispatch_schedule(
@@ -426,7 +420,10 @@ pub async fn dispatch_schedule(
 
     let scheduled_prompt = format_scheduled_message(&schedule.name, &spec.input_message);
     let mut labels = HashMap::new();
-    labels.insert("talon.impalasys.com/message-source".to_string(), "schedule".to_string());
+    labels.insert(
+        "talon.impalasys.com/message-source".to_string(),
+        "schedule".to_string(),
+    );
     labels.insert(
         "talon.impalasys.com/schedule-name".to_string(),
         schedule.name.clone(),
@@ -474,7 +471,7 @@ pub fn normalize_session_mode(session_mode: &str) -> Result<String> {
 
 pub async fn create_session(cp: &ControlPlane, ns: &str, agent: &str) -> Result<String> {
     cp.kv
-        .get_msg::<models::Agent>(ns, &keys::agent(agent))
+        .get_msg::<models::Agent>(&keys::agent(ns, agent))
         .await?
         .ok_or_else(|| anyhow!("agent '{}' not found", agent))?;
     let session_id = uuid::Uuid::now_v7().to_string();
@@ -489,7 +486,7 @@ pub async fn create_session(cp: &ControlPlane, ns: &str, agent: &str) -> Result<
         labels: std::collections::HashMap::new(),
     };
     cp.kv
-        .set_msg(ns, &keys::session(agent, &session_id), &session)
+        .set_msg(&keys::session(ns, agent, &session_id), &session)
         .await?;
     tracing::info!(
         namespace = %ns,
@@ -527,13 +524,13 @@ pub async fn send_message(
         return Err(EmptyMessageError.into());
     }
 
-    let key = keys::session(agent, session_id);
+    let key = keys::session(ns, agent, session_id);
     let now_micros = now.timestamp_micros();
     let timeout_micros = session_processing_timeout_micros();
 
     let mut acquired = false;
     for _ in 0..MAX_CAS_RETRIES {
-        let current = kv.get(ns, &key).await?;
+        let current = kv.get(&key).await?;
         let Some(current_bytes) = current.as_ref() else {
             return Err(SessionNotFoundError.into());
         };
@@ -549,7 +546,7 @@ pub async fn send_message(
         session.last_active = now_micros;
         let updated = session.encode_to_vec();
         if kv
-            .compare_and_swap(ns, &key, Some(current_bytes.as_slice()), &updated)
+            .compare_and_swap(&key, Some(current_bytes.as_slice()), &updated)
             .await?
         {
             acquired = true;
@@ -570,14 +567,13 @@ pub async fn send_message(
     };
     if let Err(err) = kv
         .set_msg(
-            ns,
-            &keys::session_message(agent, session_id, &user_msg.id),
+            &keys::session_message(ns, agent, session_id, &user_msg.id),
             &user_msg,
         )
         .await
     {
         log_session_release_failure(
-            try_release_session_lock_after_send_failure(kv, ns, &key, now_micros).await,
+            try_release_session_lock_after_send_failure(kv, &key, now_micros).await,
             ns,
             &key,
         );
@@ -602,7 +598,7 @@ pub async fn send_message(
         .await
     {
         log_session_release_failure(
-            try_release_session_lock_after_send_failure(kv, ns, &key, now_micros).await,
+            try_release_session_lock_after_send_failure(kv, &key, now_micros).await,
             ns,
             &key,
         );
@@ -626,12 +622,11 @@ fn log_session_release_failure(result: Result<()>, namespace: &str, key: &str) {
 
 async fn try_release_session_lock_after_send_failure(
     kv: &dyn KeyValueStore,
-    namespace: &str,
     key: &str,
     expected_last_active: i64,
 ) -> Result<()> {
     for _ in 0..MAX_CAS_RETRIES {
-        let Some(current_bytes) = kv.get(namespace, key).await? else {
+        let Some(current_bytes) = kv.get(key).await? else {
             return Ok(());
         };
         let mut session = models::Session::decode(current_bytes.as_slice())?;
@@ -641,7 +636,7 @@ async fn try_release_session_lock_after_send_failure(
         session.status = "IDLE".to_string();
         let updated = session.encode_to_vec();
         if kv
-            .compare_and_swap(namespace, key, Some(current_bytes.as_slice()), &updated)
+            .compare_and_swap(key, Some(current_bytes.as_slice()), &updated)
             .await?
         {
             return Ok(());
@@ -661,13 +656,13 @@ pub async fn claim_schedule_wakeup(
     intended_run_at: i64,
     now: DateTime<Utc>,
 ) -> Result<Option<models::Schedule>> {
-    let key = keys::schedule(schedule_id);
+    let key = keys::schedule(namespace, schedule_id);
     let claim_expires_at = now
         .timestamp_micros()
         .saturating_add(schedule_claim_timeout_micros());
 
     for _ in 0..MAX_CAS_RETRIES {
-        let current = kv.get(namespace, &key).await?;
+        let current = kv.get(&key).await?;
         let Some(current_bytes) = current.as_ref() else {
             tracing::warn!(
                 namespace = %namespace,
@@ -730,7 +725,7 @@ pub async fn claim_schedule_wakeup(
         );
         let updated = schedule.encode_to_vec();
         if kv
-            .compare_and_swap(namespace, &key, Some(current_bytes.as_slice()), &updated)
+            .compare_and_swap(&key, Some(current_bytes.as_slice()), &updated)
             .await?
         {
             return Ok(Some(schedule));
@@ -784,35 +779,27 @@ mod tests {
         store: Mutex<HashMap<String, Vec<u8>>>,
     }
 
-    impl MockKvStore {
-        fn make_key(namespace: &str, key: &str) -> String {
-            format!("{namespace}/{key}")
-        }
-    }
-
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, namespace: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
             let map = self.store.lock().await;
-            Ok(map.get(&Self::make_key(namespace, key)).cloned())
+            Ok(map.get(key).cloned())
         }
 
-        async fn set(&self, namespace: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
-            map.insert(Self::make_key(namespace, key), value.to_vec());
+            map.insert(key.to_string(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            namespace: &str,
             key: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut map = self.store.lock().await;
-            let full_key = Self::make_key(namespace, key);
-            let current = map.get(&full_key).cloned();
+            let current = map.get(key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
@@ -821,24 +808,22 @@ mod tests {
             if !matches {
                 return Ok(false);
             }
-            map.insert(full_key, value.to_vec());
+            map.insert(key.to_string(), value.to_vec());
             Ok(true)
         }
 
-        async fn delete(&self, namespace: &str, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
-            map.remove(&Self::make_key(namespace, key));
+            map.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, namespace: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
             let map = self.store.lock().await;
-            let ns_prefix = format!("{namespace}/{prefix}");
-            let ns_root = format!("{namespace}/");
             Ok(map
                 .keys()
-                .filter(|key| key.starts_with(&ns_prefix))
-                .map(|key| key.strip_prefix(&ns_root).unwrap().to_string())
+                .filter(|key| key.starts_with(prefix))
+                .cloned()
                 .collect())
         }
     }
@@ -1125,8 +1110,7 @@ mod tests {
             labels: HashMap::new(),
         };
         kv.set_msg(
-            "conic:test",
-            &keys::session("assistant", "session-1"),
+            &keys::session("conic:test", "assistant", "session-1"),
             &session,
         )
         .await
@@ -1180,8 +1164,7 @@ mod tests {
             labels: HashMap::new(),
         };
         kv.set_msg(
-            "conic:test",
-            &keys::session("assistant", "session-1"),
+            &keys::session("conic:test", "assistant", "session-1"),
             &session,
         )
         .await
@@ -1227,7 +1210,10 @@ mod tests {
             .contains("session_mode"));
 
         assert_eq!(normalize_cron_expression("0 9 * * *"), "0 0 9 * * * *");
-        assert_eq!(normalize_cron_expression("0 */15 * * * *"), "0 */15 * * * * *");
+        assert_eq!(
+            normalize_cron_expression("0 */15 * * * *"),
+            "0 */15 * * * * *"
+        );
 
         let dt = parse_run_at("2026-05-03T09:00:00").unwrap();
         let expected = DateTime::parse_from_rfc3339("2026-05-03T09:00:00Z")
@@ -1287,7 +1273,13 @@ mod tests {
             .contains("schedule target is required"));
 
         let mut missing_agent = schedule("every");
-        let target = missing_agent.spec.as_mut().unwrap().target.as_mut().unwrap();
+        let target = missing_agent
+            .spec
+            .as_mut()
+            .unwrap()
+            .target
+            .as_mut()
+            .unwrap();
         target.agent.clear();
         assert!(validate_schedule(&missing_agent)
             .unwrap_err()
@@ -1295,8 +1287,14 @@ mod tests {
             .contains("schedule target agent is required"));
 
         let mut invalid_mode = schedule("every");
-        invalid_mode.spec.as_mut().unwrap().target.as_mut().unwrap().session_mode =
-            "odd".to_string();
+        invalid_mode
+            .spec
+            .as_mut()
+            .unwrap()
+            .target
+            .as_mut()
+            .unwrap()
+            .session_mode = "odd".to_string();
         assert!(validate_schedule(&invalid_mode)
             .unwrap_err()
             .to_string()
@@ -1372,7 +1370,7 @@ mod tests {
             template_deps: Vec::new(),
             labels: HashMap::new(),
         };
-        kv.set_msg("conic:test", &keys::agent("assistant"), &agent)
+        kv.set_msg(&keys::agent("conic:test", "assistant"), &agent)
             .await
             .unwrap();
 
@@ -1383,15 +1381,29 @@ mod tests {
             .await
             .unwrap();
         let session = kv
-            .get_msg::<models::Session>("conic:test", &keys::session("assistant", &session_id))
+            .get_msg::<models::Session>(&keys::session("conic:test", "assistant", &session_id))
             .await
             .unwrap()
             .expect("session should be persisted");
         assert_eq!(session.agent, "assistant");
 
         let mut scheduled = schedule("every");
-        scheduled.spec.as_mut().unwrap().target.as_mut().unwrap().session_mode = "reuse".to_string();
-        scheduled.spec.as_mut().unwrap().target.as_mut().unwrap().session_id = session_id.clone();
+        scheduled
+            .spec
+            .as_mut()
+            .unwrap()
+            .target
+            .as_mut()
+            .unwrap()
+            .session_mode = "reuse".to_string();
+        scheduled
+            .spec
+            .as_mut()
+            .unwrap()
+            .target
+            .as_mut()
+            .unwrap()
+            .session_id = session_id.clone();
         let dispatched_session = dispatch_schedule(&cp, &scheduled, now).await.unwrap();
         assert_eq!(dispatched_session, session_id);
         assert_eq!(pubsub.messages.lock().await.len(), 2);
@@ -1411,8 +1423,7 @@ mod tests {
             labels: HashMap::new(),
         };
         kv.set_msg(
-            "conic:test",
-            &keys::session("assistant", "session-1"),
+            &keys::session("conic:test", "assistant", "session-1"),
             &session,
         )
         .await
@@ -1436,7 +1447,7 @@ mod tests {
         assert!(err.to_string().contains("publish failed"));
 
         let updated = kv
-            .get_msg::<models::Session>("conic:test", &keys::session("assistant", "session-1"))
+            .get_msg::<models::Session>(&keys::session("conic:test", "assistant", "session-1"))
             .await
             .unwrap()
             .expect("session should still exist");
@@ -1465,11 +1476,21 @@ mod tests {
         assert_eq!(status.claim_expires_at, None);
 
         for idx in 0..(MAX_RECENT_SCHEDULE_EVENTS + 5) {
-            append_schedule_event(&mut schedule, Utc::now(), "phase", "ok", format!("event-{idx}"));
+            append_schedule_event(
+                &mut schedule,
+                Utc::now(),
+                "phase",
+                "ok",
+                format!("event-{idx}"),
+            );
         }
         let events = &schedule.status.as_ref().unwrap().recent_events;
         assert_eq!(events.len(), MAX_RECENT_SCHEDULE_EVENTS);
         assert!(events.first().unwrap().detail.ends_with("event-5"));
-        assert!(events.last().unwrap().detail.ends_with(&format!("event-{}", MAX_RECENT_SCHEDULE_EVENTS + 4)));
+        assert!(events
+            .last()
+            .unwrap()
+            .detail
+            .ends_with(&format!("event-{}", MAX_RECENT_SCHEDULE_EVENTS + 4)));
     }
 }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 
 use crate::control::events;
 use crate::control::{
-    keys,
+    keys::{self, ResourceKey},
     scheduler::{ScheduleWakeupRequest, SchedulerBackend},
     ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
 };
@@ -614,7 +614,7 @@ pub async fn send_message(
     Ok(())
 }
 
-fn log_session_release_failure(result: Result<()>, namespace: &str, key: &str) {
+fn log_session_release_failure(result: Result<()>, namespace: &str, key: &ResourceKey) {
     if let Err(err) = result {
         tracing::warn!(namespace = %namespace, key = %key, error = %err, "failed to release session lock after send_message error");
     }
@@ -622,7 +622,7 @@ fn log_session_release_failure(result: Result<()>, namespace: &str, key: &str) {
 
 async fn try_release_session_lock_after_send_failure(
     kv: &dyn KeyValueStore,
-    key: &str,
+    key: &ResourceKey,
     expected_last_active: i64,
 ) -> Result<()> {
     for _ in 0..MAX_CAS_RETRIES {
@@ -767,7 +767,11 @@ pub fn append_schedule_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::control::{scheduler::NoopSchedulerBackend, KeyValueStore, MessagePublisher};
+    use crate::control::{
+        keys::{ResourceKey, ResourceList},
+        scheduler::NoopSchedulerBackend,
+        KeyValueStore, MessagePublisher,
+    };
     use crate::gateway::rpc::manifests;
     use futures::stream;
     use std::pin::Pin;
@@ -776,25 +780,25 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        store: Mutex<HashMap<String, Vec<u8>>>,
+        store: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             let map = self.store.lock().await;
             Ok(map.get(key).cloned())
         }
 
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
-            map.insert(key.to_string(), value.to_vec());
+            map.insert(key.clone(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            key: &str,
+            key: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
@@ -808,21 +812,21 @@ mod tests {
             if !matches {
                 return Ok(false);
             }
-            map.insert(key.to_string(), value.to_vec());
+            map.insert(key.clone(), value.to_vec());
             Ok(true)
         }
 
-        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
             let mut map = self.store.lock().await;
             map.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let map = self.store.lock().await;
             Ok(map
                 .keys()
-                .filter(|key| key.starts_with(prefix))
+                .filter(|key| list.matches(key))
                 .cloned()
                 .collect())
         }

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -196,7 +196,9 @@ mod tests {
             path: PathBuf::from("/tmp/skills/summarize/SKILL.md"),
         }]);
 
-        let tool = registry.get_tool("summarize").expect("skill tool should exist");
+        let tool = registry
+            .get_tool("summarize")
+            .expect("skill tool should exist");
         assert_eq!(tool.description, "Summarize input");
         assert_eq!(tool.source, ToolSource::Skill("summarize".to_string()));
         assert_eq!(tool.input_schema["type"], "object");
@@ -225,12 +227,15 @@ mod tests {
 
         let provider_tools = registry.to_provider_tools();
         assert_eq!(provider_tools.len(), 3);
-        assert!(provider_tools.iter().any(|tool| tool.name == "builtin"
-            && tool.description == "builtin-desc"));
+        assert!(provider_tools
+            .iter()
+            .any(|tool| tool.name == "builtin" && tool.description == "builtin-desc"));
         assert!(provider_tools.iter().any(|tool| tool.name == "mcp_tool"
             && tool.input_schema["properties"]["q"]["type"] == "string"));
-        assert!(provider_tools.iter().any(|tool| tool.name == "skill_tool"
-            && tool.input_schema["required"] == json!(["input"])));
+        assert!(provider_tools
+            .iter()
+            .any(|tool| tool.name == "skill_tool"
+                && tool.input_schema["required"] == json!(["input"])));
     }
 
     #[test]

--- a/src/worker/mcp_registry.rs
+++ b/src/worker/mcp_registry.rs
@@ -162,8 +162,9 @@ mod tests {
     use super::{filter_allowed_tools, McpRegistry};
     use crate::connectors::mcp::McpTool;
     use crate::control::{
-        scheduler::NoopSchedulerBackend, ControlPlane, KeyValueStore, MessagePublisher,
-        ProtoKeyValueStoreExt,
+        keys::{ResourceKey, ResourceList},
+        scheduler::NoopSchedulerBackend,
+        ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::manifests;
     use serde_json::json;
@@ -174,44 +175,41 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<String, Vec<u8>>>,
+        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .insert(key.to_string(), value.to_vec());
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(key.clone(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            _key: &str,
+            _key: &ResourceKey,
             _expected: Option<&[u8]>,
             _value: &[u8],
         ) -> anyhow::Result<bool> {
             Ok(false)
         }
 
-        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
             self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)

--- a/src/worker/mcp_registry.rs
+++ b/src/worker/mcp_registry.rs
@@ -63,10 +63,10 @@ impl McpRegistry {
             return Ok(existing);
         }
 
-        let binding_key = keys::mcp_server_binding(name);
+        let binding_key = keys::mcp_server_binding(namespace, name);
         let binding = cp
             .kv
-            .get_msg::<manifests::McpServerBinding>(namespace, &binding_key)
+            .get_msg::<manifests::McpServerBinding>(&binding_key)
             .await?;
         let (server_ref, extra_args, extra_headers, disabled, auth_broker, allowed_tool_names) =
             match binding {
@@ -105,7 +105,7 @@ impl McpRegistry {
         let key = keys::mcp_server(&server_ref);
         let server = cp
             .kv
-            .get_msg::<manifests::McpServer>(ns::TALON_SYSTEM, &key)
+            .get_msg::<manifests::McpServer>(&key)
             .await?
             .ok_or_else(|| {
                 anyhow!(
@@ -174,31 +174,25 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+        data: Mutex<HashMap<String, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, ns: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(ns.to_string(), key.to_string()))
-                .cloned())
+        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, ns: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             self.data
                 .lock()
                 .await
-                .insert((ns.to_string(), key.to_string()), value.to_vec());
+                .insert(key.to_string(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            _ns: &str,
             _key: &str,
             _expected: Option<&[u8]>,
             _value: &[u8],
@@ -206,20 +200,18 @@ mod tests {
             Ok(false)
         }
 
-        async fn delete(&self, ns: &str, key: &str) -> anyhow::Result<()> {
-            self.data.lock().await.remove(&(ns.to_string(), key.to_string()));
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+            self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(prefix)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -350,8 +342,16 @@ mod tests {
     #[tokio::test]
     async fn invalidate_all_clears_every_namespace() {
         let registry = McpRegistry::new();
-        registry.cache.write().await.insert("one".to_string(), HashMap::new());
-        registry.cache.write().await.insert("two".to_string(), HashMap::new());
+        registry
+            .cache
+            .write()
+            .await
+            .insert("one".to_string(), HashMap::new());
+        registry
+            .cache
+            .write()
+            .await
+            .insert("two".to_string(), HashMap::new());
 
         registry.invalidate_all().await;
 
@@ -365,8 +365,7 @@ mod tests {
         let registry = McpRegistry::new();
 
         kv.set_msg(
-            "conic",
-            &crate::control::keys::mcp_server_binding("github"),
+            &crate::control::keys::mcp_server_binding("conic", "github"),
             &manifests::McpServerBinding {
                 api_version: "talon.impalasys.com/v1".to_string(),
                 kind: "McpServerBinding".to_string(),
@@ -388,7 +387,7 @@ mod tests {
             .unwrap_err();
         assert!(missing_spec.to_string().contains("missing spec"));
 
-        kv.delete("conic", &crate::control::keys::mcp_server_binding("github"))
+        kv.delete(&crate::control::keys::mcp_server_binding("conic", "github"))
             .await
             .unwrap();
         let missing_server = registry
@@ -405,7 +404,6 @@ mod tests {
         let registry = McpRegistry::new();
 
         kv.set_msg(
-            crate::control::ns::TALON_SYSTEM,
             &crate::control::keys::mcp_server("docs-server"),
             &manifests::McpServer {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -420,7 +418,10 @@ mod tests {
                     transport: "http".to_string(),
                     target: "https://example.com/mcp".to_string(),
                     args: vec!["--server".to_string()],
-                    headers: HashMap::from([("Authorization".to_string(), "Bearer token".to_string())]),
+                    headers: HashMap::from([(
+                        "Authorization".to_string(),
+                        "Bearer token".to_string(),
+                    )]),
                     disabled: false,
                 }),
             },
@@ -428,8 +429,7 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "conic",
-            &crate::control::keys::mcp_server_binding("docs"),
+            &crate::control::keys::mcp_server_binding("conic", "docs"),
             &manifests::McpServerBinding {
                 api_version: "talon.impalasys.com/v1".to_string(),
                 kind: "McpServerBinding".to_string(),
@@ -442,7 +442,10 @@ mod tests {
                 spec: Some(manifests::McpServerBindingSpec {
                     server_ref: "docs-server".to_string(),
                     args: vec!["--binding".to_string()],
-                    headers: HashMap::from([("Authorization".to_string(), "Bearer override".to_string())]),
+                    headers: HashMap::from([(
+                        "Authorization".to_string(),
+                        "Bearer override".to_string(),
+                    )]),
                     disabled: true,
                     auth_broker: Some(manifests::McpAuthBrokerSpec {
                         kind: "oauth".to_string(),
@@ -457,7 +460,10 @@ mod tests {
         .await
         .unwrap();
 
-        let err = registry.resolve_server(&cp, "docs", "conic").await.unwrap_err();
+        let err = registry
+            .resolve_server(&cp, "docs", "conic")
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("disabled"));
         assert!(registry.cache.read().await.is_empty());
     }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -274,6 +274,7 @@ mod tests {
     use crate::config::Config;
     use crate::control::{
         events::{LifecycleEvent, MessageDirection, SessionControlEvent, SessionMessageEvent},
+        keys::{ResourceKey, ResourceList},
         scheduler::NoopSchedulerBackend,
         topics, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
@@ -288,26 +289,23 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<String, Vec<u8>>>,
+        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .insert(key.to_string(), value.to_vec());
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(key.clone(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            key: &str,
+            key: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
@@ -319,23 +317,23 @@ mod tests {
                 _ => false,
             };
             if matches {
-                data.insert(key.to_string(), value.to_vec());
+                data.insert(key.clone(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
             self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -24,8 +24,9 @@ pub struct WorkerEventHandler {
     pub config: Arc<Config>,
     pub mcp_registry: Arc<mcp_registry::McpRegistry>,
     pub scheduler_authenticator: Arc<scheduler_auth::SchedulerRequestAuthenticator>,
-    pub session_cancellations:
-        Arc<tokio::sync::Mutex<std::collections::HashMap<String, tokio_util::sync::CancellationToken>>>,
+    pub session_cancellations: Arc<
+        tokio::sync::Mutex<std::collections::HashMap<String, tokio_util::sync::CancellationToken>>,
+    >,
 }
 
 impl WorkerEventHandler {
@@ -277,79 +278,64 @@ mod tests {
         topics, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{manifests, models};
-    use crate::worker::{
-        mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator,
-    };
+    use crate::worker::{mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator};
     use async_trait::async_trait;
     use chrono::{Duration, Utc};
     use futures::stream;
     use prost::Message;
-    use std::{
-        collections::HashMap,
-        pin::Pin,
-        sync::Arc,
-    };
+    use std::{collections::HashMap, pin::Pin, sync::Arc};
     use tokio::sync::Mutex;
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+        data: Mutex<HashMap<String, Vec<u8>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, ns: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(ns.to_string(), key.to_string()))
-                .cloned())
+        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, ns: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             self.data
                 .lock()
                 .await
-                .insert((ns.to_string(), key.to_string()), value.to_vec());
+                .insert(key.to_string(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            ns: &str,
             key: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let full_key = (ns.to_string(), key.to_string());
-            let current = data.get(&full_key).cloned();
+            let current = data.get(key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(full_key, value.to_vec());
+                data.insert(key.to_string(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, ns: &str, key: &str) -> anyhow::Result<()> {
-            self.data.lock().await.remove(&(ns.to_string(), key.to_string()));
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+            self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(prefix)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -429,8 +415,7 @@ mod tests {
 
     async fn seed_agent_and_session(kv: &MockKvStore) {
         kv.set_msg(
-            "conic:test",
-            &crate::control::keys::agent("assistant"),
+            &crate::control::keys::agent("conic:test", "assistant"),
             &models::Agent {
                 name: "assistant".to_string(),
                 ns: "conic:test".to_string(),
@@ -443,8 +428,7 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "conic:test",
-            &crate::control::keys::session("assistant", "session-1"),
+            &crate::control::keys::session("conic:test", "assistant", "session-1"),
             &models::Session {
                 id: "session-1".to_string(),
                 agent: "assistant".to_string(),
@@ -483,18 +467,26 @@ mod tests {
             )),
             Some("resource_lifecycle")
         );
-        assert_eq!(WorkerEventHandler::event_type_for_subscription("unknown"), None);
+        assert_eq!(
+            WorkerEventHandler::event_type_for_subscription("unknown"),
+            None
+        );
     }
 
     #[tokio::test]
     async fn dispatch_rejects_unknown_event_types_and_payloads() {
-        let handler = handler(Arc::new(MockKvStore::default()), Arc::new(MockPubSub::default()));
+        let handler = handler(
+            Arc::new(MockKvStore::default()),
+            Arc::new(MockPubSub::default()),
+        );
 
         let unknown_type = handler
             .dispatch(Some("wat"), &[])
             .await
             .expect_err("unknown event type should fail");
-        assert!(unknown_type.to_string().contains("Unknown worker event type"));
+        assert!(unknown_type
+            .to_string()
+            .contains("Unknown worker event type"));
 
         let unknown_payload = handler
             .dispatch(None, b"not-protobuf")
@@ -511,11 +503,10 @@ mod tests {
         let pubsub = Arc::new(MockPubSub::default());
         let handler = handler(kv, pubsub);
 
-        handler
-            .session_cancellations
-            .lock()
-            .await
-            .insert("session-1".to_string(), tokio_util::sync::CancellationToken::new());
+        handler.session_cancellations.lock().await.insert(
+            "session-1".to_string(),
+            tokio_util::sync::CancellationToken::new(),
+        );
 
         let lifecycle = LifecycleEvent {
             resource_type: "McpServerBinding".to_string(),
@@ -544,7 +535,10 @@ mod tests {
 
     #[tokio::test]
     async fn handle_schedule_wakeup_returns_ok_when_no_schedule_matches() {
-        let handler = handler(Arc::new(MockKvStore::default()), Arc::new(MockPubSub::default()));
+        let handler = handler(
+            Arc::new(MockKvStore::default()),
+            Arc::new(MockPubSub::default()),
+        );
 
         handler
             .handle_schedule_wakeup(crate::scheduling::ScheduleWakeupPayload {
@@ -564,8 +558,7 @@ mod tests {
         let handler = handler(kv.clone(), pubsub);
         let intended = (Utc::now() + Duration::seconds(30)).timestamp_micros();
         kv.set_msg(
-            "conic:test",
-            &crate::control::keys::schedule("nightly"),
+            &crate::control::keys::schedule("conic:test", "nightly"),
             &schedule(3, intended, "reuse"),
         )
         .await
@@ -582,7 +575,7 @@ mod tests {
             .expect("early wakeup should defer");
 
         let updated = kv
-            .get_msg::<models::Schedule>("conic:test", &crate::control::keys::schedule("nightly"))
+            .get_msg::<models::Schedule>(&crate::control::keys::schedule("conic:test", "nightly"))
             .await
             .unwrap()
             .unwrap();
@@ -603,8 +596,7 @@ mod tests {
         seed_agent_and_session(kv.as_ref()).await;
         let intended = (Utc::now() - Duration::seconds(2)).timestamp_micros();
         kv.set_msg(
-            "conic:test",
-            &crate::control::keys::schedule("nightly"),
+            &crate::control::keys::schedule("conic:test", "nightly"),
             &schedule(7, intended, "reuse"),
         )
         .await
@@ -621,7 +613,7 @@ mod tests {
             .expect("schedule dispatch should succeed");
 
         let updated = kv
-            .get_msg::<models::Schedule>("conic:test", &crate::control::keys::schedule("nightly"))
+            .get_msg::<models::Schedule>(&crate::control::keys::schedule("conic:test", "nightly"))
             .await
             .unwrap()
             .unwrap();
@@ -632,20 +624,22 @@ mod tests {
         assert!(status.next_run_at.is_some());
 
         let session = kv
-            .get_msg::<models::Session>(
+            .get_msg::<models::Session>(&crate::control::keys::session(
                 "conic:test",
-                &crate::control::keys::session("assistant", "session-1"),
-            )
+                "assistant",
+                "session-1",
+            ))
             .await
             .unwrap()
             .unwrap();
         assert_eq!(session.status, "PROCESSING");
 
         let message_keys = kv
-            .list_keys(
+            .list_keys(&crate::control::keys::session_message_prefix(
                 "conic:test",
-                &crate::control::keys::session_message_prefix("assistant", "session-1"),
-            )
+                "assistant",
+                "session-1",
+            ))
             .await
             .unwrap();
         assert_eq!(message_keys.len(), 1);

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -372,6 +372,7 @@ mod tests {
     use crate::connectors::mcp::McpConnectionConfig;
     use crate::control::{
         events::{SessionStepEvent, StepType},
+        keys::{ResourceKey, ResourceList},
         scheduler::NoopSchedulerBackend,
         ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
@@ -384,55 +385,51 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<String, Vec<u8>>>,
+        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .insert(key.to_string(), value.to_vec());
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(key.clone(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            key: &str,
+            key: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let full_key = key.to_string();
-            let current = data.get(&full_key).cloned();
+            let current = data.get(key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(full_key, value.to_vec());
+                data.insert(key.clone(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
             self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -14,10 +14,10 @@ use crate::core::executor::{
     AgentExecutor, ContextAssembler, ExecutionContext, LoopMessage, RegisteredMcpTool,
 };
 use crate::gateway::rpc::models;
+use crate::gateway::rpc::{manifests, protobuf_value::value::Kind as ProtoValueKind};
 use crate::knowledge::KvKnowledgeBook;
 use crate::llm::ToolCall;
 use crate::skills::registry::ToolRegistry;
-use crate::gateway::rpc::{manifests, protobuf_value::value::Kind as ProtoValueKind};
 
 /// Fully-assembled, ready-to-run environment for one agent session.
 /// Build it from identity coordinates; it resolves everything else
@@ -38,10 +38,10 @@ impl AgentRuntime {
         mcp_registry: &McpRegistry,
     ) -> Result<Self> {
         // 1. Fetch AgentSpec from KV
-        let agent_key = crate::control::keys::agent(agent_id);
+        let agent_key = crate::control::keys::agent(ns, agent_id);
         let agent = cp
             .kv
-            .get_msg::<models::Agent>(ns, &agent_key)
+            .get_msg::<models::Agent>(&agent_key)
             .await?
             .ok_or_else(|| anyhow::anyhow!("Agent '{}' not found in ns '{}'", agent_id, ns))?;
         let spec = agent
@@ -49,18 +49,15 @@ impl AgentRuntime {
             .ok_or_else(|| anyhow::anyhow!("Agent '{}' has no effective spec", agent_id))?;
 
         // 2. Load session history from KV
-        let msg_prefix = crate::control::keys::session_message_prefix(agent_id, session_id);
-        let mut msg_keys = cp.kv.list_keys(ns, &msg_prefix).await?;
+        let msg_prefix = crate::control::keys::session_message_prefix(ns, agent_id, session_id);
+        let mut msg_keys = cp.kv.list_keys(&msg_prefix).await?;
         msg_keys.sort();
 
         let mut history = Vec::new();
         for key in msg_keys {
-            if key.strip_prefix(&msg_prefix).unwrap_or(&key).contains('/') {
-                continue;
-            }
             if let Some(msg) = cp
                 .kv
-                .get_msg::<models::SessionMessage>(ns, &key)
+                .get_msg::<models::SessionMessage>(&key)
                 .await
                 .unwrap_or(None)
             {
@@ -76,16 +73,16 @@ impl AgentRuntime {
 
                 if msg.role == 2 {
                     let step_prefix = crate::control::keys::session_message_step_prefix(
-                        agent_id, session_id, &msg.id,
+                        ns, agent_id, session_id, &msg.id,
                     );
-                    let mut step_keys = cp.kv.list_keys(ns, &step_prefix).await?;
+                    let mut step_keys = cp.kv.list_keys(&step_prefix).await?;
                     step_keys.sort();
 
                     let mut collected_tool_calls = Vec::new();
                     for step_key in step_keys {
                         if let Some(step) = cp
                             .kv
-                            .get_msg::<SessionStepEvent>(ns, &step_key)
+                            .get_msg::<SessionStepEvent>(&step_key)
                             .await
                             .unwrap_or(None)
                         {
@@ -242,7 +239,8 @@ fn visible_tools_for_agent(
         return tools.to_vec();
     }
 
-    tools.iter()
+    tools
+        .iter()
         .filter(|tool| {
             if is_schedule_tool_name(&tool.name) {
                 return match tool.name.as_str() {
@@ -274,7 +272,10 @@ fn visible_tools_for_agent(
 fn is_schedule_tool_name(name: &str) -> bool {
     matches!(
         name,
-        "list_schedules" | "get_schedule" | "create_schedule" | "update_schedule"
+        "list_schedules"
+            | "get_schedule"
+            | "create_schedule"
+            | "update_schedule"
             | "delete_schedule"
     )
 }
@@ -364,11 +365,11 @@ fn tool_result_message_from_step(step: &SessionStepEvent) -> Option<LoopMessage>
 #[cfg(test)]
 mod tests {
     use super::{
-        builtin_tool_names, has_capability_action, qualify_mcp_tool_name, tool_result_message_from_step,
-        visible_tools_for_agent, AgentRuntime,
+        builtin_tool_names, has_capability_action, qualify_mcp_tool_name,
+        tool_result_message_from_step, visible_tools_for_agent, AgentRuntime,
     };
-    use crate::connectors::mcp::McpConnectionConfig;
     use crate::config::{proto, Config, ProviderConfig, Secret};
+    use crate::connectors::mcp::McpConnectionConfig;
     use crate::control::{
         events::{SessionStepEvent, StepType},
         scheduler::NoopSchedulerBackend,
@@ -383,37 +384,31 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+        data: Mutex<HashMap<String, Vec<u8>>>,
     }
 
     #[async_trait::async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, ns: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(ns.to_string(), key.to_string()))
-                .cloned())
+        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, ns: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             self.data
                 .lock()
                 .await
-                .insert((ns.to_string(), key.to_string()), value.to_vec());
+                .insert(key.to_string(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            ns: &str,
             key: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let full_key = (ns.to_string(), key.to_string());
+            let full_key = key.to_string();
             let current = data.get(&full_key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
@@ -426,20 +421,18 @@ mod tests {
             Ok(matches)
         }
 
-        async fn delete(&self, ns: &str, key: &str) -> anyhow::Result<()> {
-            self.data.lock().await.remove(&(ns.to_string(), key.to_string()));
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+            self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(prefix)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -490,9 +483,7 @@ mod tests {
                             base_url: "http://127.0.0.1:1".to_string(),
                             model: "test-model".to_string(),
                             api_key: Some(Secret {
-                                source: Some(proto::secret::Source::Plain(
-                                    "test-key".to_string(),
-                                )),
+                                source: Some(proto::secret::Source::Plain("test-key".to_string())),
                             }),
                         },
                     )),
@@ -607,11 +598,9 @@ mod tests {
                             values: actions
                                 .iter()
                                 .map(|action| protobuf_value::Value {
-                                    kind: Some(
-                                        protobuf_value::value::Kind::StringValue(
-                                            (*action).to_string(),
-                                        ),
-                                    ),
+                                    kind: Some(protobuf_value::value::Kind::StringValue(
+                                        (*action).to_string(),
+                                    )),
                                 })
                                 .collect(),
                         },
@@ -657,7 +646,10 @@ mod tests {
 
         let visible =
             visible_tools_for_agent(&config("talon-ops", Some("talon-ops")), &tools, &spec);
-        let names = visible.into_iter().map(|tool| tool.name).collect::<Vec<_>>();
+        let names = visible
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect::<Vec<_>>();
 
         assert!(names.contains(&"list_schedules".to_string()));
         assert!(names.contains(&"create_schedule".to_string()));
@@ -732,15 +724,17 @@ mod tests {
         let config = runtime_config();
         let registry = crate::worker::mcp_registry::McpRegistry::new();
 
-        let missing = match AgentRuntime::build("conic", "missing", "session-1", &cp, &config, &registry).await {
-            Ok(_) => panic!("expected missing agent error"),
-            Err(err) => err,
-        };
+        let missing =
+            match AgentRuntime::build("conic", "missing", "session-1", &cp, &config, &registry)
+                .await
+            {
+                Ok(_) => panic!("expected missing agent error"),
+                Err(err) => err,
+            };
         assert!(missing.to_string().contains("Agent 'missing' not found"));
 
         kv.set_msg(
-            "conic",
-            &crate::control::keys::agent("writer"),
+            &crate::control::keys::agent("conic", "writer"),
             &models::Agent {
                 name: "writer".to_string(),
                 ns: "conic".to_string(),
@@ -753,7 +747,16 @@ mod tests {
         .await
         .unwrap();
 
-        let no_spec = match AgentRuntime::build("conic", "writer", "session-1", &cp, &config, &registry).await {
+        let no_spec = match AgentRuntime::build(
+            "conic",
+            "writer",
+            "session-1",
+            &cp,
+            &config,
+            &registry,
+        )
+        .await
+        {
             Ok(_) => panic!("expected missing effective spec error"),
             Err(err) => err,
         };
@@ -775,8 +778,7 @@ mod tests {
         };
 
         kv.set_msg(
-            "conic",
-            &crate::control::keys::agent("writer"),
+            &crate::control::keys::agent("conic", "writer"),
             &models::Agent {
                 name: "writer".to_string(),
                 ns: "conic".to_string(),
@@ -789,8 +791,7 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "conic",
-            &crate::control::keys::session_message("writer", "session-1", "msg-1"),
+            &crate::control::keys::session_message("conic", "writer", "session-1", "msg-1"),
             &models::SessionMessage {
                 id: "msg-1".to_string(),
                 role: 1,
@@ -802,8 +803,7 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "conic",
-            &crate::control::keys::session_message("writer", "session-1", "msg-2"),
+            &crate::control::keys::session_message("conic", "writer", "session-1", "msg-2"),
             &models::SessionMessage {
                 id: "msg-2".to_string(),
                 role: 2,
@@ -815,15 +815,19 @@ mod tests {
         .await
         .unwrap();
         kv.set(
-            "conic",
-            &crate::control::keys::session_message("writer", "session-1", "msg-2/sub"),
+            &crate::control::keys::session_message("conic", "writer", "session-1", "msg-2/sub"),
             b"nested",
         )
         .await
         .unwrap();
         kv.set_msg(
-            "conic",
-            &crate::control::keys::session_message_step("writer", "session-1", "msg-2", "step-1"),
+            &crate::control::keys::session_message_step(
+                "conic",
+                "writer",
+                "session-1",
+                "msg-2",
+                "step-1",
+            ),
             &SessionStepEvent {
                 session_id: "session-1".to_string(),
                 step_type: StepType::Action as i32,
@@ -843,8 +847,13 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "conic",
-            &crate::control::keys::session_message_step("writer", "session-1", "msg-2", "step-2"),
+            &crate::control::keys::session_message_step(
+                "conic",
+                "writer",
+                "session-1",
+                "msg-2",
+                "step-2",
+            ),
             &SessionStepEvent {
                 session_id: "session-1".to_string(),
                 step_type: StepType::Observation as i32,
@@ -864,10 +873,9 @@ mod tests {
         .await
         .unwrap();
 
-        let runtime =
-            AgentRuntime::build("conic", "writer", "session-1", &cp, &config, &registry)
-                .await
-                .unwrap();
+        let runtime = AgentRuntime::build("conic", "writer", "session-1", &cp, &config, &registry)
+            .await
+            .unwrap();
 
         assert_eq!(runtime.context.agent_id, "writer");
         assert_eq!(runtime.context.history.len(), 3);

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -207,6 +207,7 @@ mod tests {
     use crate::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::{
         events::{MessageDirection, SessionMessageEvent},
+        keys::{ResourceKey, ResourceList},
         scheduler::NoopSchedulerBackend,
         ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
@@ -260,55 +261,51 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: AsyncMutex<HashMap<String, Vec<u8>>>,
+        data: AsyncMutex<HashMap<ResourceKey, Vec<u8>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
-            self.data
-                .lock()
-                .await
-                .insert(key.to_string(), value.to_vec());
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
+            self.data.lock().await.insert(key.clone(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            key: &str,
+            key: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let full_key = key.to_string();
-            let current = data.get(&full_key).cloned();
+            let current = data.get(key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
                 (Some(current), Some(expected)) => current == expected,
                 _ => false,
             };
             if matches {
-                data.insert(full_key, value.to_vec());
+                data.insert(key.clone(), value.to_vec());
             }
             Ok(matches)
         }
 
-        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
             self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
+                .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -626,7 +623,7 @@ mod tests {
             crate::control::keys::session_message_prefix("conic:test", "assistant", "session-1");
         let mut reply = None;
         for key in message_keys {
-            if key.strip_prefix(&prefix).unwrap_or(&key).contains('/') {
+            if !prefix.matches(&key) {
                 continue;
             }
             if let Some(message) = kv.get_msg::<models::SessionMessage>(&key).await.unwrap() {

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -87,6 +87,7 @@ impl WorkerEventHandler {
             // Pre-allocate the assistant reply slot in KV
             let reply_msg_id = uuid::Uuid::now_v7().to_string();
             let reply_msg_key = crate::control::keys::session_message(
+                ns,
                 &event.agent,
                 &event.session_id,
                 &reply_msg_id,
@@ -95,7 +96,6 @@ impl WorkerEventHandler {
                 .cp
                 .kv
                 .set_msg(
-                    ns,
                     &reply_msg_key,
                     &models::SessionMessage {
                         id: reply_msg_id.clone(),
@@ -118,14 +118,12 @@ impl WorkerEventHandler {
             );
 
             execute_with_panic_boundary(
-                runtime
-                    .executor
-                    .execute(
-                        &mut runtime.context,
-                        &event.message,
-                        &sink,
-                        Some(&cancellation_token),
-                    ),
+                runtime.executor.execute(
+                    &mut runtime.context,
+                    &event.message,
+                    &sink,
+                    Some(&cancellation_token),
+                ),
                 &sink,
                 &event.agent,
                 &event.session_id,
@@ -195,10 +193,10 @@ impl WorkerEventHandler {
     }
 
     async fn release_session_lock(&self, ns: &str, agent_id: &str, session_id: &str) {
-        let key = crate::control::keys::session(agent_id, session_id);
-        if let Ok(Some(mut session)) = self.cp.kv.get_msg::<models::Session>(ns, &key).await {
+        let key = crate::control::keys::session(ns, agent_id, session_id);
+        if let Ok(Some(mut session)) = self.cp.kv.get_msg::<models::Session>(&key).await {
             session.status = "IDLE".to_string();
-            let _ = self.cp.kv.set_msg(ns, &key, &session).await;
+            let _ = self.cp.kv.set_msg(&key, &session).await;
         }
     }
 }
@@ -209,8 +207,8 @@ mod tests {
     use crate::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::{
         events::{MessageDirection, SessionMessageEvent},
-        scheduler::NoopSchedulerBackend, ControlPlane, KeyValueStore, MessagePublisher,
-        ProtoKeyValueStoreExt,
+        scheduler::NoopSchedulerBackend,
+        ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::core::executor::ExecutionSink;
     use crate::gateway::rpc::{manifests, models};
@@ -218,14 +216,14 @@ mod tests {
         mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator,
         WorkerEventHandler,
     };
-    use axum::{routing::post, Json, Router};
     use async_trait::async_trait;
+    use axum::{routing::post, Json, Router};
     use futures::stream;
     use serde_json::json;
+    use serde_json::Value;
     use std::collections::HashMap;
     use std::pin::Pin;
     use std::sync::Arc;
-    use serde_json::Value;
     use std::sync::Mutex;
     use tokio::net::TcpListener;
     use tokio::sync::Mutex as AsyncMutex;
@@ -262,37 +260,31 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        data: AsyncMutex<HashMap<(String, String), Vec<u8>>>,
+        data: AsyncMutex<HashMap<String, Vec<u8>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, ns: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .data
-                .lock()
-                .await
-                .get(&(ns.to_string(), key.to_string()))
-                .cloned())
+        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.data.lock().await.get(key).cloned())
         }
 
-        async fn set(&self, ns: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             self.data
                 .lock()
                 .await
-                .insert((ns.to_string(), key.to_string()), value.to_vec());
+                .insert(key.to_string(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            ns: &str,
             key: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut data = self.data.lock().await;
-            let full_key = (ns.to_string(), key.to_string());
+            let full_key = key.to_string();
             let current = data.get(&full_key).cloned();
             let matches = match (current.as_deref(), expected) {
                 (None, None) => true,
@@ -305,20 +297,18 @@ mod tests {
             Ok(matches)
         }
 
-        async fn delete(&self, ns: &str, key: &str) -> anyhow::Result<()> {
-            self.data.lock().await.remove(&(ns.to_string(), key.to_string()));
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+            self.data.lock().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, ns: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
             let mut keys = self
                 .data
                 .lock()
                 .await
                 .keys()
-                .filter_map(|(stored_ns, key)| {
-                    (stored_ns == ns && key.starts_with(prefix)).then(|| key.clone())
-                })
+                .filter_map(|key| key.starts_with(prefix).then(|| key.clone()))
                 .collect::<Vec<_>>();
             keys.sort();
             Ok(keys)
@@ -416,9 +406,10 @@ mod tests {
     #[tokio::test]
     async fn execute_with_panic_boundary_reports_success_and_string_panic() {
         let sink = CaptureErrorSink::new();
-        let ok = execute_with_panic_boundary(async { Ok("done".to_string()) }, &sink, "infra", "s1")
-            .await
-            .unwrap();
+        let ok =
+            execute_with_panic_boundary(async { Ok("done".to_string()) }, &sink, "infra", "s1")
+                .await
+                .unwrap();
         assert_eq!(ok, SessionCompletionStatus::Completed);
         assert!(sink.errors().is_empty());
 
@@ -508,8 +499,7 @@ mod tests {
             labels: HashMap::new(),
         };
         kv.set_msg(
-            "conic:test",
-            &crate::control::keys::session("assistant", "session-1"),
+            &crate::control::keys::session("conic:test", "assistant", "session-1"),
             &session,
         )
         .await
@@ -520,10 +510,11 @@ mod tests {
             .await;
 
         let updated = kv
-            .get_msg::<models::Session>(
+            .get_msg::<models::Session>(&crate::control::keys::session(
                 "conic:test",
-                &crate::control::keys::session("assistant", "session-1"),
-            )
+                "assistant",
+                "session-1",
+            ))
             .await
             .expect("session should load")
             .expect("session should exist");
@@ -565,8 +556,7 @@ mod tests {
         };
 
         kv.set_msg(
-            "conic:test",
-            &crate::control::keys::agent("assistant"),
+            &crate::control::keys::agent("conic:test", "assistant"),
             &models::Agent {
                 name: "assistant".to_string(),
                 ns: "conic:test".to_string(),
@@ -579,8 +569,7 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "conic:test",
-            &crate::control::keys::session("assistant", "session-1"),
+            &crate::control::keys::session("conic:test", "assistant", "session-1"),
             &models::Session {
                 id: "session-1".to_string(),
                 agent: "assistant".to_string(),
@@ -609,10 +598,11 @@ mod tests {
             .unwrap();
 
         let session = kv
-            .get_msg::<models::Session>(
+            .get_msg::<models::Session>(&crate::control::keys::session(
                 "conic:test",
-                &crate::control::keys::session("assistant", "session-1"),
-            )
+                "assistant",
+                "session-1",
+            ))
             .await
             .unwrap()
             .unwrap();
@@ -625,23 +615,21 @@ mod tests {
             .is_none());
 
         let message_keys = kv
-            .list_keys(
+            .list_keys(&crate::control::keys::session_message_prefix(
                 "conic:test",
-                &crate::control::keys::session_message_prefix("assistant", "session-1"),
-            )
+                "assistant",
+                "session-1",
+            ))
             .await
             .unwrap();
-        let prefix = crate::control::keys::session_message_prefix("assistant", "session-1");
+        let prefix =
+            crate::control::keys::session_message_prefix("conic:test", "assistant", "session-1");
         let mut reply = None;
         for key in message_keys {
             if key.strip_prefix(&prefix).unwrap_or(&key).contains('/') {
                 continue;
             }
-            if let Some(message) = kv
-                .get_msg::<models::SessionMessage>("conic:test", &key)
-                .await
-                .unwrap()
-            {
+            if let Some(message) = kv.get_msg::<models::SessionMessage>(&key).await.unwrap() {
                 reply = Some(message);
                 break;
             }

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -141,6 +141,7 @@ impl PubSubSessionSink {
         payload_json: String,
     ) {
         let key = crate::control::keys::session_message_step(
+            &self.ns,
             &self.agent_id,
             &self.session_id,
             &self.reply_msg_id,
@@ -157,13 +158,8 @@ impl PubSubSessionSink {
             name,
             payload_json,
         };
-        let _ = crate::control::ProtoKeyValueStoreExt::set_msg(
-            self.kv.as_ref(),
-            &self.ns,
-            &key,
-            &event,
-        )
-        .await;
+        let _ =
+            crate::control::ProtoKeyValueStoreExt::set_msg(self.kv.as_ref(), &key, &event).await;
     }
 
     async fn flush_persisted_text(&self) {
@@ -281,7 +277,6 @@ impl PubSubSessionSink {
         if should_flush {
             *self.last_flush.lock().unwrap() = Instant::now();
             let kv = self.kv.clone();
-            let ns = self.ns.clone();
             let key = self.reply_msg_key.clone();
             let msg_id = self.reply_msg_id.clone();
             tokio::spawn(async move {
@@ -293,7 +288,7 @@ impl PubSubSessionSink {
                     labels: std::collections::HashMap::new(),
                 };
                 if let Err(e) =
-                    crate::control::ProtoKeyValueStoreExt::set_msg(kv.as_ref(), &ns, &key, &partial)
+                    crate::control::ProtoKeyValueStoreExt::set_msg(kv.as_ref(), &key, &partial)
                         .await
                 {
                     tracing::error!("Failed to persist partial message: {}", e);
@@ -437,7 +432,6 @@ impl ExecutionSink for PubSubSessionSink {
         self.flush_reasoning_event_buffer().await;
         // Final KV write (complete message)
         let kv = self.kv.clone();
-        let ns = self.ns.clone();
         let key = self.reply_msg_key.clone();
         let msg_id = self.reply_msg_id.clone();
         let reply = reply.to_string();
@@ -450,8 +444,7 @@ impl ExecutionSink for PubSubSessionSink {
                 created_at: chrono::Utc::now().timestamp_micros(),
                 labels: std::collections::HashMap::new(),
             };
-            let _ =
-                crate::control::ProtoKeyValueStoreExt::set_msg(kv.as_ref(), &ns, &key, &msg).await;
+            let _ = crate::control::ProtoKeyValueStoreExt::set_msg(kv.as_ref(), &key, &msg).await;
         });
 
         self.publish_event(AgentEvent::Done(reply_for_event)).await;
@@ -480,7 +473,6 @@ impl ExecutionSink for PubSubSessionSink {
         };
         let _ = crate::control::ProtoKeyValueStoreExt::set_msg(
             self.kv.as_ref(),
-            &self.ns,
             &self.reply_msg_key,
             &msg,
         )
@@ -521,39 +513,37 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        entries: Arc<Mutex<Vec<(String, String, Vec<u8>)>>>,
+        entries: Arc<Mutex<Vec<(String, Vec<u8>)>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, _ns: &str, _k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, _k: &str) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(None)
         }
-        async fn set(&self, ns: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             self.entries
                 .lock()
                 .await
-                .push((ns.to_string(), key.to_string(), value.to_vec()));
+                .push((key.to_string(), value.to_vec()));
             Ok(())
         }
         async fn compare_and_swap(
             &self,
-            _ns: &str,
             _k: &str,
             _expected: Option<&[u8]>,
             _value: &[u8],
         ) -> anyhow::Result<bool> {
             Ok(true)
         }
-        async fn delete(&self, _ns: &str, _k: &str) -> anyhow::Result<()> {
+        async fn delete(&self, _k: &str) -> anyhow::Result<()> {
             Ok(())
         }
-        async fn list_keys(&self, _ns: &str, _p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, _p: &str) -> anyhow::Result<Vec<String>> {
             Ok(vec![])
         }
         async fn list_keys_page(
             &self,
-            _ns: &str,
             _prefix: &str,
             _before_key: Option<&str>,
             _limit: usize,
@@ -677,7 +667,7 @@ mod tests {
         let entries = kv.entries.lock().await.clone();
         let persisted_reasoning = entries
             .iter()
-            .filter_map(|(_, _, value)| SessionStepEvent::decode(value.as_slice()).ok())
+            .filter_map(|(_, value)| SessionStepEvent::decode(value.as_slice()).ok())
             .filter(|event| event.step_type == StepType::Reasoning as i32)
             .map(|event| event.content)
             .collect::<Vec<_>>();
@@ -711,7 +701,7 @@ mod tests {
         let entries = kv.entries.lock().await.clone();
         let persisted = entries
             .iter()
-            .find_map(|(_, _, value)| SessionStepEvent::decode(value.as_slice()).ok())
+            .find_map(|(_, value)| SessionStepEvent::decode(value.as_slice()).ok())
             .filter(|event| event.step_type == StepType::Observation as i32)
             .unwrap();
         let payload: serde_json::Value = serde_json::from_str(&persisted.payload_json).unwrap();
@@ -754,7 +744,7 @@ mod tests {
         let entries = kv.entries.lock().await.clone();
         let persisted_messages = entries
             .iter()
-            .filter_map(|(_, _, value)| {
+            .filter_map(|(_, value)| {
                 crate::gateway::rpc::models::SessionMessage::decode(value.as_slice()).ok()
             })
             .collect::<Vec<_>>();
@@ -767,7 +757,7 @@ mod tests {
 
         let persisted_steps = entries
             .iter()
-            .filter_map(|(_, _, value)| SessionStepEvent::decode(value.as_slice()).ok())
+            .filter_map(|(_, value)| SessionStepEvent::decode(value.as_slice()).ok())
             .collect::<Vec<_>>();
         assert!(persisted_steps
             .iter()

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::control::events::{SessionStepEvent, StepType};
-use crate::control::{topics, KeyValueStore, MessagePublisher};
+use crate::control::{keys::ResourceKey, topics, KeyValueStore, MessagePublisher};
 use crate::core::context_budget::tool_result_preview;
 use crate::core::executor::{AgentEvent, ExecutionSink};
 use crate::gateway::rpc::models;
@@ -37,7 +37,7 @@ pub struct PubSubSessionSink {
     pub session_id: String,
     pub agent_id: String,
     pub reply_msg_id: String,
-    pub reply_msg_key: String,
+    pub reply_msg_key: ResourceKey,
     pub status_topic: String,
     token_publish_interval: Duration,
     started_at: Instant,
@@ -69,7 +69,7 @@ impl PubSubSessionSink {
         session_id: impl Into<String>,
         agent_id: impl Into<String>,
         reply_msg_id: impl Into<String>,
-        reply_msg_key: impl Into<String>,
+        reply_msg_key: ResourceKey,
     ) -> Self {
         Self::new_with_token_publish_interval(
             kv,
@@ -90,7 +90,7 @@ impl PubSubSessionSink {
         session_id: impl Into<String>,
         agent_id: impl Into<String>,
         reply_msg_id: impl Into<String>,
-        reply_msg_key: impl Into<String>,
+        reply_msg_key: ResourceKey,
         token_publish_interval: Duration,
     ) -> Self {
         let session_id = session_id.into();
@@ -102,7 +102,7 @@ impl PubSubSessionSink {
             session_id,
             agent_id: agent_id.into(),
             reply_msg_id: reply_msg_id.into(),
-            reply_msg_key: reply_msg_key.into(),
+            reply_msg_key,
             status_topic,
             token_publish_interval,
             started_at: Instant::now(),
@@ -502,6 +502,7 @@ fn token_publish_interval() -> Duration {
 mod tests {
     use super::{token_publish_interval, PubSubSessionSink};
     use crate::control::events::{SessionStepEvent, StepType};
+    use crate::control::keys::{self, ResourceKey, ResourceList};
     use crate::control::{KeyValueStore, MessagePublisher};
     use crate::core::executor::ExecutionSink;
     use async_trait::async_trait;
@@ -516,12 +517,16 @@ mod tests {
         entries: Arc<Mutex<Vec<(String, Vec<u8>)>>>,
     }
 
+    fn reply_key() -> ResourceKey {
+        keys::session_message("conic", "infra", "session-1", "reply-1")
+    }
+
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, _k: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, _k: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(None)
         }
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
             self.entries
                 .lock()
                 .await
@@ -530,24 +535,24 @@ mod tests {
         }
         async fn compare_and_swap(
             &self,
-            _k: &str,
+            _k: &ResourceKey,
             _expected: Option<&[u8]>,
             _value: &[u8],
         ) -> anyhow::Result<bool> {
             Ok(true)
         }
-        async fn delete(&self, _k: &str) -> anyhow::Result<()> {
+        async fn delete(&self, _k: &ResourceKey) -> anyhow::Result<()> {
             Ok(())
         }
-        async fn list_keys(&self, _p: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, _list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(vec![])
         }
         async fn list_keys_page(
             &self,
-            _prefix: &str,
+            _list: &ResourceList,
             _before_key: Option<&str>,
             _limit: usize,
-        ) -> anyhow::Result<Vec<String>> {
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(vec![])
         }
     }
@@ -586,7 +591,7 @@ mod tests {
             "session-1",
             "infra",
             "reply-1",
-            "reply-key",
+            reply_key(),
             Duration::from_millis(5),
         );
 
@@ -618,7 +623,7 @@ mod tests {
             "session-1",
             "infra",
             "reply-1",
-            "reply-key",
+            reply_key(),
             Duration::from_secs(10),
         );
 
@@ -647,7 +652,7 @@ mod tests {
             "session-1",
             "infra",
             "reply-1",
-            "reply-key",
+            reply_key(),
             Duration::from_millis(5),
         );
 
@@ -687,7 +692,7 @@ mod tests {
             "session-1",
             "infra",
             "reply-1",
-            "reply-key",
+            reply_key(),
             Duration::from_secs(10),
         );
         let raw_output = format!(
@@ -724,7 +729,7 @@ mod tests {
             "session-1",
             "infra",
             "reply-1",
-            "reply-key",
+            reply_key(),
             Duration::from_secs(10),
         );
 
@@ -780,7 +785,7 @@ mod tests {
             "session-1",
             "infra",
             "reply-1",
-            "reply-key",
+            reply_key(),
             Duration::from_millis(1),
         );
 

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -41,7 +41,6 @@ use super::WorkerEventHandler;
 const TALON_OPS_SERVER_NAME: &str = "talon-ops";
 const TALON_OPS_AUDIENCE: &str = "talon-ops";
 const MCP_AUTH_BROKER_AUDIENCE: &str = "conic-mcp-auth-broker";
-const META_NS: &str = "talon-system:ns";
 const DEFAULT_MAX_LIST_LIMIT: i32 = 100;
 const DEFAULT_MAX_HISTORY_LOOKBACK_SECONDS: i32 = 7 * 24 * 60 * 60;
 const DEFAULT_ACCESS_TOKEN_TTL_SECONDS: i64 = 3600;
@@ -150,21 +149,14 @@ impl TalonOpsServer {
         &self.handler.cp.kv
     }
 
-    async fn load_messages<M>(
-        &self,
-        namespace: &str,
-        keys: Vec<String>,
-        concurrency: usize,
-    ) -> Result<Vec<M>>
+    async fn load_messages<M>(&self, keys: Vec<String>, concurrency: usize) -> Result<Vec<M>>
     where
         M: prost::Message + Default + Send + 'static,
     {
         let kv = self.handler.cp.kv.clone();
-        let namespace = namespace.to_string();
         let mut items = stream::iter(keys.into_iter().map(move |key| {
             let kv = kv.clone();
-            let namespace = namespace.clone();
-            async move { kv.get_msg::<M>(&namespace, &key).await }
+            async move { kv.get_msg::<M>(&key).await }
         }))
         .buffer_unordered(concurrency.max(1))
         .collect::<Vec<_>>()
@@ -179,11 +171,12 @@ impl TalonOpsServer {
     }
 
     async fn list_all_namespaces(&self) -> Result<Vec<models::Namespace>> {
-        let mut keys = self.kv().list_keys(META_NS, "Namespace/").await?;
-        keys.sort();
-        let namespaces = self
-            .load_messages::<models::Namespace>(META_NS, keys, 32)
+        let mut keys = self
+            .kv()
+            .list_keys(&keys::namespace_metadata_prefix())
             .await?;
+        keys.sort();
+        let namespaces = self.load_messages::<models::Namespace>(keys, 32).await?;
         Ok(namespaces
             .into_iter()
             .filter(|namespace| !namespace.is_deleted)
@@ -191,33 +184,27 @@ impl TalonOpsServer {
     }
 
     async fn get_namespace_model(&self, name: &str) -> Result<models::Namespace> {
-        let key = format!("Namespace/{name}");
+        let key = keys::namespace_metadata(name);
         self.kv()
-            .get_msg::<models::Namespace>(META_NS, &key)
+            .get_msg::<models::Namespace>(&key)
             .await?
             .filter(|ns| !ns.is_deleted)
             .ok_or_else(|| anyhow!("namespace '{name}' not found"))
     }
 
     async fn list_agent_names(&self, namespace: &str) -> Result<Vec<String>> {
-        let mut keys = self.kv().list_keys(namespace, "Agent/").await?;
+        let prefix = keys::agent_prefix(namespace);
+        let mut keys = self.kv().list_keys(&prefix).await?;
         keys.sort();
         Ok(keys
             .into_iter()
-            .filter_map(|key| {
-                let stripped = key.strip_prefix("Agent/").unwrap_or(&key);
-                if stripped.contains('/') {
-                    None
-                } else {
-                    Some(stripped.to_string())
-                }
-            })
+            .filter_map(|key| keys::direct_child_name(&prefix, &key))
             .collect())
     }
 
     async fn get_agent_model(&self, namespace: &str, name: &str) -> Result<models::Agent> {
         self.kv()
-            .get_msg::<models::Agent>(namespace, &keys::agent(name))
+            .get_msg::<models::Agent>(&keys::agent(namespace, name))
             .await?
             .ok_or_else(|| anyhow!("agent '{name}' not found in namespace '{namespace}'"))
     }
@@ -227,18 +214,10 @@ impl TalonOpsServer {
         namespace: &str,
         agent: &str,
     ) -> Result<Vec<models::Session>> {
-        let prefix = keys::session_prefix(agent);
-        let mut keys = self.kv().list_keys(namespace, &prefix).await?;
+        let prefix = keys::session_prefix(namespace, agent);
+        let mut keys = self.kv().list_keys(&prefix).await?;
         keys.sort();
-        let session_keys = keys
-            .into_iter()
-            .filter(|key| {
-                let stripped = key.strip_prefix(&prefix).unwrap_or(key);
-                !stripped.contains('/')
-            })
-            .collect::<Vec<_>>();
-        self.load_messages::<models::Session>(namespace, session_keys, 32)
-            .await
+        self.load_messages::<models::Session>(keys, 32).await
     }
 
     async fn get_session_messages(
@@ -247,18 +226,10 @@ impl TalonOpsServer {
         agent: &str,
         session_id: &str,
     ) -> Result<Vec<models::SessionMessage>> {
-        let prefix = keys::session_message_prefix(agent, session_id);
-        let mut keys = self.kv().list_keys(namespace, &prefix).await?;
+        let prefix = keys::session_message_prefix(namespace, agent, session_id);
+        let mut keys = self.kv().list_keys(&prefix).await?;
         keys.sort();
-        let message_keys = keys
-            .into_iter()
-            .filter(|key| {
-                let stripped = key.strip_prefix(&prefix).unwrap_or(key);
-                !stripped.contains('/')
-            })
-            .collect::<Vec<_>>();
-        self.load_messages::<models::SessionMessage>(namespace, message_keys, 32)
-            .await
+        self.load_messages::<models::SessionMessage>(keys, 32).await
     }
 
     async fn get_session_steps(
@@ -267,35 +238,25 @@ impl TalonOpsServer {
         agent: &str,
         session_id: &str,
     ) -> Result<Vec<events::SessionStepEvent>> {
-        let prefix = keys::session_message_prefix(agent, session_id);
-        let mut keys = self.kv().list_keys(namespace, &prefix).await?;
+        let prefix =
+            keys::recursive_prefix(namespace, &[("Agent", agent), ("Session", session_id)]);
+        let mut keys = self.kv().list_keys(&prefix).await?;
         keys.sort();
         let step_keys = keys
             .into_iter()
-            .filter(|key| {
-                let stripped = key.strip_prefix(&prefix).unwrap_or(key);
-                stripped.contains("/Steps/")
-            })
+            .filter(|key| key.contains("/@/SessionStep/"))
             .collect::<Vec<_>>();
-        self.load_messages::<events::SessionStepEvent>(namespace, step_keys, 64)
+        self.load_messages::<events::SessionStepEvent>(step_keys, 64)
             .await
     }
 
     async fn list_schedule_models(&self, namespace: &str) -> Result<Vec<models::Schedule>> {
         let mut keys = self
             .kv()
-            .list_keys(namespace, keys::schedule_prefix())
+            .list_keys(&keys::schedule_prefix(namespace))
             .await?;
         keys.sort();
-        let schedule_keys = keys
-            .into_iter()
-            .filter(|key| {
-                let stripped = key.strip_prefix(keys::schedule_prefix()).unwrap_or(key);
-                !stripped.contains('/')
-            })
-            .collect::<Vec<_>>();
-        self.load_messages::<models::Schedule>(namespace, schedule_keys, 32)
-            .await
+        self.load_messages::<models::Schedule>(keys, 32).await
     }
 
     async fn upsert_schedule(
@@ -350,11 +311,13 @@ impl TalonOpsServer {
                     } else {
                         args.agent.clone()
                     },
-                    session_mode: crate::scheduling::normalize_session_mode(&args
-                        .session_mode
-                        .clone()
-                        .or_else(|| existing_target.map(|target| target.session_mode.clone()))
-                        .unwrap_or_else(|| "new".to_string()))?,
+                    session_mode: crate::scheduling::normalize_session_mode(
+                        &args
+                            .session_mode
+                            .clone()
+                            .or_else(|| existing_target.map(|target| target.session_mode.clone()))
+                            .unwrap_or_else(|| "new".to_string()),
+                    )?,
                     session_id: args
                         .session_id
                         .clone()
@@ -617,7 +580,9 @@ impl TalonOpsServer {
             .get_agent_model(&args.namespace, &args.name)
             .await
             .map_err(internal_mcp_error)?;
-        to_json_string(&json!({ "agent": crate::manifest::render_agent_json(&agent).map_err(internal_mcp_error)? }))
+        to_json_string(
+            &json!({ "agent": crate::manifest::render_agent_json(&agent).map_err(internal_mcp_error)? }),
+        )
     }
 
     #[tool(description = "List sessions in one or more visible namespaces and agents.")]
@@ -675,10 +640,11 @@ impl TalonOpsServer {
         require_namespace_access(&access, &args.namespace)?;
         let session = self
             .kv()
-            .get_msg::<models::Session>(
+            .get_msg::<models::Session>(&keys::session(
                 &args.namespace,
-                &keys::session(&args.agent, &args.session_id),
-            )
+                &args.agent,
+                &args.session_id,
+            ))
             .await
             .map_err(internal_mcp_error)?
             .ok_or_else(|| McpError::invalid_params("session not found".to_string(), None))?;
@@ -784,7 +750,7 @@ impl TalonOpsServer {
         let limit = bounded_limit(&access, args.limit);
         let mut keys = self
             .kv()
-            .list_keys(&args.namespace, keys::mcp_server_binding_prefix())
+            .list_keys(&keys::mcp_server_binding_prefix(&args.namespace))
             .await
             .map_err(internal_mcp_error)?;
         keys.sort();
@@ -792,7 +758,7 @@ impl TalonOpsServer {
         for key in keys.into_iter().take(limit) {
             if let Some(binding) = self
                 .kv()
-                .get_msg::<manifests::McpServerBinding>(&args.namespace, &key)
+                .get_msg::<manifests::McpServerBinding>(&key)
                 .await
                 .map_err(internal_mcp_error)?
             {
@@ -814,10 +780,10 @@ impl TalonOpsServer {
         require_namespace_access(&access, &args.namespace)?;
         let binding = self
             .kv()
-            .get_msg::<manifests::McpServerBinding>(
+            .get_msg::<manifests::McpServerBinding>(&keys::mcp_server_binding(
                 &args.namespace,
-                &keys::mcp_server_binding(&args.name),
-            )
+                &args.name,
+            ))
             .await
             .map_err(internal_mcp_error)?
             .ok_or_else(|| McpError::invalid_params("MCP binding not found".to_string(), None))?;
@@ -832,7 +798,7 @@ impl TalonOpsServer {
         let limit = args.limit.unwrap_or(DEFAULT_MAX_LIST_LIMIT as usize);
         let mut keys = self
             .kv()
-            .list_keys(crate::control::ns::TALON_SYSTEM, keys::mcp_server_prefix())
+            .list_keys(&keys::mcp_server_prefix())
             .await
             .map_err(internal_mcp_error)?;
         keys.sort();
@@ -840,7 +806,7 @@ impl TalonOpsServer {
         for key in keys.into_iter().take(limit) {
             if let Some(server) = self
                 .kv()
-                .get_msg::<manifests::McpServer>(crate::control::ns::TALON_SYSTEM, &key)
+                .get_msg::<manifests::McpServer>(&key)
                 .await
                 .map_err(internal_mcp_error)?
             {
@@ -857,10 +823,7 @@ impl TalonOpsServer {
     ) -> Result<String, McpError> {
         let server = self
             .kv()
-            .get_msg::<manifests::McpServer>(
-                crate::control::ns::TALON_SYSTEM,
-                &keys::mcp_server(&args.name),
-            )
+            .get_msg::<manifests::McpServer>(&keys::mcp_server(&args.name))
             .await
             .map_err(internal_mcp_error)?
             .ok_or_else(|| McpError::invalid_params("MCP server not found".to_string(), None))?;
@@ -934,10 +897,10 @@ impl TalonOpsServer {
     ) -> Result<String, McpError> {
         let access = talon_ops_access_from_parts(&parts)?;
         require_namespace_access(&access, &args.namespace)?;
-        let key = keys::schedule(&args.name);
+        let key = keys::schedule(&args.namespace, &args.name);
         if self
             .kv()
-            .get_msg::<models::Schedule>(&args.namespace, &key)
+            .get_msg::<models::Schedule>(&key)
             .await
             .map_err(internal_mcp_error)?
             .is_some()
@@ -992,10 +955,10 @@ impl TalonOpsServer {
     ) -> Result<String, McpError> {
         let access = talon_ops_access_from_parts(&parts)?;
         require_namespace_access(&access, &args.namespace)?;
-        let key = keys::schedule(&args.name);
+        let key = keys::schedule(&args.namespace, &args.name);
         if let Some(schedule) = self
             .kv()
-            .get_msg::<models::Schedule>(&args.namespace, &key)
+            .get_msg::<models::Schedule>(&key)
             .await
             .map_err(internal_mcp_error)?
         {
@@ -1008,10 +971,7 @@ impl TalonOpsServer {
                     .map_err(internal_mcp_error)?;
             }
         }
-        self.kv()
-            .delete(&args.namespace, &key)
-            .await
-            .map_err(internal_mcp_error)?;
+        self.kv().delete(&key).await.map_err(internal_mcp_error)?;
         to_json_string(&json!({ "deleted": true }))
     }
 }
@@ -1130,7 +1090,7 @@ async fn talon_ops_auth_broker(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("failed to mint talon-ops token: {error}"),
             )
-                .into_response()
+                .into_response();
         }
     };
 
@@ -1173,7 +1133,7 @@ async fn load_talon_ops_binding(
     agent_name: Option<&str>,
 ) -> Result<TalonOpsAccess> {
     let binding = kv
-        .get_msg::<manifests::McpServerBinding>(namespace, &keys::mcp_server_binding(binding_name))
+        .get_msg::<manifests::McpServerBinding>(&keys::mcp_server_binding(namespace, binding_name))
         .await?
         .ok_or_else(|| anyhow!("binding '{binding_name}' not found in namespace '{namespace}'"))?;
     let spec = binding
@@ -1197,10 +1157,7 @@ async fn load_talon_ops_binding(
 
 async fn load_talon_ops_policy(kv: &dyn crate::control::KeyValueStore) -> Result<TalonOpsPolicy> {
     let server = kv
-        .get_msg::<manifests::McpServer>(
-            crate::control::ns::TALON_SYSTEM,
-            &keys::mcp_server(TALON_OPS_SERVER_NAME),
-        )
+        .get_msg::<manifests::McpServer>(&keys::mcp_server(TALON_OPS_SERVER_NAME))
         .await?
         .ok_or_else(|| anyhow!("MCPServer '{}' not found", TALON_OPS_SERVER_NAME))?;
     let spec = server
@@ -1473,12 +1430,11 @@ mod tests {
         parse_non_negative_i32_query_param, parse_talon_ops_access_claims,
         parse_talon_ops_policy_from_target, require_namespace_access, schedule_json,
         talon_jwt_secret, talon_ops_access_from_parts, talon_ops_access_from_request,
-        talon_ops_auth_broker, to_json_string, DeleteScheduleArgs, GetAgentArgs,
-        GetScheduleArgs, ListMcpBindingsArgs, ListMcpServersArgs, ListNamespacesArgs,
-        ListRecentStepsArgs, ListSchedulesArgs, ListSessionsArgs, McpAuthBrokerClaims,
-        McpAuthBrokerRequest, PutScheduleArgs, TalonOpsAccess, TalonOpsAccessClaims,
-        TalonOpsPolicy, TalonOpsServer, DEFAULT_MAX_HISTORY_LOOKBACK_SECONDS,
-        DEFAULT_MAX_LIST_LIMIT, META_NS,
+        talon_ops_auth_broker, to_json_string, DeleteScheduleArgs, GetAgentArgs, GetScheduleArgs,
+        ListMcpBindingsArgs, ListMcpServersArgs, ListNamespacesArgs, ListRecentStepsArgs,
+        ListSchedulesArgs, ListSessionsArgs, McpAuthBrokerClaims, McpAuthBrokerRequest,
+        PutScheduleArgs, TalonOpsAccess, TalonOpsAccessClaims, TalonOpsPolicy, TalonOpsServer,
+        DEFAULT_MAX_HISTORY_LOOKBACK_SECONDS, DEFAULT_MAX_LIST_LIMIT,
     };
     use crate::config::Config;
     use crate::control::{
@@ -1502,70 +1458,57 @@ mod tests {
     use prost::Message;
     use rmcp::handler::server::wrapper::Parameters;
     use serde_json::json;
-    use std::{
-        collections::HashMap,
-        pin::Pin,
-        sync::Arc,
-    };
+    use std::{collections::HashMap, pin::Pin, sync::Arc};
     use tokio::sync::Mutex as AsyncMutex;
 
     #[derive(Default)]
     struct MockKvStore {
-        entries: Arc<tokio::sync::RwLock<HashMap<(String, String), Vec<u8>>>>,
+        entries: Arc<tokio::sync::RwLock<HashMap<String, Vec<u8>>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, namespace: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self
-                .entries
-                .read()
-                .await
-                .get(&(namespace.to_string(), key.to_string()))
-                .cloned())
+        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+            Ok(self.entries.read().await.get(key).cloned())
         }
 
-        async fn set(&self, namespace: &str, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
             self.entries
                 .write()
                 .await
-                .insert((namespace.to_string(), key.to_string()), value.to_vec());
+                .insert(key.to_string(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            namespace: &str,
             key: &str,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut entries = self.entries.write().await;
-            let current = entries.get(&(namespace.to_string(), key.to_string())).cloned();
+            let current = entries.get(key).cloned();
             if current.as_deref() == expected {
-                entries.insert((namespace.to_string(), key.to_string()), value.to_vec());
+                entries.insert(key.to_string(), value.to_vec());
                 Ok(true)
             } else {
                 Ok(false)
             }
         }
 
-        async fn delete(&self, namespace: &str, key: &str) -> anyhow::Result<()> {
-            self.entries
-                .write()
-                .await
-                .remove(&(namespace.to_string(), key.to_string()));
+        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+            self.entries.write().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, namespace: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
             Ok(self
                 .entries
                 .read()
                 .await
                 .keys()
-                .filter(|(ns, key)| ns == namespace && key.starts_with(prefix))
-                .map(|(_, key)| key.clone())
+                .filter(|key| key.starts_with(prefix))
+                .cloned()
                 .collect())
         }
     }
@@ -1607,7 +1550,6 @@ mod tests {
 
     async fn seed_talon_ops_binding(kv: &MockKvStore, namespace: &str, binding_name: &str) {
         kv.set_msg(
-            crate::control::ns::TALON_SYSTEM,
             &keys::mcp_server("talon-ops"),
             &manifests::McpServer {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -1632,8 +1574,7 @@ mod tests {
         .await
         .expect("talon-ops server should persist");
         kv.set_msg(
-            namespace,
-            &keys::mcp_server_binding(binding_name),
+            &keys::mcp_server_binding(namespace, binding_name),
             &manifests::McpServerBinding {
                 api_version: "talon.impalasys.com/v1".to_string(),
                 kind: "McpServerBinding".to_string(),
@@ -1684,8 +1625,7 @@ mod tests {
 
     async fn seed_namespace(kv: &MockKvStore, name: &str, parent: &str) {
         kv.set_msg(
-            META_NS,
-            &format!("Namespace/{name}"),
+            &keys::namespace_metadata(name),
             &models::Namespace {
                 name: name.to_string(),
                 parent: parent.to_string(),
@@ -1700,8 +1640,7 @@ mod tests {
 
     async fn seed_agent(kv: &MockKvStore, namespace: &str, name: &str) {
         kv.set_msg(
-            namespace,
-            &keys::agent(name),
+            &keys::agent(namespace, name),
             &models::Agent {
                 name: name.to_string(),
                 ns: namespace.to_string(),
@@ -1850,8 +1789,14 @@ mod tests {
 
     #[test]
     fn normalize_schedule_kind_maps_interval_to_every() {
-        assert_eq!(crate::scheduling::normalize_schedule_kind("interval"), "every");
-        assert_eq!(crate::scheduling::normalize_schedule_kind(" every "), "every");
+        assert_eq!(
+            crate::scheduling::normalize_schedule_kind("interval"),
+            "every"
+        );
+        assert_eq!(
+            crate::scheduling::normalize_schedule_kind(" every "),
+            "every"
+        );
         assert_eq!(crate::scheduling::normalize_schedule_kind("cron"), "cron");
     }
 
@@ -1896,7 +1841,10 @@ mod tests {
         assert!(parse_bool_query_param("enabled", "true").is_err());
 
         assert_eq!(parse_non_negative_i32_query_param("limit", "0").unwrap(), 0);
-        assert_eq!(parse_non_negative_i32_query_param("limit", "42").unwrap(), 42);
+        assert_eq!(
+            parse_non_negative_i32_query_param("limit", "42").unwrap(),
+            42
+        );
         assert!(parse_non_negative_i32_query_param("limit", "-1").is_err());
         assert!(parse_non_negative_i32_query_param("limit", "abc").is_err());
     }
@@ -1938,10 +1886,11 @@ mod tests {
             std::env::set_var("TALON_JWT_SECRET", "secret-for-tests");
         }
 
-        let access_token = mint_talon_ops_access_token("conic", "talon-ops", Some("cmo"), 4_102_444_800)
-            .expect("access token should mint");
-        let access_claims =
-            parse_talon_ops_access_claims(&format!("Bearer {access_token}")).expect("claims should parse");
+        let access_token =
+            mint_talon_ops_access_token("conic", "talon-ops", Some("cmo"), 4_102_444_800)
+                .expect("access token should mint");
+        let access_claims = parse_talon_ops_access_claims(&format!("Bearer {access_token}"))
+            .expect("claims should parse");
         assert_eq!(access_claims.namespace, "conic");
         assert_eq!(access_claims.binding_name, "talon-ops");
         assert_eq!(access_claims.agent_name.as_deref(), Some("cmo"));
@@ -2105,7 +2054,6 @@ mod tests {
     async fn load_talon_ops_policy_and_binding_validate_kv_records() {
         let kv = MockKvStore::default();
         kv.set_msg(
-            crate::control::ns::TALON_SYSTEM,
             &keys::mcp_server("talon-ops"),
             &manifests::McpServer {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -2128,8 +2076,7 @@ mod tests {
         .await
         .expect("talon-ops server should persist");
         kv.set_msg(
-            "conic",
-            &keys::mcp_server_binding("talon-ops"),
+            &keys::mcp_server_binding("conic", "talon-ops"),
             &manifests::McpServerBinding {
                 api_version: "talon.impalasys.com/v1".to_string(),
                 kind: "McpServerBinding".to_string(),
@@ -2152,7 +2099,9 @@ mod tests {
         .await
         .expect("binding should persist");
 
-        let policy = load_talon_ops_policy(&kv).await.expect("policy should load");
+        let policy = load_talon_ops_policy(&kv)
+            .await
+            .expect("policy should load");
         assert_eq!(policy.allowed_namespace_prefixes, vec!["conic".to_string()]);
         assert!(policy.allow_session_messages);
 
@@ -2168,7 +2117,6 @@ mod tests {
     async fn load_talon_ops_binding_rejects_missing_or_wrong_server_binding() {
         let kv = MockKvStore::default();
         kv.set_msg(
-            crate::control::ns::TALON_SYSTEM,
             &keys::mcp_server("talon-ops"),
             &manifests::McpServer {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -2181,7 +2129,8 @@ mod tests {
                 }),
                 spec: Some(manifests::McpServerSpec {
                     transport: "streamable_http".to_string(),
-                    target: "https://worker.example.com/mcp/talon-ops?allowed_prefix=conic".to_string(),
+                    target: "https://worker.example.com/mcp/talon-ops?allowed_prefix=conic"
+                        .to_string(),
                     args: Vec::new(),
                     headers: HashMap::new(),
                     disabled: false,
@@ -2197,8 +2146,7 @@ mod tests {
         assert!(missing.to_string().contains("not found"));
 
         kv.set_msg(
-            "conic",
-            &keys::mcp_server_binding("wrong"),
+            &keys::mcp_server_binding("conic", "wrong"),
             &manifests::McpServerBinding {
                 api_version: "talon.impalasys.com/v1".to_string(),
                 kind: "McpServerBinding".to_string(),
@@ -2354,8 +2302,7 @@ mod tests {
         seed_agent(kv.as_ref(), "default", "hidden").await;
 
         kv.set_msg(
-            "conic",
-            &keys::session("alpha", "session-old"),
+            &keys::session("conic", "alpha", "session-old"),
             &models::Session {
                 id: "session-old".to_string(),
                 agent: "alpha".to_string(),
@@ -2370,8 +2317,7 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "conic",
-            &keys::session("beta", "session-new"),
+            &keys::session("conic", "beta", "session-new"),
             &models::Session {
                 id: "session-new".to_string(),
                 agent: "beta".to_string(),
@@ -2386,8 +2332,7 @@ mod tests {
         .await
         .unwrap();
         kv.set_msg(
-            "conic",
-            &keys::session_message("beta", "session-new", "msg-1"),
+            &keys::session_message("conic", "beta", "session-new", "msg-1"),
             &models::SessionMessage {
                 id: "msg-1".to_string(),
                 role: 1,
@@ -2399,8 +2344,7 @@ mod tests {
         .await
         .unwrap();
         kv.set(
-            "conic",
-            &keys::session_message_step("beta", "session-new", "msg-1", "step-1"),
+            &keys::session_message_step("conic", "beta", "session-new", "msg-1", "step-1"),
             &crate::control::events::SessionStepEvent {
                 session_id: "session-new".to_string(),
                 step_type: crate::control::events::StepType::Action as i32,
@@ -2418,8 +2362,7 @@ mod tests {
         .unwrap();
 
         kv.set_msg(
-            "conic",
-            &keys::mcp_server_binding("talon-ops"),
+            &keys::mcp_server_binding("conic", "talon-ops"),
             &manifests::McpServerBinding {
                 api_version: "talon.impalasys.com/v1".to_string(),
                 kind: "McpServerBinding".to_string(),

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -31,7 +31,11 @@ use std::{
 };
 
 use crate::{
-    control::{events, keys, ProtoKeyValueStoreExt},
+    control::{
+        events,
+        keys::{self, ResourceKey},
+        ProtoKeyValueStoreExt,
+    },
     gateway::rpc::{manifests, models},
     scheduling,
 };
@@ -149,7 +153,7 @@ impl TalonOpsServer {
         &self.handler.cp.kv
     }
 
-    async fn load_messages<M>(&self, keys: Vec<String>, concurrency: usize) -> Result<Vec<M>>
+    async fn load_messages<M>(&self, keys: Vec<ResourceKey>, concurrency: usize) -> Result<Vec<M>>
     where
         M: prost::Message + Default + Send + 'static,
     {
@@ -238,14 +242,23 @@ impl TalonOpsServer {
         agent: &str,
         session_id: &str,
     ) -> Result<Vec<events::SessionStepEvent>> {
-        let prefix =
-            keys::recursive_prefix(namespace, &[("Agent", agent), ("Session", session_id)]);
-        let mut keys = self.kv().list_keys(&prefix).await?;
-        keys.sort();
-        let step_keys = keys
-            .into_iter()
-            .filter(|key| key.contains("/@/SessionStep/"))
-            .collect::<Vec<_>>();
+        let message_prefix = keys::session_message_prefix(namespace, agent, session_id);
+        let mut message_keys = self.kv().list_keys(&message_prefix).await?;
+        message_keys.sort();
+        let mut step_keys = Vec::new();
+        for message_key in message_keys {
+            let mut keys = self
+                .kv()
+                .list_keys(&keys::session_message_step_prefix(
+                    namespace,
+                    agent,
+                    session_id,
+                    &message_key.name,
+                ))
+                .await?;
+            step_keys.append(&mut keys);
+        }
+        step_keys.sort();
         self.load_messages::<events::SessionStepEvent>(step_keys, 64)
             .await
     }
@@ -1438,8 +1451,9 @@ mod tests {
     };
     use crate::config::Config;
     use crate::control::{
-        keys, scheduler::NoopSchedulerBackend, ControlPlane, KeyValueStore, MessagePublisher,
-        ProtoKeyValueStoreExt,
+        keys::{self, ResourceKey, ResourceList},
+        scheduler::NoopSchedulerBackend,
+        ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{manifests, models};
     use crate::worker::{
@@ -1463,51 +1477,51 @@ mod tests {
 
     #[derive(Default)]
     struct MockKvStore {
-        entries: Arc<tokio::sync::RwLock<HashMap<String, Vec<u8>>>>,
+        entries: Arc<tokio::sync::RwLock<HashMap<ResourceKey, Vec<u8>>>>,
     }
 
     #[async_trait]
     impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
             Ok(self.entries.read().await.get(key).cloned())
         }
 
-        async fn set(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
+        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
             self.entries
                 .write()
                 .await
-                .insert(key.to_string(), value.to_vec());
+                .insert(key.clone(), value.to_vec());
             Ok(())
         }
 
         async fn compare_and_swap(
             &self,
-            key: &str,
+            key: &ResourceKey,
             expected: Option<&[u8]>,
             value: &[u8],
         ) -> anyhow::Result<bool> {
             let mut entries = self.entries.write().await;
             let current = entries.get(key).cloned();
             if current.as_deref() == expected {
-                entries.insert(key.to_string(), value.to_vec());
+                entries.insert(key.clone(), value.to_vec());
                 Ok(true)
             } else {
                 Ok(false)
             }
         }
 
-        async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
             self.entries.write().await.remove(key);
             Ok(())
         }
 
-        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(self
                 .entries
                 .read()
                 .await
                 .keys()
-                .filter(|key| key.starts_with(prefix))
+                .filter(|key| list.matches(key))
                 .cloned()
                 .collect())
         }

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -61,7 +61,7 @@ function selectionFromSearchParams(searchParams: URLSearchParams): Selection | n
   if (type === 'template' && resourceName) {
     return {
       type: 'template',
-      ns: 'talon-system',
+      ns: 'Sys',
       resourceName,
       fullPath: `template/${resourceName}`,
     };
@@ -70,7 +70,7 @@ function selectionFromSearchParams(searchParams: URLSearchParams): Selection | n
   if (type === 'mcp-server' && resourceName) {
     return {
       type: 'mcp-server',
-      ns: 'talon-system',
+      ns: 'Sys',
       resourceName,
       fullPath: `mcp/${resourceName}`,
     };
@@ -182,8 +182,8 @@ function getSelectionSubtitle(selection: Selection | null) {
   if (selection.type === 'schedule') return `${selection.ns} / Schedule`;
   if (selection.type === 'mcp-binding') return `${selection.ns} / MCP Binding`;
   if (selection.type === 'knowledge') return `${selection.ns} / Knowledge`;
-  if (selection.type === 'template') return 'talon-system / AgentTemplate';
-  return 'talon-system / MCPServer';
+  if (selection.type === 'template') return 'Sys / AgentTemplate';
+  return 'Sys / MCPServer';
 }
 
 function positiveIntParam(searchParams: URLSearchParams, name: string) {

--- a/ui/components/Namespaces/NamespaceExplorer.tsx
+++ b/ui/components/Namespaces/NamespaceExplorer.tsx
@@ -959,7 +959,7 @@ export function NamespaceExplorer({
             : 'No template summary',
       selection: {
         type: 'template' as const,
-        ns: 'talon-system',
+        ns: 'Sys',
         resourceName: template.metadata?.name || '',
         fullPath: `template/${template.metadata?.name || 'unknown-template'}`,
       },
@@ -974,7 +974,7 @@ export function NamespaceExplorer({
       tone: server.spec?.disabled ? 'warning' as const : 'success' as const,
       selection: {
         type: 'mcp-server' as const,
-        ns: 'talon-system',
+        ns: 'Sys',
         resourceName: server.metadata?.name || '',
         fullPath: `mcp/${server.metadata?.name || 'unknown-server'}`,
       },
@@ -1075,7 +1075,7 @@ export function NamespaceExplorer({
       >
         <ResourceList
           items={mcpCards}
-          emptyState="No MCP servers found in talon-system."
+          emptyState="No MCP servers found in Sys."
           selectedId={selectedNode?.fullPath || null}
           onSelect={onSelect}
         />

--- a/ui/proto/proto/models_pb.ts
+++ b/ui/proto/proto/models_pb.ts
@@ -334,7 +334,7 @@ export type Namespace = Message<"talon.models.Namespace"> & {
   name: string;
 
   /**
-   * e.g. "talon-system", "default:subs"
+   * e.g. "Sys", "default:subs"
    *
    * @generated from field: string parent = 2;
    */


### PR DESCRIPTION
## Summary
- replace raw string KV keys with structured `ResourceKey` / `ResourceList` values at the storage boundary
- migrate Postgres and SQLite KV tables to `(namespace, parent_path, kind, name, value)` with direct-child listing by exact column predicates
- preserve canonical string keys only for docs, logs, and legacy migration compatibility
- walk recursive deletes through direct children instead of relying on recursive prefix scans
- add Postgres advisory locking around KV schema migration/startup to avoid gateway/worker races
- update docs/wiki/key-formats.md for the structured storage design

## Verification
- `cargo test --locked`
- `cargo test --locked --no-run`
- `git diff --check`
- `docker compose -p tutorial up --build -d`
- verified tutorial Postgres `talon_kv_store` columns: `namespace`, `parent_path`, `kind`, `name`, `value`
- verified `tutorial-gateway-1` healthy and `tutorial-worker-1` running