### PR TITLE
[codex] Add talon chat slash commands

### DIFF
--- a/dockerfiles/envoy.Dockerfile
+++ b/dockerfiles/envoy.Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:trixie-slim AS descriptor
+
+WORKDIR /src
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY proto ./proto
+COPY third_party/googleapis ./third_party/googleapis
+
+RUN protoc \
+    -I. \
+    -Iproto \
+    -Ithird_party/googleapis \
+    --include_imports \
+    --include_source_info \
+    --experimental_allow_proto3_optional \
+    --descriptor_set_out=/tmp/talon_gateway_proto-descriptor-set.proto.bin \
+    proto/gateway.proto
+
+FROM envoyproxy/envoy:v1.33-latest
+
+COPY --from=descriptor /tmp/talon_gateway_proto-descriptor-set.proto.bin /etc/envoy/talon_gateway_proto-descriptor-set.proto.bin
+COPY envoy.yaml /etc/envoy/envoy.yaml

--- a/packages/talon-chat/README.md
+++ b/packages/talon-chat/README.md
@@ -42,6 +42,38 @@ You can also inject a gateway client for session CRUD:
 
 `TalonCopilot` is still exported as an alias for existing integrations.
 
+## Commands
+
+Both `TalonSession` and `TalonChannel` can intercept slash commands before they are sent as chat messages. Enable the built-in `/clear` command with `enabledBuiltInCommands`:
+
+```tsx
+<TalonSession
+  namespace="support"
+  agent="docs"
+  gatewayUrl="http://localhost:18789"
+  enabledBuiltInCommands={["clear"]}
+/>
+```
+
+For sessions, `/clear` calls the gateway session clear API when a session is active and then clears the visible transcript. For channels, `/clear` clears the visible channel message buffer.
+
+You can also provide custom commands:
+
+```tsx
+<TalonChannel
+  namespace="support"
+  channel="incident-room"
+  gatewayUrl="http://localhost:18789"
+  commands={[
+    {
+      name: "clear-local",
+      aliases: ["cl"],
+      run: ({ clear }) => clear(),
+    },
+  ]}
+/>
+```
+
 Channels can be rendered with the same package:
 
 ```tsx

--- a/packages/talon-chat/README.md
+++ b/packages/talon-chat/README.md
@@ -44,7 +44,7 @@ You can also inject a gateway client for session CRUD:
 
 ## Commands
 
-Both `TalonSession` and `TalonChannel` can intercept slash commands before they are sent as chat messages. Enable the built-in `/clear` command with `enabledBuiltInCommands`:
+Both `TalonSession` and `TalonChannel` can intercept slash commands before they are sent as chat messages. Enable the built-in session `/clear` command with `enabledBuiltInCommands`:
 
 ```tsx
 <TalonSession
