### PR TITLE
[codex] Add Talon chat Storybook previews

### DIFF
--- a/.github/workflows/talon-chat-chromatic.yml
+++ b/.github/workflows/talon-chat-chromatic.yml
@@ -1,0 +1,56 @@
+name: Talon Chat Chromatic
+
+on:
+  pull_request:
+    paths:
+      - "packages/talon-chat/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/talon-chat-chromatic.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/talon-chat/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/talon-chat-chromatic.yml"
+
+concurrency:
+  group: talon-chat-chromatic-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chromatic:
+    name: Publish Storybook
+    runs-on: ubuntu-latest
+    env:
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.17.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Skip Chromatic without project token
+        if: env.CHROMATIC_PROJECT_TOKEN == ''
+        run: echo "CHROMATIC_PROJECT_TOKEN is not configured; skipping Chromatic."
+
+      - name: Run Chromatic
+        if: env.CHROMATIC_PROJECT_TOKEN != ''
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ env.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/talon-chat

--- a/.github/workflows/talon-chat-screenshots.yml
+++ b/.github/workflows/talon-chat-screenshots.yml
@@ -1,0 +1,102 @@
+name: Talon Chat Screenshots
+
+on:
+  pull_request:
+    paths:
+      - "packages/talon-chat/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/talon-chat-screenshots.yml"
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: talon-chat-screenshots-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    name: Capture Storybook Screenshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.17.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @impalasys/talon-chat exec playwright install --with-deps chromium
+
+      - name: Build Storybook
+        run: pnpm --filter @impalasys/talon-chat build-storybook
+
+      - name: Capture screenshots
+        run: pnpm --filter @impalasys/talon-chat screenshots
+
+      - name: Upload screenshots
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: talon-chat-storybook-screenshots
+          path: packages/talon-chat/storybook-screenshots/*.png
+          if-no-files-found: error
+
+      - name: Comment artifact link
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = "<!-- talon-chat-screenshots -->";
+            const artifactUrl = "${{ steps.upload.outputs.artifact-url }}";
+            const body = [
+              marker,
+              "## Talon Chat screenshots",
+              "",
+              "Storybook screenshots were captured for this PR.",
+              "",
+              `[Download the screenshot artifact](${artifactUrl})`,
+              "",
+              "The artifact includes light and dark captures for TalonSession and TalonChannel component stories.",
+            ].join("\n");
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 bench/results*/
 node_modules/
 packages/*/dist/
+packages/*/storybook-static/
 sdk/js/*/dist/
 sdk/examples/js/dist/
 sdk/java/.gradle/
@@ -23,3 +24,7 @@ ui/node_modules/
 ui/playwright-report/
 ui/test-results/
 ui/tsconfig.tsbuildinfo
+build-storybook.log
+chromatic.log
+chromatic-build-*.xml
+chromatic-diagnostics.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bench/results*/
 node_modules/
 packages/*/dist/
 packages/*/storybook-static/
+packages/*/storybook-screenshots/
 sdk/js/*/dist/
 sdk/examples/js/dist/
 sdk/java/.gradle/

--- a/packages/talon-chat/.storybook/main.ts
+++ b/packages/talon-chat/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.@(ts|tsx)"],
+  addons: ["@storybook/addon-docs"],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+  docs: {
+    autodocs: "tag",
+  },
+};
+
+export default config;

--- a/packages/talon-chat/.storybook/preview.tsx
+++ b/packages/talon-chat/.storybook/preview.tsx
@@ -1,0 +1,76 @@
+import type React from "react";
+import type { Preview } from "@storybook/react-vite";
+
+const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: "Preview theme",
+      defaultValue: "light",
+      toolbar: {
+        icon: "mirror",
+        items: [
+          { value: "light", title: "Light" },
+          { value: "dark", title: "Dark" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const isDark = context.globals.theme === "dark";
+      const themeStyle = {
+        height: "100vh",
+        overflow: "hidden",
+        background: isDark ? "#09090b" : "#fafafa",
+        color: isDark ? "#fafafa" : "#18181b",
+        colorScheme: isDark ? "dark" : "light",
+        "--background": isDark ? "#09090b" : "#ffffff",
+        "--foreground": isDark ? "#fafafa" : "#18181b",
+        "--talon-chat-surface": isDark ? "#18181b" : "#ffffff",
+        "--talon-chat-border": isDark ? "rgba(212,212,216,0.24)" : "rgba(212,212,216,0.7)",
+        "--talon-chat-muted-fg": isDark ? "rgba(212,212,216,0.68)" : "rgba(82,82,91,0.88)",
+        "--talon-chat-subtle-fg": isDark ? "rgba(161,161,170,0.78)" : "rgba(113,113,122,0.9)",
+        "--talon-chat-divider": isDark ? "rgba(212,212,216,0.14)" : "rgba(212,212,216,0.7)",
+        "--talon-chat-code-bg": isDark ? "rgba(255,255,255,0.06)" : "rgba(24,24,27,0.05)",
+        "--talon-chat-user-bubble-bg": isDark ? "rgba(255,255,255,0.09)" : "rgba(24,24,27,0.07)",
+        "--talon-chat-composer-bg": isDark
+          ? "linear-gradient(to top, rgba(24,24,27,0.96), rgba(24,24,27,0.78) 58%, rgba(24,24,27,0))"
+          : "linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0))",
+        "--talon-chat-scrollbar-thumb": isDark ? "rgba(212,212,216,0.38)" : "rgba(113,113,122,0.52)",
+        "--talon-chat-avatar-bg": isDark ? "#fafafa" : "#18181b",
+        "--talon-chat-avatar-fg": isDark ? "#18181b" : "#ffffff",
+        "--copilot-input-bg": isDark ? "rgba(39,39,42,0.94)" : "rgba(255,255,255,0.96)",
+        "--copilot-input-border": isDark ? "rgba(212,212,216,0.22)" : "rgba(212,212,216,0.72)",
+        "--copilot-input-placeholder": isDark ? "rgba(212,212,216,0.56)" : "rgba(82,82,91,0.64)",
+        "--copilot-input-shadow": isDark ? "0 4px 18px rgba(0,0,0,0.34), 0 1px 2px rgba(0,0,0,0.28)" : "0 2px 8px rgba(24,24,27,0.06), 0 1px 2px rgba(24,24,27,0.08)",
+        "--copilot-channel-input-bg": isDark ? "rgba(39,39,42,0.88)" : "rgba(255,255,255,0.72)",
+        "--copilot-channel-message-bg": isDark ? "rgba(39,39,42,0.82)" : "rgba(255,255,255,0.72)",
+      } as React.CSSProperties;
+
+      return (
+        <div style={themeStyle}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  parameters: {
+    backgrounds: {
+      default: "light",
+      values: [
+        { name: "light", value: "#fafafa" },
+        { name: "dark", value: "#09090b" },
+      ],
+    },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    layout: "fullscreen",
+  },
+};
+
+export default preview;

--- a/packages/talon-chat/README.md
+++ b/packages/talon-chat/README.md
@@ -13,11 +13,11 @@ pnpm add @impalasys/talon-chat
 ## Usage
 
 ```tsx
-import { TalonCopilot } from "@impalasys/talon-chat";
+import { TalonSession } from "@impalasys/talon-chat";
 
 export function App() {
   return (
-    <TalonCopilot
+    <TalonSession
       namespace="support"
       agent="docs"
       gatewayUrl="http://localhost:18789"
@@ -30,7 +30,7 @@ export function App() {
 You can also inject a gateway client for session CRUD:
 
 ```tsx
-<TalonCopilot
+<TalonSession
   namespace="support"
   agent="docs"
   gatewayUrl="http://localhost:18789"
@@ -39,6 +39,8 @@ You can also inject a gateway client for session CRUD:
   onSessionChange={(nextSessionId) => setSessionId(nextSessionId)}
 />
 ```
+
+`TalonCopilot` is still exported as an alias for existing integrations.
 
 Channels can be rendered with the same package:
 
@@ -69,3 +71,25 @@ talon-cli --jwt-secret "$GATEWAY_JWT_SECRET" auth channel-token \
 ```
 
 The token is scoped to channel message APIs for that namespace/channel only.
+
+## Storybook and Chromatic
+
+Run the component preview locally:
+
+```bash
+pnpm --filter @impalasys/talon-chat storybook
+```
+
+Build the static Storybook:
+
+```bash
+pnpm --filter @impalasys/talon-chat build-storybook
+```
+
+Publish visual snapshots to Chromatic:
+
+```bash
+CHROMATIC_PROJECT_TOKEN=chpt_... pnpm --filter @impalasys/talon-chat chromatic
+```
+
+GitHub Actions also publishes Chromatic builds for `packages/talon-chat` changes. Configure the repository secret `CHROMATIC_PROJECT_TOKEN` before enabling that check.

--- a/packages/talon-chat/chromatic.config.json
+++ b/packages/talon-chat/chromatic.config.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.chromatic.com/config-file.schema.json",
+  "buildScriptName": "build-storybook",
+  "storybookBaseDir": "packages/talon-chat",
+  "onlyChanged": true,
+  "exitZeroOnChanges": true
+}

--- a/packages/talon-chat/package.json
+++ b/packages/talon-chat/package.json
@@ -37,6 +37,7 @@
     "chromatic": "chromatic --config-file chromatic.config.json",
     "clean": "rm -rf dist",
     "prepack": "pnpm run build",
+    "screenshots": "node scripts/capture-storybook-screenshots.mjs",
     "storybook": "storybook dev -p 6006"
   },
   "publishConfig": {
@@ -51,6 +52,7 @@
     "streamdown": "^2.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-docs": "^10.4.2",
     "@storybook/react-vite": "^10.4.2",
     "@types/react": "^19.2.2",

--- a/packages/talon-chat/package.json
+++ b/packages/talon-chat/package.json
@@ -33,8 +33,11 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts",
+    "build-storybook": "storybook build",
+    "chromatic": "chromatic --config-file chromatic.config.json",
     "clean": "rm -rf dist",
-    "prepack": "pnpm run build"
+    "prepack": "pnpm run build",
+    "storybook": "storybook dev -p 6006"
   },
   "publishConfig": {
     "access": "public"
@@ -48,9 +51,14 @@
     "streamdown": "^2.5.0"
   },
   "devDependencies": {
+    "@storybook/addon-docs": "^10.4.2",
+    "@storybook/react-vite": "^10.4.2",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
+    "chromatic": "^17.2.0",
+    "storybook": "^10.4.2",
     "tsup": "^8.5.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }

--- a/packages/talon-chat/scripts/capture-storybook-screenshots.mjs
+++ b/packages/talon-chat/scripts/capture-storybook-screenshots.mjs
@@ -1,0 +1,125 @@
+import { createServer } from "node:http";
+import { mkdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const storybookDir = path.join(packageDir, "storybook-static");
+const outputDir = path.join(packageDir, "storybook-screenshots");
+
+const stories = [
+  {
+    id: "talon-chat-talonsession--existing-session",
+    name: "talon-session-existing",
+    waitForText: "Worked for 11s",
+  },
+  {
+    id: "talon-chat-talonsession--streaming-response",
+    name: "talon-session-streaming-working",
+    waitForText: "Working for",
+  },
+  {
+    id: "talon-chat-talonsession--disabled",
+    name: "talon-session-disabled",
+    waitForText: "Launch update",
+  },
+  {
+    id: "talon-chat-talonchannel--open-channel",
+    name: "talon-channel-open",
+    waitForText: "Rollback guardrail",
+  },
+  {
+    id: "talon-chat-talonchannel--read-only",
+    name: "talon-channel-read-only",
+    waitForText: "Rollback guardrail",
+  },
+];
+
+const themes = ["light", "dark"];
+
+function contentTypeFor(filePath) {
+  if (filePath.endsWith(".html")) return "text/html; charset=utf-8";
+  if (filePath.endsWith(".js")) return "text/javascript; charset=utf-8";
+  if (filePath.endsWith(".css")) return "text/css; charset=utf-8";
+  if (filePath.endsWith(".svg")) return "image/svg+xml";
+  if (filePath.endsWith(".png")) return "image/png";
+  if (filePath.endsWith(".json")) return "application/json; charset=utf-8";
+  if (filePath.endsWith(".woff2")) return "font/woff2";
+  return "application/octet-stream";
+}
+
+async function createStaticServer(rootDir) {
+  const server = createServer(async (request, response) => {
+    try {
+      const requestUrl = new URL(request.url || "/", "http://127.0.0.1");
+      const decodedPath = decodeURIComponent(requestUrl.pathname);
+      const normalizedPath = path.normalize(decodedPath).replace(/^(\.\.[/\\])+/, "");
+      const filePath = path.join(rootDir, normalizedPath === "/" ? "index.html" : normalizedPath);
+      const resolvedPath = path.resolve(filePath);
+
+      if (!resolvedPath.startsWith(rootDir)) {
+        response.writeHead(403);
+        response.end("Forbidden");
+        return;
+      }
+
+      const fileStat = await stat(resolvedPath);
+      const finalPath = fileStat.isDirectory() ? path.join(resolvedPath, "index.html") : resolvedPath;
+      const body = await readFile(finalPath);
+      response.writeHead(200, { "Content-Type": contentTypeFor(finalPath) });
+      response.end(body);
+    } catch {
+      response.writeHead(404);
+      response.end("Not found");
+    }
+  });
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to start Storybook static server.");
+  }
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))),
+  };
+}
+
+async function main() {
+  await stat(storybookDir);
+  await mkdir(outputDir, { recursive: true });
+
+  const server = await createStaticServer(storybookDir);
+  const browser = await chromium.launch();
+
+  try {
+    const page = await browser.newPage({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 1 });
+
+    for (const theme of themes) {
+      for (const story of stories) {
+        const url = `${server.origin}/iframe.html?id=${story.id}&viewMode=story&globals=theme:${theme}`;
+        await page.goto(url, { waitUntil: "domcontentloaded" });
+        await page.getByText(story.waitForText).first().waitFor({ state: "visible", timeout: 10_000 });
+        await page.screenshot({
+          path: path.join(outputDir, `${story.name}-${theme}.png`),
+          fullPage: false,
+        });
+      }
+    }
+  } finally {
+    await browser.close();
+    await server.close();
+  }
+
+  console.log(`Captured ${stories.length * themes.length} Storybook screenshots in ${outputDir}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/talon-chat/src/TalonChannel.stories.tsx
+++ b/packages/talon-chat/src/TalonChannel.stories.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TalonChannel, type TalonChannelProps } from "./TalonChannel";
+
+const channelMessages = [
+  {
+    id: "018f4b50-8cc0-7000-8000-000000000101",
+    authorKind: "agent",
+    author: "triage",
+    content: "I found a spike in failed ingestion jobs starting at 09:08.",
+    createdAt: "2026-06-05T16:08:15.000Z",
+    sourceAgent: "triage",
+    sourceSessionId: "session-101",
+  },
+  {
+    id: "018f4b50-a234-7000-8000-000000000102",
+    authorKind: "user",
+    author: "sightline",
+    content: "Can you verify whether the rollback guardrail fired?",
+    createdAt: "2026-06-05T16:09:22.000Z",
+  },
+  {
+    id: "018f4b52-4444-7000-8000-000000000103",
+    authorKind: "agent",
+    author: "release-watch",
+    content: "Rollback guardrail fired successfully. Queue depth is back under the alert threshold.",
+    createdAt: "2026-06-05T16:12:45.000Z",
+    sourceAgent: "release-watch",
+    sourceSessionId: "session-202",
+  },
+];
+
+const originalFetch = globalThis.fetch;
+
+const mockedFetch: typeof fetch = async (_input, init) => {
+  if (init?.method === "POST") {
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response(JSON.stringify({ messages: channelMessages, hasMore: false }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+function MockChannelGateway({ children }: { children: React.ReactNode }) {
+  globalThis.fetch = mockedFetch;
+
+  useEffect(() => {
+    return () => {
+      globalThis.fetch = originalFetch;
+    };
+  }, []);
+
+  return children;
+}
+
+const meta = {
+  title: "Talon Chat/TalonChannel",
+  component: TalonChannel,
+  decorators: [
+    (Story) => (
+      <MockChannelGateway>
+        <Story />
+      </MockChannelGateway>
+    ),
+  ],
+  tags: ["autodocs"],
+  args: {
+    namespace: "support",
+    channel: { name: "incident-room", status: "open" },
+    gatewayUrl: "http://localhost:18789",
+    refreshIntervalMs: false,
+    formatTimestamp: () => "Jun 5, 2026, 9:12 AM",
+  },
+  render: (args) => (
+    <div style={{ height: "100%", padding: 24, overflow: "hidden" }}>
+      <div style={{ height: "min(560px, calc(100vh - 48px))", maxWidth: 480, margin: "0 auto", border: "1px solid var(--talon-chat-border, rgba(148,163,184,0.32))", background: "var(--talon-chat-surface, #fff)" }}>
+        <TalonChannel {...args} />
+      </div>
+    </div>
+  ),
+} satisfies Meta<TalonChannelProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OpenChannel: Story = {};
+
+export const ReadOnly: Story = {
+  args: {
+    disableUserInput: true,
+  },
+};

--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -512,6 +512,15 @@ export function TalonChannel({
   }, []);
 
   const canPost = Boolean(draft.trim()) && !isPosting && !isUserInputDisabled;
+  const inputRows = useMemo(() => {
+    let rowCount = 1;
+    for (let index = 0; index < draft.length; index += 1) {
+      if (draft.charCodeAt(index) === 10) {
+        rowCount += 1;
+      }
+    }
+    return Math.min(rowCount, 8);
+  }, [draft]);
 
   useEffect(() => {
     isNearBottomRef.current = true;
@@ -627,7 +636,7 @@ export function TalonChannel({
               onValueChange={setDraft}
               onSubmit={(content) => void submitChannelMessage(content)}
               placeholder={`Message #${channelName}`}
-              rows={1}
+              rows={inputRows}
               disabled={isUserInputDisabled}
               canSubmit={canPost}
               textareaMinHeight={40}

--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Hash, Send } from "lucide-react";
+import { Hash } from "lucide-react";
 import { buildGatewayHeaders, normalizeGatewayUrl } from "./lib/grpc";
+import { ChatInputBox } from "./lib/ChatInputBox";
 import { MarkdownMessage } from "./lib/MarkdownMessage";
 
 function border(color: string) {
   return `1px solid ${color}`;
 }
 
-const activeControlBackground = "var(--copilot-control-bg, var(--foreground, #020617))";
-const activeControlColor = "var(--copilot-control-fg, var(--background, #ffffff))";
+const talonChatFontFamily =
+  'var(--talon-chat-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)';
+
 const CHANNEL_SCROLL_LOAD_THRESHOLD_PX = 64;
 const CHANNEL_SCROLL_BOTTOM_THRESHOLD_PX = 96;
 
@@ -545,9 +547,8 @@ export function TalonChannel({
     });
   }, [hasMoreMessages, isLoadingOlderMessages, loadOlderMessages]);
 
