### PR TITLE
[codex] Render CLI get output as reusable manifests

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -509,7 +509,117 @@ async fn rest_get_yaml(
             .cloned()
             .with_context(|| format!("REST response missing {}", response_key))?
     };
-    serde_yaml::to_string(&value).with_context(|| format!("Failed to serialize {} YAML", kind))
+    render_rest_get_yaml(response_key, value)
+        .with_context(|| format!("Failed to serialize {} YAML", kind))
+}
+
+fn render_rest_get_yaml(response_key: &str, value: serde_json::Value) -> Result<String> {
+    match response_key {
+        "agent" => render_rest_agent_yaml(value),
+        "namespace" => render_rest_namespace_yaml(value),
+        "server" => {
+            let mut value = value;
+            normalize_manifest_metadata_maps(&mut value);
+            let server: talon::gateway::rpc::manifests::McpServer =
+                serde_json::from_value(value).context("Failed to decode MCPServer JSON")?;
+            talon::manifest::render_mcp_server_yaml(&server)
+        }
+        "binding" => {
+            let mut value = value;
+            normalize_manifest_metadata_maps(&mut value);
+            let binding: talon::gateway::rpc::manifests::McpServerBinding =
+                serde_json::from_value(value).context("Failed to decode McpServerBinding JSON")?;
+            talon::manifest::render_mcp_server_binding_yaml(&binding)
+        }
+        "knowledge" => {
+            let mut value = value;
+            normalize_manifest_metadata_maps(&mut value);
+            let knowledge: talon::gateway::rpc::manifests::Knowledge =
+                serde_json::from_value(value).context("Failed to decode Knowledge JSON")?;
+            talon::manifest::render_knowledge_yaml(&knowledge)
+        }
+        "template" => {
+            let mut value = value;
+            normalize_manifest_metadata_maps(&mut value);
+            let template_json =
+                serde_json::to_string(&value).context("Failed to serialize AgentTemplate JSON")?;
+            let template = talon::manifest::parse_agent_template(&template_json)
+                .context("Failed to decode AgentTemplate manifest")?;
+            talon::manifest::render_agent_template_yaml(&template)
+        }
+        "schedule" => serde_yaml::to_string(&value).context("Failed to serialize Schedule YAML"),
+        other => anyhow::bail!("Unsupported REST response resource '{}'", other),
+    }
+}
+
+fn normalize_manifest_metadata_maps(value: &mut serde_json::Value) {
+    let Some(metadata) = value
+        .get_mut("metadata")
+        .and_then(|metadata| metadata.as_object_mut())
+    else {
+        return;
+    };
+
+    for key in ["labels", "annotations"] {
+        if metadata.get(key).is_some_and(|value| value.is_null()) {
+            metadata.insert(key.to_string(), json!({}));
+        }
+    }
+}
+
+fn render_rest_agent_yaml(agent: serde_json::Value) -> Result<String> {
+    let name = agent
+        .get("name")
+        .or_else(|| agent.get("agent"))
+        .and_then(|name| name.as_str())
+        .context("Agent response missing name")?;
+    let namespace = agent
+        .get("ns")
+        .and_then(|namespace| namespace.as_str())
+        .context("Agent response missing ns")?;
+    let definition = agent
+        .get("definition")
+        .cloned()
+        .context("Agent response missing definition")?;
+    let labels = agent
+        .get("labels")
+        .filter(|labels| !labels.is_null())
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    serde_yaml::to_string(&json!({
+        "apiVersion": "talon.impalasys.com/v1",
+        "kind": "Agent",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": labels,
+        },
+        "definition": definition,
+    }))
+    .context("Failed to serialize Agent YAML")
+}
+
+fn render_rest_namespace_yaml(namespace: serde_json::Value) -> Result<String> {
+    let name = namespace
+        .get("name")
+        .and_then(|name| name.as_str())
+        .context("Namespace response missing name")?;
+    let labels = namespace
+        .get("labels")
+        .filter(|labels| !labels.is_null())
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    serde_yaml::to_string(&json!({
+        "apiVersion": "talon.impalasys.com/v1",
+        "kind": "Namespace",
+        "metadata": {
+            "name": name,
+            "labels": labels,
+        },
+    }))
+    .context("Failed to serialize Namespace YAML")
 }
 
 async fn rest_delete_resource(
@@ -1290,7 +1400,7 @@ async fn grpc_get_yaml(
                 .await
                 .with_context(|| format!("Failed to fetch MCPServer '{}'", name))?;
             let server = resp.into_inner().server.context("Resource not found.")?;
-            serde_yaml::to_string(&server).context("Failed to serialize to YAML")
+            talon::manifest::render_mcp_server_yaml(&server)
         }
         GrpcGetTarget::Knowledge { ns, name } => {
             let resp = client
@@ -1756,11 +1866,12 @@ mod tests {
         grpc_get_yaml, knowledge_delete, knowledge_get, knowledge_list, knowledge_resource_name,
         knowledge_set, manifest_json_payload, parse_raw_manifest, parse_vars,
         read_knowledge_content, relative_knowledge_path, render_json_payload, render_manifest_file,
-        render_manifest_template, resolve_authorization_header, resolve_manifest_sources,
-        rest_apply_manifest, rest_client, rest_delete_path, rest_delete_resource, rest_get_path,
-        rest_get_yaml, rest_request_json, run_cli, schedule_json, sdk_method_for_template,
-        sdk_methods_from_dir, sync_knowledge_dir, to_camel_case, Cli, Commands, GrpcApplyPlan,
-        GrpcDeleteTarget, GrpcGetTarget, KnowledgeCommands, RenderFormat,
+        render_manifest_template, render_rest_get_yaml, resolve_authorization_header,
+        resolve_manifest_sources, rest_apply_manifest, rest_client, rest_delete_path,
+        rest_delete_resource, rest_get_path, rest_get_yaml, rest_request_json, run_cli,
+        schedule_json, sdk_method_for_template, sdk_methods_from_dir, sync_knowledge_dir,
+        to_camel_case, Cli, Commands, GrpcApplyPlan, GrpcDeleteTarget, GrpcGetTarget,
+        KnowledgeCommands, RenderFormat,
     };
     use axum::{
         extract::{Path as AxumPath, State},
@@ -1988,6 +2099,66 @@ mod tests {
         )
         .unwrap();
         assert_eq!(raw.kind, "Namespace");
+    }
+
+    #[test]
+    fn render_rest_get_yaml_canonicalizes_template_and_ignores_null_labels() {
+        let template_yaml = render_rest_get_yaml(
+            "template",
+            json!({
+                "apiVersion": "talon.impalasys.com/v1",
+                "kind": "AgentTemplate",
+                "metadata": {
+                    "name": "writer",
+                    "labels": null,
+                },
+                "definition": {
+                    "customSpec": {
+                        "systemPrompt": "Write"
+                    }
+                }
+            }),
+        )
+        .unwrap();
+        let template =
+            talon::manifest::parse_agent_template(&template_yaml).expect("template should parse");
+        assert_eq!(
+            template.metadata.as_ref().map(|meta| meta.name.as_str()),
+            Some("writer")
+        );
+
+        let agent_yaml = render_rest_get_yaml(
+            "agent",
+            json!({
+                "name": "writer",
+                "ns": "conic",
+                "labels": null,
+                "definition": {
+                    "customSpec": {
+                        "systemPrompt": "Write"
+                    }
+                }
+            }),
+        )
+        .unwrap();
+        assert!(!agent_yaml.contains("labels: null"));
+        let agent = talon::manifest::parse_agent(&agent_yaml).expect("agent should parse");
+        assert_eq!(agent.name, "writer");
+        assert!(agent.labels.is_empty());
+
+        let namespace_yaml = render_rest_get_yaml(
+            "namespace",
+            json!({
+                "name": "conic",
+                "labels": null,
+            }),
+        )
+        .unwrap();
+        assert!(!namespace_yaml.contains("labels: null"));
+        let namespace =
+            talon::manifest::parse_namespace(&namespace_yaml).expect("namespace should parse");
+        assert_eq!(namespace.name, "conic");
+        assert!(namespace.labels.is_empty());
     }
 
     #[test]
@@ -2945,7 +3116,12 @@ mod tests {
         let initial_yaml = grpc_get_yaml(&cli, "agent", "conic/writer", None)
             .await
             .unwrap();
+        assert_eq!(parse_raw_manifest(&initial_yaml).unwrap().kind, "Agent");
+        assert!(initial_yaml.contains("apiVersion: talon.impalasys.com/v1"));
+        assert!(initial_yaml.contains("namespace: conic"));
         assert!(initial_yaml.contains("systemPrompt: First version"));
+        let reapplied = grpc_apply_manifest(&cli, &initial_yaml).await.unwrap();
+        assert!(reapplied.contains("Agent 'conic/writer' applied successfully."));
 
         let updated = grpc_apply_manifest(
             &cli,
@@ -2999,8 +3175,11 @@ mod tests {
         let mcp_yaml = grpc_get_yaml(&cli, "mcp", "docs-server", None)
             .await
             .unwrap();
+        assert_eq!(parse_raw_manifest(&mcp_yaml).unwrap().kind, "McpServer");
         assert!(mcp_yaml.contains("name: docs-server"));
         assert!(mcp_yaml.contains("transport: streamable-http"));
+        let reapplied_mcp = grpc_apply_manifest(&cli, &mcp_yaml).await.unwrap();
+        assert!(reapplied_mcp.contains("MCPServer 'docs-server' applied successfully."));
 
         let deleted_mcp = grpc_delete_resource(&cli, "mcp", "docs-server", None)
             .await
@@ -3180,7 +3359,14 @@ mod tests {
         let created_yaml = rest_get_yaml(&cli, "agent", "conic/writer", None)
             .await
             .unwrap();
+        assert_eq!(parse_raw_manifest(&created_yaml).unwrap().kind, "Agent");
+        assert!(created_yaml.contains("apiVersion: talon.impalasys.com/v1"));
+        assert!(created_yaml.contains("namespace: conic"));
         assert!(created_yaml.contains("systemPrompt: REST create"));
+        let reapplied_agent = rest_apply_manifest(&cli, &created_yaml, true)
+            .await
+            .unwrap();
+        assert!(reapplied_agent.contains("Agent 'conic/writer' applied successfully."));
 
         let updated_agent = rest_apply_manifest(
             &cli,
@@ -3357,6 +3543,10 @@ mod tests {
         let namespace_yaml = rest_get_yaml(&cli, "namespace", "conic", None)
             .await
             .unwrap();
+        assert_eq!(
+            parse_raw_manifest(&namespace_yaml).unwrap().kind,
+            "Namespace"
+        );
         assert!(namespace_yaml.contains("name: conic"));
         let namespace_deleted = rest_delete_resource(&cli, "namespace", "conic", None)
             .await
@@ -3392,6 +3582,10 @@ mod tests {
         let binding_yaml = rest_get_yaml(&cli, "mcpbinding", "docs", Some(&namespace))
             .await
             .unwrap();
+        assert_eq!(
+            parse_raw_manifest(&binding_yaml).unwrap().kind,
+            "McpServerBinding"
+        );
         assert!(binding_yaml.contains("name: docs"));
         let binding_deleted = rest_delete_resource(&cli, "mcpbinding", "docs", Some(&namespace))
             .await
@@ -3409,6 +3603,7 @@ mod tests {
         let server_yaml = rest_get_yaml(&cli, "mcp", "docs-server", None)
             .await
             .unwrap();
+        assert_eq!(parse_raw_manifest(&server_yaml).unwrap().kind, "McpServer");
         assert!(server_yaml.contains("transport: streamable-http"));
         let server_deleted = rest_delete_resource(&cli, "mcp", "docs-server", None)
             .await

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -390,21 +390,75 @@ pub fn render_agent_yaml(agent: &models::Agent) -> Result<String> {
         .definition
         .as_ref()
         .ok_or_else(|| anyhow!("Agent missing definition"))?;
-    let effective_spec = agent
-        .effective_spec
-        .as_ref()
-        .ok_or_else(|| anyhow!("Agent missing effective_spec"))?;
 
-    let yaml_agent = AgentYaml {
-        name: &agent.name,
-        ns: &agent.ns,
-        definition: AgentDefinitionYaml::from_proto(definition)?,
-        effective_spec: AgentSpecManifest::from_proto(effective_spec),
-        template_deps: &agent.template_deps,
-        labels: &agent.labels,
+    let yaml_agent = AgentManifest {
+        api_version: "talon.impalasys.com/v1".to_string(),
+        kind: "Agent".to_string(),
+        metadata: ObjectMetaManifest {
+            name: agent.name.clone(),
+            namespace: agent.ns.clone(),
+            labels: agent.labels.clone(),
+            annotations: HashMap::new(),
+        },
+        definition: AgentDefinitionManifest::from_proto(definition)?,
     };
 
     serde_yaml::to_string(&yaml_agent).context("Failed to serialize Agent to YAML")
+}
+
+pub fn render_mcp_server_yaml(server: &manifests::McpServer) -> Result<String> {
+    let metadata = server
+        .metadata
+        .as_ref()
+        .ok_or_else(|| anyhow!("MCPServer missing metadata"))?;
+    let spec = server
+        .spec
+        .as_ref()
+        .ok_or_else(|| anyhow!("MCPServer missing spec"))?;
+
+    let yaml_server = McpServerManifest {
+        api_version: server.api_version.clone(),
+        kind: server.kind.clone(),
+        metadata: ObjectMetaManifest::from_proto(metadata),
+        spec: McpServerSpecManifest::from_proto(spec),
+    };
+
+    serde_yaml::to_string(&yaml_server).context("Failed to serialize MCPServer to YAML")
+}
+
+pub fn render_mcp_server_binding_yaml(binding: &manifests::McpServerBinding) -> Result<String> {
+    let metadata = binding
+        .metadata
+        .as_ref()
+        .ok_or_else(|| anyhow!("McpServerBinding missing metadata"))?;
+    let spec = binding
+        .spec
+        .as_ref()
+        .ok_or_else(|| anyhow!("McpServerBinding missing spec"))?;
+
+    let yaml_binding = McpServerBindingManifest {
+        api_version: binding.api_version.clone(),
+        kind: binding.kind.clone(),
+        metadata: ObjectMetaManifest::from_proto(metadata),
+        spec: McpServerBindingSpecManifest::from_proto(spec),
+    };
+
+    serde_yaml::to_string(&yaml_binding).context("Failed to serialize McpServerBinding to YAML")
+}
+
+pub fn render_namespace_yaml(namespace: &models::Namespace) -> Result<String> {
+    let yaml_namespace = NamespaceManifest {
+        api_version: "talon.impalasys.com/v1".to_string(),
+        kind: "Namespace".to_string(),
+        metadata: ObjectMetaManifest {
+            name: namespace.name.clone(),
+            namespace: String::new(),
+            labels: namespace.labels.clone(),
+            annotations: HashMap::new(),
+        },
+    };
+
+    serde_yaml::to_string(&yaml_namespace).context("Failed to serialize Namespace to YAML")
 }
 
 pub fn render_agent_json(agent: &models::Agent) -> Result<serde_json::Value> {
@@ -490,6 +544,37 @@ impl McpServerBindingSpecManifest {
                 audience: spec.audience,
             }),
             allowed_tool_names: self.allowed_tool_names,
+        }
+    }
+
+    fn from_proto(spec: &manifests::McpServerBindingSpec) -> Self {
+        Self {
+            server_ref: spec.server_ref.clone(),
+            args: spec.args.clone(),
+            headers: spec.headers.clone(),
+            disabled: spec.disabled,
+            auth_broker: spec
+                .auth_broker
+                .as_ref()
+                .map(|broker| McpAuthBrokerSpecManifest {
+                    kind: broker.kind.clone(),
+                    url: broker.url.clone(),
+                    cache_ttl_seconds: broker.cache_ttl_seconds,
+                    audience: broker.audience.clone(),
+                }),
+            allowed_tool_names: spec.allowed_tool_names.clone(),
+        }
+    }
+}
+
+impl McpServerSpecManifest {
+    fn from_proto(spec: &manifests::McpServerSpec) -> Self {
+        Self {
+            transport: spec.transport.clone(),
+            target: spec.target.clone(),
+            args: spec.args.clone(),
+            headers: spec.headers.clone(),
+            disabled: spec.disabled,
         }
     }
 }
@@ -1186,7 +1271,7 @@ spec:
     }
 
     #[test]
-    fn render_agent_yaml_and_json_include_definition_and_effective_spec() {
+    fn render_agent_yaml_round_trips_manifest_and_json_includes_runtime_fields() {
         let agent = models::Agent {
             name: "ctl".to_string(),
             ns: "conic".to_string(),
@@ -1249,11 +1334,18 @@ spec:
 
         let yaml = render_agent_yaml(&agent).expect("agent yaml should render");
         let json = render_agent_json(&agent).expect("agent json should render");
+        let reparsed = parse_agent(&yaml).expect("rendered agent manifest should parse");
 
+        assert!(yaml.contains("apiVersion: talon.impalasys.com/v1"));
+        assert!(yaml.contains("kind: Agent"));
+        assert!(yaml.contains("namespace: conic"));
         assert!(yaml.contains("templateName: assistant"));
-        assert!(yaml.contains("systemPrompt: test"));
+        assert!(yaml.contains("append: ' extra'"));
+        assert_eq!(reparsed.name, "ctl");
+        assert_eq!(reparsed.ns, "conic");
         assert_eq!(json["name"], "ctl");
         assert_eq!(json["ns"], "conic");
+        assert_eq!(json["effectiveSpec"]["systemPrompt"], "test");
         assert_eq!(json["templateDeps"][0], "assistant");
         assert_eq!(json["labels"]["visibility"], "internal");
     }


### PR DESCRIPTION
## What changed

- Render `talon-cli get agent ...` as canonical `Agent` manifests with `apiVersion`, `kind`, `metadata`, and `definition` instead of the runtime `Agent` model shape.
- Normalize REST `get` output for apply-supported resources so gateway-backed reads produce reusable manifest YAML.
- Render MCP server and binding resources through manifest helpers instead of raw response serialization.
- Add round-trip coverage proving CLI `get` output can be fed back into `apply` for agents and MCP servers across gRPC and REST paths.

## Root cause

The gRPC agent renderer serialized the persisted runtime model (`name`, `ns`, `effectiveSpec`, `templateDeps`, etc.), while `apply` only accepts the manifest shape (`apiVersion`, `kind`, `metadata`, `definition`). REST `get` had the same class of problem because it dumped gateway response JSON directly.

## Validation

- `cargo test manifest::tests`
- `cargo test --bin talon-cli`
- `cargo test`

I did not spin up the full Docker Compose stack; the failing behavior is covered directly by the CLI and manifest round-trip tests.