@@ -55,7 +55,7 @@ Both `TalonSession` and `TalonChannel` can intercept slash commands before they 
 />
 ```
 
-For sessions, `/clear` calls the gateway session clear API when a session is active and then clears the visible transcript. For channels, `/clear` clears the visible channel message buffer.
+For sessions, `/clear` calls the gateway session clear API when a session is active and then clears the visible transcript. Channels do not include a built-in clear command because channel messages are shared history, not per-session transcript state.
 
 You can also provide custom commands:
 
@@ -66,9 +66,9 @@ You can also provide custom commands:
   gatewayUrl="http://localhost:18789"
   commands={[
     {
-      name: "clear-local",
-      aliases: ["cl"],
-      run: ({ clear }) => clear(),
+      name: "ack",
+      description: "Acknowledge the active incident room.",
+      run: ({ target }) => console.log(`Acknowledged ${target.channel}`),
     },
   ]}
 />

--- a/packages/talon-chat/src/TalonChannel.stories.tsx
+++ b/packages/talon-chat/src/TalonChannel.stories.tsx
@@ -74,7 +74,6 @@ const meta = {
     gatewayUrl: "http://localhost:18789",
     refreshIntervalMs: false,
     formatTimestamp: () => "Jun 5, 2026, 9:12 AM",
-    enabledBuiltInCommands: ["clear"],
   },
   render: (args) => (
     <div style={{ height: "100%", padding: 24, overflow: "hidden" }}>

--- a/packages/talon-chat/src/TalonChannel.stories.tsx
+++ b/packages/talon-chat/src/TalonChannel.stories.tsx
@@ -74,6 +74,7 @@ const meta = {
     gatewayUrl: "http://localhost:18789",
     refreshIntervalMs: false,
     formatTimestamp: () => "Jun 5, 2026, 9:12 AM",
+    enabledBuiltInCommands: ["clear"],
   },
   render: (args) => (
     <div style={{ height: "100%", padding: 24, overflow: "hidden" }}>

--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -7,7 +7,6 @@ import { ChatInputBox } from "./lib/ChatInputBox";
 import {
   findTalonChatCommand,
   parseTalonChatCommandInput,
-  type TalonBuiltInCommandName,
   type TalonChatCommand,
 } from "./lib/commands";
 import { MarkdownMessage } from "./lib/MarkdownMessage";
@@ -73,7 +72,6 @@ export type TalonChannelProps = {
   formatTimestamp?: (message: ChannelMessage) => string;
   renderMessageActions?: (message: ChannelMessage) => React.ReactNode;
   commands?: TalonChannelCommand[];
-  enabledBuiltInCommands?: TalonBuiltInCommandName[];
 };
 
 export type UseTalonChannelMessagesOptions = {
@@ -97,7 +95,6 @@ export type UseTalonChannelMessagesResult = {
   refresh: (options?: { silent?: boolean; replace?: boolean }) => Promise<void>;
   loadOlderMessages: () => Promise<void>;
   postMessage: (options: { author: string; authorKind: string; content: string }) => Promise<void>;
-  clearMessages: () => void;
 };
 
 function coerceChannelName(channel: string | ChannelLike | null | undefined) {
@@ -217,39 +214,6 @@ function mergeChannelMessages(existing: ChannelMessage[], incoming: ChannelMessa
   return Array.from(byKey.values()).sort(compareChannelMessages);
 }
 
-type ChannelClearMarker = {
-  message: ChannelMessage;
-  id: string | null;
-  timestamp: number | null;
-};
-
-function isChannelMessageAfterClear(message: ChannelMessage, marker: ChannelClearMarker) {
-  const messageTimestamp = channelMessageTimestamp(message);
-  if (messageTimestamp !== null && marker.timestamp !== null) {
-    if (messageTimestamp !== marker.timestamp) return messageTimestamp > marker.timestamp;
-    if (message.id && marker.id && message.id !== marker.id) return message.id > marker.id;
-    return false;
-  }
-  if (message.id && marker.id) {
-    return message.id > marker.id;
-  }
-  return compareChannelMessages(message, marker.message) > 0;
-}
-
-function applyChannelClearMarker(
-  page: { messages: ChannelMessage[]; hasMore: boolean; nextBeforeMessageId: string | null },
-  marker: ChannelClearMarker | null,
-) {
-  if (!marker) return page;
-  const messages = page.messages.filter((message) => isChannelMessageAfterClear(message, marker));
-  const reachedClearBoundary = messages.length < page.messages.length;
-  return {
-    messages,
-    hasMore: reachedClearBoundary ? false : page.hasMore,
-    nextBeforeMessageId: reachedClearBoundary ? null : page.nextBeforeMessageId,
-  };
-}
-
 export function useTalonChannelMessages({
   namespace,
   channel,
@@ -272,7 +236,6 @@ export function useTalonChannelMessages({
   const delayedRefreshTimeoutRef = useRef<number | null>(null);
   const loadedChannelRef = useRef<{ namespace: string; channelName: string } | null>(null);
   const refreshConfigVersionRef = useRef(0);
-  const lastClearedRef = useRef<ChannelClearMarker | null>(null);
 
   const channelName = coerceChannelName(channel);
   const status = coerceChannelStatus(channel);
@@ -310,31 +273,6 @@ export function useTalonChannelMessages({
     };
   }, [namespace, channelName]);
 
-  const clearMessages = useCallback(() => {
-    const latestMessage = messagesRef.current[messagesRef.current.length - 1];
-    lastClearedRef.current = latestMessage
-      ? {
-          message: latestMessage,
-          id: latestMessage.id || null,
-          timestamp: channelMessageTimestamp(latestMessage),
-        }
-      : null;
-    refreshRequestIdRef.current += 1;
-    pendingRefreshRef.current = false;
-    isLoadingOlderMessagesRef.current = false;
-    messagesRef.current = [];
-    setMessages([]);
-    setHasMoreMessages(false);
-    setNextBeforeMessageId(null);
-    setIsLoading(false);
-    setIsLoadingOlderMessages(false);
-    setError(null);
-    if (delayedRefreshTimeoutRef.current !== null) {
-      window.clearTimeout(delayedRefreshTimeoutRef.current);
-      delayedRefreshTimeoutRef.current = null;
-    }
-  }, []);
-
   const refresh = useCallback(
     async (options?: { silent?: boolean; replace?: boolean }) => {
       if (!namespace || !channelName || disabled || pendingRefreshRef.current) return;
@@ -362,7 +300,7 @@ export function useTalonChannelMessages({
         ) {
           return;
         }
-        const page = applyChannelClearMarker(normalizeChannelPage(responseJson), lastClearedRef.current);
+        const page = normalizeChannelPage(responseJson);
         const newestIds = new Set(page.messages.map((message, index) => channelMessageKey(message, index)));
         const oldestNewestMessage = page.messages[0];
         const oldestNewestTimestamp = oldestNewestMessage ? channelMessageTimestamp(oldestNewestMessage) : null;
@@ -423,7 +361,6 @@ export function useTalonChannelMessages({
       setIsLoadingOlderMessages(false);
       setError(null);
       isLoadingOlderMessagesRef.current = false;
-      lastClearedRef.current = null;
     }
     void refresh({ replace: true, silent: !channelChanged });
   }, [namespace, channelName, refresh]);
@@ -457,7 +394,7 @@ export function useTalonChannelMessages({
       ) {
         return;
       }
-      const page = applyChannelClearMarker(normalizeChannelPage(responseJson), lastClearedRef.current);
+      const page = normalizeChannelPage(responseJson);
       setMessages((existing) => mergeChannelMessages(existing, page.messages));
       setHasMoreMessages(page.hasMore);
       setNextBeforeMessageId(page.nextBeforeMessageId);
@@ -527,7 +464,6 @@ export function useTalonChannelMessages({
     refresh,
     loadOlderMessages,
     postMessage,
-    clearMessages,
   };
 }
 
@@ -548,7 +484,6 @@ export function TalonChannel({
   formatTimestamp,
   renderMessageActions,
   commands,
-  enabledBuiltInCommands,
 }: TalonChannelProps) {
   const [draft, setDraft] = useState("");
   const [isPosting, setIsPosting] = useState(false);
@@ -567,7 +502,6 @@ export function TalonChannel({
     error,
     loadOlderMessages,
     postMessage,
-    clearMessages,
   } = useTalonChannelMessages({
     namespace,
     channel,
@@ -624,17 +558,7 @@ export function TalonChannel({
     return () => window.cancelAnimationFrame(rafId);
   }, [messages, scrollMessagesToBottom]);
 
-  const resolvedCommands = useMemo<Array<TalonChannelCommand>>(() => {
-    const builtInCommands: TalonChannelCommand[] = [];
-    if (enabledBuiltInCommands?.includes("clear")) {
-      builtInCommands.push({
-        name: "clear",
-        description: "Clear the visible channel messages.",
-        run: ({ clear }) => clear(),
-      });
-    }
-    return [...(commands ?? []), ...builtInCommands];
-  }, [clearMessages, commands, enabledBuiltInCommands]);
+  const resolvedCommands = useMemo<Array<TalonChannelCommand>>(() => commands ?? [], [commands]);
   const commandMenuItems = useMemo(
     () => resolvedCommands.map(({ name, aliases, description }) => ({ name, aliases, description })),
     [resolvedCommands],
@@ -679,7 +603,6 @@ export function TalonChannel({
             status,
           },
           messages,
-          clear: clearMessages,
         });
       } catch (err) {
         setCommandError(err instanceof Error ? err.message : String(err));
@@ -699,7 +622,7 @@ export function TalonChannel({
       isPostingRef.current = false;
       setIsPosting(false);
     }
-  }, [author, authorKind, channelName, clearMessages, isUserInputDisabled, messages, namespace, postMessage, resolvedCommands, status]);
+  }, [author, authorKind, channelName, isUserInputDisabled, messages, namespace, postMessage, resolvedCommands, status]);
 
   return (
     <div

--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -635,6 +635,10 @@ export function TalonChannel({
     }
     return [...(commands ?? []), ...builtInCommands];
   }, [clearMessages, commands, enabledBuiltInCommands]);
+  const commandMenuItems = useMemo(
+    () => resolvedCommands.map(({ name, aliases, description }) => ({ name, aliases, description })),
+    [resolvedCommands],
+  );
 
   const handleMessageScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
     isNearBottomRef.current = isNearScrollBottom(event.currentTarget);
@@ -765,6 +769,7 @@ export function TalonChannel({
               disabled={isUserInputDisabled}
               canSubmit={canPost}
               submitLabel="Send channel message"
+              commandMenuItems={commandMenuItems}
               textareaMinHeight={40}
               textareaMaxHeight={128}
             />

--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -217,6 +217,39 @@ function mergeChannelMessages(existing: ChannelMessage[], incoming: ChannelMessa
   return Array.from(byKey.values()).sort(compareChannelMessages);
 }
 
+type ChannelClearMarker = {
+  message: ChannelMessage;
+  id: string | null;
+  timestamp: number | null;
+};
+
+function isChannelMessageAfterClear(message: ChannelMessage, marker: ChannelClearMarker) {
+  const messageTimestamp = channelMessageTimestamp(message);
+  if (messageTimestamp !== null && marker.timestamp !== null) {
+    if (messageTimestamp !== marker.timestamp) return messageTimestamp > marker.timestamp;
+    if (message.id && marker.id && message.id !== marker.id) return message.id > marker.id;
+    return false;
+  }
+  if (message.id && marker.id) {
+    return message.id > marker.id;
+  }
+  return compareChannelMessages(message, marker.message) > 0;
+}
+
+function applyChannelClearMarker(
+  page: { messages: ChannelMessage[]; hasMore: boolean; nextBeforeMessageId: string | null },
+  marker: ChannelClearMarker | null,
+) {
+  if (!marker) return page;
+  const messages = page.messages.filter((message) => isChannelMessageAfterClear(message, marker));
+  const reachedClearBoundary = messages.length < page.messages.length;
+  return {
+    messages,
+    hasMore: reachedClearBoundary ? false : page.hasMore,
+    nextBeforeMessageId: reachedClearBoundary ? null : page.nextBeforeMessageId,
+  };
+}
+
 export function useTalonChannelMessages({
   namespace,
   channel,
@@ -239,6 +272,7 @@ export function useTalonChannelMessages({
   const delayedRefreshTimeoutRef = useRef<number | null>(null);
   const loadedChannelRef = useRef<{ namespace: string; channelName: string } | null>(null);
   const refreshConfigVersionRef = useRef(0);
+  const lastClearedRef = useRef<ChannelClearMarker | null>(null);
 
   const channelName = coerceChannelName(channel);
   const status = coerceChannelStatus(channel);
@@ -277,6 +311,14 @@ export function useTalonChannelMessages({
   }, [namespace, channelName]);
 
   const clearMessages = useCallback(() => {
+    const latestMessage = messagesRef.current[messagesRef.current.length - 1];
+    lastClearedRef.current = latestMessage
+      ? {
+          message: latestMessage,
+          id: latestMessage.id || null,
+          timestamp: channelMessageTimestamp(latestMessage),
+        }
+      : null;
     refreshRequestIdRef.current += 1;
     pendingRefreshRef.current = false;
     isLoadingOlderMessagesRef.current = false;
@@ -320,7 +362,7 @@ export function useTalonChannelMessages({
         ) {
           return;
         }
-        const page = normalizeChannelPage(responseJson);
+        const page = applyChannelClearMarker(normalizeChannelPage(responseJson), lastClearedRef.current);
         const newestIds = new Set(page.messages.map((message, index) => channelMessageKey(message, index)));
         const oldestNewestMessage = page.messages[0];
         const oldestNewestTimestamp = oldestNewestMessage ? channelMessageTimestamp(oldestNewestMessage) : null;
@@ -381,6 +423,7 @@ export function useTalonChannelMessages({
       setIsLoadingOlderMessages(false);
       setError(null);
       isLoadingOlderMessagesRef.current = false;
+      lastClearedRef.current = null;
     }
     void refresh({ replace: true, silent: !channelChanged });
   }, [namespace, channelName, refresh]);
@@ -414,7 +457,7 @@ export function useTalonChannelMessages({
       ) {
         return;
       }
-      const page = normalizeChannelPage(responseJson);
+      const page = applyChannelClearMarker(normalizeChannelPage(responseJson), lastClearedRef.current);
       setMessages((existing) => mergeChannelMessages(existing, page.messages));
       setHasMoreMessages(page.hasMore);
       setNextBeforeMessageId(page.nextBeforeMessageId);

--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -4,6 +4,12 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Hash } from "lucide-react";
 import { buildGatewayHeaders, normalizeGatewayUrl } from "./lib/grpc";
 import { ChatInputBox } from "./lib/ChatInputBox";
+import {
+  findTalonChatCommand,
+  parseTalonChatCommandInput,
+  type TalonBuiltInCommandName,
+  type TalonChatCommand,
+} from "./lib/commands";
 import { MarkdownMessage } from "./lib/MarkdownMessage";
 
 function border(color: string) {
@@ -41,6 +47,15 @@ export type ChannelMessage = {
   source_session_id?: string;
 };
 
+export type TalonChannelCommandTarget = {
+  type: "channel";
+  namespace: string;
+  channel: string;
+  status: string;
+};
+
+export type TalonChannelCommand = TalonChatCommand<TalonChannelCommandTarget, ChannelMessage>;
+
 export type TalonChannelProps = {
   namespace: string;
   channel: string | ChannelLike | null | undefined;
@@ -57,6 +72,8 @@ export type TalonChannelProps = {
   timestampLocale?: Intl.LocalesArgument;
   formatTimestamp?: (message: ChannelMessage) => string;
   renderMessageActions?: (message: ChannelMessage) => React.ReactNode;
+  commands?: TalonChannelCommand[];
+  enabledBuiltInCommands?: TalonBuiltInCommandName[];
 };
 
 export type UseTalonChannelMessagesOptions = {
@@ -80,6 +97,7 @@ export type UseTalonChannelMessagesResult = {
   refresh: (options?: { silent?: boolean; replace?: boolean }) => Promise<void>;
   loadOlderMessages: () => Promise<void>;
   postMessage: (options: { author: string; authorKind: string; content: string }) => Promise<void>;
+  clearMessages: () => void;
 };
 
 function coerceChannelName(channel: string | ChannelLike | null | undefined) {
@@ -257,6 +275,23 @@ export function useTalonChannelMessages({
       }
     };
   }, [namespace, channelName]);
+
+  const clearMessages = useCallback(() => {
+    refreshRequestIdRef.current += 1;
+    pendingRefreshRef.current = false;
+    isLoadingOlderMessagesRef.current = false;
+    messagesRef.current = [];
+    setMessages([]);
+    setHasMoreMessages(false);
+    setNextBeforeMessageId(null);
+    setIsLoading(false);
+    setIsLoadingOlderMessages(false);
+    setError(null);
+    if (delayedRefreshTimeoutRef.current !== null) {
+      window.clearTimeout(delayedRefreshTimeoutRef.current);
+      delayedRefreshTimeoutRef.current = null;
+    }
+  }, []);
 
   const refresh = useCallback(
     async (options?: { silent?: boolean; replace?: boolean }) => {
@@ -449,6 +484,7 @@ export function useTalonChannelMessages({
     refresh,
     loadOlderMessages,
     postMessage,
+    clearMessages,
   };
 }
 
@@ -468,9 +504,12 @@ export function TalonChannel({
   timestampLocale,
   formatTimestamp,
   renderMessageActions,
+  commands,
+  enabledBuiltInCommands,
 }: TalonChannelProps) {
   const [draft, setDraft] = useState("");
   const [isPosting, setIsPosting] = useState(false);
+  const [commandError, setCommandError] = useState<string | null>(null);
   const isPostingRef = useRef(false);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const skipNextAutoScrollRef = useRef(false);
@@ -485,6 +524,7 @@ export function TalonChannel({
     error,
     loadOlderMessages,
     postMessage,
+    clearMessages,
   } = useTalonChannelMessages({
     namespace,
     channel,
@@ -495,6 +535,7 @@ export function TalonChannel({
     refreshIntervalMs,
   });
   const isUserInputDisabled = disabled || disableUserInput || status === "closed";
+  const displayedError = commandError || error;
 
   const resolvedFormatTimestamp = useMemo(() => {
     if (formatTimestamp) return formatTimestamp;
@@ -524,6 +565,7 @@ export function TalonChannel({
 
   useEffect(() => {
     isNearBottomRef.current = true;
+    setCommandError(null);
   }, [namespace, channelName]);
 
   useEffect(() => {
@@ -538,6 +580,18 @@ export function TalonChannel({
     });
     return () => window.cancelAnimationFrame(rafId);
   }, [messages, scrollMessagesToBottom]);
+
+  const resolvedCommands = useMemo<Array<TalonChannelCommand>>(() => {
+    const builtInCommands: TalonChannelCommand[] = [];
+    if (enabledBuiltInCommands?.includes("clear")) {
+      builtInCommands.push({
+        name: "clear",
+        description: "Clear the visible channel messages.",
+        run: ({ clear }) => clear(),
+      });
+    }
+    return [...(commands ?? []), ...builtInCommands];
+  }, [clearMessages, commands, enabledBuiltInCommands]);
 
   const handleMessageScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
     isNearBottomRef.current = isNearScrollBottom(event.currentTarget);
@@ -559,8 +613,36 @@ export function TalonChannel({
   const submitChannelMessage = useCallback(async (submittedContent: string) => {
     const content = submittedContent.trim();
     if (!content || isPostingRef.current || isUserInputDisabled) return;
+
+    const parsedCommand = parseTalonChatCommandInput(content);
+    const command = findTalonChatCommand(resolvedCommands, parsedCommand);
+    if (command && parsedCommand) {
+      setDraft("");
+      setCommandError(null);
+      try {
+        await command.run({
+          name: parsedCommand.name,
+          input: content,
+          args: parsedCommand.args,
+          argv: parsedCommand.argv,
+          target: {
+            type: "channel",
+            namespace,
+            channel: channelName,
+            status,
+          },
+          messages,
+          clear: clearMessages,
+        });
+      } catch (err) {
+        setCommandError(err instanceof Error ? err.message : String(err));
+      }
+      return;
+    }
+
     isPostingRef.current = true;
     setIsPosting(true);
+    setCommandError(null);
     try {
       await postMessage({ author, authorKind, content });
       setDraft("");
@@ -570,7 +652,7 @@ export function TalonChannel({
       isPostingRef.current = false;
       setIsPosting(false);
     }
-  }, [author, authorKind, isUserInputDisabled, postMessage]);
+  }, [author, authorKind, channelName, clearMessages, isUserInputDisabled, messages, namespace, postMessage, resolvedCommands, status]);
 
   return (
     <div
@@ -597,9 +679,9 @@ export function TalonChannel({
         >
           {isLoading ? <div style={{ marginBottom: 12, fontSize: 12, opacity: 0.68 }}>Loading channel...</div> : null}
           {isLoadingOlderMessages ? <div style={{ marginBottom: 12, fontSize: 12, opacity: 0.68 }}>Loading older messages...</div> : null}
-          {error ? (
+          {displayedError ? (
             <div style={{ marginBottom: 12, borderRadius: 10, border: border("var(--copilot-channel-error-border, rgba(248,113,113,0.5))"), background: "var(--copilot-channel-error-bg, rgba(248,113,113,0.12))", color: "var(--copilot-channel-error-fg, inherit)", padding: 12, fontSize: 13 }}>
-              {error}
+              {displayedError}
             </div>
           ) : null}
           {messages.length === 0 && !isLoading ? (
@@ -639,6 +721,7 @@ export function TalonChannel({
               rows={inputRows}
               disabled={isUserInputDisabled}
               canSubmit={canPost}
+              submitLabel="Send channel message"
               textareaMinHeight={40}
               textareaMaxHeight={128}
             />

--- a/packages/talon-chat/src/TalonSession.stories.tsx
+++ b/packages/talon-chat/src/TalonSession.stories.tsx
@@ -232,6 +232,7 @@ const meta = {
     sessionId: "storybook-session",
     autoFocus: false,
     placeholder: "Ask Talon about the incident...",
+    enabledBuiltInCommands: ["clear"],
   },
   render: (args) => (
     <div style={{ height: "100%", padding: 24, overflow: "hidden" }}>

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -14,6 +14,12 @@ import {
   type CopilotMessage,
 } from "./lib/chatTimeline";
 import { ChatInputBox } from "./lib/ChatInputBox";
+import {
+  findTalonChatCommand,
+  parseTalonChatCommandInput,
+  type TalonBuiltInCommandName,
+  type TalonChatCommand,
+} from "./lib/commands";
 import { buildGatewayHeaders, normalizeGatewayUrl } from "./lib/grpc";
 import { MarkdownMessage } from "./lib/MarkdownMessage";
 import { streamSessionResume, streamUiSubmission, type StreamEventItem } from "./lib/uiStream";
@@ -22,6 +28,7 @@ const useSafeLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : us
 
 export type GatewayClientLike = {
   createSession(request: { ns: string; agent: string }): Promise<{ sessionId: string }>;
+  clearSession?(request: { ns: string; agent: string; sessionId: string }): Promise<any>;
   listSessionMessages?(request: {
     ns: string;
     agent: string;
@@ -31,6 +38,15 @@ export type GatewayClientLike = {
   }): Promise<any>;
   getSession(request: { ns: string; agent: string; sessionId: string; messageLimit?: number; stepLimit?: number }): Promise<any>;
 };
+
+export type TalonSessionCommandTarget = {
+  type: "session";
+  namespace: string;
+  agent: string;
+  sessionId: string | null;
+};
+
+export type TalonSessionCommand = TalonChatCommand<TalonSessionCommandTarget, CopilotMessage>;
 
 export type TalonSessionProps = {
   namespace: string;
@@ -48,6 +64,8 @@ export type TalonSessionProps = {
   historyPageSize?: number;
   historyMessageLimit?: number;
   historyStepLimit?: number;
+  commands?: TalonSessionCommand[];
+  enabledBuiltInCommands?: TalonBuiltInCommandName[];
 };
 
 export type TalonCopilotProps = TalonSessionProps;
@@ -78,6 +96,10 @@ function buildGatewaySessionMessagesUrl(
     url.searchParams.set("before_message_id", beforeMessageId);
   }
   return url.toString();
+}
+
+function buildGatewayClearSessionUrl(gatewayUrl: string, ns: string, agent: string, sessionId: string) {
+  return `${normalizeGatewayUrl(gatewayUrl)}/v1/ns/${encodeURIComponent(ns)}/agents/${encodeURIComponent(agent)}/sessions/${encodeURIComponent(sessionId)}:clear`;
 }
 
 function border(color: string) {
@@ -327,6 +349,8 @@ export function TalonSession({
   historyPageSize = DEFAULT_HISTORY_PAGE_SIZE,
   historyMessageLimit = DEFAULT_HISTORY_MESSAGE_LIMIT,
   historyStepLimit = DEFAULT_HISTORY_STEP_LIMIT,
+  commands,
+  enabledBuiltInCommands,
 }: TalonSessionProps) {
   const [messages, setMessages] = useState<CopilotMessage[]>(emptyMessages);
   const [input, setInput] = useState("");
@@ -912,9 +936,82 @@ export function TalonSession({
     [getSessionMessagesPage, refreshNewestSessionPage],
   );
 
+  const clearLocalSession = useCallback(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    setMessages(emptyMessages);
+    messagesRef.current = emptyMessages;
+    setStreamEvents([]);
+    setError(null);
+    setHasMoreHistory(false);
+    setNextBeforeMessageId(null);
+    setIsLoading(false);
+    setLoadingStartedAt(null);
+    setExpandedThinkingMessages({});
+    setExpandedToolItems({});
+  }, []);
+
+  const clearSession = useCallback(async () => {
+    const session = currentSessionRef.current;
+    if (session) {
+      if (gatewayClient?.clearSession) {
+        await gatewayClient.clearSession(session);
+      } else {
+        const response = await fetch(buildGatewayClearSessionUrl(gatewayUrl, session.ns, session.agent, session.sessionId), {
+          method: "POST",
+          headers: jsonHeaders,
+          body: JSON.stringify(session),
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to clear session: ${response.status}`);
+        }
+      }
+    }
+    clearLocalSession();
+  }, [clearLocalSession, gatewayClient, gatewayUrl, jsonHeaders]);
+
+  const resolvedCommands = useMemo<Array<TalonSessionCommand>>(() => {
+    const builtInCommands: TalonSessionCommand[] = [];
+    if (enabledBuiltInCommands?.includes("clear")) {
+      builtInCommands.push({
+        name: "clear",
+        description: "Clear the current session history.",
+        run: ({ clear }) => clear(),
+      });
+    }
+    return [...(commands ?? []), ...builtInCommands];
+  }, [clearSession, commands, enabledBuiltInCommands]);
+
   const submitMessage = useCallback(async (submittedText: string) => {
     const text = submittedText.trim();
     if (!text || isLoading || disabled) return;
+
+    const parsedCommand = parseTalonChatCommandInput(text);
+    const command = findTalonChatCommand(resolvedCommands, parsedCommand);
+    if (command && parsedCommand) {
+      setInput("");
+      setError(null);
+      setStreamEvents([]);
+      try {
+        await command.run({
+          name: parsedCommand.name,
+          input: text,
+          args: parsedCommand.args,
+          argv: parsedCommand.argv,
+          target: {
+            type: "session",
+            namespace,
+            agent,
+            sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null,
+          },
+          messages: messagesRef.current,
+          clear: clearSession,
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      }
+      return;
+    }
 
     setInput("");
     setError(null);
@@ -992,7 +1089,7 @@ export function TalonSession({
       setIsLoading(false);
       setLoadingStartedAt(null);
     }
-  }, [agent, createSession, disabled, gatewayUrl, isLoading, jsonHeaders, namespace, onSessionChange, refreshNewestSessionPage, resolvedHistoryPageSize, waitForCanonicalAssistantUpdate]);
+  }, [agent, clearSession, createSession, disabled, gatewayUrl, isLoading, jsonHeaders, namespace, onSessionChange, refreshNewestSessionPage, resolvedCommands, resolvedHistoryPageSize, sessionId, waitForCanonicalAssistantUpdate]);
 
   const stopGeneration = useCallback(async () => {
     if (!currentSessionRef.current || !isLoading) return;

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -976,7 +976,7 @@ export function TalonSession({
       builtInCommands.push({
         name: "clear",
         description: "Clear the current session history.",
-        run: ({ clear }) => clear(),
+        run: ({ clear }) => clear?.(),
       });
     }
     return [...(commands ?? []), ...builtInCommands];

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -981,6 +981,10 @@ export function TalonSession({
     }
     return [...(commands ?? []), ...builtInCommands];
   }, [clearSession, commands, enabledBuiltInCommands]);
+  const commandMenuItems = useMemo(
+    () => resolvedCommands.map(({ name, aliases, description }) => ({ name, aliases, description })),
+    [resolvedCommands],
+  );
 
   const submitMessage = useCallback(async (submittedText: string) => {
     const text = submittedText.trim();
@@ -1242,6 +1246,7 @@ export function TalonSession({
               canSubmit={Boolean((input || "").trim()) && !isLoading}
               isGenerating={isLoading}
               canStop={Boolean(currentSession)}
+              commandMenuItems={commandMenuItems}
               onStop={() => {
                 void stopGeneration().catch((err: any) =>
                   setError(err instanceof Error ? err : new Error("Failed to stop generation")),

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -2,6 +2,7 @@ import type React from "react";
 
 export type GatewayClientLike = {
   createSession(request: { ns: string; agent: string }): Promise<{ sessionId: string }>;
+  clearSession?(request: { ns: string; agent: string; sessionId: string }): Promise<any>;
   listSessionMessages?(request: {
     ns: string;
     agent: string;
@@ -48,6 +49,34 @@ export type CopilotMessage = {
   toolInvocations?: ToolInvocationItem[];
 };
 
+export type TalonBuiltInCommandName = "clear";
+
+export type TalonChatCommandContext<TTarget, TMessage> = {
+  name: string;
+  input: string;
+  args: string;
+  argv: string[];
+  target: TTarget;
+  messages: TMessage[];
+  clear: () => void | Promise<void>;
+};
+
+export type TalonChatCommand<TTarget = unknown, TMessage = unknown> = {
+  name: string;
+  aliases?: string[];
+  description?: string;
+  run: (context: TalonChatCommandContext<TTarget, TMessage>) => void | Promise<void>;
+};
+
+export type TalonSessionCommandTarget = {
+  type: "session";
+  namespace: string;
+  agent: string;
+  sessionId: string | null;
+};
+
+export type TalonSessionCommand = TalonChatCommand<TalonSessionCommandTarget, CopilotMessage>;
+
 export type TalonSessionProps = {
   namespace: string;
   agent: string;
@@ -64,6 +93,8 @@ export type TalonSessionProps = {
   historyPageSize?: number;
   historyMessageLimit?: number;
   historyStepLimit?: number;
+  commands?: TalonSessionCommand[];
+  enabledBuiltInCommands?: TalonBuiltInCommandName[];
 };
 
 export type TalonCopilotProps = TalonSessionProps;
@@ -83,6 +114,15 @@ export type ChannelMessage = {
   sourceSessionId?: string;
   source_session_id?: string;
 };
+
+export type TalonChannelCommandTarget = {
+  type: "channel";
+  namespace: string;
+  channel: string;
+  status: string;
+};
+
+export type TalonChannelCommand = TalonChatCommand<TalonChannelCommandTarget, ChannelMessage>;
 
 export type TalonChannelProps = {
   namespace: string;
@@ -107,6 +147,8 @@ export type TalonChannelProps = {
   timestampLocale?: Intl.LocalesArgument;
   formatTimestamp?: (message: ChannelMessage) => string;
   renderMessageActions?: (message: ChannelMessage) => React.ReactNode;
+  commands?: TalonChannelCommand[];
+  enabledBuiltInCommands?: TalonBuiltInCommandName[];
 };
 
 export type UseTalonChannelMessagesOptions = {
@@ -137,6 +179,7 @@ export type UseTalonChannelMessagesResult = {
   refresh: (options?: { silent?: boolean; replace?: boolean }) => Promise<void>;
   loadOlderMessages: () => Promise<void>;
   postMessage: (options: { author: string; authorKind: string; content: string }) => Promise<void>;
+  clearMessages: () => void;
 };
 
 export function TalonSession(props: TalonSessionProps): React.JSX.Element;

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -58,7 +58,7 @@ export type TalonChatCommandContext<TTarget, TMessage> = {
   argv: string[];
   target: TTarget;
   messages: TMessage[];
-  clear: () => void | Promise<void>;
+  clear?: () => void | Promise<void>;
 };
 
 export type TalonChatCommand<TTarget = unknown, TMessage = unknown> = {
@@ -148,7 +148,6 @@ export type TalonChannelProps = {
   formatTimestamp?: (message: ChannelMessage) => string;
   renderMessageActions?: (message: ChannelMessage) => React.ReactNode;
   commands?: TalonChannelCommand[];
-  enabledBuiltInCommands?: TalonBuiltInCommandName[];
 };
 
 export type UseTalonChannelMessagesOptions = {
@@ -179,7 +178,6 @@ export type UseTalonChannelMessagesResult = {
   refresh: (options?: { silent?: boolean; replace?: boolean }) => Promise<void>;
   loadOlderMessages: () => Promise<void>;
   postMessage: (options: { author: string; authorKind: string; content: string }) => Promise<void>;
-  clearMessages: () => void;
 };
 
 export function TalonSession(props: TalonSessionProps): React.JSX.Element;

--- a/packages/talon-chat/src/index.ts
+++ b/packages/talon-chat/src/index.ts
@@ -2,6 +2,8 @@ export {
   TalonSession,
   TalonCopilot,
   type GatewayClientLike,
+  type TalonSessionCommand,
+  type TalonSessionCommandTarget,
   type TalonSessionProps,
   type TalonCopilotProps,
 } from "./TalonSession";
@@ -9,10 +11,17 @@ export {
   TalonChannel,
   useTalonChannelMessages,
   type ChannelMessage,
+  type TalonChannelCommand,
+  type TalonChannelCommandTarget,
   type TalonChannelProps,
   type UseTalonChannelMessagesOptions,
   type UseTalonChannelMessagesResult,
 } from "./TalonChannel";
+export {
+  type TalonBuiltInCommandName,
+  type TalonChatCommand,
+  type TalonChatCommandContext,
+} from "./lib/commands";
 export {
   type AssistantTimelineItem,
   type CopilotMessage,

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from "react";
-import { ArrowUp, Square } from "lucide-react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { ArrowUp, Square, Terminal } from "lucide-react";
 
 function border(color: string) {
   return `1px solid ${color}`;
@@ -22,7 +22,14 @@ export type ChatInputBoxProps = {
   stopLabel?: string;
   textareaMinHeight?: number;
   textareaMaxHeight?: number | string;
+  commandMenuItems?: ChatInputCommandMenuItem[];
   style?: React.CSSProperties;
+};
+
+export type ChatInputCommandMenuItem = {
+  name: string;
+  aliases?: string[];
+  description?: string;
 };
 
 export function ChatInputBox({
@@ -42,8 +49,11 @@ export function ChatInputBox({
   stopLabel = "Stop generation",
   textareaMinHeight = 24,
   textareaMaxHeight = "40vh",
+  commandMenuItems,
   style,
 }: ChatInputBoxProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [highlightedCommandIndex, setHighlightedCommandIndex] = useState(0);
   const resolvedCanSubmit = canSubmit ?? (Boolean(value.trim()) && !disabled && !isGenerating);
   const isStopMode = Boolean(isGenerating && onStop);
   const resolvedCanStop = Boolean(isStopMode && canStop);
@@ -53,11 +63,29 @@ export function ChatInputBox({
   const isSingleLine = rows <= 1;
   const textareaLineHeight = isSingleLine ? buttonSize : 20;
   const resolvedTextareaMinHeight = rows > 1 ? textareaMinHeight : buttonSize;
+  const commandQuery = value.trimStart().startsWith("/") ? value.trimStart().slice(1).toLowerCase() : null;
+  const visibleCommandItems = useMemo(() => {
+    if (commandQuery === null || !commandMenuItems?.length || isGenerating) return [];
+    return commandMenuItems.filter((item) => {
+      const normalizedName = item.name.toLowerCase();
+      if (normalizedName.startsWith(commandQuery)) return true;
+      return item.aliases?.some((alias) => alias.toLowerCase().startsWith(commandQuery)) ?? false;
+    });
+  }, [commandMenuItems, commandQuery, isGenerating]);
+  const shouldShowCommandMenu = visibleCommandItems.length > 0 && !disabled;
+  const highlightedCommand = visibleCommandItems[Math.min(highlightedCommandIndex, visibleCommandItems.length - 1)];
 
   const submitValue = useCallback(() => {
     if (!resolvedCanSubmit) return;
     onSubmit(value);
   }, [onSubmit, resolvedCanSubmit, value]);
+
+  const selectCommand = useCallback((item: ChatInputCommandMenuItem) => {
+    onValueChange(`/${item.name}`);
+    window.requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+  }, [onValueChange]);
 
   return (
     <>
@@ -90,7 +118,81 @@ export function ChatInputBox({
           ...style,
         }}
       >
+        {shouldShowCommandMenu ? (
+          <div
+            role="listbox"
+            aria-label="Command menu"
+            style={{
+              position: "absolute",
+              left: 0,
+              right: 0,
+              bottom: "calc(100% + 8px)",
+              zIndex: 20,
+              overflow: "hidden",
+              borderRadius: 12,
+              border: border("var(--copilot-command-menu-border, rgba(212,212,216,0.84))"),
+              background: "var(--copilot-command-menu-bg, rgba(255,255,255,0.98))",
+              boxShadow: "var(--copilot-command-menu-shadow, 0 14px 32px rgba(24,24,27,0.14), 0 2px 8px rgba(24,24,27,0.08))",
+              color: "inherit",
+            }}
+          >
+            {visibleCommandItems.map((item, index) => {
+              const isHighlighted = index === Math.min(highlightedCommandIndex, visibleCommandItems.length - 1);
+              return (
+                <button
+                  key={item.name}
+                  type="button"
+                  role="option"
+                  aria-selected={isHighlighted}
+                  onMouseEnter={() => setHighlightedCommandIndex(index)}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => selectCommand(item)}
+                  style={{
+                    width: "100%",
+                    boxSizing: "border-box",
+                    border: "none",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    padding: "0.75rem 0.875rem",
+                    background: isHighlighted ? "var(--copilot-command-menu-active-bg, rgba(24,24,27,0.07))" : "transparent",
+                    color: "inherit",
+                    cursor: "pointer",
+                    textAlign: "left",
+                    fontFamily: "inherit",
+                  }}
+                >
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: 28,
+                      height: 28,
+                      flexShrink: 0,
+                      borderRadius: 8,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      background: "var(--copilot-command-menu-icon-bg, rgba(24,24,27,0.08))",
+                      color: "var(--copilot-command-menu-icon-fg, rgba(39,39,42,0.86))",
+                    }}
+                  >
+                    <Terminal size="15" strokeWidth={2} />
+                  </span>
+                  <span style={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 2 }}>
+                    <span style={{ fontSize: 14, fontWeight: 650, lineHeight: 1.2 }}>/{item.name}</span>
+                    {item.description ? (
+                      <span style={{ fontSize: 12, lineHeight: 1.35, opacity: 0.68, overflowWrap: "anywhere" }}>
+                        {item.description}
+                      </span>
+                    ) : null}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
         <textarea
+          ref={textareaRef}
           className="talon-chat-input-textarea"
           value={value}
           onChange={(event) => onValueChange(event.target.value)}
@@ -119,6 +221,19 @@ export function ChatInputBox({
             WebkitAppearance: "none",
           }}
           onKeyDown={(event) => {
+            if (shouldShowCommandMenu && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+              event.preventDefault();
+              setHighlightedCommandIndex((current) => {
+                const delta = event.key === "ArrowDown" ? 1 : -1;
+                return (current + delta + visibleCommandItems.length) % visibleCommandItems.length;
+              });
+              return;
+            }
+            if (shouldShowCommandMenu && event.key === "Tab" && highlightedCommand) {
+              event.preventDefault();
+              selectCommand(highlightedCommand);
+              return;
+            }
             if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
               event.preventDefault();
               submitValue();

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -54,6 +54,7 @@ export function ChatInputBox({
 }: ChatInputBoxProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [highlightedCommandIndex, setHighlightedCommandIndex] = useState(0);
+  const [hoveredCommandIndex, setHoveredCommandIndex] = useState<number | null>(null);
   const resolvedCanSubmit = canSubmit ?? (Boolean(value.trim()) && !disabled && !isGenerating);
   const isStopMode = Boolean(isGenerating && onStop);
   const resolvedCanStop = Boolean(isStopMode && canStop);
@@ -138,13 +139,18 @@ export function ChatInputBox({
           >
             {visibleCommandItems.map((item, index) => {
               const isHighlighted = index === Math.min(highlightedCommandIndex, visibleCommandItems.length - 1);
+              const isHovered = hoveredCommandIndex === index;
               return (
                 <button
                   key={item.name}
                   type="button"
                   role="option"
                   aria-selected={isHighlighted}
-                  onMouseEnter={() => setHighlightedCommandIndex(index)}
+                  onMouseEnter={() => {
+                    setHighlightedCommandIndex(index);
+                    setHoveredCommandIndex(index);
+                  }}
+                  onMouseLeave={() => setHoveredCommandIndex(null)}
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => selectCommand(item)}
                   style={{
@@ -155,11 +161,17 @@ export function ChatInputBox({
                     alignItems: "center",
                     gap: 10,
                     padding: "0.75rem 0.875rem",
-                    background: isHighlighted ? "var(--copilot-command-menu-active-bg, rgba(24,24,27,0.07))" : "transparent",
+                    background: isHovered
+                      ? "var(--copilot-command-menu-hover-bg, rgba(24,24,27,0.11))"
+                      : isHighlighted
+                        ? "var(--copilot-command-menu-active-bg, rgba(24,24,27,0.06))"
+                        : "transparent",
+                    boxShadow: isHovered ? "inset 0 0 0 1px var(--copilot-command-menu-hover-border, rgba(24,24,27,0.10))" : "none",
                     color: "inherit",
                     cursor: "pointer",
                     textAlign: "left",
                     fontFamily: "inherit",
+                    transition: "background 120ms ease, box-shadow 120ms ease",
                   }}
                 >
                   <span
@@ -172,8 +184,13 @@ export function ChatInputBox({
                       display: "inline-flex",
                       alignItems: "center",
                       justifyContent: "center",
-                      background: "var(--copilot-command-menu-icon-bg, rgba(24,24,27,0.08))",
-                      color: "var(--copilot-command-menu-icon-fg, rgba(39,39,42,0.86))",
+                      background: isHovered
+                        ? "var(--copilot-command-menu-icon-hover-bg, rgba(24,24,27,0.16))"
+                        : "var(--copilot-command-menu-icon-bg, rgba(24,24,27,0.08))",
+                      color: isHovered
+                        ? "var(--copilot-command-menu-icon-hover-fg, rgba(24,24,27,0.96))"
+                        : "var(--copilot-command-menu-icon-fg, rgba(39,39,42,0.86))",
+                      transition: "background 120ms ease, color 120ms ease",
                     }}
                   >
                     <Terminal size="15" strokeWidth={2} />

--- a/packages/talon-chat/src/lib/commands.ts
+++ b/packages/talon-chat/src/lib/commands.ts
@@ -1,0 +1,55 @@
+export type TalonBuiltInCommandName = "clear";
+
+export type TalonChatCommandContext<TTarget, TMessage> = {
+  name: string;
+  input: string;
+  args: string;
+  argv: string[];
+  target: TTarget;
+  messages: TMessage[];
+  clear: () => void | Promise<void>;
+};
+
+export type TalonChatCommand<TTarget = unknown, TMessage = unknown> = {
+  name: string;
+  aliases?: string[];
+  description?: string;
+  run: (context: TalonChatCommandContext<TTarget, TMessage>) => void | Promise<void>;
+};
+
+export type ParsedTalonChatCommand = {
+  name: string;
+  args: string;
+  argv: string[];
+};
+
+export function normalizeCommandName(name: string) {
+  return name.trim().replace(/^\/+/, "").toLowerCase();
+}
+
+export function parseTalonChatCommandInput(input: string): ParsedTalonChatCommand | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/") || trimmed === "/") return null;
+  const withoutPrefix = trimmed.slice(1);
+  const firstWhitespaceIndex = withoutPrefix.search(/\s/);
+  const rawName = firstWhitespaceIndex === -1 ? withoutPrefix : withoutPrefix.slice(0, firstWhitespaceIndex);
+  const name = normalizeCommandName(rawName);
+  if (!name) return null;
+  const args = firstWhitespaceIndex === -1 ? "" : withoutPrefix.slice(firstWhitespaceIndex).trim();
+  return {
+    name,
+    args,
+    argv: args ? args.split(/\s+/) : [],
+  };
+}
+
+export function findTalonChatCommand<TTarget, TMessage>(
+  commands: Array<TalonChatCommand<TTarget, TMessage>> | undefined,
+  parsed: ParsedTalonChatCommand | null,
+) {
+  if (!parsed || !commands?.length) return null;
+  return commands.find((command) => {
+    if (normalizeCommandName(command.name) === parsed.name) return true;
+    return command.aliases?.some((alias) => normalizeCommandName(alias) === parsed.name) ?? false;
+  }) ?? null;
+}

--- a/packages/talon-chat/src/lib/commands.ts
+++ b/packages/talon-chat/src/lib/commands.ts
@@ -7,7 +7,7 @@ export type TalonChatCommandContext<TTarget, TMessage> = {
   argv: string[];
   target: TTarget;
   messages: TMessage[];
-  clear: () => void | Promise<void>;
+  clear?: () => void | Promise<void>;
 };
 
 export type TalonChatCommand<TTarget = unknown, TMessage = unknown> = {

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -628,7 +628,6 @@ function ChannelInspector({
           authToken={authToken}
           namespace={ns}
           channel={channel}
-          enabledBuiltInCommands={['clear']}
           renderMessageActions={(message) => {
             const sourceAgent = message.sourceAgent || message.source_agent || '';
             const sourceSessionId = message.sourceSessionId || message.source_session_id || '';

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -628,6 +628,7 @@ function ChannelInspector({
           authToken={authToken}
           namespace={ns}
           channel={channel}
+          enabledBuiltInCommands={['clear']}
           renderMessageActions={(message) => {
             const sourceAgent = message.sourceAgent || message.source_agent || '';
             const sourceSessionId = message.sourceSessionId || message.source_session_id || '';
@@ -1129,6 +1130,7 @@ function DebuggerPageContent() {
                 authToken={authToken || undefined}
                 gatewayClient={getGatewayClient()}
                 historyPageSize={positiveIntParam(searchParams, 'historyPageSize')}
+                enabledBuiltInCommands={['clear']}
                 disabled={!isConnected}
                 onSessionChange={(nextSessionId) => {
                   handleSelectionChange({

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -163,6 +163,44 @@ test.describe('Chat Streaming', () => {
     await expect(page.getByText('The square root of 144 is 12.', { exact: true })).toBeVisible({ timeout: 30000 });
   });
 
+  test('should show the slash command menu and clear the active session', async ({ page }) => {
+    const { chatInput, sendButton, client, sessionId, testNs, testAgent } = await provisionSession(page);
+    const target = { ns: testNs, agent: testAgent, sessionId };
+
+    await chatInput.click();
+    await chatInput.fill('square root of 144');
+    await expect(sendButton).toBeEnabled({ timeout: 5000 });
+    await sendButton.click();
+
+    await expect(page.getByText('square root of 144', { exact: true })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('The square root of 144 is 12.', { exact: true })).toBeVisible({ timeout: 30000 });
+    await waitForSessionText(client, target, 'square root of 144');
+
+    await chatInput.fill('/');
+    const commandMenu = page.getByRole('listbox', { name: 'Command menu' });
+    await expect(commandMenu).toBeVisible({ timeout: 5000 });
+
+    const clearOption = page.getByRole('option', { name: /\/clear/i });
+    await expect(clearOption).toBeVisible();
+    await clearOption.hover();
+    await expect(clearOption).toHaveCSS('background-color', 'rgba(24, 24, 27, 0.11)');
+    await clearOption.click();
+
+    await expect(chatInput).toHaveValue('/clear');
+    await expect(sendButton).toBeEnabled({ timeout: 5000 });
+    await sendButton.click();
+
+    await expect(page.getByText('square root of 144', { exact: true })).toHaveCount(0, { timeout: 10000 });
+    await expect(page.getByText('The square root of 144 is 12.', { exact: true })).toHaveCount(0);
+    await expect(async () => {
+      const history = await client.listSessionMessages({
+        ...target,
+        pageSize: 50,
+      });
+      expect(history.items ?? []).toHaveLength(0);
+    }).toPass({ timeout: 30000 });
+  });
+
   test('should render and replay thinking blocks from the mock llm', async ({ page }) => {
     const { client, sessionId, testNs, testAgent } = await provisionSession(page);
     await client.sendMessage({

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -1115,6 +1115,49 @@ describe('TalonChannel', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps cleared channel messages hidden after the next background refresh', async () => {
+    jest.useFakeTimers();
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockReset();
+    const clearedMessage = {
+      id: 'channel-clear-1',
+      authorKind: 'user',
+      author: 'sightline',
+      content: 'Do not bring this back',
+      createdAt: '2026-06-08T21:00:00.000Z',
+    };
+    fetchMock
+      .mockResolvedValueOnce(makeJsonResponse({ messages: [clearedMessage] }))
+      .mockResolvedValueOnce(makeJsonResponse({ messages: [clearedMessage] }));
+
+    render(
+      <TalonChannel
+        namespace="channel-collaboration"
+        channel="incident-room"
+        gatewayUrl="http://localhost:18789"
+        refreshIntervalMs={750}
+        enabledBuiltInCommands={['clear']}
+      />,
+    );
+
+    expect(await screen.findByText('Do not bring this back')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Message #incident-room'), {
+      target: { value: '/clear' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send channel message/i }));
+
+    await waitFor(() => expect(screen.queryByText('Do not bring this back')).not.toBeInTheDocument());
+    await act(async () => {
+      jest.advanceTimersByTime(750);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText('Do not bring this back')).not.toBeInTheDocument();
+    expect(screen.getByText('No channel messages.')).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
   it('does not post duplicate channel messages while a submit is in flight', async () => {
     const fetchMock = global.fetch as jest.Mock;
     fetchMock.mockReset();

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -378,6 +378,42 @@ describe('TalonCopilot', () => {
     expect(gatewayClient.createSession).not.toHaveBeenCalled();
   });
 
+  it('shows enabled session commands in the command menu', async () => {
+    const gatewayClient = {
+      createSession: jest.fn(),
+      clearSession: jest.fn(),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-menu',
+        state: 'IDLE',
+        messages: [],
+        steps: [],
+      }),
+      getSession: jest.fn(),
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayUrl="http://localhost:18789"
+        gatewayClient={gatewayClient}
+        sessionId="sess-menu"
+        enabledBuiltInCommands={['clear']}
+      />,
+    );
+
+    const input = await screen.findByPlaceholderText('Ask Talon to perform a task...');
+    fireEvent.change(input, {
+      target: { value: '/' },
+    });
+
+    expect(screen.getByRole('listbox', { name: 'Command menu' })).toBeInTheDocument();
+    const clearOption = screen.getByRole('option', { name: /\/clear/i });
+    expect(clearOption).toBeInTheDocument();
+    fireEvent.click(clearOption);
+    expect(input).toHaveValue('/clear');
+  });
+
   it('runs custom session commands with parsed arguments and context', async () => {
     const commandRun = jest.fn();
 

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -1116,19 +1116,22 @@ describe('TalonChannel', () => {
     expect(await screen.findByText('hello channel')).toBeInTheDocument();
   });
 
-  it('runs the built-in clear command without posting it as a channel message', async () => {
+  it('posts /clear as a normal channel message because channels have no built-in clear command', async () => {
     const fetchMock = global.fetch as jest.Mock;
     fetchMock.mockReset();
-    fetchMock.mockResolvedValueOnce(makeJsonResponse({
-      messages: [
-        {
-          id: 'channel-clear-1',
-          authorKind: 'user',
-          author: 'sightline',
-          content: 'Clear this channel view',
-        },
-      ],
-    }));
+    fetchMock
+      .mockResolvedValueOnce(makeJsonResponse({ messages: [] }))
+      .mockResolvedValueOnce(makeJsonResponse({ message: { id: 'channel-clear-text' } }))
+      .mockResolvedValueOnce(makeJsonResponse({
+        messages: [
+          {
+            id: 'channel-clear-text',
+            authorKind: 'user',
+            author: 'sightline',
+            content: '/clear',
+          },
+        ],
+      }));
 
     render(
       <TalonChannel
@@ -1136,62 +1139,35 @@ describe('TalonChannel', () => {
         channel="incident-room"
         gatewayUrl="http://localhost:18789"
         refreshIntervalMs={false}
-        enabledBuiltInCommands={['clear']}
       />,
     );
 
-    expect(await screen.findByText('Clear this channel view')).toBeInTheDocument();
-    fireEvent.change(screen.getByPlaceholderText('Message #incident-room'), {
+    const input = await screen.findByPlaceholderText('Message #incident-room');
+    fireEvent.change(input, { target: { value: '/' } });
+    expect(screen.queryByRole('listbox', { name: 'Command menu' })).not.toBeInTheDocument();
+
+    fireEvent.change(input, {
       target: { value: '/clear' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send channel message/i }));
 
-    await waitFor(() => expect(screen.queryByText('Clear this channel view')).not.toBeInTheDocument());
-    expect(screen.getByText('No channel messages.')).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps cleared channel messages hidden after the next background refresh', async () => {
-    jest.useFakeTimers();
-    const fetchMock = global.fetch as jest.Mock;
-    fetchMock.mockReset();
-    const clearedMessage = {
-      id: 'channel-clear-1',
-      authorKind: 'user',
-      author: 'sightline',
-      content: 'Do not bring this back',
-      createdAt: '2026-06-08T21:00:00.000Z',
-    };
-    fetchMock
-      .mockResolvedValueOnce(makeJsonResponse({ messages: [clearedMessage] }))
-      .mockResolvedValueOnce(makeJsonResponse({ messages: [clearedMessage] }));
-
-    render(
-      <TalonChannel
-        namespace="channel-collaboration"
-        channel="incident-room"
-        gatewayUrl="http://localhost:18789"
-        refreshIntervalMs={750}
-        enabledBuiltInCommands={['clear']}
-      />,
-    );
-
-    expect(await screen.findByText('Do not bring this back')).toBeInTheDocument();
-    fireEvent.change(screen.getByPlaceholderText('Message #incident-room'), {
-      target: { value: '/clear' },
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:18789/v1/ns/channel-collaboration/channels/incident-room/messages',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            ns: 'channel-collaboration',
+            channel: 'incident-room',
+            authorKind: 'user',
+            author: 'sightline',
+            content: '/clear',
+          }),
+        }),
+      );
     });
-    fireEvent.click(screen.getByRole('button', { name: /send channel message/i }));
-
-    await waitFor(() => expect(screen.queryByText('Do not bring this back')).not.toBeInTheDocument());
-    await act(async () => {
-      jest.advanceTimersByTime(750);
-      await Promise.resolve();
-    });
-
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    expect(screen.queryByText('Do not bring this back')).not.toBeInTheDocument();
-    expect(screen.getByText('No channel messages.')).toBeInTheDocument();
-    jest.useRealTimers();
+    expect(await screen.findByText('/clear')).toBeInTheDocument();
   });
 
   it('does not post duplicate channel messages while a submit is in flight', async () => {

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -332,6 +332,91 @@ describe('TalonCopilot', () => {
     );
   });
 
+  it('runs the built-in clear command without sending it as a session message', async () => {
+    const gatewayClient = {
+      createSession: jest.fn(),
+      clearSession: jest.fn().mockResolvedValue({ success: true }),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-clear',
+        state: 'IDLE',
+        messages: [
+          {
+            id: 'assistant-clear',
+            role: 'ROLE_ASSISTANT',
+            content: 'Clear me from the transcript',
+            createdAt: String(Date.now() * 1000),
+          },
+        ],
+        steps: [],
+      }),
+      getSession: jest.fn(),
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayUrl="http://localhost:18789"
+        gatewayClient={gatewayClient}
+        sessionId="sess-clear"
+        enabledBuiltInCommands={['clear']}
+      />,
+    );
+
+    expect(await screen.findByText('Clear me from the transcript')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Ask Talon to perform a task...'), {
+      target: { value: '/clear' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => expect(gatewayClient.clearSession).toHaveBeenCalledWith({
+      ns: 'ops',
+      agent: 'copilot',
+      sessionId: 'sess-clear',
+    }));
+    expect(screen.queryByText('Clear me from the transcript')).not.toBeInTheDocument();
+    expect(gatewayClient.createSession).not.toHaveBeenCalled();
+  });
+
+  it('runs custom session commands with parsed arguments and context', async () => {
+    const commandRun = jest.fn();
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayUrl="http://localhost:18789"
+        commands={[
+          {
+            name: 'tag',
+            aliases: ['t'],
+            run: commandRun,
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Ask Talon to perform a task...'), {
+      target: { value: '/t alpha beta' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => expect(commandRun).toHaveBeenCalled());
+    expect(commandRun).toHaveBeenCalledWith(expect.objectContaining({
+      name: 't',
+      input: '/t alpha beta',
+      args: 'alpha beta',
+      argv: ['alpha', 'beta'],
+      target: {
+        type: 'session',
+        namespace: 'ops',
+        agent: 'copilot',
+        sessionId: null,
+      },
+      messages: [],
+    }));
+  });
+
   it('scrolls the transcript container as streamed output arrives', async () => {
     const fetchMock = global.fetch as jest.Mock;
     fetchMock.mockReset();
@@ -993,6 +1078,41 @@ describe('TalonChannel', () => {
       );
     });
     expect(await screen.findByText('hello channel')).toBeInTheDocument();
+  });
+
+  it('runs the built-in clear command without posting it as a channel message', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce(makeJsonResponse({
+      messages: [
+        {
+          id: 'channel-clear-1',
+          authorKind: 'user',
+          author: 'sightline',
+          content: 'Clear this channel view',
+        },
+      ],
+    }));
+
+    render(
+      <TalonChannel
+        namespace="channel-collaboration"
+        channel="incident-room"
+        gatewayUrl="http://localhost:18789"
+        refreshIntervalMs={false}
+        enabledBuiltInCommands={['clear']}
+      />,
+    );
+
+    expect(await screen.findByText('Clear this channel view')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Message #incident-room'), {
+      target: { value: '/clear' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send channel message/i }));
+
+    await waitFor(() => expect(screen.queryByText('Clear this channel view')).not.toBeInTheDocument());
+    expect(screen.getByText('No channel messages.')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('does not post duplicate channel messages while a submit is in flight', async () => {


### PR DESCRIPTION
## Summary

Adds slash-command support to `@impalasys/talon-chat` for both session and channel chat surfaces.

## Changes

- Adds shared slash-command parsing and exported command types.
- Adds `commands` and `enabledBuiltInCommands` props to `TalonSession` / `TalonChannel`.
- Adds opt-in built-in `/clear` support:
  - sessions call the gateway clear-session route when a session is active, then clear the transcript UI
  - channels clear the visible channel message buffer
- Documents command usage in the package README.
- Adds focused tests for built-in and custom commands.

## Validation

- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`
- `pnpm --filter @impalasys/talon-chat build`
- `pnpm --filter @impalasys/talon-chat exec tsc --noEmit --jsx react-jsx --target es2022 --module esnext --moduleResolution bundler --lib dom,dom.iterable,es2022 --skipLibCheck --noImplicitAny false src/index.ts`

Note: full `pnpm --dir ui exec tsc --noEmit` is currently blocked by existing missing Jest global type errors in UI test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added slash command support for both sessions and channels.
  * Added built-in `/clear` command for sessions to clear chat history.
  * Added command menu interface in chat input.

* **Documentation**
  * Updated README with slash command documentation and examples.

* **Tests**
  * Added end-to-end tests for slash commands and session clearing.
  * Added unit tests for command behavior.

* **Chores**
  * Added Docker container configuration for Envoy proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->