### PR TITLE
[codex] Fix Sightline direct gateway transport

### DIFF
--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -55,11 +55,31 @@ export type TalonChannelCommandTarget = {
 
 export type TalonChannelCommand = TalonChatCommand<TalonChannelCommandTarget, ChannelMessage>;
 
+export type ChannelGatewayClientLike = {
+  listChannelMessages(request: {
+    ns: string;
+    channel: string;
+    limit?: number;
+    pageSize?: number;
+    beforeMessageId?: string;
+  }): Promise<any>;
+  postChannelMessage(request: {
+    ns: string;
+    channel: string;
+    authorKind: string;
+    author: string;
+    content: string;
+    subscriptionNames?: string[];
+    labels?: Record<string, string>;
+  }): Promise<any>;
+};
+
 export type TalonChannelProps = {
   namespace: string;
   channel: string | ChannelLike | null | undefined;
   gatewayUrl: string;
   authToken?: string | null;
+  gatewayClient?: ChannelGatewayClientLike;
   className?: string;
   style?: React.CSSProperties;
   disabled?: boolean;
@@ -79,6 +99,7 @@ export type UseTalonChannelMessagesOptions = {
   channel: string | ChannelLike | null | undefined;
   gatewayUrl: string;
   authToken?: string | null;
+  gatewayClient?: ChannelGatewayClientLike;
   disabled?: boolean;
   messageLimit?: number;
   refreshIntervalMs?: number | false;
@@ -219,6 +240,7 @@ export function useTalonChannelMessages({
   channel,
   gatewayUrl,
   authToken,
+  gatewayClient,
   disabled = false,
   messageLimit = 100,
   refreshIntervalMs = 2000,
@@ -250,7 +272,7 @@ export function useTalonChannelMessages({
     refreshRequestIdRef.current += 1;
     pendingRefreshRef.current = false;
     setIsLoading(false);
-  }, [authToken, disabled, gatewayUrl, messageLimit]);
+  }, [authToken, disabled, gatewayClient, gatewayUrl, messageLimit]);
 
   const headers = useCallback(
     (json = false): HeadersInit => ({
@@ -287,12 +309,21 @@ export function useTalonChannelMessages({
       }
       setError(null);
       try {
-        const messagesResponse = await fetch(
-          buildGatewayChannelMessagesUrl(gatewayUrl, requestNamespace, requestChannelName, messageLimit),
-          { headers: headers() },
-        );
-        if (!messagesResponse.ok) throw new Error(`Messages HTTP ${messagesResponse.status}`);
-        const responseJson = await messagesResponse.json();
+        const responseJson = gatewayClient
+          ? await gatewayClient.listChannelMessages({
+              ns: requestNamespace,
+              channel: requestChannelName,
+              limit: messageLimit,
+              pageSize: messageLimit,
+            })
+          : await (async () => {
+              const messagesResponse = await fetch(
+                buildGatewayChannelMessagesUrl(gatewayUrl, requestNamespace, requestChannelName, messageLimit),
+                { headers: headers() },
+              );
+              if (!messagesResponse.ok) throw new Error(`Messages HTTP ${messagesResponse.status}`);
+              return messagesResponse.json();
+            })();
         if (
           requestNamespace !== currentChannelRef.current.namespace ||
           requestChannelName !== currentChannelRef.current.channelName ||
@@ -340,7 +371,7 @@ export function useTalonChannelMessages({
         }
       }
     },
-    [channelName, disabled, gatewayUrl, headers, messageLimit, namespace],
+    [channelName, disabled, gatewayClient, gatewayUrl, headers, messageLimit, namespace],
   );
 
   useEffect(() => {
@@ -382,12 +413,22 @@ export function useTalonChannelMessages({
     setIsLoadingOlderMessages(true);
     setError(null);
     try {
-      const response = await fetch(
-        buildGatewayChannelMessagesUrl(gatewayUrl, requestNamespace, requestChannelName, messageLimit, nextBeforeMessageId),
-        { headers: headers() },
-      );
-      if (!response.ok) throw new Error(`Messages HTTP ${response.status}`);
-      const responseJson = await response.json();
+      const responseJson = gatewayClient
+        ? await gatewayClient.listChannelMessages({
+            ns: requestNamespace,
+            channel: requestChannelName,
+            limit: messageLimit,
+            pageSize: messageLimit,
+            beforeMessageId: nextBeforeMessageId,
+          })
+        : await (async () => {
+            const response = await fetch(
+              buildGatewayChannelMessagesUrl(gatewayUrl, requestNamespace, requestChannelName, messageLimit, nextBeforeMessageId),
+              { headers: headers() },
+            );
+            if (!response.ok) throw new Error(`Messages HTTP ${response.status}`);
+            return response.json();
+          })();
       if (
         requestNamespace !== currentChannelRef.current.namespace ||
         requestChannelName !== currentChannelRef.current.channelName
@@ -414,7 +455,7 @@ export function useTalonChannelMessages({
         setIsLoadingOlderMessages(false);
       }
     }
-  }, [channelName, disabled, gatewayUrl, hasMoreMessages, headers, messageLimit, namespace, nextBeforeMessageId]);
+  }, [channelName, disabled, gatewayClient, gatewayUrl, hasMoreMessages, headers, messageLimit, namespace, nextBeforeMessageId]);
 
   const postMessage = useCallback(
     async ({ author, authorKind, content }: { author: string; authorKind: string; content: string }) => {
@@ -422,21 +463,33 @@ export function useTalonChannelMessages({
       if (!trimmedContent || !namespace || !channelName || disabled || status === "closed") return;
       setError(null);
       try {
-        const response = await fetch(
-          `${normalizeGatewayUrl(gatewayUrl)}/v1/ns/${encodeURIComponent(namespace)}/channels/${encodeURIComponent(channelName)}/messages`,
-          {
-            method: "POST",
-            headers: headers(true),
-            body: JSON.stringify({
-              ns: namespace,
-              channel: channelName,
-              authorKind,
-              author,
-              content: trimmedContent,
-            }),
-          },
-        );
-        if (!response.ok) throw new Error(`Post HTTP ${response.status}`);
+        if (gatewayClient) {
+          await gatewayClient.postChannelMessage({
+            ns: namespace,
+            channel: channelName,
+            authorKind,
+            author,
+            content: trimmedContent,
+            subscriptionNames: [],
+            labels: {},
+          });
+        } else {
+          const response = await fetch(
+            `${normalizeGatewayUrl(gatewayUrl)}/v1/ns/${encodeURIComponent(namespace)}/channels/${encodeURIComponent(channelName)}/messages`,
+            {
+              method: "POST",
+              headers: headers(true),
+              body: JSON.stringify({
+                ns: namespace,
+                channel: channelName,
+                authorKind,
+                author,
+                content: trimmedContent,
+              }),
+            },
+          );
+          if (!response.ok) throw new Error(`Post HTTP ${response.status}`);
+        }
         await refresh();
         if (delayedRefreshTimeoutRef.current !== null) {
           window.clearTimeout(delayedRefreshTimeoutRef.current);
@@ -450,7 +503,7 @@ export function useTalonChannelMessages({
         throw err;
       }
     },
-    [channelName, disabled, gatewayUrl, headers, namespace, refresh, status],
+    [channelName, disabled, gatewayClient, gatewayUrl, headers, namespace, refresh, status],
   );
 
   return {
@@ -472,6 +525,7 @@ export function TalonChannel({
   channel,
   gatewayUrl,
   authToken,
+  gatewayClient,
   className,
   style,
   disabled = false,
@@ -507,6 +561,7 @@ export function TalonChannel({
     channel,
     gatewayUrl,
     authToken,
+    gatewayClient,
     disabled,
     messageLimit,
     refreshIntervalMs,

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -124,6 +124,25 @@ export type TalonChannelCommandTarget = {
 
 export type TalonChannelCommand = TalonChatCommand<TalonChannelCommandTarget, ChannelMessage>;
 
+export type ChannelGatewayClientLike = {
+  listChannelMessages(request: {
+    ns: string;
+    channel: string;
+    limit?: number;
+    pageSize?: number;
+    beforeMessageId?: string;
+  }): Promise<any>;
+  postChannelMessage(request: {
+    ns: string;
+    channel: string;
+    authorKind: string;
+    author: string;
+    content: string;
+    subscriptionNames?: string[];
+    labels?: Record<string, string>;
+  }): Promise<any>;
+};
+
 export type TalonChannelProps = {
   namespace: string;
   channel: string | {
@@ -136,6 +155,7 @@ export type TalonChannelProps = {
   };
   gatewayUrl: string;
   authToken?: string | null;
+  gatewayClient?: ChannelGatewayClientLike;
   className?: string;
   style?: React.CSSProperties;
   disabled?: boolean;
@@ -162,6 +182,7 @@ export type UseTalonChannelMessagesOptions = {
   } | null | undefined;
   gatewayUrl: string;
   authToken?: string | null;
+  gatewayClient?: ChannelGatewayClientLike;
   disabled?: boolean;
   messageLimit?: number;
   refreshIntervalMs?: number | false;

--- a/packages/talon-chat/src/index.ts
+++ b/packages/talon-chat/src/index.ts
@@ -10,6 +10,7 @@ export {
 export {
   TalonChannel,
   useTalonChannelMessages,
+  type ChannelGatewayClientLike,
   type ChannelMessage,
   type TalonChannelCommand,
   type TalonChannelCommandTarget,

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -30,14 +30,23 @@ import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { TalonChannel, TalonCopilot } from '@impalasys/talon-chat';
 import { NamespaceExplorer, type Selection } from '../components/Namespaces/NamespaceExplorer';
-import { updateGatewayClient, getGatewayClient, buildGatewayHeaders, normalizeGatewayUrl } from '../lib/grpc';
+import { updateGatewayClient, getGatewayClient } from '../lib/grpc';
 
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-function buildGatewayChatUiUrl(gatewayUrl: string, ns: string, agent: string, sessionId: string) {
-  return `${normalizeGatewayUrl(gatewayUrl)}/v1/ui/ns/${encodeURIComponent(ns)}/agents/${encodeURIComponent(agent)}/sessions/${encodeURIComponent(sessionId)}`;
+function yamlSafeValue(value: any): any {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(yamlSafeValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entryValue]) => typeof entryValue !== 'undefined')
+        .map(([key, entryValue]) => [key, yamlSafeValue(entryValue)]),
+    );
+  }
+  return value;
 }
 
 function areSelectionsEqual(left: Selection | null, right: Selection | null) {
@@ -515,10 +524,6 @@ function ChannelInspector({
     currentChannelRef.current = { ns, channelName };
   }, [ns, channelName]);
 
-  const headers = useCallback(() => ({
-    ...(buildGatewayHeaders(authToken) || {}),
-  }), [authToken]);
-
   const refresh = useCallback(async () => {
     if (!ns || !channelName) return;
     const requestNs = ns;
@@ -526,10 +531,10 @@ function ChannelInspector({
     setIsLoading(true);
     setError(null);
     try {
-      const baseUrl = normalizeGatewayUrl(gatewayUrl);
-      const subscriptionsResponse = await fetch(`${baseUrl}/v1/ns/${encodeURIComponent(requestNs)}/channels/${encodeURIComponent(requestChannelName)}/subscriptions`, { headers: headers() });
-      if (!subscriptionsResponse.ok) throw new Error(`Subscriptions HTTP ${subscriptionsResponse.status}`);
-      const subscriptionsPayload = await subscriptionsResponse.json();
+      const subscriptionsPayload = await getGatewayClient().listChannelSubscriptions({
+        ns: requestNs,
+        channel: requestChannelName,
+      });
       if (
         requestNs !== currentChannelRef.current.ns ||
         requestChannelName !== currentChannelRef.current.channelName
@@ -552,7 +557,7 @@ function ChannelInspector({
         setIsLoading(false);
       }
     }
-  }, [channelName, gatewayUrl, headers, ns]);
+  }, [channelName, ns]);
 
   useEffect(() => {
     setSubscriptions([]);
@@ -626,6 +631,7 @@ function ChannelInspector({
           className="min-h-0 flex-1"
           gatewayUrl={gatewayUrl}
           authToken={authToken}
+          gatewayClient={getGatewayClient()}
           namespace={ns}
           channel={channel}
           renderMessageActions={(message) => {
@@ -671,7 +677,7 @@ function extractStreamEvents(data: unknown): StreamEventItem[] {
   });
 }
 
-function KnowledgeExplorer({ gatewayUrl, isConnected, selection }: { gatewayUrl: string, isConnected: boolean, selection: Selection | null }) {
+function KnowledgeExplorer({ isConnected, selection }: { isConnected: boolean, selection: Selection | null }) {
   const [activeTab, setActiveTab] = useState<'context'|'search'>('context');
   const [contextData, setContextData] = useState<string>('');
   const [searchQuery, setSearchQuery] = useState('');
@@ -683,26 +689,20 @@ function KnowledgeExplorer({ gatewayUrl, isConnected, selection }: { gatewayUrl:
   useEffect(() => {
     if (isConnected && activeTab === 'context') {
       setIsLoading(true);
-      fetch(`${gatewayUrl}/v1/ns/${encodeURIComponent(targetNamespace)}/agents/${encodeURIComponent(targetAgent)}/knowledge`)
-        .then(res => res.json())
+      getGatewayClient().getKnowledge({ ns: targetNamespace, agent: targetAgent })
         .then(data => {
           setContextData(data.modules?.map((m: any) => `[${m.path}]\n${m.content}`).join('\n\n') || '');
           setIsLoading(false);
         })
         .catch(() => setIsLoading(false));
     }
-  }, [isConnected, activeTab, gatewayUrl, targetAgent, targetNamespace]);
+  }, [isConnected, activeTab, targetAgent, targetNamespace]);
 
   useEffect(() => {
     if (isConnected && activeTab === 'search' && searchQuery.trim().length > 2) {
       const timer = setTimeout(() => {
         setIsLoading(true);
-        fetch(`${gatewayUrl}/v1/ns/${encodeURIComponent(targetNamespace)}/agents/${encodeURIComponent(targetAgent)}/knowledge/search`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ query: searchQuery })
-        })
-          .then(res => res.json())
+        getGatewayClient().searchKnowledge({ ns: targetNamespace, agent: targetAgent, query: searchQuery })
           .then(data => {
             setSearchResults(data.results?.map((r: any) => `[${r.path}]\n${r.snippet}`) || []);
             setIsLoading(false);
@@ -713,7 +713,7 @@ function KnowledgeExplorer({ gatewayUrl, isConnected, selection }: { gatewayUrl:
     } else {
       setSearchResults([]);
     }
-  }, [isConnected, activeTab, searchQuery, gatewayUrl, targetAgent, targetNamespace]);
+  }, [isConnected, activeTab, searchQuery, targetAgent, targetNamespace]);
 
   return (
     <div className="flex flex-col h-full">
@@ -785,6 +785,7 @@ function DebuggerPageContent() {
   const searchParams = useSearchParams();
   const nextHistoryModeRef = useRef<'push' | 'replace'>('replace');
   const [gatewayUrl, setGatewayUrl] = useState('');
+  const [gatewayHttpUrl, setGatewayHttpUrl] = useState('');
   const [authToken, setAuthToken] = useState('');
   const [isConnected, setIsConnected] = useState(false);
   const [isHoveringConnection, setIsHoveringConnection] = useState(false);
@@ -810,10 +811,17 @@ function DebuggerPageContent() {
 
   useEffect(() => {
     const savedUrl = localStorage.getItem('talon_gateway_url');
+    const defaultGatewayUrl = process.env.NEXT_PUBLIC_GATEWAY_URL || 'https://envoy.talon.orb.local';
     if (savedUrl) {
       setGatewayUrl(savedUrl);
     } else {
-      setGatewayUrl(process.env.NEXT_PUBLIC_GATEWAY_URL || 'https://envoy.talon.orb.local');
+      setGatewayUrl(defaultGatewayUrl);
+    }
+    const savedHttpUrl = localStorage.getItem('talon_gateway_http_url');
+    if (savedHttpUrl) {
+      setGatewayHttpUrl(savedHttpUrl);
+    } else {
+      setGatewayHttpUrl(process.env.NEXT_PUBLIC_GATEWAY_HTTP_URL || defaultGatewayUrl);
     }
     const savedToken = localStorage.getItem('talon_auth_token');
     if (savedToken) {
@@ -842,6 +850,8 @@ function DebuggerPageContent() {
       setIsConnected(false);
     }
   }, [storageHydrated, searchParams, gatewayUrl]);
+
+  const effectiveGatewayHttpUrl = gatewayHttpUrl.trim() || gatewayUrl.trim();
 
   useEffect(() => {
     if (!storageHydrated) return;
@@ -875,65 +885,57 @@ function DebuggerPageContent() {
       setResourceLoading(true);
       setResourceError(null);
 
-      const headers = buildGatewayHeaders(authToken);
-      let path = '';
-
-      switch (selection.type) {
-        case 'namespace':
-          path = `/v1/namespaces/${encodeURIComponent(selection.ns)}`;
-          break;
-        case 'agent':
-          path = `/v1/ns/${encodeURIComponent(selection.ns)}/agents/${encodeURIComponent(selection.agent || '')}`;
-          break;
-        case 'channel':
-          path = `/v1/ns/${encodeURIComponent(selection.ns)}/channels/${encodeURIComponent(selection.resourceName || selection.channel || '')}`;
-          break;
-        case 'channel-subscription':
-          path = `/v1/ns/${encodeURIComponent(selection.ns)}/channels/${encodeURIComponent(selection.channel || '')}/subscriptions/${encodeURIComponent(selection.resourceName || '')}`;
-          break;
-        case 'schedule':
-          path = `/v1/ns/${encodeURIComponent(selection.ns)}/schedules/${encodeURIComponent(selection.resourceName || '')}`;
-          break;
-        case 'template':
-          path = `/v1/templates/${encodeURIComponent(selection.resourceName || '')}`;
-          break;
-        case 'mcp-server':
-          path = `/v1/mcp-servers/${encodeURIComponent(selection.resourceName || '')}`;
-          break;
-        case 'mcp-binding':
-          path = `/v1/namespaces/${encodeURIComponent(selection.ns)}/mcp-bindings/${encodeURIComponent(selection.resourceName || '')}`;
-          break;
-        case 'knowledge':
-          path = `/v1/namespaces/${encodeURIComponent(selection.ns)}/knowledge/${encodeURIComponent(selection.resourceName || '')}`;
-          break;
-      }
-
       try {
-        const response = await fetch(`${normalizeGatewayUrl(gatewayUrl)}${path}`, { headers });
-        if (!response.ok) {
-          throw new Error(`Failed to load resource: ${response.status}`);
+        let document: any;
+        switch (selection.type) {
+          case 'namespace':
+            document = await getGatewayClient().getNamespace({ name: selection.ns });
+            break;
+          case 'agent':
+            document = (await getGatewayClient().getAgent({ ns: selection.ns, name: selection.agent || '' })).agent;
+            break;
+          case 'channel':
+            document = (await getGatewayClient().getChannel({
+              ns: selection.ns,
+              name: selection.resourceName || selection.channel || '',
+            })).channel;
+            break;
+          case 'channel-subscription':
+            document = (await getGatewayClient().getChannelSubscription({
+              ns: selection.ns,
+              channel: selection.channel || '',
+              name: selection.resourceName || '',
+            })).subscription;
+            break;
+          case 'schedule':
+            document = (await getGatewayClient().getSchedule({ ns: selection.ns, name: selection.resourceName || '' })).schedule;
+            break;
+          case 'template':
+            document = (await getGatewayClient().getAgentTemplate({ name: selection.resourceName || '' })).template;
+            break;
+          case 'mcp-server':
+            document = (await getGatewayClient().getMcpServer({ name: selection.resourceName || '' })).server;
+            break;
+          case 'mcp-binding':
+            document = (await getGatewayClient().getMcpServerBinding({
+              ns: selection.ns,
+              name: selection.resourceName || '',
+            })).binding;
+            break;
+          case 'knowledge':
+            document = (await getGatewayClient().getNamespaceKnowledge({
+              ns: selection.ns,
+              name: selection.resourceName || '',
+            })).knowledge;
+            break;
         }
-        const payload = await response.json();
-        const document =
-          selection.type === 'agent'
-            ? payload.agent
-            : selection.type === 'channel'
-              ? payload.channel
-            : selection.type === 'channel-subscription'
-              ? payload.subscription
-            : selection.type === 'schedule'
-              ? payload.schedule
-            : selection.type === 'template'
-              ? payload.template
-              : selection.type === 'mcp-server'
-                ? payload.server
-                : selection.type === 'mcp-binding'
-                  ? payload.binding
-                : payload;
+        if (!document) {
+          throw new Error('Resource not found');
+        }
 
         if (!cancelled) {
           setResourceDocument(document);
-          setResourceYaml(dump(document, { noRefs: true, lineWidth: 100 }));
+          setResourceYaml(dump(yamlSafeValue(document), { noRefs: true, lineWidth: 100 }));
         }
       } catch (err: any) {
         if (!cancelled) {
@@ -952,12 +954,17 @@ function DebuggerPageContent() {
     return () => {
       cancelled = true;
     };
-  }, [authToken, gatewayUrl, isConnected, selectedNamespace]);
+  }, [isConnected, selectedNamespace]);
 
   const handleConnect = (e: React.FormEvent) => {
     e.preventDefault();
     if (gatewayUrl.trim()) {
       localStorage.setItem('talon_gateway_url', gatewayUrl.trim());
+      if (gatewayHttpUrl.trim()) {
+        localStorage.setItem('talon_gateway_http_url', gatewayHttpUrl.trim());
+      } else {
+        localStorage.removeItem('talon_gateway_http_url');
+      }
       if (authToken.trim()) {
         localStorage.setItem('talon_auth_token', authToken.trim());
       } else {
@@ -1012,7 +1019,6 @@ function DebuggerPageContent() {
         <div className="w-64 lg:w-72 h-full flex flex-col flex-shrink-0">
           <NamespaceExplorer 
             isConnected={isConnected} 
-            gatewayUrl={gatewayUrl}
             selectedNode={selectedNamespace} 
             onSelect={setSelectedNamespace} 
           />
@@ -1079,13 +1085,13 @@ function DebuggerPageContent() {
                   </div>
                   <div>
                     <h2 className="text-lg font-semibold text-foreground">Connect to Talon Engine</h2>
-                    <p className="text-[13px] text-muted-foreground mt-1">Provide the gateway URL for the autonomous agent.</p>
+                    <p className="text-[13px] text-muted-foreground mt-1">Provide gateway endpoints for this workspace.</p>
                   </div>
                 </div>
                 
                 <form onSubmit={handleConnect} className="space-y-4">
                   <div className="space-y-2">
-                    <label className="text-[12px] font-medium text-foreground">Gateway URL</label>
+                    <label className="text-[12px] font-medium text-foreground">gRPC Gateway URL</label>
                     <input 
                       type="url" 
                       required
@@ -1094,6 +1100,16 @@ function DebuggerPageContent() {
                       className="w-full bg-white/[0.03] border border-border/70 text-foreground px-3 py-2.5 rounded-xl focus:outline-none focus:ring-1 focus:ring-ring focus:border-ring text-sm transition-shadow font-mono"
                       placeholder="http://localhost:18789"
                       autoFocus
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-[12px] font-medium text-foreground">HTTP Gateway URL</label>
+                    <input
+                      type="url"
+                      value={gatewayHttpUrl}
+                      onChange={(e) => setGatewayHttpUrl(e.target.value)}
+                      className="w-full bg-white/[0.03] border border-border/70 text-foreground px-3 py-2.5 rounded-xl focus:outline-none focus:ring-1 focus:ring-ring focus:border-ring text-sm transition-shadow font-mono"
+                      placeholder="http://localhost:50052"
                     />
                   </div>
                   <div className="space-y-2">
@@ -1125,7 +1141,7 @@ function DebuggerPageContent() {
                 namespace={selectedNamespace.ns}
                 agent={selectedNamespace.agent || 'default'}
                 sessionId={selectedNamespace.type === 'session' ? selectedNamespace.sessionId : undefined}
-                gatewayUrl={gatewayUrl}
+                gatewayUrl={effectiveGatewayHttpUrl}
                 authToken={authToken || undefined}
                 gatewayClient={getGatewayClient()}
                 historyPageSize={positiveIntParam(searchParams, 'historyPageSize')}
@@ -1194,7 +1210,7 @@ function DebuggerPageContent() {
                   />
                 ) : selectedNamespace.type === 'channel' && resourceDocument ? (
                   <ChannelInspector
-                    gatewayUrl={gatewayUrl}
+                    gatewayUrl={effectiveGatewayHttpUrl}
                     authToken={authToken}
                     channel={resourceDocument as ChannelDocument}
                     resourceYaml={resourceYaml}
@@ -1292,7 +1308,7 @@ function DebuggerPageContent() {
           <div className="h-px w-full bg-border flex-shrink-0" />
 
           <div className="flex-1 min-h-0 overflow-hidden">
-            <KnowledgeExplorer gatewayUrl={gatewayUrl} isConnected={isConnected} selection={selectedNamespace} />
+            <KnowledgeExplorer isConnected={isConnected} selection={selectedNamespace} />
           </div>
         </div>
       </motion.div>}

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -954,7 +954,7 @@ function DebuggerPageContent() {
     return () => {
       cancelled = true;
     };
-  }, [isConnected, selectedNamespace]);
+  }, [authToken, gatewayUrl, isConnected, selectedNamespace]);
 
   const handleConnect = (e: React.FormEvent) => {
     e.preventDefault();

--- a/ui/components/Namespaces/NamespaceExplorer.tsx
+++ b/ui/components/Namespaces/NamespaceExplorer.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, type ReactNode } from 'react'
 import { Box, Activity, ChevronRight, ChevronDown, Folder, Cpu, MessageSquare, Trash2, PlusCircle, Plug, Clock3, FileText, Hash, Radio } from 'lucide-react';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { getGatewayClient, buildGatewayHeaders, normalizeGatewayUrl } from '../../lib/grpc';
+import { getGatewayClient } from '../../lib/grpc';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Button } from "../tailgrids/core/button";
 import { DropdownMenu as Dropdown, DropdownMenuTrigger as DropdownTrigger, DropdownMenuContent as DropdownMenu, DropdownMenuItem as DropdownItem } from "../tailgrids/core/dropdown";
@@ -488,12 +488,10 @@ function NamespaceNode({
 
 export function NamespaceExplorer({ 
   isConnected, 
-  gatewayUrl,
   selectedNode, 
   onSelect 
 }: { 
   isConnected: boolean, 
-  gatewayUrl: string,
   selectedNode: Selection | null, 
   onSelect: (selection: Selection) => void 
 }) {
@@ -557,7 +555,7 @@ export function NamespaceExplorer({
   useEffect(() => {
     refreshChannelsConfigVersionRef.current += 1;
     refreshChannelsAbortRef.current?.abort();
-  }, [gatewayUrl, isConnected]);
+  }, [isConnected]);
 
   useEffect(() => {
     return () => {
@@ -817,23 +815,11 @@ export function NamespaceExplorer({
 
     try {
       const namespaces = collectExpandedNamespaceIds(expanded, selectedNode);
-      const baseUrl = normalizeGatewayUrl(gatewayUrl);
-      const headers =
-        typeof window === 'undefined'
-          ? undefined
-          : buildGatewayHeaders(window.localStorage.getItem('talon_auth_token'));
       const bindingEntries = await Promise.all(
         Array.from(namespaces).map(async (ns) => {
           try {
-            const response = await fetch(
-              `${baseUrl}/v1/namespaces/${encodeURIComponent(ns)}/mcp-bindings`,
-              { headers },
-            );
-            if (!response.ok) {
-              throw new Error(`HTTP ${response.status}`);
-            }
-            const payload = await response.json();
-            return [ns, payload.bindings || []] as const;
+            const response = await getGatewayClient().listMcpServerBindings({ ns });
+            return [ns, response.bindings || []] as const;
           } catch (e) {
             console.warn(`Could not fetch MCP bindings for ns ${ns}`, e);
             return [ns, []] as const;
@@ -845,7 +831,7 @@ export function NamespaceExplorer({
       console.warn('Could not list namespaces for MCP bindings', e);
       setMcpBindingsByNamespace({});
     }
-  }, [expanded, gatewayUrl, isConnected, selectedNode]);
+  }, [expanded, isConnected, selectedNode]);
 
   const refreshSchedules = useCallback(async () => {
     if (!isConnected) {
@@ -921,21 +907,11 @@ export function NamespaceExplorer({
     try {
       const currentExpanded = expandedRef.current;
       const namespaces = collectExpandedNamespaceIds(currentExpanded, selectedNodeRef.current);
-      const baseUrl = normalizeGatewayUrl(gatewayUrl);
-      const headers =
-        typeof window === 'undefined'
-          ? undefined
-          : buildGatewayHeaders(window.localStorage.getItem('talon_auth_token'));
       const channelEntries = await Promise.all(
         Array.from(namespaces).map(async (ns) => {
           try {
-            const response = await fetch(`${baseUrl}/v1/ns/${encodeURIComponent(ns)}/channels`, {
-              headers,
-              signal: abortController.signal,
-            });
-            if (!response.ok) throw new Error(`HTTP ${response.status}`);
-            const payload = await response.json();
-            return [ns, payload.channels || []] as const;
+            const response = await getGatewayClient().listChannels({ ns });
+            return [ns, response.channels || []] as const;
           } catch (e) {
             if (abortController.signal.aborted) throw e;
             console.warn(`Could not fetch channels for ns ${ns}`, e);
@@ -966,13 +942,8 @@ export function NamespaceExplorer({
       const subscriptionEntries = await Promise.all(
         expandedChannels.map(async ({ ns, name }) => {
           try {
-            const response = await fetch(
-              `${baseUrl}/v1/ns/${encodeURIComponent(ns)}/channels/${encodeURIComponent(name)}/subscriptions`,
-              { headers, signal: abortController.signal },
-            );
-            if (!response.ok) throw new Error(`HTTP ${response.status}`);
-            const payload = await response.json();
-            return [`${ns}/${name}`, payload.subscriptions || []] as const;
+            const response = await getGatewayClient().listChannelSubscriptions({ ns, channel: name });
+            return [`${ns}/${name}`, response.subscriptions || []] as const;
           } catch (e) {
             if (abortController.signal.aborted) throw e;
             console.warn(`Could not fetch channel subscriptions for ${ns}/${name}`, e);
@@ -1000,7 +971,7 @@ export function NamespaceExplorer({
         void refreshChannels();
       }
     }
-  }, [gatewayUrl, isConnected]);
+  }, [isConnected]);
 
   useEffect(() => {
     refreshData();
@@ -1127,24 +1098,19 @@ export function NamespaceExplorer({
     if (!channelForm.name.trim()) return;
     setIsSubmittingChannel(true);
     try {
-      const baseUrl = normalizeGatewayUrl(gatewayUrl);
-      const headers = {
-        'Content-Type': 'application/json',
-        ...(typeof window === 'undefined' ? {} : (buildGatewayHeaders(window.localStorage.getItem('talon_auth_token')) || {})),
-      };
-      const response = await fetch(`${baseUrl}/v1/ns/${encodeURIComponent(channelModalOpen.ns)}/channels`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
+      await getGatewayClient().createChannel({
+        ns: channelModalOpen.ns,
+        channel: {
+          name: channelForm.name.trim(),
+          title: channelForm.title.trim(),
+          status: 'open',
           ns: channelModalOpen.ns,
-          channel: {
-            name: channelForm.name.trim(),
-            title: channelForm.title.trim(),
-            status: 'open',
-          },
-        }),
+          createdAt: BigInt(0),
+          updatedAt: BigInt(0),
+          metadata: {},
+          labels: {},
+        },
       });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
       setExpanded(prev => new Set(prev).add(channelModalOpen.ns));
       await refreshChannels();
       await refreshData();
@@ -1163,30 +1129,22 @@ export function NamespaceExplorer({
     if (!subscriptionForm.name.trim() || !subscriptionForm.agent.trim()) return;
     setIsSubmittingSubscription(true);
     try {
-      const baseUrl = normalizeGatewayUrl(gatewayUrl);
-      const headers = {
-        'Content-Type': 'application/json',
-        ...(typeof window === 'undefined' ? {} : (buildGatewayHeaders(window.localStorage.getItem('talon_auth_token')) || {})),
-      };
-      const response = await fetch(
-        `${baseUrl}/v1/ns/${encodeURIComponent(subscriptionModalOpen.ns)}/channels/${encodeURIComponent(subscriptionModalOpen.channel)}/subscriptions`,
-        {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({
-            ns: subscriptionModalOpen.ns,
-            channel: subscriptionModalOpen.channel,
-            subscription: {
-              name: subscriptionForm.name.trim(),
-              agent: subscriptionForm.agent.trim(),
-              enabled: subscriptionForm.enabled,
-              trigger: subscriptionForm.trigger,
-              replyMode: subscriptionForm.replyMode,
-            },
-          }),
+      await getGatewayClient().createChannelSubscription({
+        ns: subscriptionModalOpen.ns,
+        channel: subscriptionModalOpen.channel,
+        subscription: {
+          name: subscriptionForm.name.trim(),
+          ns: subscriptionModalOpen.ns,
+          channel: subscriptionModalOpen.channel,
+          agent: subscriptionForm.agent.trim(),
+          enabled: subscriptionForm.enabled,
+          trigger: subscriptionForm.trigger,
+          replyMode: subscriptionForm.replyMode,
+          contextPolicy: undefined,
+          metadata: {},
+          labels: {},
         },
-      );
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      });
       setExpanded(prev => new Set(prev).add(`${subscriptionModalOpen.ns}:channel:${subscriptionModalOpen.channel}`));
       await refreshChannels();
       await refreshData();
@@ -1212,23 +1170,13 @@ export function NamespaceExplorer({
       } else if (selection.type === 'session') {
         await getGatewayClient().deleteSession({ ns: selection.ns, agent: selection.agent!, sessionId: selection.sessionId! });
       } else if (selection.type === 'channel') {
-        const response = await fetch(
-          `${normalizeGatewayUrl(gatewayUrl)}/v1/ns/${encodeURIComponent(selection.ns)}/channels/${encodeURIComponent(selection.resourceName || selection.channel || '')}`,
-          {
-            method: 'DELETE',
-            headers: typeof window === 'undefined' ? undefined : buildGatewayHeaders(window.localStorage.getItem('talon_auth_token')),
-          },
-        );
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        await getGatewayClient().deleteChannel({ ns: selection.ns, name: selection.resourceName || selection.channel || '' });
       } else if (selection.type === 'channel-subscription') {
-        const response = await fetch(
-          `${normalizeGatewayUrl(gatewayUrl)}/v1/ns/${encodeURIComponent(selection.ns)}/channels/${encodeURIComponent(selection.channel || '')}/subscriptions/${encodeURIComponent(selection.resourceName || '')}`,
-          {
-            method: 'DELETE',
-            headers: typeof window === 'undefined' ? undefined : buildGatewayHeaders(window.localStorage.getItem('talon_auth_token')),
-          },
-        );
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        await getGatewayClient().deleteChannelSubscription({
+          ns: selection.ns,
+          channel: selection.channel || '',
+          name: selection.resourceName || '',
+        });
       } else if (selection.type === 'schedule') {
         await getGatewayClient().deleteSchedule({ ns: selection.ns, name: selection.resourceName || '' });
       }

--- a/ui/components/Namespaces/NamespaceExplorer.tsx
+++ b/ui/components/Namespaces/NamespaceExplorer.tsx
@@ -910,7 +910,7 @@ export function NamespaceExplorer({
       const channelEntries = await Promise.all(
         Array.from(namespaces).map(async (ns) => {
           try {
-            const response = await getGatewayClient().listChannels({ ns });
+            const response = await getGatewayClient().listChannels({ ns }, { signal: abortController.signal });
             return [ns, response.channels || []] as const;
           } catch (e) {
             if (abortController.signal.aborted) throw e;
@@ -942,7 +942,10 @@ export function NamespaceExplorer({
       const subscriptionEntries = await Promise.all(
         expandedChannels.map(async ({ ns, name }) => {
           try {
-            const response = await getGatewayClient().listChannelSubscriptions({ ns, channel: name });
+            const response = await getGatewayClient().listChannelSubscriptions(
+              { ns, channel: name },
+              { signal: abortController.signal },
+            );
             return [`${ns}/${name}`, response.subscriptions || []] as const;
           } catch (e) {
             if (abortController.signal.aborted) throw e;


### PR DESCRIPTION
## Summary

Fix Sightline's direct-to-local Talon mode so resource details and channel messages do not rely on Envoy's REST transcoder.

## Root Cause

Sightline mixed transports: the sidebar could enumerate namespaces and agents through the generated gRPC-web client, while several resource detail views and channel message operations still used raw REST endpoints. Running without Envoy means those REST paths either target the UI HTTP server or miss the transcoder entirely, producing URL pattern errors or `Messages HTTP 404` even when the resource exists.

## Changes

- Add separate Sightline connection inputs for gRPC and HTTP gateway URLs.
- Move namespace/resource detail, MCP binding, channel, subscription, and knowledge reads onto the generated gateway client.
- Let `TalonChannel` list and post channel messages through an optional gateway client, with REST retained as a fallback for existing consumers.
- Export the new channel gateway client type from `@impalasys/talon-chat`.

## Validation

- `pnpm --dir packages/talon-chat run build`
- `pnpm --dir ui run build`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable gateway clients in channel messaging operations.
  * Introduced separate HTTP gateway endpoint configuration for improved flexibility.

* **Improvements**
  * Enhanced data loading and resource synchronization across the application.
  * Improved YAML serialization handling for better data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->