-  const handleSubmit = useCallback(async (event: React.FormEvent) => {
-    event.preventDefault();
-    const content = draft.trim();
+  const submitChannelMessage = useCallback(async (submittedContent: string) => {
+    const content = submittedContent.trim();
     if (!content || isPostingRef.current || isUserInputDisabled) return;
     isPostingRef.current = true;
     setIsPosting(true);
@@ -560,7 +561,7 @@ export function TalonChannel({
       isPostingRef.current = false;
       setIsPosting(false);
     }
-  }, [author, authorKind, draft, isUserInputDisabled, postMessage]);
+  }, [author, authorKind, isUserInputDisabled, postMessage]);
 
   return (
     <div
@@ -574,6 +575,7 @@ export function TalonChannel({
         overflow: "hidden",
         background: "transparent",
         color: "inherit",
+        fontFamily: talonChatFontFamily,
         ...style,
       }}
     >
@@ -619,57 +621,19 @@ export function TalonChannel({
         </div>
 
         {disableUserInput ? null : (
-          <form onSubmit={handleSubmit} style={{ display: "flex", alignItems: "flex-end", gap: 8, borderTop: border("rgba(148,163,184,0.2)"), background: "var(--copilot-channel-input-bg, rgba(255,255,255,0.72))", padding: "0.75rem" }}>
-            <textarea
+          <div style={{ borderTop: border("rgba(148,163,184,0.2)"), background: "var(--copilot-channel-input-bg, rgba(255,255,255,0.72))", padding: "0.75rem" }}>
+            <ChatInputBox
               value={draft}
-              onChange={(event) => setDraft(event.target.value)}
+              onValueChange={setDraft}
+              onSubmit={(content) => void submitChannelMessage(content)}
               placeholder={`Message #${channelName}`}
               rows={1}
               disabled={isUserInputDisabled}
-              style={{
-                flex: 1,
-                minHeight: 40,
-                maxHeight: 128,
-                resize: "none",
-                borderRadius: 10,
-                border: border("rgba(148,163,184,0.28)"),
-                background: "rgba(255,255,255,0.9)",
-                padding: "0.55rem 0.7rem",
-                fontSize: 14,
-                color: "inherit",
-                outline: "none",
-              }}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" && !event.shiftKey) {
-                  event.preventDefault();
-                  if (canPost) {
-                    event.currentTarget.form?.requestSubmit();
-                  }
-                }
-              }}
+              canSubmit={canPost}
+              textareaMinHeight={40}
+              textareaMaxHeight={128}
             />
-            <button
-              type="submit"
-              disabled={!canPost}
-              aria-label="Send channel message"
-              style={{
-                width: 40,
-                height: 40,
-                flexShrink: 0,
-                borderRadius: 12,
-                border: "none",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                cursor: canPost ? "pointer" : "not-allowed",
-                opacity: canPost ? 1 : 0.5,
-                background: activeControlBackground,
-                color: activeControlColor,
-              }}
-            >
-              <Send size="16" strokeWidth={2} />
-            </button>
-          </form>
+          </div>
         )}
       </div>
     </div>

--- a/packages/talon-chat/src/TalonSession.stories.tsx
+++ b/packages/talon-chat/src/TalonSession.stories.tsx
@@ -1,0 +1,280 @@
+import React, { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TalonSession, type GatewayClientLike, type TalonSessionProps } from "./TalonSession";
+
+const fixedMessages = [
+  {
+    id: "018f4b50-8cc0-7000-8000-000000000001",
+    role: "ROLE_USER",
+    parts: [{ type: "text", text: "Summarize the latest incident notes and identify the next owner." }],
+    createdAt: "2026-06-05T16:15:00.000Z",
+  },
+  {
+    id: "018f4b50-a234-7000-8000-000000000002",
+    role: "ROLE_ASSISTANT",
+    parts: [
+      {
+        type: "reasoning",
+        text: "I need to inspect the latest incident notes, identify the active mitigation owner, and separate rollback validation from release readiness.",
+      },
+      {
+        type: "tool-getIncidentId",
+        toolCallId: "get-incident-id",
+        toolName: "getIncidentId",
+        input: {
+          alias: "latest",
+        },
+        state: "output-available",
+        output: {
+          id: "inc-7429"
+        },
+      },
+      {
+        type: "tool-searchIncidentNotes",
+        toolCallId: "call-incident-notes",
+        toolName: "searchIncidentNotes",
+        input: {
+          incidentId: "inc-7429",
+          limit: 3,
+        },
+        state: "output-available",
+        output: {
+          latestNoteId: "note-18",
+          summary: "Deployment alert is scoped to ingestion; rollback validation assigned to Mia; Ravi is monitoring queue drain.",
+        },
+      },
+      {
+        type: "text",
+        text: "The deployment alert is isolated to the ingestion worker. Mia owns rollback validation, and Ravi is checking the queue drain rate before the next release window.",
+      },
+      {
+        type: "SESSION_MESSAGE_PART_TYPE_USAGE",
+        payloadJson: JSON.stringify({
+          input_tokens: 842,
+          output_tokens: 42,
+          reasoning_tokens: 96,
+          total_tokens: 980,
+        }),
+      },
+    ],
+    createdAt: "2026-06-05T16:15:11.000Z",
+  },
+  {
+    id: "018f4b52-4444-7000-8000-000000000003",
+    role: "ROLE_USER",
+    parts: [{ type: "text", text: "Draft a concise update for the launch channel." }],
+    createdAt: "2026-06-05T16:16:05.000Z",
+  },
+  {
+    id: "018f4b52-9000-7000-8000-000000000004",
+    role: "ROLE_ASSISTANT",
+    parts: [
+      {
+        type: "text",
+        text: "Launch update: ingestion is healthy after the rollback guardrail, queue depth is trending down, and the team will hold the next release until validation completes.",
+      },
+    ],
+    createdAt: "2026-06-05T16:16:18.000Z",
+  },
+];
+
+const gatewayClient: GatewayClientLike = {
+  createSession: async () => ({ sessionId: "storybook-session" }),
+  listSessionMessages: async () => ({
+    messages: fixedMessages,
+    hasMore: false,
+    state: "IDLE",
+  }),
+};
+
+const streamingPrompt = "Summarize the latest incident notes and identify the next owner.";
+const streamingAssistantMessage = fixedMessages[1];
+const originalFetch = globalThis.fetch;
+
+function uiStreamLine(code: string, value: unknown) {
+  return `${code}:${JSON.stringify(value)}\n`;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createStreamingResponse(signal?: AbortSignal | null) {
+  const encoder = new TextEncoder();
+  const parts = Array.isArray(streamingAssistantMessage.parts) ? streamingAssistantMessage.parts : [];
+  const reasoningPart = parts.find((part: any) => part?.type === "reasoning") as any;
+  const toolParts = parts.filter((part: any) => typeof part?.type === "string" && part.type.startsWith("tool-")) as any[];
+  const textPart = parts.find((part: any) => part?.type === "text") as any;
+  const usagePart = parts.find((part: any) => part?.type === "SESSION_MESSAGE_PART_TYPE_USAGE") as any;
+  const text = typeof textPart?.text === "string" ? textPart.text : "";
+  const textChunks = [
+    text.slice(0, 54),
+    text.slice(54, 128),
+    text.slice(128),
+  ].filter(Boolean);
+  const reasoningText = typeof reasoningPart?.text === "string" ? reasoningPart.text : "";
+  const reasoningChunks = [
+    reasoningText.slice(0, 70),
+    reasoningText.slice(70),
+  ].filter(Boolean);
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const enqueue = async (line: string, wait = 360) => {
+        if (signal?.aborted) {
+          controller.close();
+          return false;
+        }
+        await delay(wait);
+        if (signal?.aborted) {
+          controller.close();
+          return false;
+        }
+        controller.enqueue(encoder.encode(line));
+        return true;
+      };
+
+      if (!(await enqueue(uiStreamLine("f", { messageId: streamingAssistantMessage.id }), 180))) return;
+      for (const chunk of reasoningChunks) {
+        if (!(await enqueue(uiStreamLine("g", chunk)))) return;
+      }
+      for (const toolPart of toolParts) {
+        if (!(await enqueue(uiStreamLine("9", {
+          toolCallId: toolPart.toolCallId,
+          toolName: toolPart.toolName,
+          args: toolPart.input,
+        })))) return;
+        if (!(await enqueue(uiStreamLine("a", {
+          toolCallId: toolPart.toolCallId,
+          result: toolPart.output,
+        })))) return;
+      }
+      for (const chunk of textChunks) {
+        if (!(await enqueue(uiStreamLine("0", chunk)))) return;
+      }
+      if (usagePart?.payloadJson) {
+        await enqueue(uiStreamLine("h", JSON.parse(usagePart.payloadJson)), 220);
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}
+
+function createStreamingGatewayClient() {
+  let submitted = false;
+  return {
+    createSession: async () => ({ sessionId: "storybook-streaming-session" }),
+    listSessionMessages: async () => ({
+      messages: submitted ? fixedMessages : [],
+      hasMore: false,
+      state: submitted ? "IDLE" : "RUNNING",
+    }),
+    markSubmitted: () => {
+      submitted = true;
+    },
+  };
+}
+
+function MockStreamingGateway({ children, gateway }: { children: React.ReactNode; gateway: ReturnType<typeof createStreamingGatewayClient> }) {
+  globalThis.fetch = async (_input, init) => {
+    if (init?.method === "DELETE") {
+      return new Response(null, { status: 204 });
+    }
+    if (init?.method === "POST") {
+      gateway.markSubmitted();
+      return createStreamingResponse(init?.signal);
+    }
+    return originalFetch(_input, init);
+  };
+
+  useEffect(() => {
+    return () => {
+      globalThis.fetch = originalFetch;
+    };
+  }, []);
+
+  return children;
+}
+
+function AutoSubmitPrompt() {
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+      if (!textarea) return;
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      valueSetter?.call(textarea, streamingPrompt);
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      window.setTimeout(() => {
+        textarea.form?.requestSubmit();
+      }, 80);
+    }, 500);
+
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  return null;
+}
+
+const meta = {
+  title: "Talon Chat/TalonSession",
+  component: TalonSession,
+  tags: ["autodocs"],
+  args: {
+    namespace: "support",
+    agent: "triage",
+    gatewayUrl: "http://localhost:18789",
+    gatewayClient,
+    sessionId: "storybook-session",
+    autoFocus: false,
+    placeholder: "Ask Talon about the incident...",
+  },
+  render: (args) => (
+    <div style={{ height: "100%", padding: 24, overflow: "hidden" }}>
+      <div style={{ height: "min(680px, calc(100vh - 48px))", maxWidth: 480, margin: "0 auto", border: "1px dotted var(--talon-chat-border, rgba(212,212,216,0.7))", background: "var(--talon-chat-surface, #fff)" }}>
+        <TalonSession {...args} />
+      </div>
+    </div>
+  ),
+} satisfies Meta<TalonSessionProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExistingSession: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    placeholder: "The copilot is temporarily unavailable",
+  },
+};
+
+export const StreamingResponse: Story = {
+  args: {
+    sessionId: undefined,
+    autoFocus: false,
+    placeholder: "Streaming mock response...",
+  },
+  render: (args) => {
+    const streamingGateway = createStreamingGatewayClient();
+    return (
+      <MockStreamingGateway gateway={streamingGateway}>
+        <AutoSubmitPrompt />
+        <div style={{ height: "100%", padding: 24, overflow: "hidden" }}>
+          <div style={{ height: "min(680px, calc(100vh - 48px))", maxWidth: 480, margin: "0 auto", border: "1px dotted var(--talon-chat-border, rgba(212,212,216,0.7))", background: "var(--talon-chat-surface, #fff)" }}>
+            <TalonSession
+              {...args}
+              gatewayClient={streamingGateway}
+              sessionId={undefined}
+            />
+          </div>
+        </div>
+      </MockStreamingGateway>
+    );
+  },
+};

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -495,9 +495,15 @@ export function TalonSession({
       const isStreamingAssistantMessage = isLoading && isLatestMessage && message.role === "assistant" && !content;
       const hasExpandedWorkDetails = Boolean(reasoningContent) || toolTimelineItems.length > 0 || Boolean(usageSummary);
       const hasWorkDetails = message.role === "assistant" && (hasExpandedWorkDetails || isStreamingAssistantMessage);
-      const previousUserMessage = message.role === "assistant"
-        ? messages.slice(0, messageIndex).reverse().find((previousMessage) => previousMessage.role === "user")
-        : undefined;
+      let previousUserMessage: CopilotMessage | undefined;
+      if (message.role === "assistant") {
+        for (let index = messageIndex - 1; index >= 0; index -= 1) {
+          if (messages[index].role === "user") {
+            previousUserMessage = messages[index];
+            break;
+          }
+        }
+      }
       const workLabel = isStreamingAssistantMessage
         ? formatWorkingDuration(loadingStartedAt, loadingNow)
         : formatWorkDuration(previousUserMessage?.createdAt, message.createdAt);

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -937,7 +937,7 @@ export function TalonSession({
       };
 
       setMessages((prev) => [...prev, userMessage]);
-      setLoadingStartedAt(userMessage.createdAt ?? Date.now());
+      setLoadingStartedAt(normalizeEpochToMilliseconds(userMessage.createdAt) ?? Date.now());
       setLoadingNow(Date.now());
       setIsLoading(true);
 

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Activity, ChevronRight, Send, Square, User } from "lucide-react";
+import { Activity, ChevronRight, Wrench } from "lucide-react";
 import {
   formatUsageSummary,
   getMessageAssistantTimeline,
@@ -13,6 +13,7 @@ import {
   type AssistantTimelineItem,
   type CopilotMessage,
 } from "./lib/chatTimeline";
+import { ChatInputBox } from "./lib/ChatInputBox";
 import { buildGatewayHeaders, normalizeGatewayUrl } from "./lib/grpc";
 import { MarkdownMessage } from "./lib/MarkdownMessage";
 import { streamSessionResume, streamUiSubmission, type StreamEventItem } from "./lib/uiStream";
@@ -31,7 +32,7 @@ export type GatewayClientLike = {
   getSession(request: { ns: string; agent: string; sessionId: string; messageLimit?: number; stepLimit?: number }): Promise<any>;
 };
 
-export type TalonCopilotProps = {
+export type TalonSessionProps = {
   namespace: string;
   agent: string;
   gatewayUrl: string;
@@ -44,37 +45,18 @@ export type TalonCopilotProps = {
   placeholder?: string;
   autoFocus?: boolean;
   disabled?: boolean;
-  talonIcon?: React.ReactNode;
-  timestampLocale?: Intl.LocalesArgument;
-  formatTimestamp?: (message: CopilotMessage) => string;
   historyPageSize?: number;
   historyMessageLimit?: number;
   historyStepLimit?: number;
 };
 
-const bootMessage: CopilotMessage[] = [
-  { id: "1", role: "system", content: "Talon runtime initialized." },
-];
+export type TalonCopilotProps = TalonSessionProps;
+
+const emptyMessages: CopilotMessage[] = [];
 const DEFAULT_HISTORY_PAGE_SIZE = 50;
 const DEFAULT_HISTORY_MESSAGE_LIMIT = 100;
 const DEFAULT_HISTORY_STEP_LIMIT = 1000;
 const HISTORY_SCROLL_LOAD_THRESHOLD_PX = 120;
-
-function DefaultTalonIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 1000 1000" fill="none" aria-hidden="true">
-      <rect width="1000" height="1000" fill="#09090B" />
-      <g stroke="#5B8CFF" strokeWidth="80" fill="none" strokeLinejoin="miter" strokeLinecap="butt">
-        <path d="M330 500L670 500" />
-        <path d="M500 250L500 750" />
-        <path d="M330 333.33L330 500" />
-        <path d="M670 333.33L670 500" />
-      </g>
-      <path d="M296.91 477.50L363.09 522.50L216.40 750L119.60 750L296.91 477.50Z" fill="#5B8CFF" />
-      <path d="M636.91 522.50L703.09 477.50L880.40 750L783.60 750L636.91 522.50Z" fill="#5B8CFF" />
-    </svg>
-  );
-}
 
 function buildGatewayChatUiUrl(gatewayUrl: string, ns: string, agent: string, sessionId: string) {
   return `${normalizeGatewayUrl(gatewayUrl)}/v1/ui/ns/${encodeURIComponent(ns)}/agents/${encodeURIComponent(agent)}/sessions/${encodeURIComponent(sessionId)}`;
@@ -101,6 +83,9 @@ function buildGatewaySessionMessagesUrl(
 function border(color: string) {
   return `1px solid ${color}`;
 }
+
+const talonChatFontFamily =
+  'var(--talon-chat-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)';
 
 function cn(...parts: Array<string | false | null | undefined>) {
   return parts.filter(Boolean).join(" ");
@@ -158,57 +143,6 @@ function normalizeEpochToMilliseconds(value: unknown) {
   return null;
 }
 
-function defaultFormatMessageTimestamp(message: CopilotMessage, timestampLocale?: Intl.LocalesArgument) {
-  function formatTimestampValue(value: unknown) {
-    const timestampMs = normalizeEpochToMilliseconds(value);
-    if (timestampMs === null) {
-      return "—";
-    }
-    return new Date(timestampMs).toLocaleString(timestampLocale, {
-      year: "numeric",
-      month: "numeric",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: true,
-    });
-  }
-
-  function millisecondsFromUuidLike(id: unknown) {
-    if (typeof id !== "string") return null;
-    const compactHex = id.replace(/[^0-9a-fA-F]/g, "");
-    if (compactHex.length >= 32 && compactHex.charAt(12) === "7") {
-      const time = parseInt(compactHex.slice(0, 12), 16);
-      return Number.isNaN(time) ? null : time;
-    }
-    return null;
-  }
-
-  function millisecondsFromUlidLike(id: unknown) {
-    if (typeof id !== "string") return null;
-    const value = id.trim().toUpperCase();
-    if (!/^[0-9A-HJKMNP-TV-Z]{26}$/.test(value)) {
-      return null;
-    }
-    const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-    let timestampMs = 0;
-    for (const char of value.slice(0, 10)) {
-      const index = alphabet.indexOf(char);
-      if (index < 0) return null;
-      timestampMs = (timestampMs * 32) + index;
-    }
-    return Number.isFinite(timestampMs) && timestampMs > 0 ? timestampMs : null;
-  }
-
-  const explicit = message?.createdAt ?? (message as CopilotMessage & { created_at?: string | number | bigint }).created_at;
-  if (explicit !== undefined && explicit !== null && explicit !== "") {
-    return formatTimestampValue(explicit);
-  }
-  const inferred = millisecondsFromUuidLike(message?.id) ?? millisecondsFromUlidLike(message?.id);
-  return inferred ? formatTimestampValue(inferred) : "—";
-}
-
 function getAssistantSignature(messages: any[] | undefined) {
   if (!Array.isArray(messages)) return "";
   return messages
@@ -222,6 +156,12 @@ type SessionHistoryPage = {
   state: string;
   hasMore: boolean;
   nextBeforeMessageId: string | null;
+};
+
+type ScrollThumbState = {
+  visible: boolean;
+  top: number;
+  height: number;
 };
 
 function stableStringHash(value: string) {
@@ -244,6 +184,35 @@ function stableHistoryMessageId(message: any, index: number) {
 
 function historyMessageTimestamp(message: Pick<CopilotMessage, "createdAt">) {
   return normalizeEpochToMilliseconds(message.createdAt);
+}
+
+function formatWorkDuration(start: unknown, end: unknown) {
+  const startMs = normalizeEpochToMilliseconds(start);
+  const endMs = normalizeEpochToMilliseconds(end);
+  if (startMs === null || endMs === null || endMs <= startMs) {
+    return "Worked";
+  }
+  const totalSeconds = Math.max(1, Math.round((endMs - startMs) / 1000));
+  if (totalSeconds < 60) {
+    return `Worked for ${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `Worked for ${minutes}m ${seconds}s` : `Worked for ${minutes}m`;
+}
+
+function formatWorkingDuration(start: unknown, now = Date.now()) {
+  const startMs = normalizeEpochToMilliseconds(start);
+  if (startMs === null || now < startMs) {
+    return "Working";
+  }
+  const totalSeconds = Math.max(1, Math.floor((now - startMs) / 1000));
+  if (totalSeconds < 60) {
+    return `Working for ${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `Working for ${minutes}m ${seconds}s` : `Working for ${minutes}m`;
 }
 
 function isLocalMessageId(id: string) {
@@ -342,7 +311,7 @@ function mergeNewestCanonicalPage(existingMessages: CopilotMessage[], newestPage
   return Array.from(dedupedMessages.values());
 }
 
-export function TalonCopilot({
+export function TalonSession({
   namespace,
   agent,
   gatewayUrl,
@@ -355,16 +324,15 @@ export function TalonCopilot({
   placeholder = "Ask Talon to perform a task...",
   autoFocus = true,
   disabled = false,
-  talonIcon = <DefaultTalonIcon />,
-  timestampLocale,
-  formatTimestamp,
   historyPageSize = DEFAULT_HISTORY_PAGE_SIZE,
   historyMessageLimit = DEFAULT_HISTORY_MESSAGE_LIMIT,
   historyStepLimit = DEFAULT_HISTORY_STEP_LIMIT,
-}: TalonCopilotProps) {
-  const [messages, setMessages] = useState<CopilotMessage[]>(bootMessage);
+}: TalonSessionProps) {
+  const [messages, setMessages] = useState<CopilotMessage[]>(emptyMessages);
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
+  const [loadingNow, setLoadingNow] = useState(Date.now());
   const [error, setError] = useState<Error | null>(null);
   const [streamEvents, setStreamEvents] = useState<StreamEventItem[]>([]);
   const [expandedThinkingMessages, setExpandedThinkingMessages] = useState<Record<string, boolean>>({});
@@ -373,16 +341,43 @@ export function TalonCopilot({
   const [hasMoreHistory, setHasMoreHistory] = useState(false);
   const [nextBeforeMessageId, setNextBeforeMessageId] = useState<string | null>(null);
   const [isLoadingOlderHistory, setIsLoadingOlderHistory] = useState(false);
+  const [scrollThumb, setScrollThumb] = useState<ScrollThumbState>({ visible: false, top: 0, height: 0 });
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const transcriptContentRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const resumeAbortControllerRef = useRef<AbortController | null>(null);
   const currentSessionRef = useRef<{ ns: string; agent: string; sessionId: string } | null>(null);
-  const messagesRef = useRef<CopilotMessage[]>(bootMessage);
+  const messagesRef = useRef<CopilotMessage[]>(emptyMessages);
   const skipNextAutoScrollRef = useRef(false);
   const prependScrollRestoreRef = useRef<{ previousScrollTop: number; previousScrollHeight: number } | null>(null);
   const isLoadingOlderHistoryRef = useRef(false);
+
+  const updateTranscriptScrollThumb = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const isScrollable = container.scrollHeight > container.clientHeight + 1;
+    if (!isScrollable) {
+      setScrollThumb((prev) => prev.visible ? { visible: false, top: 0, height: 0 } : prev);
+      return;
+    }
+
+    const trackInset = 8;
+    const trackHeight = Math.max(0, container.clientHeight - trackInset * 2);
+    const thumbHeight = Math.max(32, Math.round((container.clientHeight / container.scrollHeight) * trackHeight));
+    const maxScrollTop = container.scrollHeight - container.clientHeight;
+    const maxThumbTravel = Math.max(0, trackHeight - thumbHeight);
+    const scrollRatio = maxScrollTop > 0 ? container.scrollTop / maxScrollTop : 0;
+    const next = {
+      visible: true,
+      top: Math.round(trackInset + maxThumbTravel * scrollRatio),
+      height: thumbHeight,
+    };
+
+    setScrollThumb((prev) =>
+      prev.visible === next.visible && prev.top === next.top && prev.height === next.height ? prev : next,
+    );
+  }, []);
 
   useEffect(() => {
     messagesRef.current = messages;
@@ -412,7 +407,8 @@ export function TalonCopilot({
     const delta = container.scrollHeight - restore.previousScrollHeight;
     container.scrollTop = restore.previousScrollTop + delta;
     prependScrollRestoreRef.current = null;
-  }, [messages]);
+    updateTranscriptScrollThumb();
+  }, [messages, updateTranscriptScrollThumb]);
 
   useEffect(() => {
     if (skipNextAutoScrollRef.current) {
@@ -421,25 +417,29 @@ export function TalonCopilot({
     }
     const rafId = window.requestAnimationFrame(() => {
       scrollTranscriptToBottom("auto");
+      updateTranscriptScrollThumb();
     });
     return () => window.cancelAnimationFrame(rafId);
-  }, [currentSession?.sessionId, messages, streamEvents, isLoading, error, scrollTranscriptToBottom]);
+  }, [currentSession?.sessionId, messages, streamEvents, isLoading, error, scrollTranscriptToBottom, updateTranscriptScrollThumb]);
 
   useEffect(() => {
-    const content = transcriptContentRef.current;
-    if (!content || typeof ResizeObserver === "undefined") {
+    updateTranscriptScrollThumb();
+    window.addEventListener("resize", updateTranscriptScrollThumb);
+    return () => window.removeEventListener("resize", updateTranscriptScrollThumb);
+  }, [updateTranscriptScrollThumb]);
+
+  useSafeLayoutEffect(() => {
+    updateTranscriptScrollThumb();
+  }, [messages, expandedThinkingMessages, expandedToolItems, isLoading, error, streamEvents, updateTranscriptScrollThumb]);
+
+  useEffect(() => {
+    if (!isLoading || loadingStartedAt === null) {
       return;
     }
-
-    const observer = new ResizeObserver(() => {
-      if (skipNextAutoScrollRef.current || prependScrollRestoreRef.current) {
-        return;
-      }
-      scrollTranscriptToBottom("auto");
-    });
-    observer.observe(content);
-    return () => observer.disconnect();
-  }, [currentSession?.sessionId, scrollTranscriptToBottom]);
+    setLoadingNow(Date.now());
+    const intervalId = window.setInterval(() => setLoadingNow(Date.now()), 250);
+    return () => window.clearInterval(intervalId);
+  }, [isLoading, loadingStartedAt]);
 
   useEffect(() => {
     return () => {
@@ -456,13 +456,6 @@ export function TalonCopilot({
     }
     return headers;
   }, [authToken]);
-
-  const resolvedTimestampFormatter = useMemo(() => {
-    if (formatTimestamp) {
-      return formatTimestamp;
-    }
-    return (message: CopilotMessage) => defaultFormatMessageTimestamp(message, timestampLocale);
-  }, [formatTimestamp, timestampLocale]);
 
   const inputRows = useMemo(() => {
     let rowCount = 1;
@@ -489,73 +482,165 @@ export function TalonCopilot({
   }, []);
 
   const renderedMessages = useMemo(() => {
-    return messages.map((message) => {
+    return messages.map((message, messageIndex) => {
       const content = getMessageContent(message);
       const timeline = getMessageAssistantTimeline(message);
+      const textTimelineItems = timeline.filter((item): item is Extract<AssistantTimelineItem, { type: "text" }> => item.type === "text");
+      const toolTimelineItems = timeline.filter((item): item is Extract<AssistantTimelineItem, { type: "tool" }> => item.type === "tool");
       const reasoningContent = getMessageReasoningContent(message);
       const usage = getMessageUsage(message);
       const usageSummary = formatUsageSummary(usage);
+      const isUserMessage = message.role === "user";
+      const isLatestMessage = messageIndex === messages.length - 1;
+      const isStreamingAssistantMessage = isLoading && isLatestMessage && message.role === "assistant" && !content;
+      const hasExpandedWorkDetails = Boolean(reasoningContent) || toolTimelineItems.length > 0 || Boolean(usageSummary);
+      const hasWorkDetails = message.role === "assistant" && (hasExpandedWorkDetails || isStreamingAssistantMessage);
+      const previousUserMessage = message.role === "assistant"
+        ? messages.slice(0, messageIndex).reverse().find((previousMessage) => previousMessage.role === "user")
+        : undefined;
+      const workLabel = isStreamingAssistantMessage
+        ? formatWorkingDuration(loadingStartedAt, loadingNow)
+        : formatWorkDuration(previousUserMessage?.createdAt, message.createdAt);
+      const isWorkExpanded = expandedThinkingMessages[message.id] ?? false;
       return (
-        <div key={message.id} style={{ display: "flex", gap: "1rem" }}>
-          <div style={{ flexShrink: 0, marginTop: 2 }}>
-            {message.role === "user" ? (
-              <div style={{ width: 24, height: 24, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(148,163,184,0.16)", border: border("rgba(148,163,184,0.24)") }}>
-                <User size="14" strokeWidth={1.75} />
-              </div>
-            ) : (
-              <div style={{ width: 24, height: 24, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", background: "currentColor", color: "var(--copilot-inverse-color, #fff)" }}>
-                {talonIcon}
-              </div>
-            )}
-          </div>
-
-          <div style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column", gap: 8 }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <span style={{ fontSize: 13, fontWeight: 600 }}>{message.role === "user" ? "Operator" : "Talon"}</span>
-              <span style={{ fontSize: 11, opacity: 0.64, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>
-                {resolvedTimestampFormatter(message)}
-              </span>
-            </div>
-
-            {reasoningContent ? (
-              <div style={{ paddingBottom: 8 }}>
+        <div
+          key={message.id}
+          style={{
+            display: "flex",
+            justifyContent: isUserMessage ? "flex-end" : "stretch",
+            width: "100%",
+          }}
+        >
+          <div
+            style={{
+              width: isUserMessage ? "auto" : "100%",
+              maxWidth: isUserMessage ? "min(80%, 36rem)" : "100%",
+              overflow: "hidden",
+              borderRadius: isUserMessage ? 18 : 0,
+              background: isUserMessage
+                ? "var(--talon-chat-user-bubble-bg, rgba(24,24,27,0.07))"
+                : "transparent",
+              color: isUserMessage ? "var(--talon-chat-user-bubble-fg, inherit)" : "inherit",
+              padding: isUserMessage ? "0.65rem 0.85rem" : 0,
+            }}
+          >
+            {hasWorkDetails ? (
+              <div style={{ marginBottom: 16 }}>
                 <button
                   type="button"
-                  onClick={() => toggleThinkingMessage(message.id)}
+                  onClick={() => {
+                    if (hasExpandedWorkDetails) {
+                      toggleThinkingMessage(message.id);
+                    }
+                  }}
+                  disabled={!hasExpandedWorkDetails}
                   style={{
                     width: "100%",
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "space-between",
-                    borderRadius: 12,
-                    border: border("rgba(245,158,11,0.28)"),
-                    background: "rgba(251,191,36,0.1)",
-                    padding: "0.625rem 0.75rem",
-                    cursor: "pointer",
+                    gap: 12,
+                    border: "none",
+                    background: "transparent",
+                    padding: "0 0 0.65rem",
+                    cursor: hasExpandedWorkDetails ? "pointer" : "default",
                     textAlign: "left",
+                    color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))",
                   }}
                 >
-                  <span style={{ fontSize: 12, fontWeight: 600, color: "rgba(180,83,9,1)" }}>
-                    Thinking{usageSummary ? ` • ${usageSummary}` : ""}
+                  <span style={{ fontSize: 13, fontWeight: 500 }}>
+                    {workLabel}
                   </span>
-                  <ChevronRight
-                    size="16"
-                    style={{
-                      transform: expandedThinkingMessages[message.id] ? "rotate(90deg)" : "rotate(0deg)",
-                      transition: "transform 160ms ease",
-                      color: "rgba(180,83,9,0.8)",
-                    }}
-                  />
+                  {hasExpandedWorkDetails ? (
+                    <ChevronRight
+                      size="16"
+                      style={{
+                        flexShrink: 0,
+                        transform: isWorkExpanded ? "rotate(90deg)" : "rotate(0deg)",
+                        transition: "transform 160ms ease",
+                        color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))",
+                      }}
+                    />
+                  ) : null}
                 </button>
+                <div style={{ borderTop: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }} />
 
-                {expandedThinkingMessages[message.id] ? (
-                  <div style={{ marginTop: 12, borderRadius: 12, border: border("rgba(245,158,11,0.24)"), background: "rgba(251,191,36,0.06)", padding: 12 }}>
-                    <div style={{ marginBottom: 8, fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em", color: "rgba(180,83,9,0.8)" }}>
-                      Raw Reasoning
-                    </div>
-                    <div style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontFamily: "ui-monospace, SFMono-Regular, monospace", fontSize: 12, lineHeight: 1.6 }}>
-                      {reasoningContent}
-                    </div>
+                {isWorkExpanded ? (
+                  <div style={{ display: "flex", flexDirection: "column", gap: 6, paddingTop: 12, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
+                    {reasoningContent ? (
+                      <div style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 13, lineHeight: 1.55 }}>
+                        {reasoningContent}
+                      </div>
+                    ) : null}
+
+                    {toolTimelineItems.map((item, index) => {
+                      const toolKey = `${message.id}-${item.toolCallId || index}`;
+                      const isToolExpanded = expandedToolItems[toolKey] ?? false;
+                      return (
+                        <div key={toolKey}>
+                          <button
+                            className="talon-session-tool-row"
+                            type="button"
+                            onClick={() => toggleToolItem(toolKey)}
+                            style={{
+                              width: "auto",
+                              maxWidth: "100%",
+                              display: "flex",
+                              alignItems: "center",
+                              gap: 8,
+                              border: "none",
+                              background: "transparent",
+                              padding: "0.25rem 0",
+                              color: "inherit",
+                              cursor: "pointer",
+                              textAlign: "left",
+                            }}
+                          >
+                            <Wrench size="14" strokeWidth={1.9} style={{ flexShrink: 0, color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))" }} />
+                            <span style={{ minWidth: 0, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                              Called <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{item.toolName}</span>
+                            </span>
+                            <ChevronRight
+                              className="talon-session-tool-chevron"
+                              size="14"
+                              style={{
+                                flexShrink: 0,
+                                transform: isToolExpanded ? "rotate(90deg)" : "rotate(0deg)",
+                                color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))",
+                              }}
+                            />
+                          </button>
+                          {isToolExpanded ? (
+                            <div style={{ display: "flex", flexDirection: "column", gap: 10, paddingBottom: 12, paddingLeft: 22 }}>
+                              <div>
+                                <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                                  Input
+                                </div>
+                                <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
+                                  <code>{JSON.stringify(item.args ?? {}, null, 2)}</code>
+                                </pre>
+                              </div>
+                              {item.result !== undefined ? (
+                                <div>
+                                  <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                                    Output
+                                  </div>
+                                  <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
+                                    <code>{typeof item.result === "string" ? item.result : JSON.stringify(item.result, null, 2)}</code>
+                                  </pre>
+                                </div>
+                              ) : null}
+                            </div>
+                          ) : null}
+                        </div>
+                      );
+                    })}
+
+                    {usageSummary ? (
+                      <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                        {usageSummary}
+                      </div>
+                    ) : null}
                   </div>
                 ) : null}
               </div>
@@ -574,74 +659,13 @@ export function TalonCopilot({
                 fontFamily: message.role === "system" ? "ui-monospace, SFMono-Regular, monospace" : undefined,
               }}
             >
-              {message.role === "assistant" && timeline.length > 0 ? (
+              {message.role === "assistant" && textTimelineItems.length > 0 ? (
                 <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                  {timeline.map((item: AssistantTimelineItem, index: number) =>
-                    item.type === "text" ? (
-                      <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "normal", overflowWrap: "anywhere" }}>
-                        <MarkdownMessage>{item.text}</MarkdownMessage>
-                      </div>
-                    ) : (() => {
-                      const toolKey = `${message.id}-${item.toolCallId ?? index}`;
-                      const isExpanded = expandedToolItems[toolKey] ?? false;
-                      return (
-                        <div key={toolKey} style={{ borderRadius: 16, border: border("rgba(148,163,184,0.24)"), background: "rgba(148,163,184,0.08)", padding: 12 }}>
-                          <button
-                            type="button"
-                            onClick={() => toggleToolItem(toolKey)}
-                            style={{
-                              width: "100%",
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "space-between",
-                              gap: 12,
-                              background: "transparent",
-                              border: "none",
-                              padding: 0,
-                              cursor: "pointer",
-                              textAlign: "left",
-                            }}
-                          >
-                            <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, fontWeight: 600, minWidth: 0 }}>
-                              <span style={{ borderRadius: 999, background: "rgba(255,255,255,0.74)", padding: "2px 8px", fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em", color: "rgba(100,116,139,1)" }}>
-                                Tool
-                              </span>
-                              <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace", overflow: "hidden", textOverflow: "ellipsis" }}>{item.toolName}</span>
-                            </div>
-                            <ChevronRight
-                              size="16"
-                              style={{
-                                flexShrink: 0,
-                                transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)",
-                                transition: "transform 160ms ease",
-                                color: "rgba(100,116,139,0.8)",
-                              }}
-                            />
-                          </button>
-                          {isExpanded ? (
-                            <>
-                              <div style={{ marginTop: 12, marginBottom: 8, fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em", color: "rgba(100,116,139,1)" }}>
-                                Arguments
-                              </div>
-                              <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 10, border: border("rgba(148,163,184,0.24)"), background: "rgba(255,255,255,0.72)", padding: 12, fontSize: 12 }}>
-                                <code>{JSON.stringify(item.args ?? {}, null, 2)}</code>
-                              </pre>
-                              {item.result !== undefined ? (
-                                <>
-                                  <div style={{ marginTop: 12, marginBottom: 8, fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em", color: "rgba(100,116,139,1)" }}>
-                                    Result
-                                  </div>
-                                  <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 10, border: border("rgba(148,163,184,0.24)"), background: "rgba(255,255,255,0.72)", padding: 12, fontSize: 12 }}>
-                                    <code>{typeof item.result === "string" ? item.result : JSON.stringify(item.result, null, 2)}</code>
-                                  </pre>
-                                </>
-                              ) : null}
-                            </>
-                          ) : null}
-                        </div>
-                      );
-                    })(),
-                  )}
+                  {textTimelineItems.map((item, index) => (
+                    <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "normal", overflowWrap: "anywhere" }}>
+                      <MarkdownMessage>{item.text}</MarkdownMessage>
+                    </div>
+                  ))}
                 </div>
               ) : (
                 message.role === "assistant" ? <MarkdownMessage>{content}</MarkdownMessage> : content
@@ -651,7 +675,7 @@ export function TalonCopilot({
         </div>
       );
     });
-  }, [messages, expandedThinkingMessages, expandedToolItems, resolvedTimestampFormatter, talonIcon, toggleThinkingMessage, toggleToolItem]);
+  }, [messages, expandedThinkingMessages, expandedToolItems, isLoading, loadingNow, loadingStartedAt, toggleThinkingMessage, toggleToolItem]);
 
   const resolvedHistoryPageSize = Math.max(
     1,
@@ -720,7 +744,7 @@ export function TalonCopilot({
   const loadInitialSessionPage = useCallback(
     async (target: { ns: string; agent: string; sessionId: string }) => {
       const res = normalizeHistoryPage(await getSessionMessagesPage(target));
-      setMessages(res.messages.length > 0 ? res.messages : bootMessage);
+      setMessages(res.messages);
       setHasMoreHistory(res.hasMore);
       setNextBeforeMessageId(res.nextBeforeMessageId);
       setStreamEvents([]);
@@ -794,7 +818,7 @@ export function TalonCopilot({
       });
       setMessages((prev) => {
         const merged = mergeNewestCanonicalPage(prev, res.messages);
-        return merged.length > 0 ? merged : bootMessage;
+        return merged;
       });
       if (!hasLoadedOlderHistory) {
         setHasMoreHistory(res.hasMore);
@@ -831,7 +855,7 @@ export function TalonCopilot({
         return;
       }
       setCurrentSession(null);
-      setMessages(bootMessage);
+      setMessages(emptyMessages);
       setHasMoreHistory(false);
       setNextBeforeMessageId(null);
       setIsLoadingOlderHistory(false);
@@ -865,22 +889,6 @@ export function TalonCopilot({
       controller.abort();
     };
   }, [agent, loadInitialSessionPage, namespace, resumeStream, sessionId]);
-
-  const getLatestStatus = useCallback(() => {
-    const reasoningItems = streamEvents.filter((item) => item.type === "reasoning");
-    if (reasoningItems.length > 0) {
-      return "Thinking";
-    }
-    const statusItems = streamEvents.filter((item) => item.type === "status");
-    if (statusItems.length > 0) {
-      return statusItems[statusItems.length - 1].content;
-    }
-    const latestToolCall = streamEvents.filter((item) => item.type === "tool_call").at(-1);
-    if (latestToolCall?.name) {
-      return `Calling ${latestToolCall.name}`;
-    }
-    return "Thinking...";
-  }, [streamEvents]);
 
   const waitForCanonicalAssistantUpdate = useCallback(
     async (session: { ns: string; agent: string; sessionId: string }, baselineSignature: string) => {
@@ -929,6 +937,8 @@ export function TalonCopilot({
       };
 
       setMessages((prev) => [...prev, userMessage]);
+      setLoadingStartedAt(userMessage.createdAt ?? Date.now());
+      setLoadingNow(Date.now());
       setIsLoading(true);
 
       const controller = new AbortController();
@@ -974,6 +984,7 @@ export function TalonCopilot({
     } finally {
       abortControllerRef.current = null;
       setIsLoading(false);
+      setLoadingStartedAt(null);
     }
   }, [agent, createSession, disabled, gatewayUrl, isLoading, jsonHeaders, namespace, onSessionChange, refreshNewestSessionPage, resolvedHistoryPageSize, waitForCanonicalAssistantUpdate]);
 
@@ -983,6 +994,7 @@ export function TalonCopilot({
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
     setIsLoading(false);
+    setLoadingStartedAt(null);
 
     const session = currentSessionRef.current;
     const response = await fetch(buildGatewayChatUiUrl(gatewayUrl, session.ns, session.agent, session.sessionId), {
@@ -997,6 +1009,7 @@ export function TalonCopilot({
   }, [gatewayUrl, isLoading, jsonHeaders]);
 
   const handleTranscriptScroll = useCallback(() => {
+    updateTranscriptScrollThumb();
     const container = scrollContainerRef.current;
     const session = currentSessionRef.current;
     if (!container || !session || isLoadingOlderHistoryRef.current || !hasMoreHistory || !nextBeforeMessageId) {
@@ -1005,7 +1018,7 @@ export function TalonCopilot({
     if (container.scrollTop <= HISTORY_SCROLL_LOAD_THRESHOLD_PX) {
       void loadOlderHistoryPage(session);
     }
-  }, [hasMoreHistory, loadOlderHistoryPage, nextBeforeMessageId]);
+  }, [hasMoreHistory, loadOlderHistoryPage, nextBeforeMessageId, updateTranscriptScrollThumb]);
 
   return (
     <div
@@ -1018,43 +1031,56 @@ export function TalonCopilot({
         height: "100%",
         background: "transparent",
         color: "inherit",
+        fontFamily: talonChatFontFamily,
         ...style,
       }}
     >
-      <div
-        data-testid="copilot-transcript"
-        ref={scrollContainerRef}
-        onScroll={handleTranscriptScroll}
-        style={{ flex: 1, overflowY: "auto", overflowX: "hidden", minHeight: 0 }}
-      >
-        <div style={{ maxWidth: 896, margin: "0 auto", padding: "1rem 1rem 2rem", display: "flex", flexDirection: "column", gap: "2rem" }}>
+      <style>
+        {`
+          .talon-session-tool-chevron {
+            opacity: 0;
+            transition: opacity 120ms ease, transform 160ms ease;
+          }
+
+          .talon-session-tool-row:hover .talon-session-tool-chevron,
+          .talon-session-tool-row:focus-visible .talon-session-tool-chevron {
+            opacity: 1;
+          }
+
+          .talon-session-transcript {
+            scrollbar-width: none;
+          }
+
+          .talon-session-transcript::-webkit-scrollbar {
+            display: none;
+            width: 0;
+            height: 0;
+          }
+        `}
+      </style>
+      <div style={{ position: "relative", flex: 1, minHeight: 0 }}>
+        <div
+          className="talon-session-transcript"
+          data-testid="copilot-transcript"
+          ref={scrollContainerRef}
+          onScroll={handleTranscriptScroll}
+          style={{ height: "100%", overflowY: "auto", overflowX: "hidden", minHeight: 0 }}
+        >
+          <div style={{ maxWidth: 896, margin: "0 auto", padding: "1.5rem", display: "flex", flexDirection: "column", gap: "2rem" }}>
           {renderedMessages}
 
-          {isLoading && (messages[messages.length - 1]?.role === "user" || (messages[messages.length - 1]?.role === "assistant" && !messages[messages.length - 1]?.content)) ? (
-            <div style={{ display: "flex", gap: "1rem" }}>
-              <div style={{ flexShrink: 0, marginTop: 2 }}>
-                <div style={{ width: 24, height: 24, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", background: "currentColor", color: "var(--copilot-inverse-color, #fff)" }}>
-                  {talonIcon}
-                </div>
-              </div>
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
-                <span style={{ fontSize: 13, fontWeight: 600 }}>Talon</span>
-                <div style={{ fontSize: 12, opacity: 0.7, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>
-                  ⏳ {getLatestStatus()}
-                </div>
-                <div style={{ display: "flex", alignItems: "center", gap: 6, height: 24 }}>
-                  <div style={{ width: 6, height: 6, borderRadius: 999, background: "rgba(15,23,42,0.3)" }} />
-                  <div style={{ width: 6, height: 6, borderRadius: 999, background: "rgba(15,23,42,0.4)" }} />
-                  <div style={{ width: 6, height: 6, borderRadius: 999, background: "rgba(15,23,42,0.5)" }} />
-                </div>
+          {isLoading && messages[messages.length - 1]?.role === "user" ? (
+            <div style={{ width: "100%" }}>
+              <div style={{ fontSize: 13, fontWeight: 500, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                {formatWorkingDuration(loadingStartedAt, loadingNow)}
               </div>
             </div>
           ) : null}
 
           {error ? (
             <div style={{ display: "flex", gap: "1rem" }}>
-              <div style={{ flexShrink: 0, marginTop: 2 }}>
-                <div style={{ width: 24, height: 24, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(254,226,226,1)", border: border("rgba(252,165,165,1)") }}>
+              <div style={{ flexShrink: 0 }}>
+                <div style={{ width: 24, height: 24, borderRadius: 999, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(254,226,226,1)", border: border("rgba(252,165,165,1)") }}>
                   <Activity size="14" color="rgba(220,38,38,1)" strokeWidth={1.75} />
                 </div>
               </div>
@@ -1067,111 +1093,63 @@ export function TalonCopilot({
             </div>
           ) : null}
           <div ref={bottomRef} />
-        </div>
-      </div>
-
-      <div
-        style={{
-          position: "sticky",
-          bottom: 0,
-          zIndex: 10,
-          flexShrink: 0,
-          display: "flex",
-          justifyContent: "center",
-          width: "100%",
-          padding: "0.85rem 1rem 1rem",
-          background: "linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0))",
-          backdropFilter: "blur(10px)",
-        }}
-      >
-        <div style={{ width: "100%", maxWidth: 896, paddingBottom: 8 }}>
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              void submitMessage(input);
-            }}
-            style={{
-              position: "relative",
-              display: "flex",
-              alignItems: "flex-end",
-              gap: 8,
-              borderRadius: 22,
-              border: border("rgba(148,163,184,0.28)"),
-              background: "var(--copilot-input-bg, rgba(255,255,255,0.96))",
-              boxShadow: "0 4px 14px rgba(15,23,42,0.08), 0 1px 2px rgba(15,23,42,0.06)",
-              padding: "0.5rem 0.5rem 0.5rem 0.75rem",
-              backdropFilter: "blur(12px)",
-            }}
-          >
-            <textarea
-              value={input}
-              onChange={(event) => setInput(event.target.value)}
-              placeholder={placeholder}
-              autoFocus={autoFocus}
-              disabled={disabled}
-              rows={inputRows}
-              style={{
-                flex: 1,
-                resize: "none",
-                border: "none",
-                outline: "none",
-                boxShadow: "none",
-                background: "transparent",
-                padding: "0.5rem",
-                maxHeight: "40vh",
-                minHeight: 24,
-                fontSize: 15,
-                lineHeight: 1.6,
-                overflowY: "auto",
-                color: "inherit",
-                appearance: "none",
-                WebkitAppearance: "none",
-              }}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" && !event.shiftKey) {
-                  event.preventDefault();
-                  if ((event.currentTarget.value || "").trim() && !isLoading && !disabled) {
-                    void submitMessage(event.currentTarget.value);
-                  }
-                }
-              }}
-            />
-            <button
-              type={isLoading ? "button" : "submit"}
-              onClick={
-                isLoading
-                  ? () => {
-                      void stopGeneration().catch((err: any) =>
-                        setError(err instanceof Error ? err : new Error("Failed to stop generation")),
-                      );
-                    }
-                  : undefined
-              }
-              disabled={isLoading ? !currentSession : !(input || "").trim() || disabled}
-              aria-label={isLoading ? "Stop generation" : "Send message"}
-              style={{
-                width: 40,
-                height: 40,
-                flexShrink: 0,
-                borderRadius: 14,
-                border: "none",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                cursor: isLoading || ((input || "").trim() && !disabled) ? "pointer" : "not-allowed",
-                opacity: isLoading || ((input || "").trim() && !disabled) ? 1 : 0.5,
-                background: "currentColor",
-                color: "var(--copilot-inverse-color, #fff)",
-              }}
-            >
-              {isLoading ? <Square size="16" strokeWidth={2} fill="currentColor" /> : <Send size="16" strokeWidth={2} />}
-            </button>
-          </form>
-          <div style={{ textAlign: "center", marginTop: 12, fontSize: 11, opacity: 0.6 }}>
-            Press Return to send, Shift + Return for new line
           </div>
         </div>
+        {scrollThumb.visible ? (
+          <div
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              top: scrollThumb.top,
+              right: 2,
+              width: 5,
+              height: scrollThumb.height,
+              borderRadius: 999,
+              background: "var(--talon-chat-scrollbar-thumb, rgba(113,113,122,0.52))",
+              pointerEvents: "none",
+            }}
+          />
+        ) : null}
       </div>
+
+      {disabled ? null : (
+        <div
+          style={{
+            position: "sticky",
+            bottom: 0,
+            zIndex: 10,
+            flexShrink: 0,
+            display: "flex",
+            justifyContent: "center",
+            width: "100%",
+            boxSizing: "border-box",
+            padding: "1.5rem",
+            background: "var(--talon-chat-composer-bg, linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0)))",
+            backdropFilter: "blur(10px)",
+          }}
+        >
+          <div style={{ width: "100%", maxWidth: 896, paddingBottom: 8 }}>
+            <ChatInputBox
+              value={input}
+              onValueChange={setInput}
+              onSubmit={(nextInput) => void submitMessage(nextInput)}
+              placeholder={placeholder}
+              autoFocus={autoFocus}
+              rows={inputRows}
+              canSubmit={Boolean((input || "").trim()) && !isLoading}
+              isGenerating={isLoading}
+              canStop={Boolean(currentSession)}
+              onStop={() => {
+                void stopGeneration().catch((err: any) =>
+                  setError(err instanceof Error ? err : new Error("Failed to stop generation")),
+                );
+              }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }
+
+export const TalonCopilot = TalonSession;

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -48,7 +48,7 @@ export type CopilotMessage = {
   toolInvocations?: ToolInvocationItem[];
 };
 
-export type TalonCopilotProps = {
+export type TalonSessionProps = {
   namespace: string;
   agent: string;
   gatewayUrl: string;
@@ -61,13 +61,12 @@ export type TalonCopilotProps = {
   placeholder?: string;
   autoFocus?: boolean;
   disabled?: boolean;
-  talonIcon?: React.ReactNode;
-  timestampLocale?: Intl.LocalesArgument;
-  formatTimestamp?: (message: CopilotMessage) => string;
   historyPageSize?: number;
   historyMessageLimit?: number;
   historyStepLimit?: number;
 };
+
+export type TalonCopilotProps = TalonSessionProps;
 
 export type ChannelMessage = {
   id?: string;
@@ -140,7 +139,8 @@ export type UseTalonChannelMessagesResult = {
   postMessage: (options: { author: string; authorKind: string; content: string }) => Promise<void>;
 };
 
-export function TalonCopilot(props: TalonCopilotProps): React.JSX.Element;
+export function TalonSession(props: TalonSessionProps): React.JSX.Element;
+export const TalonCopilot: typeof TalonSession;
 export function TalonChannel(props: TalonChannelProps): React.JSX.Element;
 export function useTalonChannelMessages(
   options: UseTalonChannelMessagesOptions,

--- a/packages/talon-chat/src/index.ts
+++ b/packages/talon-chat/src/index.ts
@@ -1,4 +1,10 @@
-export { TalonCopilot, type GatewayClientLike, type TalonCopilotProps } from "./TalonCopilot";
+export {
+  TalonSession,
+  TalonCopilot,
+  type GatewayClientLike,
+  type TalonSessionProps,
+  type TalonCopilotProps,
+} from "./TalonSession";
 export {
   TalonChannel,
   useTalonChannelMessages,

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -1,0 +1,164 @@
+import React, { useCallback } from "react";
+import { ArrowUp, Square } from "lucide-react";
+
+function border(color: string) {
+  return `1px solid ${color}`;
+}
+
+export type ChatInputBoxProps = {
+  value: string;
+  onValueChange: (value: string) => void;
+  onSubmit: (value: string) => void;
+  placeholder: string;
+  autoFocus?: boolean;
+  disabled?: boolean;
+  rows?: number;
+  canSubmit?: boolean;
+  isGenerating?: boolean;
+  canStop?: boolean;
+  onStop?: () => void;
+  helperText?: string;
+  submitLabel?: string;
+  stopLabel?: string;
+  textareaMinHeight?: number;
+  textareaMaxHeight?: number | string;
+  style?: React.CSSProperties;
+};
+
+export function ChatInputBox({
+  value,
+  onValueChange,
+  onSubmit,
+  placeholder,
+  autoFocus = false,
+  disabled = false,
+  rows = 1,
+  canSubmit,
+  isGenerating = false,
+  canStop = true,
+  onStop,
+  helperText,
+  submitLabel = "Send message",
+  stopLabel = "Stop generation",
+  textareaMinHeight = 24,
+  textareaMaxHeight = "40vh",
+  style,
+}: ChatInputBoxProps) {
+  const resolvedCanSubmit = canSubmit ?? (Boolean(value.trim()) && !disabled && !isGenerating);
+  const isStopMode = Boolean(isGenerating && onStop);
+  const resolvedCanStop = Boolean(isStopMode && canStop);
+  const buttonDisabled = isStopMode ? !resolvedCanStop : !resolvedCanSubmit;
+  const buttonIsEnabled = !buttonDisabled;
+  const buttonSize = 30;
+  const isSingleLine = rows <= 1;
+  const textareaLineHeight = isSingleLine ? buttonSize : 20;
+  const resolvedTextareaMinHeight = rows > 1 ? textareaMinHeight : buttonSize;
+
+  const submitValue = useCallback(() => {
+    if (!resolvedCanSubmit) return;
+    onSubmit(value);
+  }, [onSubmit, resolvedCanSubmit, value]);
+
+  return (
+    <>
+      <style>
+        {`
+          .talon-chat-input-textarea::placeholder {
+            color: var(--copilot-input-placeholder, rgba(82,82,91,0.72));
+            opacity: 1;
+          }
+        `}
+      </style>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitValue();
+        }}
+        style={{
+          position: "relative",
+          display: "flex",
+          alignItems: "flex-end",
+          gap: 8,
+          width: "100%",
+          boxSizing: "border-box",
+          borderRadius: 18,
+          border: border("var(--copilot-input-border, rgba(212,212,216,0.72))"),
+          background: "var(--copilot-input-bg, rgba(255,255,255,0.96))",
+          boxShadow: "var(--copilot-input-shadow, 0 4px 14px rgba(24,24,27,0.08), 0 1px 2px rgba(24,24,27,0.06))",
+          padding: "0.25rem 0.3125rem 0.25rem 0.625rem",
+          backdropFilter: "blur(12px)",
+          ...style,
+        }}
+      >
+        <textarea
+          className="talon-chat-input-textarea"
+          value={value}
+          onChange={(event) => onValueChange(event.target.value)}
+          placeholder={placeholder}
+          autoFocus={autoFocus}
+          disabled={disabled}
+          rows={rows}
+          style={{
+            flex: 1,
+            boxSizing: "border-box",
+            resize: "none",
+            border: "none",
+            outline: "none",
+            boxShadow: "none",
+            background: "transparent",
+            padding: isSingleLine ? "0 0.4rem" : "0.25rem 0.4rem",
+            maxHeight: textareaMaxHeight,
+            minHeight: resolvedTextareaMinHeight,
+            height: isSingleLine ? buttonSize : undefined,
+            fontFamily: "inherit",
+            fontSize: 14,
+            lineHeight: `${textareaLineHeight}px`,
+            overflowY: isSingleLine ? "hidden" : "auto",
+            color: "inherit",
+            appearance: "none",
+            WebkitAppearance: "none",
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              submitValue();
+            }
+          }}
+        />
+        <button
+          type={isStopMode ? "button" : "submit"}
+          onClick={isStopMode && onStop ? onStop : undefined}
+          disabled={buttonDisabled}
+          aria-label={isStopMode ? stopLabel : submitLabel}
+          style={{
+            width: buttonSize,
+            height: buttonSize,
+            boxSizing: "border-box",
+            flexShrink: 0,
+            borderRadius: 999,
+            border: "none",
+            padding: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: buttonIsEnabled ? "pointer" : "not-allowed",
+            opacity: buttonIsEnabled ? 1 : 0.5,
+            background: "var(--copilot-control-bg, var(--foreground, #18181b))",
+            color: "var(--copilot-control-fg, var(--background, #ffffff))",
+          }}
+        >
+          {isStopMode ? (
+            <Square size="16" strokeWidth={2} fill="currentColor" />
+          ) : (
+            <ArrowUp size="16" strokeWidth={2.2} />
+          )}
+        </button>
+      </form>
+      {helperText ? (
+        <div style={{ textAlign: "center", marginTop: 12, fontSize: 11, opacity: 0.6 }}>
+          {helperText}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -119,7 +119,7 @@ export function ChatInputBox({
             WebkitAppearance: "none",
           }}
           onKeyDown={(event) => {
-            if (event.key === "Enter" && !event.shiftKey) {
+            if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
               event.preventDefault();
               submitValue();
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,18 +23,33 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
+      '@storybook/addon-docs':
+        specifier: ^10.4.2
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))
+      '@storybook/react-vite':
+        specifier: ^10.4.2
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))
       '@types/react':
         specifier: ^19.2.2
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.2.2
         version: 19.2.3(@types/react@19.2.14)
+      chromatic:
+        specifier: ^17.2.0
+        version: 17.2.0
+      storybook:
+        specifier: ^10.4.2
+        version: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(typescript@6.0.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)
 
   sdk/js:
     devDependencies:
@@ -514,8 +529,14 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -948,6 +969,15 @@ packages:
     resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
+    resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -964,11 +994,23 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
@@ -1029,6 +1071,242 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    resolution: {integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
+    resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.20.0':
+    resolution: {integrity: sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.20.0':
+    resolution: {integrity: sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.20.0':
+    resolution: {integrity: sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.20.0':
+    resolution: {integrity: sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
+    resolution: {integrity: sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
+    resolution: {integrity: sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
+    resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
+    resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
+    resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
+    resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
+    resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
+    resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
+    resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
+    resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
+    resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
+    resolution: {integrity: sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
+    resolution: {integrity: sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
+    resolution: {integrity: sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==}
+    cpu: [x64]
+    os: [win32]
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1046,6 +1324,113 @@ packages:
     resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
@@ -1196,6 +1581,87 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@storybook/addon-docs@10.4.2':
+    resolution: {integrity: sha512-CtW1O4xSKZPNtpWgpfp4yB/x4pj/of+3MvlEDfErSlr3Hp3QmEa2pCLaecR08H5LJqJFlt1PtG0UrIynTvgW9w==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.2
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@storybook/builder-vite@10.4.2':
+    resolution: {integrity: sha512-d3+i9vbbUfV6hvT90qabmy1WmC4bEJ7iAYDm0217doeA+S6awF25GF0qOy9gN9waU4NMntHoVpdB1YQO2wUj/w==}
+    peerDependencies:
+      storybook: ^10.4.2
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/csf-plugin@10.4.2':
+    resolution: {integrity: sha512-GqX/2DeF3/jKs5D7gpDiuT9gd0c/f2TKcnQ5av4/s3YqeN+0nhm7btkCrDfgF16uzE1Zj3OrkxvB3AOkfxWgDg==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.4.2
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.0.2':
+    resolution: {integrity: sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.4.2':
+    resolution: {integrity: sha512-Eng3Yt2NCjPX94QcfyLeUFhrMj0hec2yU9J/qafBVbfj9XrFI8o+0ZwYJ7uXb9ECbvPN4y06dgt/2W/LiR417w==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.2
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@storybook/react-vite@10.4.2':
+    resolution: {integrity: sha512-nGrS74p0ujPSQ7qD5jKLLlao2igfTTb6Kf/uRhVV8XM0uM7WvxR9K20ddCM8jFmx1jY9fRm0UBGaeaXHDIh5SA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.2
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/react@10.4.2':
+    resolution: {integrity: sha512-NfEH3CrdCAgUV4Z7SPN3Iw6nofcueqtRj8iHuo77GNjz0qSfuVi9iS7a8o7x7QFSeIBZwS0Jv3CgmhN8qvoLjg==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.2
+      typescript: '>= 4.9.x'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+      typescript:
+        optional: true
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -1394,6 +1860,12 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1411,6 +1883,9 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -1508,6 +1983,12 @@ packages:
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1538,6 +2019,9 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1554,6 +2038,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1694,6 +2181,21 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1757,6 +2259,14 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
   babel-jest@30.4.1:
     resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -1788,6 +2298,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.10.30:
     resolution: {integrity: sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==}
     engines: {node: '>=6.0.0'}
@@ -1799,6 +2313,10 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1809,6 +2327,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1838,6 +2360,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1858,9 +2384,29 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chromatic@17.2.0:
+    resolution: {integrity: sha512-jxuFtNNMuxbVcM2oAAPsa1fDuygt5e1SVJpvTmvSPkVXFQGylFvApsbhDP9a94qI8QMJeUMmts4bXMqrBotWjg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
+        optional: true
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -2140,9 +2686,25 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
@@ -2161,6 +2723,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -2190,6 +2756,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
+
   enhanced-resolve@5.21.3:
     resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
     engines: {node: '>=10.13.0'}
@@ -2204,6 +2774,10 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
 
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
@@ -2232,6 +2806,13 @@ packages:
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -2309,6 +2890,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2330,6 +2914,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -2343,6 +2931,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
@@ -2443,8 +3035,17 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -2457,6 +3058,11 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
@@ -2467,6 +3073,10 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2790,11 +3400,18 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -2978,12 +3595,19 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -3075,6 +3699,17 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
+  oxc-parser@0.127.0:
+    resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.20.0:
+    resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -3126,9 +3761,16 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3136,6 +3778,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3201,6 +3847,10 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -3231,6 +3881,15 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
+  react-docgen@8.0.3:
+    resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
+    engines: {node: ^20.9.0 || >=22}
+
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
@@ -3257,6 +3916,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -3302,8 +3965,18 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup@4.60.4:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
@@ -3315,6 +3988,10 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
@@ -3392,6 +4069,21 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  storybook@10.4.2:
+    resolution: {integrity: sha512-5Ax5vbHxFgMBGGhQDm75Rrumm/HZC4ICFhMcJaM0UlqnC/4FKj/IaZtImZFupknyiiyUEcWHPQFA2kX3/VSv1A==}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      prettier: ^2 || ^3
+      vite-plus: ^0.1.15
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      prettier:
+        optional: true
+      vite-plus:
+        optional: true
+
   streamdown@2.5.0:
     resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
     peerDependencies:
@@ -3421,6 +4113,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
@@ -3432,6 +4128,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -3471,6 +4171,10 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
@@ -3512,6 +4216,9 @@ packages:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -3522,6 +4229,18 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -3557,6 +4276,10 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3634,6 +4357,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -3665,6 +4392,49 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -3678,6 +4448,9 @@ packages:
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -3723,6 +4496,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -4122,7 +4899,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4535,6 +5323,14 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      vite: 8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)
+    optionalDependencies:
+      typescript: 6.0.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4554,6 +5350,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.14
+      react: 19.2.3
+
   '@mermaid-js/parser@1.1.1':
     dependencies:
       '@chevrotain/types': 11.1.2
@@ -4562,6 +5364,20 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.2
     optional: true
 
@@ -4593,6 +5409,135 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@oxc-project/types@0.133.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4605,6 +5550,65 @@ snapshots:
   '@react-types/shared@3.34.0(react@19.2.3)':
     dependencies:
       react: 19.2.3
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/pluginutils@5.4.0(rollup@4.60.4)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.4
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
@@ -4692,6 +5696,101 @@ snapshots:
       '@sinonjs/commons': 3.0.1
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@storybook/addon-docs@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))
+      '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/react-dom-shim': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
+  '@storybook/builder-vite@10.4.2(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      ts-dedent: 2.2.0
+      vite: 8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.4.2(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.7
+      rollup: 4.60.4
+      vite: 8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@storybook/react-dom-shim@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))
+      '@rollup/pluginutils': 5.4.0(rollup@4.60.4)
+      '@storybook/builder-vite': 10.4.2(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))
+      '@storybook/react': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)
+      empathic: 2.0.1
+      magic-string: 0.30.21
+      react: 19.2.3
+      react-docgen: 8.0.3
+      react-dom: 19.2.3(react@19.2.3)
+      resolve: 1.22.12
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      tsconfig-paths: 4.2.0
+      vite: 8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
+
+  '@storybook/react@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      react: 19.2.3
+      react-docgen: 8.0.3
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      react-dom: 19.2.3(react@19.2.3)
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
@@ -4886,6 +5985,10 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -4913,6 +6016,11 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -5035,6 +6143,10 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/doctrine@0.0.9': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -5069,6 +6181,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/mdx@2.0.13': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/node@24.12.4':
@@ -5086,6 +6200,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/resolve@1.20.6': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -5179,6 +6295,30 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@webcontainer/env@1.1.1': {}
+
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
@@ -5229,6 +6369,12 @@ snapshots:
       dequal: 2.0.3
 
   aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
 
   babel-jest@30.4.1(@babel/core@7.29.0):
     dependencies:
@@ -5286,6 +6432,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.30: {}
 
   brace-expansion@1.1.14:
@@ -5296,6 +6444,10 @@ snapshots:
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.2:
     dependencies:
@@ -5310,6 +6462,10 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -5328,6 +6484,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -5343,9 +6507,15 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  check-error@2.1.3: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chromatic@17.2.0:
+    dependencies:
+      semver: 7.8.0
 
   ci-info@4.4.0: {}
 
@@ -5626,7 +6796,18 @@ snapshots:
 
   dedent@1.7.2: {}
 
+  deep-eql@5.0.2: {}
+
   deepmerge@4.3.1: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
 
   delaunator@5.1.0:
     dependencies:
@@ -5641,6 +6822,10 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
 
@@ -5665,6 +6850,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  empathic@2.0.1: {}
+
   enhanced-resolve@5.21.3:
     dependencies:
       graceful-fs: 4.2.11
@@ -5677,6 +6864,8 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-errors@1.3.0: {}
 
   es-toolkit@1.46.1: {}
 
@@ -5718,6 +6907,10 @@ snapshots:
   esprima@4.0.1: {}
 
   estree-util-is-identifier-name@3.0.0: {}
+
+  estree-walker@2.0.2: {}
+
+  esutils@2.0.3: {}
 
   eventsource-parser@3.0.8: {}
 
@@ -5795,6 +6988,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -5812,6 +7007,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -5826,6 +7027,10 @@ snapshots:
   hachure-fill@0.5.2: {}
 
   has-flag@4.0.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-from-parse5@8.0.3:
     dependencies:
@@ -5974,7 +7179,13 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
   is-decimal@2.0.1: {}
+
+  is-docker@3.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -5982,11 +7193,19 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
   is-stream@2.0.1: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
@@ -6479,11 +7698,15 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loupe@3.2.1: {}
+
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.5.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -6889,6 +8112,10 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
@@ -6896,6 +8123,8 @@ snapshots:
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
+
+  minimist@1.2.8: {}
 
   minipass@7.1.3: {}
 
@@ -6984,6 +8213,60 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
+  oxc-parser@0.127.0:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.127.0
+      '@oxc-parser/binding-android-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-x64': 0.127.0
+      '@oxc-parser/binding-freebsd-x64': 0.127.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.127.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-musl': 0.127.0
+      '@oxc-parser/binding-openharmony-arm64': 0.127.0
+      '@oxc-parser/binding-wasm32-wasi': 0.127.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.127.0
+
+  oxc-resolver@11.20.0:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.20.0
+      '@oxc-resolver/binding-android-arm64': 11.20.0
+      '@oxc-resolver/binding-darwin-arm64': 11.20.0
+      '@oxc-resolver/binding-darwin-x64': 11.20.0
+      '@oxc-resolver/binding-freebsd-x64': 11.20.0
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.20.0
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.20.0
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-arm64-musl': 11.20.0
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.20.0
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-x64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-x64-musl': 11.20.0
+      '@oxc-resolver/binding-openharmony-arm64': 11.20.0
+      '@oxc-resolver/binding-wasm32-wasi': 11.20.0
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
+      '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -7035,14 +8318,23 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -7077,12 +8369,12 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.14):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.14
+      postcss: 8.5.15
 
   postcss@8.4.31:
     dependencies:
@@ -7091,6 +8383,12 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -7140,6 +8438,25 @@ snapshots:
       react-stately: 3.46.0(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
 
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  react-docgen@8.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   react-dom@19.2.3(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -7164,6 +8481,14 @@ snapshots:
   react@19.2.3: {}
 
   readdirp@4.1.2: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   redent@3.0.0:
     dependencies:
@@ -7231,7 +8556,35 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   robust-predicates@3.0.3: {}
+
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
 
   rollup@4.60.4:
     dependencies:
@@ -7272,6 +8625,8 @@ snapshots:
       points-on-path: 0.2.1
 
   rrweb-cssom@0.8.0: {}
+
+  run-applescript@7.1.0: {}
 
   rw@1.3.3: {}
 
@@ -7357,6 +8712,32 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.27.7
+      open: 10.2.0
+      oxc-parser: 0.127.0
+      oxc-resolver: 11.20.0
+      recast: 0.23.11
+      semver: 7.8.0
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      ws: 8.20.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
+
   streamdown@2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       clsx: 2.1.1
@@ -7410,6 +8791,8 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-bom@3.0.0: {}
+
   strip-bom@4.0.0: {}
 
   strip-final-newline@2.0.0: {}
@@ -7417,6 +8800,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-indent@4.1.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -7455,6 +8840,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   svg-parser@2.0.4: {}
 
   swr@2.4.1(react@19.2.3):
@@ -7491,6 +8878,8 @@ snapshots:
 
   throttleit@2.1.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinyexec@0.3.2: {}
 
   tinyexec@1.1.2: {}
@@ -7499,6 +8888,15 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@6.1.86: {}
 
@@ -7526,9 +8924,15 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.14)(typescript@6.0.3):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -7539,7 +8943,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.14)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)
       resolve-from: 5.0.0
       rollup: 4.60.4
       source-map: 0.7.6
@@ -7548,7 +8952,7 @@ snapshots:
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
@@ -7607,6 +9011,13 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -7664,6 +9075,19 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.5.2
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -7675,6 +9099,8 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   webidl-conversions@7.0.0: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
@@ -7711,6 +9137,10 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@8.20.1: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@storybook/addon-docs':
         specifier: ^10.4.2
         version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0))

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -187,16 +187,15 @@ test.describe('Chat Streaming', () => {
     await page.reload();
     await expect(page.getByText('Hello! I am a mock LLM. How can I assist you today?', { exact: true })).toBeVisible({ timeout: 30000 });
 
-    const thinkingToggle = page.getByRole('button', { name: /Thinking/ }).last();
-    await expect(thinkingToggle).toBeVisible({ timeout: 30000 });
-    await expect(thinkingToggle).toContainText('6 reasoning');
+    const workToggle = page.getByRole('button', { name: /Worked for \d+s/ }).last();
+    await expect(workToggle).toBeVisible({ timeout: 30000 });
     if (process.env.CAPTURE_THINKING_UI === 'true') {
       const outputDir = path.resolve(__dirname, '../../docs/pr');
       await fs.mkdir(outputDir, { recursive: true });
       await page.screenshot({ path: path.join(outputDir, 'thinking-collapsed.png'), fullPage: true });
     }
 
-    await thinkingToggle.click();
+    await workToggle.click();
     await expect(page.getByText('Inspecting the request.', { exact: false })).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('Planning a concise answer.', { exact: false })).toBeVisible({ timeout: 10000 });
     if (process.env.CAPTURE_THINKING_UI === 'true') {
@@ -205,9 +204,9 @@ test.describe('Chat Streaming', () => {
     }
 
     await page.reload();
-    const replayedThinkingToggle = page.getByRole('button', { name: /Thinking/ }).last();
-    await expect(replayedThinkingToggle).toBeVisible({ timeout: 30000 });
-    await replayedThinkingToggle.click();
+    const replayedWorkToggle = page.getByRole('button', { name: /Worked for \d+s/ }).last();
+    await expect(replayedWorkToggle).toBeVisible({ timeout: 30000 });
+    await replayedWorkToggle.click();
     await expect(page.getByText('Inspecting the request.', { exact: false })).toBeVisible({ timeout: 10000 });
   });
 
@@ -221,16 +220,17 @@ test.describe('Chat Streaming', () => {
 
     await expect(page.getByText('lookup docs.example.com', { exact: true })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Let me check that.', { exact: false })).toBeVisible({ timeout: 30000 });
-    await expect(page.getByText('Tool', { exact: true })).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('knowledge_search', { exact: true })).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('I checked knowledge_search for docs.example.com.', { exact: true })).toBeVisible({ timeout: 30000 });
 
+    const workToggle = page.getByRole('button', { name: /Worked for \d+s/ }).last();
+    await expect(workToggle).toBeVisible({ timeout: 10000 });
+    await workToggle.click();
+    await expect(page.getByText(/Called\s+knowledge_search/)).toBeVisible({ timeout: 10000 });
+
     const transcript = (await page.locator('body').textContent()) || '';
-    expect(transcript.indexOf('Let me check that.')).toBeGreaterThan(-1);
-    expect(transcript.indexOf('knowledge_search')).toBeGreaterThan(transcript.indexOf('Let me check that.'));
-    expect(transcript.indexOf('I checked knowledge_search for docs.example.com.')).toBeGreaterThan(
-      transcript.indexOf('knowledge_search'),
-    );
+    expect(transcript).toContain('Let me check that.');
+    expect(transcript).toContain('Called knowledge_search');
+    expect(transcript).toContain('I checked knowledge_search for docs.example.com.');
   });
 });
 


### PR DESCRIPTION
## Summary

- Add Storybook and Chromatic setup for `@impalasys/talon-chat`, including local scripts, static build support, ignore rules, and a GitHub Actions Chromatic workflow.
- Add a PR-only Talon Chat Screenshots workflow that builds Storybook, captures light/dark PNGs for key component stories, uploads them as an artifact, and comments the artifact link on the PR.
- Rename the primary session component to `TalonSession` while keeping `TalonCopilot` exported as an alias for existing integrations.
- Add stories for `TalonSession` and `TalonChannel`, including a streaming mock that exercises reasoning, tool calls, usage, and streamed text.
- Share the chat input box between session and channel views, and update the session UI to use user bubbles, full-width assistant responses, collapsible work/tool traces, neutral light/dark theming, and disabled-state input removal.

## Why

This makes Talon chat easier to review visually, especially while iterating on the session and channel components. The streaming story also exposes intermediate assistant states like `Working for Xs`, reasoning, tool calls, and final responses without needing a live gateway.

## Validation

- `pnpm --filter @impalasys/talon-chat build`
- `pnpm --filter @impalasys/talon-chat build-storybook`
- `pnpm --filter @impalasys/talon-chat screenshots`
- Live Storybook checks for light/dark theme, streaming state, disabled session, and transcript scrolling behavior.