### PR TITLE
Add Talon chat image upload support

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -166,6 +166,9 @@ services:
     environment:
       - NODE_ENV=production
       - NEXT_PUBLIC_GATEWAY_URL=http://localhost:18789
+      - TALON_OBJECT_STORE_PATH=/data/talon/objects
+    volumes:
+      - talon-objects:/data/talon/objects
     depends_on:
       gateway:
         condition: service_healthy

--- a/packages/talon-chat/README.md
+++ b/packages/talon-chat/README.md
@@ -42,6 +42,43 @@ You can also inject a gateway client for session CRUD:
 
 `TalonCopilot` is still exported as an alias for existing integrations.
 
+## Image uploads
+
+`TalonSession` can accept image attachments when you provide an `onImageUpload`
+callback. The callback is responsible for uploading bytes to your object store
+or backend upload route and returning the Talon `ObjectRef`. The chat request
+then sends only text plus object references.
+
+```tsx
+<TalonSession
+  namespace="support"
+  agent="docs"
+  gatewayUrl="http://localhost:18789"
+  onImageUpload={async ({ file, namespace, agent, sessionId, signal }) => {
+    const form = new FormData();
+    form.set("file", file);
+    form.set("namespace", namespace);
+    form.set("agent", agent);
+    form.set("sessionId", sessionId);
+
+    const response = await fetch("/api/talon/objects", {
+      method: "POST",
+      body: form,
+      signal,
+    });
+    if (!response.ok) {
+      throw new Error(`Upload failed: ${response.status}`);
+    }
+    return response.json();
+  }}
+/>
+```
+
+The uploader may return either an `ObjectRef` directly or `{ object:
+ObjectRef }`. Supported image types default to PNG, JPEG, GIF, and WebP. Use
+`acceptedImageTypes`, `maxImageAttachments`, and `maxImageBytes` to tune the
+composer validation.
+
 ## Commands
 
 Both `TalonSession` and `TalonChannel` can intercept slash commands before they are sent as chat messages. Enable the built-in session `/clear` command with `enabledBuiltInCommands`:

--- a/packages/talon-chat/src/TalonSession.stories.tsx
+++ b/packages/talon-chat/src/TalonSession.stories.tsx
@@ -87,6 +87,13 @@ const gatewayClient: GatewayClientLike = {
   }),
 };
 
+const mockImageUpload: TalonSessionProps["onImageUpload"] = async ({ file, namespace, agent, sessionId }) => ({
+  key: `${namespace}/${agent}/${sessionId}/uploads/${file.name}`,
+  mediaType: file.type || "image/png",
+  sizeBytes: file.size,
+  filename: file.name,
+});
+
 const streamingPrompt = "Summarize the latest incident notes and identify the next owner.";
 const streamingAssistantMessage = fixedMessages[1];
 const originalFetch = globalThis.fetch;
@@ -252,6 +259,13 @@ export const Disabled: Story = {
   args: {
     disabled: true,
     placeholder: "The copilot is temporarily unavailable",
+  },
+};
+
+export const ImageInputEnabled: Story = {
+  args: {
+    placeholder: "Ask Talon to inspect an image...",
+    onImageUpload: mockImageUpload,
   },
 };
 

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -91,6 +91,7 @@ export type TalonSessionProps = {
   commands?: TalonSessionCommand[];
   enabledBuiltInCommands?: TalonBuiltInCommandName[];
   onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
+  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined;
   maxImageAttachments?: number;
   maxImageBytes?: number;
   acceptedImageTypes?: string[];
@@ -270,6 +271,15 @@ function normalizeImageUploadResult(result: TalonImageUploadResult) {
   return "object" in result ? result.object : result;
 }
 
+function serializableMessageParts(parts: unknown) {
+  if (!Array.isArray(parts)) return [];
+  return parts.map((part: any) => {
+    if (!part || typeof part !== "object") return part;
+    const { previewUrl: _previewUrl, ...serializablePart } = part;
+    return serializablePart;
+  });
+}
+
 function parsePayloadJson(payloadJson: unknown): Record<string, unknown> {
   if (typeof payloadJson !== "string" || payloadJson.length === 0) return {};
   try {
@@ -280,7 +290,10 @@ function parsePayloadJson(payloadJson: unknown): Record<string, unknown> {
   }
 }
 
-function messageImageParts(message: CopilotMessage): Array<{ id: string; src?: string; label: string }> {
+function messageImageParts(
+  message: CopilotMessage,
+  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined,
+): Array<{ id: string; src?: string; label: string }> {
   if (!Array.isArray(message.parts)) return [];
   return message.parts.flatMap((part: any, index) => {
     const type = part?.type ?? part?.partType ?? part?.part_type;
@@ -294,10 +307,10 @@ function messageImageParts(message: CopilotMessage): Array<{ id: string; src?: s
         ? part.previewUrl
         : typeof part.url === "string"
           ? part.url
-          : typeof payload.previewUrl === "string"
-            ? payload.previewUrl
-            : typeof payload.url === "string"
-              ? payload.url
+          : typeof payload.url === "string"
+            ? payload.url
+            : object
+              ? objectUrlForRef?.(object)
               : undefined;
     const label =
       object?.filename ||
@@ -456,6 +469,7 @@ export function TalonSession({
   commands,
   enabledBuiltInCommands,
   onImageUpload,
+  objectUrlForRef,
   maxImageAttachments = 4,
   maxImageBytes = 20 * 1024 * 1024,
   acceptedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"],
@@ -629,7 +643,7 @@ export function TalonSession({
   const renderedMessages = useMemo(() => {
     return messages.map((message, messageIndex) => {
       const content = getMessageContent(message);
-      const images = messageImageParts(message);
+      const images = messageImageParts(message, objectUrlForRef);
       const timeline = getMessageAssistantTimeline(message);
       const textTimelineItems = timeline.filter((item): item is Extract<AssistantTimelineItem, { type: "text" }> => item.type === "text");
       const toolTimelineItems = timeline.filter((item): item is Extract<AssistantTimelineItem, { type: "tool" }> => item.type === "tool");
@@ -865,7 +879,7 @@ export function TalonSession({
         </div>
       );
     });
-  }, [messages, expandedThinkingMessages, expandedToolItems, isLoading, loadingNow, loadingStartedAt, toggleThinkingMessage, toggleToolItem]);
+  }, [messages, expandedThinkingMessages, expandedToolItems, isLoading, loadingNow, loadingStartedAt, objectUrlForRef, toggleThinkingMessage, toggleToolItem]);
 
   const resolvedHistoryPageSize = Math.max(
     1,
@@ -1302,7 +1316,7 @@ export function TalonSession({
             sizeBytes: attachment.object.sizeBytes ?? attachment.object.size_bytes ?? attachment.file.size,
           }),
           previewUrl: attachment.previewUrl,
-          payloadJson: JSON.stringify({ previewUrl: attachment.previewUrl, filename: attachment.file.name }),
+          payloadJson: JSON.stringify({ filename: attachment.file.name }),
         };
       });
       const messageParts = [
@@ -1333,7 +1347,9 @@ export function TalonSession({
           messages: [{
             role: userMessage.role,
             content: getMessageContent(userMessage),
-            parts: Array.isArray(userMessage.parts) ? userMessage.parts : (getMessageContent(userMessage) ? [{ type: "text", text: getMessageContent(userMessage) }] : []),
+            parts: Array.isArray(userMessage.parts)
+              ? serializableMessageParts(userMessage.parts)
+              : (getMessageContent(userMessage) ? [{ type: "text", text: getMessageContent(userMessage) }] : []),
           }],
         }),
       });

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -90,10 +90,24 @@ export type TalonSessionProps = {
   historyStepLimit?: number;
   commands?: TalonSessionCommand[];
   enabledBuiltInCommands?: TalonBuiltInCommandName[];
+  /**
+   * Uploads an image selected in the composer and returns the stored object ref.
+   * TalonSession performs client-side type and size checks for UX only; callers
+   * must validate file type, size, and content again in this upload handler
+   * before storing or processing the file.
+   */
   onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
   objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined;
   maxImageAttachments?: number;
+  /**
+   * Client-side image size limit in bytes. This improves UX only and must be
+   * enforced again by the onImageUpload implementation.
+   */
   maxImageBytes?: number;
+  /**
+   * Client-side accepted image MIME types. This can be bypassed by callers and
+   * must be enforced again by the onImageUpload implementation.
+   */
   acceptedImageTypes?: string[];
 };
 
@@ -104,6 +118,7 @@ const DEFAULT_HISTORY_PAGE_SIZE = 50;
 const DEFAULT_HISTORY_MESSAGE_LIMIT = 100;
 const DEFAULT_HISTORY_STEP_LIMIT = 1000;
 const HISTORY_SCROLL_LOAD_THRESHOLD_PX = 120;
+const SESSION_MESSAGE_PART_TYPE_IMAGE = 7;
 
 function buildGatewayChatUiUrl(gatewayUrl: string, ns: string, agent: string, sessionId: string) {
   return `${normalizeGatewayUrl(gatewayUrl)}/v1/ui/ns/${encodeURIComponent(ns)}/agents/${encodeURIComponent(agent)}/sessions/${encodeURIComponent(sessionId)}`;
@@ -302,7 +317,7 @@ function messageImageParts(
   if (!Array.isArray(message.parts)) return [];
   return message.parts.flatMap((part: any, index) => {
     const type = part?.type ?? part?.partType ?? part?.part_type;
-    if (type !== "image" && type !== 7 && type !== "SESSION_MESSAGE_PART_TYPE_IMAGE") {
+    if (type !== "image" && type !== SESSION_MESSAGE_PART_TYPE_IMAGE && type !== "SESSION_MESSAGE_PART_TYPE_IMAGE") {
       return [];
     }
     const payload = parsePayloadJson(part.payloadJson ?? part.payload_json);
@@ -1224,35 +1239,65 @@ export function TalonSession({
   ) => {
     if (!onImageUpload) return imageAttachmentsRef.current;
 
-    let attachments = imageAttachmentsRef.current;
+    const attachments = imageAttachmentsRef.current;
     const failed = attachments.find((attachment) => attachment.status === "error");
     if (failed) {
       throw new Error(failed.error || `Failed to attach ${failed.file.name}`);
     }
 
-    for (const attachment of attachments) {
-      if (attachment.object) continue;
-      setImageAttachments((current) => current.map((item) =>
-        item.id === attachment.id ? { ...item, status: "uploading", error: undefined } : item,
-      ));
-      const result = await onImageUpload({
+    const pendingUploads = attachments.filter((attachment) => !attachment.object);
+    if (pendingUploads.length === 0) {
+      return attachments;
+    }
+
+    const pendingIds = new Set(pendingUploads.map((attachment) => attachment.id));
+    const uploadingAttachments = imageAttachmentsRef.current.map((item) =>
+      pendingIds.has(item.id) ? { ...item, status: "uploading" as const, error: undefined } : item,
+    );
+    imageAttachmentsRef.current = uploadingAttachments;
+    setImageAttachments(uploadingAttachments);
+
+    const settled = await Promise.allSettled(pendingUploads.map(async (attachment) => ({
+      id: attachment.id,
+      object: normalizeImageUploadResult(await onImageUpload({
         file: attachment.file,
         namespace: session.ns,
         agent: session.agent,
         sessionId: session.sessionId,
         signal,
-      });
-      const object = normalizeImageUploadResult(result);
-      setImageAttachments((current) => current.map((item) =>
-        item.id === attachment.id ? { ...item, object, status: "ready", error: undefined } : item,
-      ));
-      attachments = imageAttachmentsRef.current.map((item) =>
-        item.id === attachment.id ? { ...item, object, status: "ready", error: undefined } : item,
-      );
-      imageAttachmentsRef.current = attachments;
+      })),
+    })));
+
+    const resultsById = new Map<string, { object?: TalonChatObjectRef; error?: string }>();
+    settled.forEach((result, index) => {
+      const attachment = pendingUploads[index];
+      if (!attachment) return;
+      if (result.status === "fulfilled") {
+        resultsById.set(attachment.id, { object: result.value.object });
+      } else {
+        const reason = result.reason;
+        resultsById.set(attachment.id, {
+          error: reason instanceof Error ? reason.message : String(reason || `Failed to attach ${attachment.file.name}`),
+        });
+      }
+    });
+
+    const nextAttachments = imageAttachmentsRef.current.map((item) => {
+      const result = resultsById.get(item.id);
+      if (!result) return item;
+      return result.object
+        ? { ...item, object: result.object, status: "ready" as const, error: undefined }
+        : { ...item, status: "error" as const, error: result.error || `Failed to attach ${item.file.name}` };
+    });
+    imageAttachmentsRef.current = nextAttachments;
+    setImageAttachments(nextAttachments);
+
+    const uploadFailure = nextAttachments.find((attachment) => attachment.status === "error");
+    if (uploadFailure) {
+      throw new Error(uploadFailure.error || `Failed to attach ${uploadFailure.file.name}`);
     }
 
-    return attachments;
+    return nextAttachments;
   }, [onImageUpload]);
 
   const submitMessage = useCallback(async (submittedText: string) => {
@@ -1351,9 +1396,7 @@ export function TalonSession({
         body: JSON.stringify({
           messages: [{
             role: userMessage.role,
-            parts: Array.isArray(userMessage.parts)
-              ? serializableMessageParts(userMessage.parts)
-              : (getMessageContent(userMessage) ? [{ type: "text", text: getMessageContent(userMessage) }] : []),
+            parts: serializableMessageParts(userMessage.parts),
           }],
         }),
       });

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -290,6 +290,11 @@ function parsePayloadJson(payloadJson: unknown): Record<string, unknown> {
   }
 }
 
+function objectRefFromPart(part: any): TalonChatObjectRef | undefined {
+  const object = part?.object ?? part?.objectRef ?? part?.object_ref;
+  return object && typeof object === "object" ? object as TalonChatObjectRef : undefined;
+}
+
 function messageImageParts(
   message: CopilotMessage,
   objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined,
@@ -301,7 +306,7 @@ function messageImageParts(
       return [];
     }
     const payload = parsePayloadJson(part.payloadJson ?? part.payload_json);
-    const object = part.object as TalonChatObjectRef | undefined;
+    const object = objectRefFromPart(part);
     const src =
       typeof part.previewUrl === "string"
         ? part.previewUrl

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -48,6 +48,30 @@ export type TalonSessionCommandTarget = {
 
 export type TalonSessionCommand = TalonChatCommand<TalonSessionCommandTarget, CopilotMessage>;
 
+export type TalonChatObjectRef = {
+  key: string;
+  mediaType?: string;
+  media_type?: string;
+  sizeBytes?: number | bigint | string;
+  size_bytes?: number | bigint | string;
+  sha256?: string;
+  filename?: string;
+  metadata?: Record<string, string>;
+};
+
+export type TalonImageUploadContext = {
+  file: File;
+  namespace: string;
+  agent: string;
+  sessionId: string;
+  signal: AbortSignal;
+};
+
+export type TalonImageUploadResult = TalonChatObjectRef | {
+  object: TalonChatObjectRef;
+  url?: string;
+};
+
 export type TalonSessionProps = {
   namespace: string;
   agent: string;
@@ -66,6 +90,10 @@ export type TalonSessionProps = {
   historyStepLimit?: number;
   commands?: TalonSessionCommand[];
   enabledBuiltInCommands?: TalonBuiltInCommandName[];
+  onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
+  maxImageAttachments?: number;
+  maxImageBytes?: number;
+  acceptedImageTypes?: string[];
 };
 
 export type TalonCopilotProps = TalonSessionProps;
@@ -186,6 +214,15 @@ type ScrollThumbState = {
   height: number;
 };
 
+type PendingImageAttachment = {
+  id: string;
+  file: File;
+  previewUrl: string;
+  object?: TalonChatObjectRef;
+  status: "queued" | "uploading" | "ready" | "error";
+  error?: string;
+};
+
 function stableStringHash(value: string) {
   let hash = 0;
   for (let index = 0; index < value.length; index += 1) {
@@ -202,6 +239,73 @@ function stableHistoryMessageId(message: any, index: number) {
   const createdAt = message?.createdAt ?? message?.created_at ?? "unknown";
   const content = getMessageContent(message);
   return `history-${role}-${createdAt}-${index}-${stableStringHash(content)}`;
+}
+
+function objectRefMediaType(object: TalonChatObjectRef | undefined) {
+  return object?.mediaType || object?.media_type || "";
+}
+
+function objectRefSizeBytes(object: TalonChatObjectRef): number {
+  const value = object.sizeBytes ?? object.size_bytes ?? 0;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return Number.isFinite(value) ? value : 0;
+}
+
+function normalizeObjectRefForJson(object: TalonChatObjectRef) {
+  return {
+    key: object.key,
+    mediaType: object.mediaType ?? object.media_type ?? "",
+    sizeBytes: objectRefSizeBytes(object),
+    sha256: object.sha256 ?? "",
+    filename: object.filename ?? "",
+    metadata: object.metadata ?? {},
+  };
+}
+
+function normalizeImageUploadResult(result: TalonImageUploadResult) {
+  return "object" in result ? result.object : result;
+}
+
+function parsePayloadJson(payloadJson: unknown): Record<string, unknown> {
+  if (typeof payloadJson !== "string" || payloadJson.length === 0) return {};
+  try {
+    const value = JSON.parse(payloadJson);
+    return value && typeof value === "object" ? value as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function messageImageParts(message: CopilotMessage): Array<{ id: string; src?: string; label: string }> {
+  if (!Array.isArray(message.parts)) return [];
+  return message.parts.flatMap((part: any, index) => {
+    const type = part?.type ?? part?.partType ?? part?.part_type;
+    if (type !== "image" && type !== 7 && type !== "SESSION_MESSAGE_PART_TYPE_IMAGE") {
+      return [];
+    }
+    const payload = parsePayloadJson(part.payloadJson ?? part.payload_json);
+    const object = part.object as TalonChatObjectRef | undefined;
+    const src =
+      typeof part.previewUrl === "string"
+        ? part.previewUrl
+        : typeof part.url === "string"
+          ? part.url
+          : typeof payload.previewUrl === "string"
+            ? payload.previewUrl
+            : typeof payload.url === "string"
+              ? payload.url
+              : undefined;
+    const label =
+      object?.filename ||
+      (typeof payload.filename === "string" ? payload.filename : undefined) ||
+      object?.key ||
+      `image-${index + 1}`;
+    return [{ id: `${message.id}-image-${index}`, src, label }];
+  });
 }
 
 function historyMessageTimestamp(message: Pick<CopilotMessage, "createdAt">) {
@@ -351,9 +455,14 @@ export function TalonSession({
   historyStepLimit = DEFAULT_HISTORY_STEP_LIMIT,
   commands,
   enabledBuiltInCommands,
+  onImageUpload,
+  maxImageAttachments = 4,
+  maxImageBytes = 20 * 1024 * 1024,
+  acceptedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"],
 }: TalonSessionProps) {
   const [messages, setMessages] = useState<CopilotMessage[]>(emptyMessages);
   const [input, setInput] = useState("");
+  const [imageAttachments, setImageAttachments] = useState<PendingImageAttachment[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
   const [loadingNow, setLoadingNow] = useState(Date.now());
@@ -372,6 +481,8 @@ export function TalonSession({
   const resumeAbortControllerRef = useRef<AbortController | null>(null);
   const currentSessionRef = useRef<{ ns: string; agent: string; sessionId: string } | null>(null);
   const messagesRef = useRef<CopilotMessage[]>(emptyMessages);
+  const imageAttachmentsRef = useRef<PendingImageAttachment[]>([]);
+  const submittedPreviewUrlsRef = useRef<string[]>([]);
   const skipNextAutoScrollRef = useRef(false);
   const prependScrollRestoreRef = useRef<{ previousScrollTop: number; previousScrollHeight: number } | null>(null);
   const isLoadingOlderHistoryRef = useRef(false);
@@ -406,6 +517,10 @@ export function TalonSession({
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  useEffect(() => {
+    imageAttachmentsRef.current = imageAttachments;
+  }, [imageAttachments]);
 
   useEffect(() => {
     currentSessionRef.current = currentSession;
@@ -469,6 +584,12 @@ export function TalonSession({
     return () => {
       abortControllerRef.current?.abort();
       resumeAbortControllerRef.current?.abort();
+      for (const attachment of imageAttachmentsRef.current) {
+        URL.revokeObjectURL(attachment.previewUrl);
+      }
+      for (const previewUrl of submittedPreviewUrlsRef.current) {
+        URL.revokeObjectURL(previewUrl);
+      }
     };
   }, []);
 
@@ -508,6 +629,7 @@ export function TalonSession({
   const renderedMessages = useMemo(() => {
     return messages.map((message, messageIndex) => {
       const content = getMessageContent(message);
+      const images = messageImageParts(message);
       const timeline = getMessageAssistantTimeline(message);
       const textTimelineItems = timeline.filter((item): item is Extract<AssistantTimelineItem, { type: "text" }> => item.type === "text");
       const toolTimelineItems = timeline.filter((item): item is Extract<AssistantTimelineItem, { type: "tool" }> => item.type === "tool");
@@ -701,6 +823,44 @@ export function TalonSession({
                 message.role === "assistant" ? <MarkdownMessage>{content}</MarkdownMessage> : content
               )}
             </div>
+            {images.length > 0 ? (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: content ? 10 : 0 }}>
+                {images.map((image) => (
+                  image.src ? (
+                    <img
+                      key={image.id}
+                      src={image.src}
+                      alt={image.label}
+                      style={{
+                        width: 132,
+                        maxWidth: "100%",
+                        aspectRatio: "1 / 1",
+                        objectFit: "cover",
+                        borderRadius: 8,
+                        border: border("var(--talon-chat-image-border, rgba(212,212,216,0.86))"),
+                      }}
+                    />
+                  ) : (
+                    <div
+                      key={image.id}
+                      title={image.label}
+                      style={{
+                        maxWidth: "100%",
+                        borderRadius: 8,
+                        border: border("var(--talon-chat-image-border, rgba(212,212,216,0.86))"),
+                        padding: "0.45rem 0.6rem",
+                        fontSize: 12,
+                        lineHeight: 1.3,
+                        color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))",
+                        overflowWrap: "anywhere",
+                      }}
+                    >
+                      {image.label}
+                    </div>
+                  )
+                ))}
+              </div>
+            ) : null}
           </div>
         </div>
       );
@@ -985,14 +1145,106 @@ export function TalonSession({
     () => resolvedCommands.map(({ name, aliases, description }) => ({ name, aliases, description })),
     [resolvedCommands],
   );
+  const imageAccept = useMemo(() => acceptedImageTypes.join(","), [acceptedImageTypes]);
+  const acceptedImageTypesSet = useMemo(() => new Set(acceptedImageTypes), [acceptedImageTypes]);
+
+  const removeImageAttachment = useCallback((id: string) => {
+    setImageAttachments((current) => {
+      const removed = current.find((attachment) => attachment.id === id);
+      if (removed) {
+        URL.revokeObjectURL(removed.previewUrl);
+      }
+      return current.filter((attachment) => attachment.id !== id);
+    });
+  }, []);
+
+  const addImageFiles = useCallback((files: File[]) => {
+    if (!onImageUpload) return;
+    setError(null);
+    setImageAttachments((current) => {
+      const availableSlots = Math.max(0, maxImageAttachments - current.length);
+      const next = [...current];
+      for (const file of files.slice(0, availableSlots)) {
+        if (!acceptedImageTypesSet.has(file.type)) {
+          next.push({
+            id: createLocalMessageId(),
+            file,
+            previewUrl: URL.createObjectURL(file),
+            status: "error",
+            error: `Unsupported image type: ${file.type || "unknown"}`,
+          });
+          continue;
+        }
+        if (file.size > maxImageBytes) {
+          next.push({
+            id: createLocalMessageId(),
+            file,
+            previewUrl: URL.createObjectURL(file),
+            status: "error",
+            error: `Image is larger than ${Math.round(maxImageBytes / (1024 * 1024))} MB`,
+          });
+          continue;
+        }
+        next.push({
+          id: createLocalMessageId(),
+          file,
+          previewUrl: URL.createObjectURL(file),
+          status: "queued",
+        });
+      }
+      if (files.length > availableSlots) {
+        setError(new Error(`You can attach up to ${maxImageAttachments} images.`));
+      }
+      return next;
+    });
+  }, [acceptedImageTypesSet, maxImageAttachments, maxImageBytes, onImageUpload]);
+
+  const uploadQueuedImages = useCallback(async (
+    session: { ns: string; agent: string; sessionId: string },
+    signal: AbortSignal,
+  ) => {
+    if (!onImageUpload) return imageAttachmentsRef.current;
+
+    let attachments = imageAttachmentsRef.current;
+    const failed = attachments.find((attachment) => attachment.status === "error");
+    if (failed) {
+      throw new Error(failed.error || `Failed to attach ${failed.file.name}`);
+    }
+
+    for (const attachment of attachments) {
+      if (attachment.object) continue;
+      setImageAttachments((current) => current.map((item) =>
+        item.id === attachment.id ? { ...item, status: "uploading", error: undefined } : item,
+      ));
+      const result = await onImageUpload({
+        file: attachment.file,
+        namespace: session.ns,
+        agent: session.agent,
+        sessionId: session.sessionId,
+        signal,
+      });
+      const object = normalizeImageUploadResult(result);
+      setImageAttachments((current) => current.map((item) =>
+        item.id === attachment.id ? { ...item, object, status: "ready", error: undefined } : item,
+      ));
+      attachments = imageAttachmentsRef.current.map((item) =>
+        item.id === attachment.id ? { ...item, object, status: "ready", error: undefined } : item,
+      );
+      imageAttachmentsRef.current = attachments;
+    }
+
+    return attachments;
+  }, [onImageUpload]);
 
   const submitMessage = useCallback(async (submittedText: string) => {
     const text = submittedText.trim();
-    if (!text || isLoading || disabled) return;
+    const pendingAttachments = imageAttachmentsRef.current;
+    const hasImages = pendingAttachments.length > 0;
+    if ((!text && !hasImages) || isLoading || disabled) return;
 
     const parsedCommand = parseTalonChatCommandInput(text);
     const command = findTalonChatCommand(resolvedCommands, parsedCommand);
-    if (command && parsedCommand) {
+    if (command && parsedCommand && !hasImages) {
       setInput("");
       setError(null);
       setStreamEvents([]);
@@ -1017,7 +1269,6 @@ export function TalonSession({
       return;
     }
 
-    setInput("");
     setError(null);
     setStreamEvents([]);
 
@@ -1035,21 +1286,44 @@ export function TalonSession({
         onSessionChange?.(session.sessionId);
       }
 
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      const uploadedImages = await uploadQueuedImages(session, controller.signal);
+      const imageParts = uploadedImages.map((attachment) => {
+        if (!attachment.object) {
+          throw new Error(`Image ${attachment.file.name} was not uploaded.`);
+        }
+        return {
+          type: "image",
+          object: normalizeObjectRefForJson({
+            ...attachment.object,
+            filename: attachment.object.filename || attachment.file.name,
+            mediaType: objectRefMediaType(attachment.object) || attachment.file.type,
+            sizeBytes: attachment.object.sizeBytes ?? attachment.object.size_bytes ?? attachment.file.size,
+          }),
+          previewUrl: attachment.previewUrl,
+          payloadJson: JSON.stringify({ previewUrl: attachment.previewUrl, filename: attachment.file.name }),
+        };
+      });
+      const messageParts = [
+        ...(text ? [{ type: "text", text }] : []),
+        ...imageParts,
+      ];
       const userMessage: CopilotMessage = {
         id: createLocalMessageId(),
         role: "user",
         content: text,
-        parts: [{ type: "text", text }],
+        parts: messageParts,
         createdAt: String(Date.now() * 1000),
       };
 
+      setInput("");
+      submittedPreviewUrlsRef.current.push(...uploadedImages.map((attachment) => attachment.previewUrl));
+      setImageAttachments([]);
       setMessages((prev) => [...prev, userMessage]);
       setLoadingStartedAt(normalizeEpochToMilliseconds(userMessage.createdAt) ?? Date.now());
       setLoadingNow(Date.now());
       setIsLoading(true);
-
-      const controller = new AbortController();
-      abortControllerRef.current = controller;
 
       const response = await fetch(buildGatewayChatUiUrl(gatewayUrl, session.ns, session.agent, session.sessionId), {
         method: "POST",
@@ -1059,7 +1333,7 @@ export function TalonSession({
           messages: [{
             role: userMessage.role,
             content: getMessageContent(userMessage),
-            parts: Array.isArray(userMessage.parts) ? userMessage.parts : [{ type: "text", text: getMessageContent(userMessage) }],
+            parts: Array.isArray(userMessage.parts) ? userMessage.parts : (getMessageContent(userMessage) ? [{ type: "text", text: getMessageContent(userMessage) }] : []),
           }],
         }),
       });
@@ -1093,7 +1367,7 @@ export function TalonSession({
       setIsLoading(false);
       setLoadingStartedAt(null);
     }
-  }, [agent, clearSession, createSession, disabled, gatewayUrl, isLoading, jsonHeaders, namespace, onSessionChange, refreshNewestSessionPage, resolvedCommands, resolvedHistoryPageSize, sessionId, waitForCanonicalAssistantUpdate]);
+  }, [agent, clearSession, createSession, disabled, gatewayUrl, isLoading, jsonHeaders, namespace, onSessionChange, refreshNewestSessionPage, resolvedCommands, resolvedHistoryPageSize, sessionId, uploadQueuedImages, waitForCanonicalAssistantUpdate]);
 
   const stopGeneration = useCallback(async () => {
     if (!currentSessionRef.current || !isLoading) return;
@@ -1243,10 +1517,21 @@ export function TalonSession({
               placeholder={placeholder}
               autoFocus={autoFocus}
               rows={inputRows}
-              canSubmit={Boolean((input || "").trim()) && !isLoading}
+              canSubmit={Boolean((input || "").trim() || imageAttachments.length > 0) && !isLoading}
               isGenerating={isLoading}
               canStop={Boolean(currentSession)}
               commandMenuItems={commandMenuItems}
+              imageAttachments={imageAttachments.map((attachment) => ({
+                id: attachment.id,
+                filename: attachment.file.name,
+                previewUrl: attachment.previewUrl,
+                status: attachment.status,
+                error: attachment.error,
+              }))}
+              imageUploadEnabled={Boolean(onImageUpload)}
+              imageAccept={imageAccept}
+              onImageFilesSelected={addImageFiles}
+              onRemoveImageAttachment={removeImageAttachment}
               onStop={() => {
                 void stopGeneration().catch((err: any) =>
                   setError(err instanceof Error ? err : new Error("Failed to stop generation")),

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -1346,7 +1346,6 @@ export function TalonSession({
         body: JSON.stringify({
           messages: [{
             role: userMessage.role,
-            content: getMessageContent(userMessage),
             parts: Array.isArray(userMessage.parts)
               ? serializableMessageParts(userMessage.parts)
               : (getMessageContent(userMessage) ? [{ type: "text", text: getMessageContent(userMessage) }] : []),

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -120,6 +120,7 @@ export type TalonSessionProps = {
   commands?: TalonSessionCommand[];
   enabledBuiltInCommands?: TalonBuiltInCommandName[];
   onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
+  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined;
   maxImageAttachments?: number;
   maxImageBytes?: number;
   acceptedImageTypes?: string[];

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -77,6 +77,30 @@ export type TalonSessionCommandTarget = {
 
 export type TalonSessionCommand = TalonChatCommand<TalonSessionCommandTarget, CopilotMessage>;
 
+export type TalonChatObjectRef = {
+  key: string;
+  mediaType?: string;
+  media_type?: string;
+  sizeBytes?: number | bigint | string;
+  size_bytes?: number | bigint | string;
+  sha256?: string;
+  filename?: string;
+  metadata?: Record<string, string>;
+};
+
+export type TalonImageUploadContext = {
+  file: File;
+  namespace: string;
+  agent: string;
+  sessionId: string;
+  signal: AbortSignal;
+};
+
+export type TalonImageUploadResult = TalonChatObjectRef | {
+  object: TalonChatObjectRef;
+  url?: string;
+};
+
 export type TalonSessionProps = {
   namespace: string;
   agent: string;
@@ -95,6 +119,10 @@ export type TalonSessionProps = {
   historyStepLimit?: number;
   commands?: TalonSessionCommand[];
   enabledBuiltInCommands?: TalonBuiltInCommandName[];
+  onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
+  maxImageAttachments?: number;
+  maxImageBytes?: number;
+  acceptedImageTypes?: string[];
 };
 
 export type TalonCopilotProps = TalonSessionProps;

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -119,10 +119,24 @@ export type TalonSessionProps = {
   historyStepLimit?: number;
   commands?: TalonSessionCommand[];
   enabledBuiltInCommands?: TalonBuiltInCommandName[];
+  /**
+   * Uploads an image selected in the composer and returns the stored object ref.
+   * TalonSession performs client-side type and size checks for UX only; callers
+   * must validate file type, size, and content again in this upload handler
+   * before storing or processing the file.
+   */
   onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
   objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined;
   maxImageAttachments?: number;
+  /**
+   * Client-side image size limit in bytes. This improves UX only and must be
+   * enforced again by the onImageUpload implementation.
+   */
   maxImageBytes?: number;
+  /**
+   * Client-side accepted image MIME types. This can be bypassed by callers and
+   * must be enforced again by the onImageUpload implementation.
+   */
   acceptedImageTypes?: string[];
 };
 

--- a/packages/talon-chat/src/index.ts
+++ b/packages/talon-chat/src/index.ts
@@ -6,6 +6,9 @@ export {
   type TalonSessionCommandTarget,
   type TalonSessionProps,
   type TalonCopilotProps,
+  type TalonChatObjectRef,
+  type TalonImageUploadContext,
+  type TalonImageUploadResult,
 } from "./TalonSession";
 export {
   TalonChannel,

--- a/packages/talon-chat/src/lib/ChatInputBox.stories.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.stories.tsx
@@ -14,14 +14,19 @@ const meta = {
     autoFocus: false,
     imageUploadEnabled: true,
     canSubmit: false,
+    previewTopPadding: 40,
+  },
+  argTypes: {
+    previewTopPadding: { table: { disable: true } },
   },
   render: (args) => {
     const [value, setValue] = useState(args.value ?? "");
+    const { previewTopPadding, ...inputArgs } = args;
     return (
-      <div style={{ padding: 40, background: "#fff" }}>
+      <div style={{ padding: `${previewTopPadding ?? 40}px 40px 40px`, background: "#fff" }}>
         <div style={{ width: "min(100%, 960px)", margin: "0 auto" }}>
           <ChatInputBox
-            {...args}
+            {...inputArgs}
             value={value}
             onValueChange={setValue}
             onSubmit={() => {}}
@@ -38,6 +43,9 @@ type Story = StoryObj<typeof meta>;
 export const ImageInputEnabled: Story = {};
 
 export const AttachmentMenuOpen: Story = {
+  args: {
+    previewTopPadding: 320,
+  },
   play: async ({ canvasElement }) => {
     const button = canvasElement.querySelector<HTMLButtonElement>('button[aria-label="Open attachment menu"]');
     button?.click();

--- a/packages/talon-chat/src/lib/ChatInputBox.stories.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.stories.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ChatInputBox, type ChatInputImageAttachment } from "./ChatInputBox";
+
+const previewImageUrl =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+const meta = {
+  title: "Talon Chat/ChatInputBox",
+  component: ChatInputBox,
+  tags: ["autodocs"],
+  args: {
+    placeholder: "Ask Talon to perform a task...",
+    autoFocus: false,
+    imageUploadEnabled: true,
+    canSubmit: false,
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? "");
+    return (
+      <div style={{ padding: 40, background: "#fff" }}>
+        <div style={{ width: "min(100%, 960px)", margin: "0 auto" }}>
+          <ChatInputBox
+            {...args}
+            value={value}
+            onValueChange={setValue}
+            onSubmit={() => {}}
+          />
+        </div>
+      </div>
+    );
+  },
+} satisfies Meta<typeof ChatInputBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ImageInputEnabled: Story = {};
+
+export const WithImageAttachment: Story = {
+  args: {
+    value: "What is this?",
+    canSubmit: true,
+    imageAttachments: [
+      {
+        id: "storybook-image",
+        filename: "favicon.PNG",
+        previewUrl: previewImageUrl,
+        status: "ready",
+      },
+    ] satisfies ChatInputImageAttachment[],
+  },
+};

--- a/packages/talon-chat/src/lib/ChatInputBox.stories.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ChatInputBox, type ChatInputImageAttachment } from "./ChatInputBox";
 
+const existingImageUrl = new URL("../../../../docs/pr/hello-world-sightline.png", import.meta.url).href;
 const previewImageUrl =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
@@ -49,6 +50,20 @@ export const AttachmentMenuOpen: Story = {
   play: async ({ canvasElement }) => {
     const button = canvasElement.querySelector<HTMLButtonElement>('button[aria-label="Open attachment menu"]');
     button?.click();
+  },
+};
+
+export const ExistingImageAttachment: Story = {
+  args: {
+    canSubmit: true,
+    imageAttachments: [
+      {
+        id: "existing-storybook-image",
+        filename: "hello-world-sightline.png",
+        previewUrl: existingImageUrl,
+        status: "ready",
+      },
+    ] satisfies ChatInputImageAttachment[],
   },
 };
 

--- a/packages/talon-chat/src/lib/ChatInputBox.stories.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.stories.tsx
@@ -37,6 +37,13 @@ type Story = StoryObj<typeof meta>;
 
 export const ImageInputEnabled: Story = {};
 
+export const AttachmentMenuOpen: Story = {
+  play: async ({ canvasElement }) => {
+    const button = canvasElement.querySelector<HTMLButtonElement>('button[aria-label="Open attachment menu"]');
+    button?.click();
+  },
+};
+
 export const WithImageAttachment: Story = {
   args: {
     value: "What is this?",

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -84,7 +84,7 @@ export function ChatInputBox({
   const resolvedCanStop = Boolean(isStopMode && canStop);
   const buttonDisabled = isStopMode ? !resolvedCanStop : !resolvedCanSubmit;
   const buttonIsEnabled = !buttonDisabled;
-  const buttonSize = 30;
+  const buttonSize = 34;
   const isSingleLine = rows <= 1;
   const attachments = imageAttachments ?? [];
   const textareaLineHeight = isSingleLine ? buttonSize : 20;

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -340,10 +340,10 @@ export function ChatInputBox({
                   left: 0,
                   bottom: "calc(100% + 8px)",
                   zIndex: 30,
-                  width: "min(240px, calc(100vw - 48px))",
+                  width: "min(176px, calc(100vw - 48px))",
                   boxSizing: "border-box",
-                  padding: "0.625rem",
-                  borderRadius: 20,
+                  padding: "0.375rem",
+                  borderRadius: 16,
                   border: border("var(--copilot-attachment-menu-border, rgba(212,212,216,0.9))"),
                   background: "var(--copilot-attachment-menu-bg, rgba(255,255,255,0.98))",
                   boxShadow: "var(--copilot-attachment-menu-shadow, 0 18px 46px rgba(24,24,27,0.16), 0 2px 8px rgba(24,24,27,0.08))",
@@ -362,13 +362,13 @@ export function ChatInputBox({
                   }}
                   style={{
                     width: "100%",
-                    minHeight: 44,
+                    minHeight: 34,
                     boxSizing: "border-box",
                     border: "none",
-                    borderRadius: 12,
-                    padding: "0.375rem 0.5rem",
+                    borderRadius: 10,
+                    padding: "0.25rem 0.375rem",
                     display: "grid",
-                    gridTemplateColumns: "32px minmax(0, 1fr)",
+                    gridTemplateColumns: "26px minmax(0, 1fr)",
                     alignItems: "center",
                     gap: 8,
                     background: hoveredAttachmentIndex === 0
@@ -377,7 +377,7 @@ export function ChatInputBox({
                     color: "inherit",
                     cursor: "pointer",
                     fontFamily: "inherit",
-                    fontSize: 16,
+                    fontSize: 14,
                     lineHeight: 1.2,
                     textAlign: "left",
                   }}
@@ -385,15 +385,15 @@ export function ChatInputBox({
                   <span
                     aria-hidden="true"
                     style={{
-                      width: 32,
-                      height: 32,
+                      width: 26,
+                      height: 26,
                       display: "inline-flex",
                       alignItems: "center",
                       justifyContent: "center",
                       color: "var(--copilot-attachment-menu-icon-fg, rgba(24,24,27,0.96))",
                     }}
                   >
-                    <ImagePlus size="21" strokeWidth={2.2} />
+                    <ImagePlus size="17" strokeWidth={2.1} />
                   </span>
                   <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                     {imageButtonLabel}

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -1,15 +1,9 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import {
   ArrowUp,
-  ChevronRight,
-  Ellipsis,
-  FileText,
-  Globe,
   ImagePlus,
-  Paperclip,
   Plus,
   Square,
-  Telescope,
   Terminal,
   X,
 } from "lucide-react";
@@ -83,7 +77,7 @@ export function ChatInputBox({
   imageAttachments,
   imageUploadEnabled = false,
   imageAccept = "image/png,image/jpeg,image/gif,image/webp",
-  imageButtonLabel = "Add photos & files",
+  imageButtonLabel = "Add image",
   onImageFilesSelected,
   onRemoveImageAttachment,
   style,
@@ -346,9 +340,9 @@ export function ChatInputBox({
                   left: 0,
                   bottom: "calc(100% + 8px)",
                   zIndex: 30,
-                  width: "min(300px, calc(100vw - 48px))",
+                  width: "min(240px, calc(100vw - 48px))",
                   boxSizing: "border-box",
-                  padding: "0.875rem 1rem",
+                  padding: "0.625rem",
                   borderRadius: 20,
                   border: border("var(--copilot-attachment-menu-border, rgba(212,212,216,0.9))"),
                   background: "var(--copilot-attachment-menu-bg, rgba(255,255,255,0.98))",
@@ -356,113 +350,55 @@ export function ChatInputBox({
                   color: "var(--copilot-attachment-menu-fg, rgba(24,24,27,0.96))",
                 }}
               >
-                {[
-                  {
-                    label: imageButtonLabel,
-                    icon: <Paperclip size="21" strokeWidth={2.3} />,
-                    action: () => {
-                      setShowAttachmentMenu(false);
-                      fileInputRef.current?.click();
-                    },
-                  },
-                  {
-                    label: "Recent files",
-                    icon: <FileText size="21" strokeWidth={2.2} />,
-                    chevron: true,
-                  },
-                  { divider: true },
-                  {
-                    label: "Create image",
-                    icon: <ImagePlus size="21" strokeWidth={2.2} />,
-                  },
-                  {
-                    label: "Deep research",
-                    icon: <Telescope size="21" strokeWidth={2.2} />,
-                  },
-                  {
-                    label: "Web search",
-                    icon: <Globe size="21" strokeWidth={2.2} />,
-                  },
-                  {
-                    label: "More",
-                    icon: <Ellipsis size="21" strokeWidth={2.2} />,
-                    chevron: true,
-                  },
-                ].map((item, index) => {
-                  if ("divider" in item) {
-                    return (
-                      <div
-                        key={`divider-${index}`}
-                        role="separator"
-                        style={{
-                          height: 1,
-                          margin: "0.5rem 0.25rem",
-                          background: "var(--copilot-attachment-menu-divider, rgba(212,212,216,0.88))",
-                        }}
-                      />
-                    );
-                  }
-                  const isActive = Boolean(item.action);
-                  const isHovered = hoveredAttachmentIndex === index;
-                  return (
-                    <button
-                      key={item.label}
-                      type="button"
-                      role="menuitem"
-                      aria-disabled={!isActive}
-                      onMouseDown={(event) => event.preventDefault()}
-                      onMouseEnter={() => setHoveredAttachmentIndex(index)}
-                      onMouseLeave={() => setHoveredAttachmentIndex(null)}
-                      onClick={() => item.action?.()}
-                      style={{
-                        width: "100%",
-                        minHeight: 44,
-                        boxSizing: "border-box",
-                        border: "none",
-                        borderRadius: 10,
-                        padding: "0.375rem 0.25rem",
-                        display: "grid",
-                        gridTemplateColumns: "32px minmax(0, 1fr) 20px",
-                        alignItems: "center",
-                        gap: 8,
-                        background: isHovered && isActive
-                          ? "var(--copilot-attachment-menu-hover-bg, rgba(24,24,27,0.07))"
-                          : "transparent",
-                        color: "inherit",
-                        cursor: isActive ? "pointer" : "default",
-                        fontFamily: "inherit",
-                        fontSize: 16,
-                        lineHeight: 1.2,
-                        textAlign: "left",
-                      }}
-                    >
-                      <span
-                        aria-hidden="true"
-                        style={{
-                          width: 32,
-                          height: 32,
-                          display: "inline-flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          color: "var(--copilot-attachment-menu-icon-fg, rgba(24,24,27,0.96))",
-                        }}
-                      >
-                        {item.icon}
-                      </span>
-                      <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                        {item.label}
-                      </span>
-                      {item.chevron ? (
-                        <ChevronRight
-                          aria-hidden="true"
-                          size="20"
-                          strokeWidth={2.1}
-                          style={{ justifySelf: "end" }}
-                        />
-                      ) : null}
-                    </button>
-                  );
-                })}
+                <button
+                  type="button"
+                  role="menuitem"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onMouseEnter={() => setHoveredAttachmentIndex(0)}
+                  onMouseLeave={() => setHoveredAttachmentIndex(null)}
+                  onClick={() => {
+                    setShowAttachmentMenu(false);
+                    fileInputRef.current?.click();
+                  }}
+                  style={{
+                    width: "100%",
+                    minHeight: 44,
+                    boxSizing: "border-box",
+                    border: "none",
+                    borderRadius: 12,
+                    padding: "0.375rem 0.5rem",
+                    display: "grid",
+                    gridTemplateColumns: "32px minmax(0, 1fr)",
+                    alignItems: "center",
+                    gap: 8,
+                    background: hoveredAttachmentIndex === 0
+                      ? "var(--copilot-attachment-menu-hover-bg, rgba(24,24,27,0.07))"
+                      : "transparent",
+                    color: "inherit",
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                    fontSize: 16,
+                    lineHeight: 1.2,
+                    textAlign: "left",
+                  }}
+                >
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: 32,
+                      height: 32,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      color: "var(--copilot-attachment-menu-icon-fg, rgba(24,24,27,0.96))",
+                    }}
+                  >
+                    <ImagePlus size="21" strokeWidth={2.2} />
+                  </span>
+                  <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {imageButtonLabel}
+                  </span>
+                </button>
               </div>
             ) : null}
             <input

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -5,6 +5,9 @@ function border(color: string) {
   return `1px solid ${color}`;
 }
 
+const talonChatFontFamily =
+  'var(--talon-chat-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)';
+
 export type ChatInputBoxProps = {
   value: string;
   onValueChange: (value: string) => void;
@@ -139,6 +142,7 @@ export function ChatInputBox({
           padding: "0.25rem 0.3125rem 0.25rem 0.625rem",
           backdropFilter: "blur(12px)",
           flexWrap: attachments.length > 0 ? "wrap" : "nowrap",
+          fontFamily: talonChatFontFamily,
           ...style,
         }}
       >

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -145,7 +145,7 @@ export function ChatInputBox({
           gap: 8,
           width: "100%",
           boxSizing: "border-box",
-          borderRadius: 18,
+          borderRadius: 999,
           border: border("var(--copilot-input-border, rgba(212,212,216,0.72))"),
           background: "var(--copilot-input-bg, rgba(255,255,255,0.96))",
           boxShadow: "var(--copilot-input-shadow, 0 4px 14px rgba(24,24,27,0.08), 0 1px 2px rgba(24,24,27,0.06))",
@@ -438,7 +438,7 @@ export function ChatInputBox({
                 justifyContent: "center",
                 cursor: disabled || isGenerating ? "not-allowed" : "pointer",
                 opacity: disabled || isGenerating ? 0.5 : 1,
-                background: "var(--copilot-secondary-control-bg, rgba(24,24,27,0.08))",
+                background: "transparent",
                 color: "var(--copilot-secondary-control-fg, rgba(39,39,42,0.88))",
               }}
             >

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { ArrowUp, Square, Terminal } from "lucide-react";
+import { ArrowUp, ImagePlus, Square, Terminal, X } from "lucide-react";
 
 function border(color: string) {
   return `1px solid ${color}`;
@@ -23,6 +23,12 @@ export type ChatInputBoxProps = {
   textareaMinHeight?: number;
   textareaMaxHeight?: number | string;
   commandMenuItems?: ChatInputCommandMenuItem[];
+  imageAttachments?: ChatInputImageAttachment[];
+  imageUploadEnabled?: boolean;
+  imageAccept?: string;
+  imageButtonLabel?: string;
+  onImageFilesSelected?: (files: File[]) => void;
+  onRemoveImageAttachment?: (id: string) => void;
   style?: React.CSSProperties;
 };
 
@@ -30,6 +36,14 @@ export type ChatInputCommandMenuItem = {
   name: string;
   aliases?: string[];
   description?: string;
+};
+
+export type ChatInputImageAttachment = {
+  id: string;
+  filename: string;
+  previewUrl: string;
+  status?: "queued" | "uploading" | "ready" | "error";
+  error?: string;
 };
 
 export function ChatInputBox({
@@ -50,9 +64,16 @@ export function ChatInputBox({
   textareaMinHeight = 24,
   textareaMaxHeight = "40vh",
   commandMenuItems,
+  imageAttachments,
+  imageUploadEnabled = false,
+  imageAccept = "image/png,image/jpeg,image/gif,image/webp",
+  imageButtonLabel = "Attach image",
+  onImageFilesSelected,
+  onRemoveImageAttachment,
   style,
 }: ChatInputBoxProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [highlightedCommandIndex, setHighlightedCommandIndex] = useState(0);
   const [hoveredCommandIndex, setHoveredCommandIndex] = useState<number | null>(null);
   const resolvedCanSubmit = canSubmit ?? (Boolean(value.trim()) && !disabled && !isGenerating);
@@ -62,6 +83,7 @@ export function ChatInputBox({
   const buttonIsEnabled = !buttonDisabled;
   const buttonSize = 30;
   const isSingleLine = rows <= 1;
+  const attachments = imageAttachments ?? [];
   const textareaLineHeight = isSingleLine ? buttonSize : 20;
   const resolvedTextareaMinHeight = rows > 1 ? textareaMinHeight : buttonSize;
   const commandQuery = value.trimStart().startsWith("/") ? value.trimStart().slice(1).toLowerCase() : null;
@@ -116,6 +138,7 @@ export function ChatInputBox({
           boxShadow: "var(--copilot-input-shadow, 0 4px 14px rgba(24,24,27,0.08), 0 1px 2px rgba(24,24,27,0.06))",
           padding: "0.25rem 0.3125rem 0.25rem 0.625rem",
           backdropFilter: "blur(12px)",
+          flexWrap: attachments.length > 0 ? "wrap" : "nowrap",
           ...style,
         }}
       >
@@ -207,6 +230,130 @@ export function ChatInputBox({
               );
             })}
           </div>
+        ) : null}
+        {attachments.length > 0 ? (
+          <div
+            style={{
+              flexBasis: "100%",
+              display: "flex",
+              gap: 8,
+              overflowX: "auto",
+              padding: "0.25rem 0.25rem 0.125rem 0",
+            }}
+          >
+            {attachments.map((attachment) => (
+              <div
+                key={attachment.id}
+                style={{
+                  position: "relative",
+                  width: 58,
+                  height: 58,
+                  flexShrink: 0,
+                  overflow: "hidden",
+                  borderRadius: 8,
+                  border: border(
+                    attachment.status === "error"
+                      ? "var(--copilot-attachment-error-border, rgba(220,38,38,0.55))"
+                      : "var(--copilot-attachment-border, rgba(212,212,216,0.9))",
+                  ),
+                  background: "var(--copilot-attachment-bg, rgba(244,244,245,0.88))",
+                }}
+                title={attachment.error || attachment.filename}
+              >
+                <img
+                  src={attachment.previewUrl}
+                  alt={attachment.filename}
+                  style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+                />
+                {attachment.status === "uploading" ? (
+                  <div
+                    aria-label="Uploading image"
+                    style={{
+                      position: "absolute",
+                      inset: 0,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      background: "rgba(24,24,27,0.42)",
+                      color: "#fff",
+                      fontSize: 11,
+                      fontWeight: 700,
+                    }}
+                  >
+                    ...
+                  </div>
+                ) : null}
+                <button
+                  type="button"
+                  aria-label={`Remove ${attachment.filename}`}
+                  onClick={() => onRemoveImageAttachment?.(attachment.id)}
+                  style={{
+                    position: "absolute",
+                    top: 4,
+                    right: 4,
+                    width: 20,
+                    height: 20,
+                    borderRadius: 999,
+                    border: "none",
+                    padding: 0,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    background: "rgba(24,24,27,0.74)",
+                    color: "#fff",
+                    cursor: "pointer",
+                  }}
+                >
+                  <X size="13" strokeWidth={2.2} />
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : null}
+        {imageUploadEnabled ? (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={imageAccept}
+              multiple
+              tabIndex={-1}
+              aria-hidden="true"
+              style={{ display: "none" }}
+              onChange={(event) => {
+                const files = Array.from(event.target.files ?? []);
+                event.target.value = "";
+                if (files.length > 0) {
+                  onImageFilesSelected?.(files);
+                }
+              }}
+            />
+            <button
+              type="button"
+              aria-label={imageButtonLabel}
+              title={imageButtonLabel}
+              disabled={disabled || isGenerating}
+              onClick={() => fileInputRef.current?.click()}
+              style={{
+                width: buttonSize,
+                height: buttonSize,
+                boxSizing: "border-box",
+                flexShrink: 0,
+                borderRadius: 999,
+                border: "none",
+                padding: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                cursor: disabled || isGenerating ? "not-allowed" : "pointer",
+                opacity: disabled || isGenerating ? 0.5 : 1,
+                background: "var(--copilot-secondary-control-bg, rgba(24,24,27,0.08))",
+                color: "var(--copilot-secondary-control-fg, rgba(39,39,42,0.88))",
+              }}
+            >
+              <ImagePlus size="16" strokeWidth={2} />
+            </button>
+          </>
         ) : null}
         <textarea
           ref={textareaRef}

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -145,7 +145,7 @@ export function ChatInputBox({
           gap: 8,
           width: "100%",
           boxSizing: "border-box",
-          borderRadius: 999,
+          borderRadius: "var(--copilot-input-radius, 22px)",
           border: border("var(--copilot-input-border, rgba(212,212,216,0.72))"),
           background: "var(--copilot-input-bg, rgba(255,255,255,0.96))",
           boxShadow: "var(--copilot-input-shadow, 0 4px 14px rgba(24,24,27,0.08), 0 1px 2px rgba(24,24,27,0.06))",

--- a/packages/talon-chat/src/lib/ChatInputBox.tsx
+++ b/packages/talon-chat/src/lib/ChatInputBox.tsx
@@ -1,5 +1,18 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { ArrowUp, ImagePlus, Square, Terminal, X } from "lucide-react";
+import {
+  ArrowUp,
+  ChevronRight,
+  Ellipsis,
+  FileText,
+  Globe,
+  ImagePlus,
+  Paperclip,
+  Plus,
+  Square,
+  Telescope,
+  Terminal,
+  X,
+} from "lucide-react";
 
 function border(color: string) {
   return `1px solid ${color}`;
@@ -70,7 +83,7 @@ export function ChatInputBox({
   imageAttachments,
   imageUploadEnabled = false,
   imageAccept = "image/png,image/jpeg,image/gif,image/webp",
-  imageButtonLabel = "Attach image",
+  imageButtonLabel = "Add photos & files",
   onImageFilesSelected,
   onRemoveImageAttachment,
   style,
@@ -79,6 +92,8 @@ export function ChatInputBox({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [highlightedCommandIndex, setHighlightedCommandIndex] = useState(0);
   const [hoveredCommandIndex, setHoveredCommandIndex] = useState<number | null>(null);
+  const [showAttachmentMenu, setShowAttachmentMenu] = useState(false);
+  const [hoveredAttachmentIndex, setHoveredAttachmentIndex] = useState<number | null>(null);
   const resolvedCanSubmit = canSubmit ?? (Boolean(value.trim()) && !disabled && !isGenerating);
   const isStopMode = Boolean(isGenerating && onStop);
   const resolvedCanStop = Boolean(isStopMode && canStop);
@@ -103,6 +118,7 @@ export function ChatInputBox({
 
   const submitValue = useCallback(() => {
     if (!resolvedCanSubmit) return;
+    setShowAttachmentMenu(false);
     onSubmit(value);
   }, [onSubmit, resolvedCanSubmit, value]);
 
@@ -144,6 +160,11 @@ export function ChatInputBox({
           flexWrap: attachments.length > 0 ? "wrap" : "nowrap",
           fontFamily: talonChatFontFamily,
           ...style,
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            setShowAttachmentMenu(false);
+          }
         }}
       >
         {shouldShowCommandMenu ? (
@@ -316,6 +337,134 @@ export function ChatInputBox({
         ) : null}
         {imageUploadEnabled ? (
           <>
+            {showAttachmentMenu && !disabled && !isGenerating ? (
+              <div
+                role="menu"
+                aria-label="Attachment menu"
+                style={{
+                  position: "absolute",
+                  left: 0,
+                  bottom: "calc(100% + 8px)",
+                  zIndex: 30,
+                  width: "min(300px, calc(100vw - 48px))",
+                  boxSizing: "border-box",
+                  padding: "0.875rem 1rem",
+                  borderRadius: 20,
+                  border: border("var(--copilot-attachment-menu-border, rgba(212,212,216,0.9))"),
+                  background: "var(--copilot-attachment-menu-bg, rgba(255,255,255,0.98))",
+                  boxShadow: "var(--copilot-attachment-menu-shadow, 0 18px 46px rgba(24,24,27,0.16), 0 2px 8px rgba(24,24,27,0.08))",
+                  color: "var(--copilot-attachment-menu-fg, rgba(24,24,27,0.96))",
+                }}
+              >
+                {[
+                  {
+                    label: imageButtonLabel,
+                    icon: <Paperclip size="21" strokeWidth={2.3} />,
+                    action: () => {
+                      setShowAttachmentMenu(false);
+                      fileInputRef.current?.click();
+                    },
+                  },
+                  {
+                    label: "Recent files",
+                    icon: <FileText size="21" strokeWidth={2.2} />,
+                    chevron: true,
+                  },
+                  { divider: true },
+                  {
+                    label: "Create image",
+                    icon: <ImagePlus size="21" strokeWidth={2.2} />,
+                  },
+                  {
+                    label: "Deep research",
+                    icon: <Telescope size="21" strokeWidth={2.2} />,
+                  },
+                  {
+                    label: "Web search",
+                    icon: <Globe size="21" strokeWidth={2.2} />,
+                  },
+                  {
+                    label: "More",
+                    icon: <Ellipsis size="21" strokeWidth={2.2} />,
+                    chevron: true,
+                  },
+                ].map((item, index) => {
+                  if ("divider" in item) {
+                    return (
+                      <div
+                        key={`divider-${index}`}
+                        role="separator"
+                        style={{
+                          height: 1,
+                          margin: "0.5rem 0.25rem",
+                          background: "var(--copilot-attachment-menu-divider, rgba(212,212,216,0.88))",
+                        }}
+                      />
+                    );
+                  }
+                  const isActive = Boolean(item.action);
+                  const isHovered = hoveredAttachmentIndex === index;
+                  return (
+                    <button
+                      key={item.label}
+                      type="button"
+                      role="menuitem"
+                      aria-disabled={!isActive}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onMouseEnter={() => setHoveredAttachmentIndex(index)}
+                      onMouseLeave={() => setHoveredAttachmentIndex(null)}
+                      onClick={() => item.action?.()}
+                      style={{
+                        width: "100%",
+                        minHeight: 44,
+                        boxSizing: "border-box",
+                        border: "none",
+                        borderRadius: 10,
+                        padding: "0.375rem 0.25rem",
+                        display: "grid",
+                        gridTemplateColumns: "32px minmax(0, 1fr) 20px",
+                        alignItems: "center",
+                        gap: 8,
+                        background: isHovered && isActive
+                          ? "var(--copilot-attachment-menu-hover-bg, rgba(24,24,27,0.07))"
+                          : "transparent",
+                        color: "inherit",
+                        cursor: isActive ? "pointer" : "default",
+                        fontFamily: "inherit",
+                        fontSize: 16,
+                        lineHeight: 1.2,
+                        textAlign: "left",
+                      }}
+                    >
+                      <span
+                        aria-hidden="true"
+                        style={{
+                          width: 32,
+                          height: 32,
+                          display: "inline-flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          color: "var(--copilot-attachment-menu-icon-fg, rgba(24,24,27,0.96))",
+                        }}
+                      >
+                        {item.icon}
+                      </span>
+                      <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {item.label}
+                      </span>
+                      {item.chevron ? (
+                        <ChevronRight
+                          aria-hidden="true"
+                          size="20"
+                          strokeWidth={2.1}
+                          style={{ justifySelf: "end" }}
+                        />
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
             <input
               ref={fileInputRef}
               type="file"
@@ -334,10 +483,12 @@ export function ChatInputBox({
             />
             <button
               type="button"
-              aria-label={imageButtonLabel}
-              title={imageButtonLabel}
+              aria-label="Open attachment menu"
+              aria-expanded={showAttachmentMenu}
+              aria-haspopup="menu"
+              title="Open attachment menu"
               disabled={disabled || isGenerating}
-              onClick={() => fileInputRef.current?.click()}
+              onClick={() => setShowAttachmentMenu((current) => !current)}
               style={{
                 width: buttonSize,
                 height: buttonSize,
@@ -355,7 +506,7 @@ export function ChatInputBox({
                 color: "var(--copilot-secondary-control-fg, rgba(39,39,42,0.88))",
               }}
             >
-              <ImagePlus size="16" strokeWidth={2} />
+              <Plus size="19" strokeWidth={2.1} />
             </button>
           </>
         ) : null}

--- a/src/gateway/ui.rs
+++ b/src/gateway/ui.rs
@@ -36,8 +36,6 @@ pub struct ChatRequestBody {
 #[derive(Deserialize)]
 pub struct UiMessage {
     #[serde(default)]
-    content: Option<String>,
-    #[serde(default)]
     parts: Vec<UiPart>,
 }
 
@@ -47,8 +45,6 @@ pub struct UiPart {
     kind: Option<String>,
     #[serde(default)]
     text: Option<String>,
-    #[serde(default)]
-    content: Option<String>,
     #[serde(default)]
     object: Option<UiObjectRef>,
     #[serde(default, rename = "payloadJson", alias = "payload_json")]
@@ -114,44 +110,11 @@ fn map_status(status: tonic::Status) -> Response {
     response_with_status(code, status.message())
 }
 
-#[cfg(test)]
-fn last_message_text(messages: &[UiMessage]) -> Option<String> {
-    messages.iter().rev().find_map(|message| {
-        if let Some(content) = &message.content {
-            if !content.trim().is_empty() {
-                return Some(content.clone());
-            }
-        }
-
-        let text = message
-            .parts
-            .iter()
-            .filter(|part| part.kind.as_deref() == Some("text"))
-            .filter_map(|part| part.text.as_deref().or(part.content.as_deref()))
-            .collect::<String>();
-
-        if text.trim().is_empty() {
-            None
-        } else {
-            Some(text)
-        }
-    })
-}
-
 fn ui_message_has_dispatchable_part(message: &UiMessage) -> bool {
-    if message
-        .content
-        .as_deref()
-        .is_some_and(|content| !content.trim().is_empty())
-    {
-        return true;
-    }
-
     message.parts.iter().any(|part| match part.kind.as_deref() {
         Some("text") => part
             .text
             .as_deref()
-            .or(part.content.as_deref())
             .is_some_and(|text| !text.trim().is_empty()),
         Some("image") => part
             .object
@@ -170,38 +133,11 @@ fn last_dispatchable_message(messages: &[UiMessage]) -> Option<&UiMessage> {
 
 fn ui_message_to_session_message(message: &UiMessage, now_micros: i64) -> models::SessionMessage {
     let mut parts = Vec::new();
-    let has_text_part = message.parts.iter().any(|part| {
-        part.kind.as_deref() == Some("text")
-            && part
-                .text
-                .as_deref()
-                .or(part.content.as_deref())
-                .is_some_and(|text| !text.trim().is_empty())
-    });
-    if !has_text_part {
-        if let Some(content) = message.content.as_deref() {
-            if !content.trim().is_empty() {
-                parts.push(models::SessionMessagePart {
-                    id: String::new(),
-                    part_type: models::SessionMessagePartType::Text as i32,
-                    content: content.to_string(),
-                    name: String::new(),
-                    payload_json: String::new(),
-                    created_at: now_micros,
-                    object: None,
-                });
-            }
-        }
-    }
 
     for part in &message.parts {
         match part.kind.as_deref() {
             Some("text") => {
-                let text = part
-                    .text
-                    .as_deref()
-                    .or(part.content.as_deref())
-                    .unwrap_or_default();
+                let text = part.text.as_deref().unwrap_or_default();
                 if text.trim().is_empty() {
                     continue;
                 }
@@ -737,9 +673,9 @@ pub async fn delete_chat(
 mod tests {
     use super::{
         data_stream_line, delete_chat, extract_tool_part_payload, fetch_session_metadata, get_chat,
-        last_message_text, latest_assistant_message_text, latest_tool_part_payload, map_status,
-        ndjson_line, part_dedup_key, post_chat, tonic_request, ChatRequestBody, SessionPath,
-        UiMessage, UiObjectRef, UiPart,
+        latest_assistant_message_text, latest_tool_part_payload, map_status, ndjson_line,
+        part_dedup_key, post_chat, tonic_request, ChatRequestBody, SessionPath, UiMessage,
+        UiObjectRef, UiPart,
     };
     use crate::control::events::{
         SessionControlEvent, SessionMessagePartEvent, SessionMessagePartEventKind,
@@ -912,53 +848,6 @@ mod tests {
             ns: ns.to_string(),
             message_id: message_id.to_string(),
         }
-    }
-
-    #[test]
-    fn last_message_text_prefers_content_then_text_parts() {
-        let messages = vec![
-            UiMessage {
-                content: Some(String::new()),
-                parts: vec![UiPart {
-                    kind: Some("text".to_string()),
-                    text: Some("hello".to_string()),
-                    content: None,
-                    object: None,
-                    payload_json: None,
-                }],
-            },
-            UiMessage {
-                content: Some("world".to_string()),
-                parts: vec![],
-            },
-        ];
-
-        assert_eq!(last_message_text(&messages).as_deref(), Some("world"));
-    }
-
-    #[test]
-    fn last_message_text_uses_text_parts_when_content_is_empty() {
-        let messages = vec![UiMessage {
-            content: Some("   ".to_string()),
-            parts: vec![
-                UiPart {
-                    kind: Some("text".to_string()),
-                    text: Some("hello".to_string()),
-                    content: None,
-                    object: None,
-                    payload_json: None,
-                },
-                UiPart {
-                    kind: Some("text".to_string()),
-                    text: Some(" world".to_string()),
-                    content: None,
-                    object: None,
-                    payload_json: None,
-                },
-            ],
-        }];
-
-        assert_eq!(last_message_text(&messages).as_deref(), Some("hello world"));
     }
 
     #[test]
@@ -1254,11 +1143,9 @@ mod tests {
             HeaderMap::new(),
             Json(ChatRequestBody {
                 messages: vec![UiMessage {
-                    content: None,
                     parts: vec![UiPart {
                         kind: Some("text".to_string()),
                         text: Some("   ".to_string()),
-                        content: None,
                         object: None,
                         payload_json: None,
                     }],
@@ -1307,19 +1194,16 @@ mod tests {
             HeaderMap::new(),
             Json(ChatRequestBody {
                 messages: vec![UiMessage {
-                    content: Some("what is in this?".to_string()),
                     parts: vec![
                         UiPart {
                             kind: Some("text".to_string()),
                             text: Some("what is in this?".to_string()),
-                            content: None,
                             object: None,
                             payload_json: None,
                         },
                         UiPart {
                             kind: Some("image".to_string()),
                             text: None,
-                            content: None,
                             object: Some(UiObjectRef {
                                 key: "sessions/session-1/uploads/photo.png".to_string(),
                                 media_type: "image/png".to_string(),
@@ -1389,8 +1273,12 @@ mod tests {
             HeaderMap::new(),
             Json(ChatRequestBody {
                 messages: vec![UiMessage {
-                    content: Some("hello".to_string()),
-                    parts: vec![],
+                    parts: vec![UiPart {
+                        kind: Some("text".to_string()),
+                        text: Some("hello".to_string()),
+                        object: None,
+                        payload_json: None,
+                    }],
                 }],
             }),
         )
@@ -1452,8 +1340,12 @@ mod tests {
             HeaderMap::new(),
             Json(ChatRequestBody {
                 messages: vec![UiMessage {
-                    content: Some("hello".to_string()),
-                    parts: vec![],
+                    parts: vec![UiPart {
+                        kind: Some("text".to_string()),
+                        text: Some("hello".to_string()),
+                        object: None,
+                        payload_json: None,
+                    }],
                 }],
             }),
         )

--- a/src/gateway/ui.rs
+++ b/src/gateway/ui.rs
@@ -4,6 +4,7 @@
 use crate::control::events::SessionMessagePartEventKind;
 use crate::gateway::rpc::{models, proto, GrpcGatewayHandler};
 use crate::gateway::Gateway;
+use crate::scheduling;
 use axum::extract::{Path, State};
 use axum::http::{header, HeaderMap, HeaderName, StatusCode};
 use axum::response::{IntoResponse, Response};
@@ -11,6 +12,7 @@ use axum::Json;
 use futures::StreamExt;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
@@ -45,6 +47,27 @@ pub struct UiPart {
     kind: Option<String>,
     #[serde(default)]
     text: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    object: Option<UiObjectRef>,
+    #[serde(default, rename = "payloadJson", alias = "payload_json")]
+    payload_json: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UiObjectRef {
+    key: String,
+    #[serde(default, rename = "mediaType", alias = "media_type")]
+    media_type: String,
+    #[serde(default, rename = "sizeBytes", alias = "size_bytes")]
+    size_bytes: u64,
+    #[serde(default)]
+    sha256: String,
+    #[serde(default)]
+    filename: String,
+    #[serde(default)]
+    metadata: HashMap<String, String>,
 }
 
 #[derive(Clone)]
@@ -91,6 +114,7 @@ fn map_status(status: tonic::Status) -> Response {
     response_with_status(code, status.message())
 }
 
+#[cfg(test)]
 fn last_message_text(messages: &[UiMessage]) -> Option<String> {
     messages.iter().rev().find_map(|message| {
         if let Some(content) = &message.content {
@@ -103,7 +127,7 @@ fn last_message_text(messages: &[UiMessage]) -> Option<String> {
             .parts
             .iter()
             .filter(|part| part.kind.as_deref() == Some("text"))
-            .filter_map(|part| part.text.as_deref())
+            .filter_map(|part| part.text.as_deref().or(part.content.as_deref()))
             .collect::<String>();
 
         if text.trim().is_empty() {
@@ -112,6 +136,110 @@ fn last_message_text(messages: &[UiMessage]) -> Option<String> {
             Some(text)
         }
     })
+}
+
+fn ui_message_has_dispatchable_part(message: &UiMessage) -> bool {
+    if message
+        .content
+        .as_deref()
+        .is_some_and(|content| !content.trim().is_empty())
+    {
+        return true;
+    }
+
+    message.parts.iter().any(|part| match part.kind.as_deref() {
+        Some("text") => part
+            .text
+            .as_deref()
+            .or(part.content.as_deref())
+            .is_some_and(|text| !text.trim().is_empty()),
+        Some("image") => part
+            .object
+            .as_ref()
+            .is_some_and(|object| !object.key.trim().is_empty()),
+        _ => false,
+    })
+}
+
+fn last_dispatchable_message(messages: &[UiMessage]) -> Option<&UiMessage> {
+    messages
+        .iter()
+        .rev()
+        .find(|message| ui_message_has_dispatchable_part(message))
+}
+
+fn ui_message_to_session_message(message: &UiMessage, now_micros: i64) -> models::SessionMessage {
+    let mut parts = Vec::new();
+    if let Some(content) = message.content.as_deref() {
+        if !content.trim().is_empty() {
+            parts.push(models::SessionMessagePart {
+                id: String::new(),
+                part_type: models::SessionMessagePartType::Text as i32,
+                content: content.to_string(),
+                name: String::new(),
+                payload_json: String::new(),
+                created_at: now_micros,
+                object: None,
+            });
+        }
+    }
+
+    for part in &message.parts {
+        match part.kind.as_deref() {
+            Some("text") => {
+                let text = part
+                    .text
+                    .as_deref()
+                    .or(part.content.as_deref())
+                    .unwrap_or_default();
+                if text.trim().is_empty() {
+                    continue;
+                }
+                parts.push(models::SessionMessagePart {
+                    id: String::new(),
+                    part_type: models::SessionMessagePartType::Text as i32,
+                    content: text.to_string(),
+                    name: String::new(),
+                    payload_json: part.payload_json.clone().unwrap_or_default(),
+                    created_at: now_micros,
+                    object: None,
+                });
+            }
+            Some("image") => {
+                let Some(object) = part.object.as_ref() else {
+                    continue;
+                };
+                if object.key.trim().is_empty() {
+                    continue;
+                }
+                parts.push(models::SessionMessagePart {
+                    id: String::new(),
+                    part_type: models::SessionMessagePartType::Image as i32,
+                    content: String::new(),
+                    name: String::new(),
+                    payload_json: part.payload_json.clone().unwrap_or_default(),
+                    created_at: now_micros,
+                    object: Some(models::ObjectRef {
+                        key: object.key.clone(),
+                        media_type: object.media_type.clone(),
+                        size_bytes: object.size_bytes,
+                        sha256: object.sha256.clone(),
+                        filename: object.filename.clone(),
+                        metadata: object.metadata.clone(),
+                    }),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    models::SessionMessage {
+        id: Uuid::now_v7().to_string(),
+        role: models::MessageRole::RoleUser as i32,
+        created_at: now_micros,
+        labels: HashMap::new(),
+        parts,
+    }
 }
 
 fn extract_tool_part_payload(part: &models::SessionMessagePart) -> Option<ToolStepPayload> {
@@ -245,23 +373,11 @@ pub async fn post_chat(
     headers: HeaderMap,
     Json(body): Json<ChatRequestBody>,
 ) -> Response {
-    let Some(message) = last_message_text(&body.messages) else {
+    let Some(ui_message) = last_dispatchable_message(&body.messages) else {
         return response_with_status(StatusCode::BAD_REQUEST, "message content is required");
     };
-
-    let send_request = match tonic_request(
-        &headers,
-        proto::SendMessageRequest {
-            ns: path.ns.clone(),
-            agent: path.agent.clone(),
-            session_id: path.session_id.clone(),
-            message,
-            labels: Default::default(),
-        },
-    ) {
-        Ok(request) => request,
-        Err(response) => return response,
-    };
+    let now = chrono::Utc::now();
+    let session_message = ui_message_to_session_message(ui_message, now.timestamp_micros());
 
     let stream_request = match tonic_request(
         &headers,
@@ -283,10 +399,35 @@ pub async fn post_chat(
         Err(status) => return map_status(status),
     };
 
-    if let Err(status) = gateway_handler(&gateway)
-        .handle_send_message(send_request)
-        .await
+    if let Err(err) = scheduling::send_session_message(
+        gateway.kv.as_ref(),
+        gateway.pubsub.as_ref(),
+        &path.ns,
+        &path.agent,
+        &path.session_id,
+        session_message,
+        now,
+    )
+    .await
     {
+        let status = if err
+            .downcast_ref::<scheduling::SessionCurrentlyProcessingError>()
+            .is_some()
+        {
+            tonic::Status::resource_exhausted("Session is currently generating a response.")
+        } else if err
+            .downcast_ref::<scheduling::EmptyMessageError>()
+            .is_some()
+        {
+            tonic::Status::invalid_argument("message content is required")
+        } else if err
+            .downcast_ref::<scheduling::SessionNotFoundError>()
+            .is_some()
+        {
+            tonic::Status::not_found("Session not found")
+        } else {
+            tonic::Status::internal(format!("Failed to send message: {}", err))
+        };
         return map_status(status);
     }
 
@@ -588,7 +729,7 @@ mod tests {
         data_stream_line, delete_chat, extract_tool_part_payload, fetch_session_metadata, get_chat,
         last_message_text, latest_assistant_message_text, latest_tool_part_payload, map_status,
         ndjson_line, part_dedup_key, post_chat, tonic_request, ChatRequestBody, SessionPath,
-        UiMessage, UiPart,
+        UiMessage, UiObjectRef, UiPart,
     };
     use crate::control::events::{
         SessionControlEvent, SessionMessagePartEvent, SessionMessagePartEventKind,
@@ -771,6 +912,9 @@ mod tests {
                 parts: vec![UiPart {
                     kind: Some("text".to_string()),
                     text: Some("hello".to_string()),
+                    content: None,
+                    object: None,
+                    payload_json: None,
                 }],
             },
             UiMessage {
@@ -790,10 +934,16 @@ mod tests {
                 UiPart {
                     kind: Some("text".to_string()),
                     text: Some("hello".to_string()),
+                    content: None,
+                    object: None,
+                    payload_json: None,
                 },
                 UiPart {
                     kind: Some("text".to_string()),
                     text: Some(" world".to_string()),
+                    content: None,
+                    object: None,
+                    payload_json: None,
                 },
             ],
         }];
@@ -1098,6 +1248,9 @@ mod tests {
                     parts: vec![UiPart {
                         kind: Some("text".to_string()),
                         text: Some("   ".to_string()),
+                        content: None,
+                        object: None,
+                        payload_json: None,
                     }],
                 }],
             }),
@@ -1107,6 +1260,105 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert!(String::from_utf8_lossy(&body).contains("message content is required"));
+    }
+
+    #[tokio::test]
+    async fn post_chat_persists_image_object_parts_for_dispatch() {
+        let kv = Arc::new(MockKvStore::default());
+        kv.set_msg(
+            &keys::session("default", "agent", "session-1"),
+            &models::Session {
+                id: "session-1".to_string(),
+                agent: "agent".to_string(),
+                ns: "default".to_string(),
+                status: "IDLE".to_string(),
+                created_at: 1,
+                last_active: 1,
+                metadata: HashMap::new(),
+                labels: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+        let published = Arc::new(Mutex::new(Vec::new()));
+        let gateway = setup_gateway(
+            kv.clone(),
+            Arc::new(Mutex::new(HashMap::new())),
+            published.clone(),
+        );
+
+        let response = post_chat(
+            State(gateway),
+            Path(SessionPath {
+                ns: "default".to_string(),
+                agent: "agent".to_string(),
+                session_id: "session-1".to_string(),
+            }),
+            HeaderMap::new(),
+            Json(ChatRequestBody {
+                messages: vec![UiMessage {
+                    content: None,
+                    parts: vec![
+                        UiPart {
+                            kind: Some("text".to_string()),
+                            text: Some("what is in this?".to_string()),
+                            content: None,
+                            object: None,
+                            payload_json: None,
+                        },
+                        UiPart {
+                            kind: Some("image".to_string()),
+                            text: None,
+                            content: None,
+                            object: Some(UiObjectRef {
+                                key: "sessions/session-1/uploads/photo.png".to_string(),
+                                media_type: "image/png".to_string(),
+                                size_bytes: 123,
+                                sha256: "abc123".to_string(),
+                                filename: "photo.png".to_string(),
+                                metadata: HashMap::new(),
+                            }),
+                            payload_json: None,
+                        },
+                    ],
+                }],
+            }),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let message_keys = kv
+            .list_keys(&keys::session_message_prefix(
+                "default",
+                "agent",
+                "session-1",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(message_keys.len(), 1);
+        let message = kv
+            .get_msg::<models::SessionMessage>(&message_keys[0])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(message.parts.len(), 2);
+        assert_eq!(
+            message.parts[0].part_type,
+            models::SessionMessagePartType::Text as i32
+        );
+        assert_eq!(message.parts[0].content, "what is in this?");
+        assert_eq!(
+            message.parts[1].part_type,
+            models::SessionMessagePartType::Image as i32
+        );
+        let object = message.parts[1].object.as_ref().unwrap();
+        assert_eq!(object.key, "sessions/session-1/uploads/photo.png");
+        assert_eq!(object.media_type, "image/png");
+        assert_eq!(object.size_bytes, 123);
+
+        let published = published.lock().await;
+        assert_eq!(published.len(), 1);
+        assert_eq!(published[0].0, topics::SESSION_DISPATCH_TOPIC);
     }
 
     #[tokio::test]

--- a/src/gateway/ui.rs
+++ b/src/gateway/ui.rs
@@ -170,17 +170,27 @@ fn last_dispatchable_message(messages: &[UiMessage]) -> Option<&UiMessage> {
 
 fn ui_message_to_session_message(message: &UiMessage, now_micros: i64) -> models::SessionMessage {
     let mut parts = Vec::new();
-    if let Some(content) = message.content.as_deref() {
-        if !content.trim().is_empty() {
-            parts.push(models::SessionMessagePart {
-                id: String::new(),
-                part_type: models::SessionMessagePartType::Text as i32,
-                content: content.to_string(),
-                name: String::new(),
-                payload_json: String::new(),
-                created_at: now_micros,
-                object: None,
-            });
+    let has_text_part = message.parts.iter().any(|part| {
+        part.kind.as_deref() == Some("text")
+            && part
+                .text
+                .as_deref()
+                .or(part.content.as_deref())
+                .is_some_and(|text| !text.trim().is_empty())
+    });
+    if !has_text_part {
+        if let Some(content) = message.content.as_deref() {
+            if !content.trim().is_empty() {
+                parts.push(models::SessionMessagePart {
+                    id: String::new(),
+                    part_type: models::SessionMessagePartType::Text as i32,
+                    content: content.to_string(),
+                    name: String::new(),
+                    payload_json: String::new(),
+                    created_at: now_micros,
+                    object: None,
+                });
+            }
         }
     }
 
@@ -1297,7 +1307,7 @@ mod tests {
             HeaderMap::new(),
             Json(ChatRequestBody {
                 messages: vec![UiMessage {
-                    content: None,
+                    content: Some("what is in this?".to_string()),
                     parts: vec![
                         UiPart {
                             kind: Some("text".to_string()),

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -532,6 +532,38 @@ pub async fn send_message(
     if message.trim().is_empty() {
         return Err(EmptyMessageError.into());
     }
+    let now_micros = now.timestamp_micros();
+    let user_msg = models::SessionMessage {
+        id: uuid::Uuid::now_v7().to_string(),
+        role: models::MessageRole::RoleUser as i32,
+        created_at: now_micros,
+        labels,
+        parts: vec![models::SessionMessagePart {
+            id: "000000".to_string(),
+            part_type: models::SessionMessagePartType::Text as i32,
+            content: message.to_string(),
+            name: String::new(),
+            payload_json: String::new(),
+            created_at: now_micros,
+            object: None,
+        }],
+    };
+
+    send_session_message(kv, pubsub, ns, agent, session_id, user_msg, now).await
+}
+
+pub async fn send_session_message(
+    kv: &dyn KeyValueStore,
+    pubsub: &dyn MessagePublisher,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+    mut user_msg: models::SessionMessage,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    if user_msg.parts.is_empty() {
+        return Err(EmptyMessageError.into());
+    }
 
     let key = keys::session(ns, agent, session_id);
     let now_micros = now.timestamp_micros();
@@ -567,21 +599,24 @@ pub async fn send_message(
         return Err(anyhow!("failed to atomically acquire session lock"));
     }
 
-    let user_msg = models::SessionMessage {
-        id: uuid::Uuid::now_v7().to_string(),
-        role: models::MessageRole::RoleUser as i32,
-        created_at: now.timestamp_micros(),
-        labels,
-        parts: vec![models::SessionMessagePart {
-            id: "000000".to_string(),
-            part_type: models::SessionMessagePartType::Text as i32,
-            content: message.to_string(),
-            name: String::new(),
-            payload_json: String::new(),
-            created_at: now.timestamp_micros(),
-            object: None,
-        }],
-    };
+    if user_msg.id.is_empty() {
+        user_msg.id = uuid::Uuid::now_v7().to_string();
+    }
+    if user_msg.role == models::MessageRole::RoleUnspecified as i32 {
+        user_msg.role = models::MessageRole::RoleUser as i32;
+    }
+    if user_msg.created_at == 0 {
+        user_msg.created_at = now_micros;
+    }
+    for (index, part) in user_msg.parts.iter_mut().enumerate() {
+        if part.id.is_empty() {
+            part.id = format!("{index:06}");
+        }
+        if part.created_at == 0 {
+            part.created_at = user_msg.created_at;
+        }
+    }
+
     if let Err(err) = kv
         .set_msg(
             &keys::session_message(ns, agent, session_id, &user_msg.id),
@@ -598,13 +633,14 @@ pub async fn send_message(
     }
 
     let message_id = user_msg.id.clone();
+    let message_text = session_message_text_projection(&user_msg);
     let message_event = events::SessionMessageEvent {
         session_id: session_id.to_string(),
         message_id: message_id.clone(),
         direction: events::MessageDirection::Inbound as i32,
         timestamp: now_micros,
         agent: agent.to_string(),
-        message: message.to_string(),
+        message: message_text,
         ns: ns.to_string(),
     };
     if let Err(err) = pubsub
@@ -629,6 +665,38 @@ pub async fn send_message(
         "Queued scheduled message for session dispatch"
     );
     Ok(())
+}
+
+fn session_message_text_projection(message: &models::SessionMessage) -> String {
+    let text = message
+        .parts
+        .iter()
+        .filter(|part| part.part_type == models::SessionMessagePartType::Text as i32)
+        .map(|part| part.content.as_str())
+        .collect::<String>();
+    if !text.trim().is_empty() {
+        return text;
+    }
+
+    let image_names = message
+        .parts
+        .iter()
+        .filter(|part| part.part_type == models::SessionMessagePartType::Image as i32)
+        .filter_map(|part| part.object.as_ref())
+        .map(|object| {
+            if object.filename.is_empty() {
+                object.key.as_str()
+            } else {
+                object.filename.as_str()
+            }
+        })
+        .filter(|name| !name.is_empty())
+        .collect::<Vec<_>>();
+    if image_names.is_empty() {
+        "[non-text message]".to_string()
+    } else {
+        format!("[Image: {}]", image_names.join(", "))
+    }
 }
 
 fn log_session_release_failure(result: Result<()>, namespace: &str, key: &ResourceKey) {

--- a/ui/app/api/talon/objects/route.ts
+++ b/ui/app/api/talon/objects/route.ts
@@ -1,0 +1,108 @@
+import { createHash, randomUUID } from 'crypto';
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const DEFAULT_OBJECT_STORE_PATH = '/data/talon/objects';
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+const SUPPORTED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
+
+function safeSegment(value: string, fallback: string) {
+  const segment = value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 96);
+  return segment || fallback;
+}
+
+function extensionForMediaType(mediaType: string) {
+  switch (mediaType) {
+    case 'image/jpeg':
+      return '.jpg';
+    case 'image/gif':
+      return '.gif';
+    case 'image/webp':
+      return '.webp';
+    case 'image/png':
+    default:
+      return '.png';
+  }
+}
+
+function objectDataPath(root: string, key: string) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(resolvedRoot, key);
+  if (!resolvedPath.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error('invalid object key');
+  }
+  return resolvedPath;
+}
+
+function metadataPath(dataPath: string) {
+  return path.join(path.dirname(dataPath), `${path.basename(dataPath)}.metadata.json`);
+}
+
+export async function POST(request: NextRequest) {
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return NextResponse.json({ error: 'multipart form data is required' }, { status: 400 });
+  }
+  const file = form.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'file is required' }, { status: 400 });
+  }
+  if (!SUPPORTED_IMAGE_TYPES.has(file.type)) {
+    return NextResponse.json({ error: 'unsupported image type' }, { status: 400 });
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return NextResponse.json({ error: 'image is too large' }, { status: 413 });
+  }
+
+  const namespace = safeSegment(String(form.get('namespace') || 'default'), 'default');
+  const agent = safeSegment(String(form.get('agent') || 'default'), 'default');
+  const sessionId = safeSegment(String(form.get('sessionId') || 'session'), 'session');
+  const originalName = file.name || `image${extensionForMediaType(file.type)}`;
+  const extension = path.extname(originalName) || extensionForMediaType(file.type);
+  const key = [
+    'sessions',
+    namespace,
+    agent,
+    sessionId,
+    'uploads',
+    `${Date.now()}-${randomUUID()}${extension}`,
+  ].join('/');
+
+  const bytes = Buffer.from(await file.arrayBuffer());
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  const root = process.env.TALON_OBJECT_STORE_PATH || DEFAULT_OBJECT_STORE_PATH;
+  const dataPath = objectDataPath(root, key);
+  const metaPath = metadataPath(dataPath);
+  const object = {
+    key,
+    mediaType: file.type,
+    sizeBytes: bytes.length,
+    sha256,
+    filename: originalName,
+    metadata: {
+      source: 'sightline',
+    },
+  };
+  const metadata = {
+    media_type: object.mediaType,
+    size_bytes: object.sizeBytes,
+    sha256: object.sha256,
+    filename: object.filename,
+    metadata: object.metadata,
+  };
+
+  await mkdir(path.dirname(dataPath), { recursive: true });
+  await writeFile(dataPath, bytes);
+  await writeFile(metaPath, JSON.stringify(metadata));
+
+  return NextResponse.json(object);
+}

--- a/ui/app/api/talon/objects/route.ts
+++ b/ui/app/api/talon/objects/route.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'crypto';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdir, readFile, rename, unlink, writeFile } from 'fs/promises';
 import path from 'path';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -15,7 +15,7 @@ function safeSegment(value: string, fallback: string) {
     .replace(/[^A-Za-z0-9._-]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 96);
-  return segment || fallback;
+  return segment && segment !== '.' && segment !== '..' ? segment : fallback;
 }
 
 function extensionForMediaType(mediaType: string) {
@@ -52,6 +52,43 @@ async function readObjectMetadata(dataPath: string) {
     return metadata && typeof metadata === 'object' ? metadata as Record<string, unknown> : {};
   } catch {
     return {};
+  }
+}
+
+async function removeIfExists(filePath: string) {
+  try {
+    await unlink(filePath);
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+}
+
+async function writeObjectWithMetadata(
+  dataPath: string,
+  metaPath: string,
+  bytes: Buffer,
+  metadata: Record<string, unknown>,
+) {
+  const tempSuffix = `.tmp-${randomUUID()}`;
+  const dataTempPath = `${dataPath}${tempSuffix}`;
+  const metaTempPath = `${metaPath}${tempSuffix}`;
+  let dataCommitted = false;
+
+  try {
+    await writeFile(dataTempPath, bytes);
+    await writeFile(metaTempPath, JSON.stringify(metadata));
+    await rename(dataTempPath, dataPath);
+    dataCommitted = true;
+    await rename(metaTempPath, metaPath);
+  } catch (err) {
+    await Promise.all([
+      removeIfExists(dataTempPath),
+      removeIfExists(metaTempPath),
+      dataCommitted ? removeIfExists(dataPath) : Promise.resolve(),
+    ]);
+    throw err;
   }
 }
 
@@ -143,8 +180,7 @@ export async function POST(request: NextRequest) {
   };
 
   await mkdir(path.dirname(dataPath), { recursive: true });
-  await writeFile(dataPath, bytes);
-  await writeFile(metaPath, JSON.stringify(metadata));
+  await writeObjectWithMetadata(dataPath, metaPath, bytes, metadata);
 
   return NextResponse.json(object);
 }

--- a/ui/app/api/talon/objects/route.ts
+++ b/ui/app/api/talon/objects/route.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'crypto';
-import { mkdir, writeFile } from 'fs/promises';
+import { mkdir, readFile, writeFile } from 'fs/promises';
 import path from 'path';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -43,6 +43,48 @@ function objectDataPath(root: string, key: string) {
 
 function metadataPath(dataPath: string) {
   return path.join(path.dirname(dataPath), `${path.basename(dataPath)}.metadata.json`);
+}
+
+async function readObjectMetadata(dataPath: string) {
+  try {
+    const bytes = await readFile(metadataPath(dataPath), 'utf8');
+    const metadata = JSON.parse(bytes);
+    return metadata && typeof metadata === 'object' ? metadata as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  if (!key) {
+    return NextResponse.json({ error: 'key is required' }, { status: 400 });
+  }
+
+  let dataPath: string;
+  try {
+    dataPath = objectDataPath(process.env.TALON_OBJECT_STORE_PATH || DEFAULT_OBJECT_STORE_PATH, key);
+  } catch {
+    return NextResponse.json({ error: 'invalid object key' }, { status: 400 });
+  }
+
+  try {
+    const [bytes, metadata] = await Promise.all([
+      readFile(dataPath),
+      readObjectMetadata(dataPath),
+    ]);
+    const mediaType = typeof metadata.media_type === 'string' && metadata.media_type
+      ? metadata.media_type
+      : 'application/octet-stream';
+    return new NextResponse(new Uint8Array(bytes), {
+      headers: {
+        'content-type': mediaType,
+        'cache-control': 'private, max-age=300',
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: 'object not found' }, { status: 404 });
+  }
 }
 
 export async function POST(request: NextRequest) {

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -28,7 +28,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { TalonChannel, TalonCopilot, type TalonImageUploadContext } from '@impalasys/talon-chat';
+import { TalonChannel, TalonCopilot, type TalonChatObjectRef, type TalonImageUploadContext } from '@impalasys/talon-chat';
 import { NamespaceExplorer, type Selection } from '../components/Namespaces/NamespaceExplorer';
 import { updateGatewayClient, getGatewayClient } from '../lib/grpc';
 
@@ -265,6 +265,10 @@ async function uploadTalonImage({ file, namespace, agent, sessionId, signal }: T
     throw new Error(message);
   }
   return response.json();
+}
+
+function talonObjectUrl(object: TalonChatObjectRef) {
+  return object.key ? `/api/talon/objects?key=${encodeURIComponent(object.key)}` : undefined;
 }
 
 type StreamEventItem = {
@@ -1167,6 +1171,7 @@ function DebuggerPageContent() {
                 historyPageSize={positiveIntParam(searchParams, 'historyPageSize')}
                 enabledBuiltInCommands={['clear']}
                 onImageUpload={uploadTalonImage}
+                objectUrlForRef={talonObjectUrl}
                 disabled={!isConnected}
                 onSessionChange={(nextSessionId) => {
                   handleSelectionChange({

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -28,7 +28,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { TalonChannel, TalonCopilot } from '@impalasys/talon-chat';
+import { TalonChannel, TalonCopilot, type TalonImageUploadContext } from '@impalasys/talon-chat';
 import { NamespaceExplorer, type Selection } from '../components/Namespaces/NamespaceExplorer';
 import { updateGatewayClient, getGatewayClient } from '../lib/grpc';
 
@@ -245,6 +245,26 @@ function selectionIcon(selection: Selection | null) {
   if (selection.type === 'knowledge') return <FileText className="w-4 h-4 text-violet-400" />;
   if (selection.type === 'template') return <FileText className="w-4 h-4 text-emerald-500" />;
   return <Plug className="w-4 h-4 text-blue-500" />;
+}
+
+async function uploadTalonImage({ file, namespace, agent, sessionId, signal }: TalonImageUploadContext) {
+  const form = new FormData();
+  form.set('file', file);
+  form.set('namespace', namespace);
+  form.set('agent', agent);
+  form.set('sessionId', sessionId);
+
+  const response = await fetch('/api/talon/objects', {
+    method: 'POST',
+    body: form,
+    signal,
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message = typeof payload?.error === 'string' ? payload.error : `Upload failed: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 }
 
 type StreamEventItem = {
@@ -1146,6 +1166,7 @@ function DebuggerPageContent() {
                 gatewayClient={getGatewayClient()}
                 historyPageSize={positiveIntParam(searchParams, 'historyPageSize')}
                 enabledBuiltInCommands={['clear']}
+                onImageUpload={uploadTalonImage}
                 disabled={!isConnected}
                 onSessionChange={(nextSessionId) => {
                   handleSelectionChange({

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -320,7 +320,6 @@ describe('TalonCopilot', () => {
       messages: [
         {
           role: 'user',
-          content: 'square root of 144',
           parts: [{ type: 'text', text: 'square root of 144' }],
         },
       ],

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -332,6 +332,88 @@ describe('TalonCopilot', () => {
     );
   });
 
+  it('uploads selected images and sends object refs as session message parts', async () => {
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    const createObjectURL = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:preview-photo');
+    jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const onImageUpload = jest.fn().mockResolvedValue({
+      key: 'sessions/sess-img/uploads/photo.png',
+      mediaType: 'image/png',
+      sizeBytes: 12,
+      sha256: 'sha',
+      filename: 'photo.png',
+      metadata: { width: '1', height: '1' },
+    });
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockReset();
+
+    fetchMock
+      .mockResolvedValueOnce(makeJsonResponse({ sessionId: 'sess-img' }))
+      .mockResolvedValueOnce(makeStreamResponse([
+        'f:{"messageId":"assistant-img"}\n',
+        '0:"That is a tiny image."\n',
+      ]))
+      .mockResolvedValueOnce(makeJsonResponse({
+        sessionId: 'sess-img',
+        state: 'IDLE',
+        messages: [],
+        steps: [],
+      }));
+
+    const { container } = render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayUrl="http://localhost:18789"
+        onImageUpload={onImageUpload}
+      />,
+    );
+
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' });
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(createObjectURL).toHaveBeenCalledWith(file);
+    expect(screen.getByAltText('photo.png')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Ask Talon to perform a task...'), {
+      target: { value: 'what is this?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => expect(onImageUpload).toHaveBeenCalledWith(expect.objectContaining({
+      file,
+      namespace: 'ops',
+      agent: 'copilot',
+      sessionId: 'sess-img',
+      signal: expect.any(AbortSignal),
+    })));
+
+    await screen.findByText('That is a tiny image.');
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(body.messages[0].parts).toEqual([
+      { type: 'text', text: 'what is this?' },
+      expect.objectContaining({
+        type: 'image',
+        object: {
+          key: 'sessions/sess-img/uploads/photo.png',
+          mediaType: 'image/png',
+          sizeBytes: 12,
+          sha256: 'sha',
+          filename: 'photo.png',
+          metadata: { width: '1', height: '1' },
+        },
+      }),
+    ]);
+    expect(body.messages[0].parts[1].previewUrl).toBe('blob:preview-photo');
+  });
+
   it('runs the built-in clear command without sending it as a session message', async () => {
     const gatewayClient = {
       createSession: jest.fn(),

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -401,6 +401,7 @@ describe('TalonCopilot', () => {
       { type: 'text', text: 'what is this?' },
       expect.objectContaining({
         type: 'image',
+        payloadJson: JSON.stringify({ filename: 'photo.png' }),
         object: {
           key: 'sessions/sess-img/uploads/photo.png',
           mediaType: 'image/png',
@@ -411,7 +412,7 @@ describe('TalonCopilot', () => {
         },
       }),
     ]);
-    expect(body.messages[0].parts[1].previewUrl).toBe('blob:preview-photo');
+    expect(body.messages[0].parts[1].previewUrl).toBeUndefined();
   });
 
   it('runs the built-in clear command without sending it as a session message', async () => {

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -468,6 +468,62 @@ describe('TalonCopilot', () => {
     expect(body.messages[0].parts[1].previewUrl).toBeUndefined();
   });
 
+  it('marks selected images as errored when upload fails', async () => {
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:failed-photo');
+    jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockReset();
+    const uploadError = new Error('upload rejected');
+    const onImageUpload = jest.fn().mockRejectedValue(uploadError);
+    const gatewayClient = {
+      createSession: jest.fn().mockResolvedValue({ sessionId: 'sess-upload-fail' }),
+      listSessionMessages: jest.fn().mockRejectedValue(new Error('no canonical recovery')),
+      getSession: jest.fn(),
+    };
+
+    const { container } = render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayUrl="http://localhost:18789"
+        gatewayClient={gatewayClient}
+        onImageUpload={onImageUpload}
+      />,
+    );
+
+    const file = new File([new Uint8Array([1, 2, 3])], 'broken.png', { type: 'image/png' });
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(screen.getByAltText('broken.png')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Ask Talon to perform a task...'), {
+      target: { value: 'what is this?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => expect(onImageUpload).toHaveBeenCalledWith(expect.objectContaining({
+      file,
+      namespace: 'ops',
+      agent: 'copilot',
+      sessionId: 'sess-upload-fail',
+      signal: expect.any(AbortSignal),
+    })));
+    expect(await screen.findByText('upload rejected')).toBeInTheDocument();
+    expect(screen.getByTitle('upload rejected')).toBeInTheDocument();
+    expect(container.querySelector('[aria-label="Uploading image"]')).toBeNull();
+    expect(gatewayClient.createSession).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('runs the built-in clear command without sending it as a session message', async () => {
     const gatewayClient = {
       createSession: jest.fn(),

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -84,6 +84,60 @@ describe('TalonCopilot', () => {
     expect(await screen.findByText('Hello from history')).toBeInTheDocument();
   });
 
+  it('renders reloaded image object refs from session history', async () => {
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-image-history',
+        state: 'IDLE',
+        items: [
+          {
+            message: {
+              id: 'user-image-history',
+              role: 'ROLE_USER',
+              parts: [
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_IMAGE',
+                  payloadJson: JSON.stringify({ filename: 'chart.png' }),
+                  objectRef: {
+                    key: 'sessions/sess-image-history/uploads/chart.png',
+                    mediaType: 'image/png',
+                    sizeBytes: 42,
+                    sha256: 'sha',
+                    filename: 'chart.png',
+                    metadata: {},
+                  },
+                },
+              ],
+              createdAt: String(Date.now() * 1000),
+            },
+            steps: [],
+          },
+        ],
+        hasMore: false,
+      }),
+      getSession: jest.fn(),
+    };
+    const objectUrlForRef = jest.fn((object) => `/api/talon/objects?key=${encodeURIComponent(object.key)}`);
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayUrl="http://localhost:18789"
+        gatewayClient={gatewayClient}
+        sessionId="sess-image-history"
+        objectUrlForRef={objectUrlForRef}
+      />,
+    );
+
+    const image = await screen.findByAltText('chart.png') as HTMLImageElement;
+    expect(image.getAttribute('src')).toBe('/api/talon/objects?key=sessions%2Fsess-image-history%2Fuploads%2Fchart.png');
+    expect(objectUrlForRef).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'sessions/sess-image-history/uploads/chart.png',
+    }));
+  });
+
   it('renders assistant markdown instead of plain text blobs', async () => {
     const gatewayClient = {
       createSession: jest.fn(),

--- a/ui/proto/proto/config_pb.ts
+++ b/ui/proto/proto/config_pb.ts
@@ -10,7 +10,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file proto/config.proto.
  */
 export const file_proto_config: GenFile = /*@__PURE__*/
-  fileDesc("ChJwcm90by9jb25maWcucHJvdG8SDHRhbG9uLmNvbmZpZyLjAgoLVGFsb25Db25maWcSOwoJcHJvdmlkZXJzGAEgAygLMigudGFsb24uY29uZmlnLlRhbG9uQ29uZmlnLlByb3ZpZGVyc0VudHJ5Ei4KCGRhdGFiYXNlGAIgASgLMhwudGFsb24uY29uZmlnLkRhdGFiYXNlQ29uZmlnEioKBnNlcnZlchgDIAEoCzIaLnRhbG9uLmNvbmZpZy5TZXJ2ZXJDb25maWcSGAoQZGVmYXVsdF9wcm92aWRlchgEIAEoCRIVCg13b3Jrc3BhY2VfZGlyGAUgASgJEjcKDWNvbnRyb2xfcGxhbmUYBiABKAsyIC50YWxvbi5jb25maWcuQ29udHJvbFBsYW5lQ29uZmlnGlEKDlByb3ZpZGVyc0VudHJ5EgsKA2tleRgBIAEoCRIuCgV2YWx1ZRgCIAEoCzIfLnRhbG9uLmNvbmZpZy5MbG1Qcm92aWRlckNvbmZpZzoCOAEi5wEKEUxsbVByb3ZpZGVyQ29uZmlnEiwKBm9wZW5haRgBIAEoCzIaLnRhbG9uLmNvbmZpZy5PcGVuQWlDb25maWdIABIyCglhbnRocm9waWMYAiABKAsyHS50YWxvbi5jb25maWcuQW50aHJvcGljQ29uZmlnSAASLAoGZ29vZ2xlGAMgASgLMhoudGFsb24uY29uZmlnLkdvb2dsZUNvbmZpZ0gAEjgKEW9wZW5haV9jb21wYXRpYmxlGAQgASgLMhsudGFsb24uY29uZmlnLkdlbmVyaWNDb25maWdIAEIICgZjb25maWciVAoMT3BlbkFpQ29uZmlnEg0KBW1vZGVsGAEgASgJEiUKB2FwaV9rZXkYAiABKAsyFC50YWxvbi5jb25maWcuU2VjcmV0Eg4KBm9yZ19pZBgDIAEoCSJHCg9BbnRocm9waWNDb25maWcSDQoFbW9kZWwYASABKAkSJQoHYXBpX2tleRgCIAEoCzIULnRhbG9uLmNvbmZpZy5TZWNyZXQiRAoMR29vZ2xlQ29uZmlnEg0KBW1vZGVsGAEgASgJEiUKB2FwaV9rZXkYAiABKAsyFC50YWxvbi5jb25maWcuU2VjcmV0ImUKDUdlbmVyaWNDb25maWcSDAoEbmFtZRgBIAEoCRIQCghiYXNlX3VybBgCIAEoCRINCgVtb2RlbBgDIAEoCRIlCgdhcGlfa2V5GAQgASgLMhQudGFsb24uY29uZmlnLlNlY3JldCJLCgZTZWNyZXQSDwoFcGxhaW4YASABKAlIABImCgNyZWYYAiABKAsyFy50YWxvbi5jb25maWcuU2VjcmV0UmVmSABCCAoGc291cmNlIoYBCglTZWNyZXRSZWYSLgoGc291cmNlGAEgASgOMh4udGFsb24uY29uZmlnLlNlY3JldFJlZi5Tb3VyY2USCwoDa2V5GAIgASgJIjwKBlNvdXJjZRIHCgNFTlYQABIHCgNHQ1AQARIMCghLRVlDSEFJThACEgcKA0FXUxADEgkKBUFaVVJFEAQiVQoORGF0YWJhc2VDb25maWcSEAoIZGF0YV9kaXIYASABKAkSDgoGZHJpdmVyGAIgASgJEiEKA3VybBgDIAEoCzIULnRhbG9uLmNvbmZpZy5TZWNyZXQiJQoTTWVzc2FnZUJyb2tlckNvbmZpZxIOCgZkcml2ZXIYASABKAkijwEKG1NjaGVkdWxlckNhbGxiYWNrQXV0aENvbmZpZxItCg1zaGFyZWRfc2VjcmV0GAEgASgLMhQudGFsb24uY29uZmlnLlNlY3JldEgAEjkKC2dvb2dsZV9vaWRjGAIgASgLMiIudGFsb24uY29uZmlnLkdvb2dsZU9pZGNBdXRoQ29uZmlnSABCBgoEYXV0aCJHChRHb29nbGVPaWRjQXV0aENvbmZpZxIQCghhdWRpZW5jZRgBIAEoCRIdChVzZXJ2aWNlX2FjY291bnRfZW1haWwYAiABKAkipgEKGUNsb3VkVGFza3NTY2hlZHVsZXJDb25maWcSEgoKcHJvamVjdF9pZBgBIAEoCRIQCghsb2NhdGlvbhgCIAEoCRINCgVxdWV1ZRgDIAEoCRISCgp0YXJnZXRfdXJsGAQgASgJEkAKDWNhbGxiYWNrX2F1dGgYBSABKAsyKS50YWxvbi5jb25maWcuU2NoZWR1bGVyQ2FsbGJhY2tBdXRoQ29uZmlnIlwKD1NjaGVkdWxlckNvbmZpZxI+CgtjbG91ZF90YXNrcxgBIAEoCzInLnRhbG9uLmNvbmZpZy5DbG91ZFRhc2tzU2NoZWR1bGVyQ29uZmlnSABCCQoHYmFja2VuZCKxAQoSQ29udHJvbFBsYW5lQ29uZmlnEi4KCGRhdGFiYXNlGAEgASgLMhwudGFsb24uY29uZmlnLkRhdGFiYXNlQ29uZmlnEjkKDm1lc3NhZ2VfYnJva2VyGAIgASgLMiEudGFsb24uY29uZmlnLk1lc3NhZ2VCcm9rZXJDb25maWcSMAoJc2NoZWR1bGVyGAMgASgLMh0udGFsb24uY29uZmlnLlNjaGVkdWxlckNvbmZpZyIqCgxTZXJ2ZXJDb25maWcSDAoEaG9zdBgBIAEoCRIMCgRwb3J0GAIgASgNYgZwcm90bzM");
+  fileDesc("ChJwcm90by9jb25maWcucHJvdG8SDHRhbG9uLmNvbmZpZyLjAgoLVGFsb25Db25maWcSOwoJcHJvdmlkZXJzGAEgAygLMigudGFsb24uY29uZmlnLlRhbG9uQ29uZmlnLlByb3ZpZGVyc0VudHJ5Ei4KCGRhdGFiYXNlGAIgASgLMhwudGFsb24uY29uZmlnLkRhdGFiYXNlQ29uZmlnEioKBnNlcnZlchgDIAEoCzIaLnRhbG9uLmNvbmZpZy5TZXJ2ZXJDb25maWcSGAoQZGVmYXVsdF9wcm92aWRlchgEIAEoCRIVCg13b3Jrc3BhY2VfZGlyGAUgASgJEjcKDWNvbnRyb2xfcGxhbmUYBiABKAsyIC50YWxvbi5jb25maWcuQ29udHJvbFBsYW5lQ29uZmlnGlEKDlByb3ZpZGVyc0VudHJ5EgsKA2tleRgBIAEoCRIuCgV2YWx1ZRgCIAEoCzIfLnRhbG9uLmNvbmZpZy5MbG1Qcm92aWRlckNvbmZpZzoCOAEi5wEKEUxsbVByb3ZpZGVyQ29uZmlnEiwKBm9wZW5haRgBIAEoCzIaLnRhbG9uLmNvbmZpZy5PcGVuQWlDb25maWdIABIyCglhbnRocm9waWMYAiABKAsyHS50YWxvbi5jb25maWcuQW50aHJvcGljQ29uZmlnSAASLAoGZ29vZ2xlGAMgASgLMhoudGFsb24uY29uZmlnLkdvb2dsZUNvbmZpZ0gAEjgKEW9wZW5haV9jb21wYXRpYmxlGAQgASgLMhsudGFsb24uY29uZmlnLkdlbmVyaWNDb25maWdIAEIICgZjb25maWciVAoMT3BlbkFpQ29uZmlnEg0KBW1vZGVsGAEgASgJEiUKB2FwaV9rZXkYAiABKAsyFC50YWxvbi5jb25maWcuU2VjcmV0Eg4KBm9yZ19pZBgDIAEoCSJHCg9BbnRocm9waWNDb25maWcSDQoFbW9kZWwYASABKAkSJQoHYXBpX2tleRgCIAEoCzIULnRhbG9uLmNvbmZpZy5TZWNyZXQiRAoMR29vZ2xlQ29uZmlnEg0KBW1vZGVsGAEgASgJEiUKB2FwaV9rZXkYAiABKAsyFC50YWxvbi5jb25maWcuU2VjcmV0ImUKDUdlbmVyaWNDb25maWcSDAoEbmFtZRgBIAEoCRIQCghiYXNlX3VybBgCIAEoCRINCgVtb2RlbBgDIAEoCRIlCgdhcGlfa2V5GAQgASgLMhQudGFsb24uY29uZmlnLlNlY3JldCJLCgZTZWNyZXQSDwoFcGxhaW4YASABKAlIABImCgNyZWYYAiABKAsyFy50YWxvbi5jb25maWcuU2VjcmV0UmVmSABCCAoGc291cmNlIoYBCglTZWNyZXRSZWYSLgoGc291cmNlGAEgASgOMh4udGFsb24uY29uZmlnLlNlY3JldFJlZi5Tb3VyY2USCwoDa2V5GAIgASgJIjwKBlNvdXJjZRIHCgNFTlYQABIHCgNHQ1AQARIMCghLRVlDSEFJThACEgcKA0FXUxADEgkKBUFaVVJFEAQiVQoORGF0YWJhc2VDb25maWcSEAoIZGF0YV9kaXIYASABKAkSDgoGZHJpdmVyGAIgASgJEiEKA3VybBgDIAEoCzIULnRhbG9uLmNvbmZpZy5TZWNyZXQiJQoTTWVzc2FnZUJyb2tlckNvbmZpZxIOCgZkcml2ZXIYASABKAkiJgoWTG9jYWxPYmplY3RTdG9yZUNvbmZpZxIMCgRwYXRoGAEgASgJIkwKFEdjc09iamVjdFN0b3JlQ29uZmlnEg4KBmJ1Y2tldBgBIAEoCRIOCgZwcmVmaXgYAiABKAkSFAoMYXBpX2Jhc2VfdXJsGAMgASgJInUKE1MzT2JqZWN0U3RvcmVDb25maWcSDgoGYnVja2V0GAEgASgJEg4KBnByZWZpeBgCIAEoCRIOCgZyZWdpb24YAyABKAkSFAoMZW5kcG9pbnRfdXJsGAQgASgJEhgKEGZvcmNlX3BhdGhfc3R5bGUYBSABKAgiuQEKEU9iamVjdFN0b3JlQ29uZmlnEjUKBWxvY2FsGAEgASgLMiQudGFsb24uY29uZmlnLkxvY2FsT2JqZWN0U3RvcmVDb25maWdIABIxCgNnY3MYAiABKAsyIi50YWxvbi5jb25maWcuR2NzT2JqZWN0U3RvcmVDb25maWdIABIvCgJzMxgDIAEoCzIhLnRhbG9uLmNvbmZpZy5TM09iamVjdFN0b3JlQ29uZmlnSABCCQoHYmFja2VuZCKPAQobU2NoZWR1bGVyQ2FsbGJhY2tBdXRoQ29uZmlnEi0KDXNoYXJlZF9zZWNyZXQYASABKAsyFC50YWxvbi5jb25maWcuU2VjcmV0SAASOQoLZ29vZ2xlX29pZGMYAiABKAsyIi50YWxvbi5jb25maWcuR29vZ2xlT2lkY0F1dGhDb25maWdIAEIGCgRhdXRoIkcKFEdvb2dsZU9pZGNBdXRoQ29uZmlnEhAKCGF1ZGllbmNlGAEgASgJEh0KFXNlcnZpY2VfYWNjb3VudF9lbWFpbBgCIAEoCSKmAQoZQ2xvdWRUYXNrc1NjaGVkdWxlckNvbmZpZxISCgpwcm9qZWN0X2lkGAEgASgJEhAKCGxvY2F0aW9uGAIgASgJEg0KBXF1ZXVlGAMgASgJEhIKCnRhcmdldF91cmwYBCABKAkSQAoNY2FsbGJhY2tfYXV0aBgFIAEoCzIpLnRhbG9uLmNvbmZpZy5TY2hlZHVsZXJDYWxsYmFja0F1dGhDb25maWciXAoPU2NoZWR1bGVyQ29uZmlnEj4KC2Nsb3VkX3Rhc2tzGAEgASgLMicudGFsb24uY29uZmlnLkNsb3VkVGFza3NTY2hlZHVsZXJDb25maWdIAEIJCgdiYWNrZW5kIugBChJDb250cm9sUGxhbmVDb25maWcSLgoIZGF0YWJhc2UYASABKAsyHC50YWxvbi5jb25maWcuRGF0YWJhc2VDb25maWcSOQoObWVzc2FnZV9icm9rZXIYAiABKAsyIS50YWxvbi5jb25maWcuTWVzc2FnZUJyb2tlckNvbmZpZxIwCglzY2hlZHVsZXIYAyABKAsyHS50YWxvbi5jb25maWcuU2NoZWR1bGVyQ29uZmlnEjUKDG9iamVjdF9zdG9yZRgEIAEoCzIfLnRhbG9uLmNvbmZpZy5PYmplY3RTdG9yZUNvbmZpZyIqCgxTZXJ2ZXJDb25maWcSDAoEaG9zdBgBIAEoCRIMCgRwb3J0GAIgASgNYgZwcm90bzM");
 
 /**
  * @generated from message talon.config.TalonConfig
@@ -330,6 +330,122 @@ export const MessageBrokerConfigSchema: GenMessage<MessageBrokerConfig> = /*@__P
   messageDesc(file_proto_config, 9);
 
 /**
+ * @generated from message talon.config.LocalObjectStoreConfig
+ */
+export type LocalObjectStoreConfig = Message<"talon.config.LocalObjectStoreConfig"> & {
+  /**
+   * @generated from field: string path = 1;
+   */
+  path: string;
+};
+
+/**
+ * Describes the message talon.config.LocalObjectStoreConfig.
+ * Use `create(LocalObjectStoreConfigSchema)` to create a new message.
+ */
+export const LocalObjectStoreConfigSchema: GenMessage<LocalObjectStoreConfig> = /*@__PURE__*/
+  messageDesc(file_proto_config, 10);
+
+/**
+ * @generated from message talon.config.GcsObjectStoreConfig
+ */
+export type GcsObjectStoreConfig = Message<"talon.config.GcsObjectStoreConfig"> & {
+  /**
+   * @generated from field: string bucket = 1;
+   */
+  bucket: string;
+
+  /**
+   * @generated from field: string prefix = 2;
+   */
+  prefix: string;
+
+  /**
+   * @generated from field: string api_base_url = 3;
+   */
+  apiBaseUrl: string;
+};
+
+/**
+ * Describes the message talon.config.GcsObjectStoreConfig.
+ * Use `create(GcsObjectStoreConfigSchema)` to create a new message.
+ */
+export const GcsObjectStoreConfigSchema: GenMessage<GcsObjectStoreConfig> = /*@__PURE__*/
+  messageDesc(file_proto_config, 11);
+
+/**
+ * @generated from message talon.config.S3ObjectStoreConfig
+ */
+export type S3ObjectStoreConfig = Message<"talon.config.S3ObjectStoreConfig"> & {
+  /**
+   * @generated from field: string bucket = 1;
+   */
+  bucket: string;
+
+  /**
+   * @generated from field: string prefix = 2;
+   */
+  prefix: string;
+
+  /**
+   * @generated from field: string region = 3;
+   */
+  region: string;
+
+  /**
+   * @generated from field: string endpoint_url = 4;
+   */
+  endpointUrl: string;
+
+  /**
+   * @generated from field: bool force_path_style = 5;
+   */
+  forcePathStyle: boolean;
+};
+
+/**
+ * Describes the message talon.config.S3ObjectStoreConfig.
+ * Use `create(S3ObjectStoreConfigSchema)` to create a new message.
+ */
+export const S3ObjectStoreConfigSchema: GenMessage<S3ObjectStoreConfig> = /*@__PURE__*/
+  messageDesc(file_proto_config, 12);
+
+/**
+ * @generated from message talon.config.ObjectStoreConfig
+ */
+export type ObjectStoreConfig = Message<"talon.config.ObjectStoreConfig"> & {
+  /**
+   * @generated from oneof talon.config.ObjectStoreConfig.backend
+   */
+  backend: {
+    /**
+     * @generated from field: talon.config.LocalObjectStoreConfig local = 1;
+     */
+    value: LocalObjectStoreConfig;
+    case: "local";
+  } | {
+    /**
+     * @generated from field: talon.config.GcsObjectStoreConfig gcs = 2;
+     */
+    value: GcsObjectStoreConfig;
+    case: "gcs";
+  } | {
+    /**
+     * @generated from field: talon.config.S3ObjectStoreConfig s3 = 3;
+     */
+    value: S3ObjectStoreConfig;
+    case: "s3";
+  } | { case: undefined; value?: undefined };
+};
+
+/**
+ * Describes the message talon.config.ObjectStoreConfig.
+ * Use `create(ObjectStoreConfigSchema)` to create a new message.
+ */
+export const ObjectStoreConfigSchema: GenMessage<ObjectStoreConfig> = /*@__PURE__*/
+  messageDesc(file_proto_config, 13);
+
+/**
  * @generated from message talon.config.SchedulerCallbackAuthConfig
  */
 export type SchedulerCallbackAuthConfig = Message<"talon.config.SchedulerCallbackAuthConfig"> & {
@@ -356,7 +472,7 @@ export type SchedulerCallbackAuthConfig = Message<"talon.config.SchedulerCallbac
  * Use `create(SchedulerCallbackAuthConfigSchema)` to create a new message.
  */
 export const SchedulerCallbackAuthConfigSchema: GenMessage<SchedulerCallbackAuthConfig> = /*@__PURE__*/
-  messageDesc(file_proto_config, 10);
+  messageDesc(file_proto_config, 14);
 
 /**
  * @generated from message talon.config.GoogleOidcAuthConfig
@@ -378,7 +494,7 @@ export type GoogleOidcAuthConfig = Message<"talon.config.GoogleOidcAuthConfig"> 
  * Use `create(GoogleOidcAuthConfigSchema)` to create a new message.
  */
 export const GoogleOidcAuthConfigSchema: GenMessage<GoogleOidcAuthConfig> = /*@__PURE__*/
-  messageDesc(file_proto_config, 11);
+  messageDesc(file_proto_config, 15);
 
 /**
  * @generated from message talon.config.CloudTasksSchedulerConfig
@@ -415,7 +531,7 @@ export type CloudTasksSchedulerConfig = Message<"talon.config.CloudTasksSchedule
  * Use `create(CloudTasksSchedulerConfigSchema)` to create a new message.
  */
 export const CloudTasksSchedulerConfigSchema: GenMessage<CloudTasksSchedulerConfig> = /*@__PURE__*/
-  messageDesc(file_proto_config, 12);
+  messageDesc(file_proto_config, 16);
 
 /**
  * @generated from message talon.config.SchedulerConfig
@@ -438,7 +554,7 @@ export type SchedulerConfig = Message<"talon.config.SchedulerConfig"> & {
  * Use `create(SchedulerConfigSchema)` to create a new message.
  */
 export const SchedulerConfigSchema: GenMessage<SchedulerConfig> = /*@__PURE__*/
-  messageDesc(file_proto_config, 13);
+  messageDesc(file_proto_config, 17);
 
 /**
  * @generated from message talon.config.ControlPlaneConfig
@@ -458,6 +574,11 @@ export type ControlPlaneConfig = Message<"talon.config.ControlPlaneConfig"> & {
    * @generated from field: talon.config.SchedulerConfig scheduler = 3;
    */
   scheduler?: SchedulerConfig;
+
+  /**
+   * @generated from field: talon.config.ObjectStoreConfig object_store = 4;
+   */
+  objectStore?: ObjectStoreConfig;
 };
 
 /**
@@ -465,7 +586,7 @@ export type ControlPlaneConfig = Message<"talon.config.ControlPlaneConfig"> & {
  * Use `create(ControlPlaneConfigSchema)` to create a new message.
  */
 export const ControlPlaneConfigSchema: GenMessage<ControlPlaneConfig> = /*@__PURE__*/
-  messageDesc(file_proto_config, 14);
+  messageDesc(file_proto_config, 18);
 
 /**
  * @generated from message talon.config.ServerConfig
@@ -487,5 +608,5 @@ export type ServerConfig = Message<"talon.config.ServerConfig"> & {
  * Use `create(ServerConfigSchema)` to create a new message.
  */
 export const ServerConfigSchema: GenMessage<ServerConfig> = /*@__PURE__*/
-  messageDesc(file_proto_config, 15);
+  messageDesc(file_proto_config, 19);
 

--- a/ui/proto/proto/models_pb.ts
+++ b/ui/proto/proto/models_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file proto/models.proto.
  */
 export const file_proto_models: GenFile = /*@__PURE__*/
-  fileDesc("ChJwcm90by9tb2RlbHMucHJvdG8SDHRhbG9uLm1vZGVscyKCAgoFQWdlbnQSDAoEbmFtZRgBIAEoCRIKCgJucxgCIAEoCRI0CgpkZWZpbml0aW9uGAMgASgLMiAudGFsb24ubWFuaWZlc3RzLkFnZW50RGVmaW5pdGlvbhIyCg5lZmZlY3RpdmVfc3BlYxgEIAEoCzIaLnRhbG9uLm1hbmlmZXN0cy5BZ2VudFNwZWMSFQoNdGVtcGxhdGVfZGVwcxgFIAMoCRIvCgZsYWJlbHMYByADKAsyHy50YWxvbi5tb2RlbHMuQWdlbnQuTGFiZWxzRW50cnkaLQoLTGFiZWxzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASKiAQoSU2Vzc2lvbk1lc3NhZ2VQYXJ0EgoKAmlkGAEgASgJEjcKCXBhcnRfdHlwZRgCIAEoDjIkLnRhbG9uLm1vZGVscy5TZXNzaW9uTWVzc2FnZVBhcnRUeXBlEg8KB2NvbnRlbnQYAyABKAkSDAoEbmFtZRgEIAEoCRIUCgxwYXlsb2FkX2pzb24YBSABKAkSEgoKY3JlYXRlZF9hdBgGIAEoAyL5AQoOU2Vzc2lvbk1lc3NhZ2USCgoCaWQYASABKAkSJwoEcm9sZRgCIAEoDjIZLnRhbG9uLm1vZGVscy5NZXNzYWdlUm9sZRISCgpjcmVhdGVkX2F0GAQgASgDEjgKBmxhYmVscxgFIAMoCzIoLnRhbG9uLm1vZGVscy5TZXNzaW9uTWVzc2FnZS5MYWJlbHNFbnRyeRIvCgVwYXJ0cxgGIAMoCzIgLnRhbG9uLm1vZGVscy5TZXNzaW9uTWVzc2FnZVBhcnQaLQoLTGFiZWxzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4AUoECAMQBCKzAgoHU2Vzc2lvbhIKCgJpZBgBIAEoCRINCgVhZ2VudBgCIAEoCRIKCgJucxgDIAEoCRIOCgZzdGF0dXMYBCABKAkSEgoKY3JlYXRlZF9hdBgFIAEoAxITCgtsYXN0X2FjdGl2ZRgGIAEoAxI1CghtZXRhZGF0YRgHIAMoCzIjLnRhbG9uLm1vZGVscy5TZXNzaW9uLk1ldGFkYXRhRW50cnkSMQoGbGFiZWxzGAggAygLMiEudGFsb24ubW9kZWxzLlNlc3Npb24uTGFiZWxzRW50cnkaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBGi0KC0xhYmVsc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEitAIKB0NoYW5uZWwSDAoEbmFtZRgBIAEoCRIKCgJucxgCIAEoCRINCgV0aXRsZRgDIAEoCRIOCgZzdGF0dXMYBCABKAkSEgoKY3JlYXRlZF9hdBgFIAEoAxISCgp1cGRhdGVkX2F0GAYgASgDEjUKCG1ldGFkYXRhGAcgAygLMiMudGFsb24ubW9kZWxzLkNoYW5uZWwuTWV0YWRhdGFFbnRyeRIxCgZsYWJlbHMYCCADKAsyIS50YWxvbi5tb2RlbHMuQ2hhbm5lbC5MYWJlbHNFbnRyeRovCg1NZXRhZGF0YUVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEaLQoLTGFiZWxzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASKdAgoOQ2hhbm5lbE1lc3NhZ2USCgoCaWQYASABKAkSCgoCbnMYAiABKAkSDwoHY2hhbm5lbBgDIAEoCRITCgthdXRob3Jfa2luZBgEIAEoCRIOCgZhdXRob3IYBSABKAkSDwoHY29udGVudBgGIAEoCRISCgpjcmVhdGVkX2F0GAcgASgDEhQKDHNvdXJjZV9hZ2VudBgIIAEoCRIZChFzb3VyY2Vfc2Vzc2lvbl9pZBgJIAEoCRI4CgZsYWJlbHMYCiADKAsyKC50YWxvbi5tb2RlbHMuQ2hhbm5lbE1lc3NhZ2UuTGFiZWxzRW50cnkaLQoLTGFiZWxzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASI6ChRDaGFubmVsQ29udGV4dFBvbGljeRIMCgRtb2RlGAEgASgJEhQKDG1heF9tZXNzYWdlcxgCIAEoDSKjAwoTQ2hhbm5lbFN1YnNjcmlwdGlvbhIMCgRuYW1lGAEgASgJEgoKAm5zGAIgASgJEg8KB2NoYW5uZWwYAyABKAkSDQoFYWdlbnQYBCABKAkSDwoHZW5hYmxlZBgFIAEoCBIPCgd0cmlnZ2VyGAYgASgJEjoKDmNvbnRleHRfcG9saWN5GAcgASgLMiIudGFsb24ubW9kZWxzLkNoYW5uZWxDb250ZXh0UG9saWN5EkEKCG1ldGFkYXRhGAggAygLMi8udGFsb24ubW9kZWxzLkNoYW5uZWxTdWJzY3JpcHRpb24uTWV0YWRhdGFFbnRyeRI9CgZsYWJlbHMYCSADKAsyLS50YWxvbi5tb2RlbHMuQ2hhbm5lbFN1YnNjcmlwdGlvbi5MYWJlbHNFbnRyeRISCgpyZXBseV9tb2RlGAogASgJGi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ARotCgtMYWJlbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIkkKDlNjaGVkdWxlVGFyZ2V0Eg0KBWFnZW50GAEgASgJEhQKDHNlc3Npb25fbW9kZRgCIAEoCRISCgpzZXNzaW9uX2lkGAMgASgJIrwBCgxTY2hlZHVsZVNwZWMSDAoEa2luZBgBIAEoCRIMCgRjcm9uGAIgASgJEhgKEGludGVydmFsX3NlY29uZHMYAyABKA0SDgoGcnVuX2F0GAQgASgJEhAKCHRpbWV6b25lGAUgASgJEiwKBnRhcmdldBgGIAEoCzIcLnRhbG9uLm1vZGVscy5TY2hlZHVsZVRhcmdldBIVCg1pbnB1dF9tZXNzYWdlGAcgASgJEg8KB2VuYWJsZWQYCCABKAgirwMKDlNjaGVkdWxlU3RhdHVzEhAKCHJldmlzaW9uGAEgASgEEhgKC25leHRfcnVuX2F0GAIgASgDSACIAQESGwoOYmFja2VuZF9oYW5kbGUYAyABKAlIAYgBARIVCg1iYWNrZW5kX2FybWVkGAQgASgIEhgKC2xhc3RfcnVuX2F0GAUgASgDSAKIAQESHAoPbGFzdF9zZXNzaW9uX2lkGAYgASgJSAOIAQESFwoKbGFzdF9lcnJvchgHIAEoCUgEiAEBEhsKDmNsYWltZWRfcnVuX2F0GAggASgDSAWIAQESHQoQY2xhaW1fZXhwaXJlc19hdBgJIAEoA0gGiAEBEjIKDXJlY2VudF9ldmVudHMYCiADKAsyGy50YWxvbi5tb2RlbHMuU2NoZWR1bGVFdmVudEIOCgxfbmV4dF9ydW5fYXRCEQoPX2JhY2tlbmRfaGFuZGxlQg4KDF9sYXN0X3J1bl9hdEISChBfbGFzdF9zZXNzaW9uX2lkQg0KC19sYXN0X2Vycm9yQhEKD19jbGFpbWVkX3J1bl9hdEITChFfY2xhaW1fZXhwaXJlc19hdCJSCg1TY2hlZHVsZUV2ZW50EhEKCXRpbWVzdGFtcBgBIAEoAxINCgVwaGFzZRgCIAEoCRIPCgdvdXRjb21lGAMgASgJEg4KBmRldGFpbBgEIAEoCSLfAQoIU2NoZWR1bGUSDAoEbmFtZRgBIAEoCRIKCgJucxgCIAEoCRIoCgRzcGVjGAMgASgLMhoudGFsb24ubW9kZWxzLlNjaGVkdWxlU3BlYxIsCgZzdGF0dXMYBCABKAsyHC50YWxvbi5tb2RlbHMuU2NoZWR1bGVTdGF0dXMSMgoGbGFiZWxzGAUgAygLMiIudGFsb24ubW9kZWxzLlNjaGVkdWxlLkxhYmVsc0VudHJ5Gi0KC0xhYmVsc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEitQEKCU5hbWVzcGFjZRIMCgRuYW1lGAEgASgJEg4KBnBhcmVudBgCIAEoCRISCgppc19kZWxldGVkGAMgASgIEhIKCmRlbGV0ZWRfYXQYBCABKAMSMwoGbGFiZWxzGAUgAygLMiMudGFsb24ubW9kZWxzLk5hbWVzcGFjZS5MYWJlbHNFbnRyeRotCgtMYWJlbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIl8KCUtub3dsZWRnZRIMCgRwYXRoGAEgASgJEg8KB2NvbnRlbnQYAiABKAkSEgoKdXBkYXRlZF9hdBgDIAEoAxIRCgluYW1lc3BhY2UYBCABKAkSDAoEbmFtZRgFIAEoCSJrChVLbm93bGVkZ2VTZWFyY2hSZXN1bHQSDAoEcGF0aBgBIAEoCRIPCgdzbmlwcGV0GAIgASgJEg0KBXNjb3JlGAMgASgCEhEKCXRpbWVzdGFtcBgEIAEoAxIRCgluYW1lc3BhY2UYBSABKAkqVwoLTWVzc2FnZVJvbGUSFAoQUk9MRV9VTlNQRUNJRklFRBAAEg0KCVJPTEVfVVNFUhABEhIKDlJPTEVfQVNTSVNUQU5UEAISDwoLUk9MRV9TWVNURU0QAyquAgoWU2Vzc2lvbk1lc3NhZ2VQYXJ0VHlwZRIpCiVTRVNTSU9OX01FU1NBR0VfUEFSVF9UWVBFX1VOU1BFQ0lGSUVEEAASIgoeU0VTU0lPTl9NRVNTQUdFX1BBUlRfVFlQRV9URVhUEAESJwojU0VTU0lPTl9NRVNTQUdFX1BBUlRfVFlQRV9SRUFTT05JTkcQAhInCiNTRVNTSU9OX01FU1NBR0VfUEFSVF9UWVBFX1RPT0xfQ0FMTBADEikKJVNFU1NJT05fTUVTU0FHRV9QQVJUX1RZUEVfVE9PTF9SRVNVTFQQBBIjCh9TRVNTSU9OX01FU1NBR0VfUEFSVF9UWVBFX1VTQUdFEAUSIwofU0VTU0lPTl9NRVNTQUdFX1BBUlRfVFlQRV9FUlJPUhAGYgZwcm90bzM", [file_proto_manifests]);
+  fileDesc("ChJwcm90by9tb2RlbHMucHJvdG8SDHRhbG9uLm1vZGVscyKCAgoFQWdlbnQSDAoEbmFtZRgBIAEoCRIKCgJucxgCIAEoCRI0CgpkZWZpbml0aW9uGAMgASgLMiAudGFsb24ubWFuaWZlc3RzLkFnZW50RGVmaW5pdGlvbhIyCg5lZmZlY3RpdmVfc3BlYxgEIAEoCzIaLnRhbG9uLm1hbmlmZXN0cy5BZ2VudFNwZWMSFQoNdGVtcGxhdGVfZGVwcxgFIAMoCRIvCgZsYWJlbHMYByADKAsyHy50YWxvbi5tb2RlbHMuQWdlbnQuTGFiZWxzRW50cnkaLQoLTGFiZWxzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASLMAQoJT2JqZWN0UmVmEgsKA2tleRgBIAEoCRISCgptZWRpYV90eXBlGAIgASgJEhIKCnNpemVfYnl0ZXMYAyABKAQSDgoGc2hhMjU2GAQgASgJEhAKCGZpbGVuYW1lGAUgASgJEjcKCG1ldGFkYXRhGAYgAygLMiUudGFsb24ubW9kZWxzLk9iamVjdFJlZi5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASLLAQoSU2Vzc2lvbk1lc3NhZ2VQYXJ0EgoKAmlkGAEgASgJEjcKCXBhcnRfdHlwZRgCIAEoDjIkLnRhbG9uLm1vZGVscy5TZXNzaW9uTWVzc2FnZVBhcnRUeXBlEg8KB2NvbnRlbnQYAyABKAkSDAoEbmFtZRgEIAEoCRIUCgxwYXlsb2FkX2pzb24YBSABKAkSEgoKY3JlYXRlZF9hdBgGIAEoAxInCgZvYmplY3QYByABKAsyFy50YWxvbi5tb2RlbHMuT2JqZWN0UmVmIvkBCg5TZXNzaW9uTWVzc2FnZRIKCgJpZBgBIAEoCRInCgRyb2xlGAIgASgOMhkudGFsb24ubW9kZWxzLk1lc3NhZ2VSb2xlEhIKCmNyZWF0ZWRfYXQYBCABKAMSOAoGbGFiZWxzGAUgAygLMigudGFsb24ubW9kZWxzLlNlc3Npb25NZXNzYWdlLkxhYmVsc0VudHJ5Ei8KBXBhcnRzGAYgAygLMiAudGFsb24ubW9kZWxzLlNlc3Npb25NZXNzYWdlUGFydBotCgtMYWJlbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBSgQIAxAEIrMCCgdTZXNzaW9uEgoKAmlkGAEgASgJEg0KBWFnZW50GAIgASgJEgoKAm5zGAMgASgJEg4KBnN0YXR1cxgEIAEoCRISCgpjcmVhdGVkX2F0GAUgASgDEhMKC2xhc3RfYWN0aXZlGAYgASgDEjUKCG1ldGFkYXRhGAcgAygLMiMudGFsb24ubW9kZWxzLlNlc3Npb24uTWV0YWRhdGFFbnRyeRIxCgZsYWJlbHMYCCADKAsyIS50YWxvbi5tb2RlbHMuU2Vzc2lvbi5MYWJlbHNFbnRyeRovCg1NZXRhZGF0YUVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEaLQoLTGFiZWxzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASK0AgoHQ2hhbm5lbBIMCgRuYW1lGAEgASgJEgoKAm5zGAIgASgJEg0KBXRpdGxlGAMgASgJEg4KBnN0YXR1cxgEIAEoCRISCgpjcmVhdGVkX2F0GAUgASgDEhIKCnVwZGF0ZWRfYXQYBiABKAMSNQoIbWV0YWRhdGEYByADKAsyIy50YWxvbi5tb2RlbHMuQ2hhbm5lbC5NZXRhZGF0YUVudHJ5EjEKBmxhYmVscxgIIAMoCzIhLnRhbG9uLm1vZGVscy5DaGFubmVsLkxhYmVsc0VudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ARotCgtMYWJlbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIp0CCg5DaGFubmVsTWVzc2FnZRIKCgJpZBgBIAEoCRIKCgJucxgCIAEoCRIPCgdjaGFubmVsGAMgASgJEhMKC2F1dGhvcl9raW5kGAQgASgJEg4KBmF1dGhvchgFIAEoCRIPCgdjb250ZW50GAYgASgJEhIKCmNyZWF0ZWRfYXQYByABKAMSFAoMc291cmNlX2FnZW50GAggASgJEhkKEXNvdXJjZV9zZXNzaW9uX2lkGAkgASgJEjgKBmxhYmVscxgKIAMoCzIoLnRhbG9uLm1vZGVscy5DaGFubmVsTWVzc2FnZS5MYWJlbHNFbnRyeRotCgtMYWJlbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIjoKFENoYW5uZWxDb250ZXh0UG9saWN5EgwKBG1vZGUYASABKAkSFAoMbWF4X21lc3NhZ2VzGAIgASgNIqMDChNDaGFubmVsU3Vic2NyaXB0aW9uEgwKBG5hbWUYASABKAkSCgoCbnMYAiABKAkSDwoHY2hhbm5lbBgDIAEoCRINCgVhZ2VudBgEIAEoCRIPCgdlbmFibGVkGAUgASgIEg8KB3RyaWdnZXIYBiABKAkSOgoOY29udGV4dF9wb2xpY3kYByABKAsyIi50YWxvbi5tb2RlbHMuQ2hhbm5lbENvbnRleHRQb2xpY3kSQQoIbWV0YWRhdGEYCCADKAsyLy50YWxvbi5tb2RlbHMuQ2hhbm5lbFN1YnNjcmlwdGlvbi5NZXRhZGF0YUVudHJ5Ej0KBmxhYmVscxgJIAMoCzItLnRhbG9uLm1vZGVscy5DaGFubmVsU3Vic2NyaXB0aW9uLkxhYmVsc0VudHJ5EhIKCnJlcGx5X21vZGUYCiABKAkaLwoNTWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBGi0KC0xhYmVsc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiSQoOU2NoZWR1bGVUYXJnZXQSDQoFYWdlbnQYASABKAkSFAoMc2Vzc2lvbl9tb2RlGAIgASgJEhIKCnNlc3Npb25faWQYAyABKAkivAEKDFNjaGVkdWxlU3BlYxIMCgRraW5kGAEgASgJEgwKBGNyb24YAiABKAkSGAoQaW50ZXJ2YWxfc2Vjb25kcxgDIAEoDRIOCgZydW5fYXQYBCABKAkSEAoIdGltZXpvbmUYBSABKAkSLAoGdGFyZ2V0GAYgASgLMhwudGFsb24ubW9kZWxzLlNjaGVkdWxlVGFyZ2V0EhUKDWlucHV0X21lc3NhZ2UYByABKAkSDwoHZW5hYmxlZBgIIAEoCCKvAwoOU2NoZWR1bGVTdGF0dXMSEAoIcmV2aXNpb24YASABKAQSGAoLbmV4dF9ydW5fYXQYAiABKANIAIgBARIbCg5iYWNrZW5kX2hhbmRsZRgDIAEoCUgBiAEBEhUKDWJhY2tlbmRfYXJtZWQYBCABKAgSGAoLbGFzdF9ydW5fYXQYBSABKANIAogBARIcCg9sYXN0X3Nlc3Npb25faWQYBiABKAlIA4gBARIXCgpsYXN0X2Vycm9yGAcgASgJSASIAQESGwoOY2xhaW1lZF9ydW5fYXQYCCABKANIBYgBARIdChBjbGFpbV9leHBpcmVzX2F0GAkgASgDSAaIAQESMgoNcmVjZW50X2V2ZW50cxgKIAMoCzIbLnRhbG9uLm1vZGVscy5TY2hlZHVsZUV2ZW50Qg4KDF9uZXh0X3J1bl9hdEIRCg9fYmFja2VuZF9oYW5kbGVCDgoMX2xhc3RfcnVuX2F0QhIKEF9sYXN0X3Nlc3Npb25faWRCDQoLX2xhc3RfZXJyb3JCEQoPX2NsYWltZWRfcnVuX2F0QhMKEV9jbGFpbV9leHBpcmVzX2F0IlIKDVNjaGVkdWxlRXZlbnQSEQoJdGltZXN0YW1wGAEgASgDEg0KBXBoYXNlGAIgASgJEg8KB291dGNvbWUYAyABKAkSDgoGZGV0YWlsGAQgASgJIt8BCghTY2hlZHVsZRIMCgRuYW1lGAEgASgJEgoKAm5zGAIgASgJEigKBHNwZWMYAyABKAsyGi50YWxvbi5tb2RlbHMuU2NoZWR1bGVTcGVjEiwKBnN0YXR1cxgEIAEoCzIcLnRhbG9uLm1vZGVscy5TY2hlZHVsZVN0YXR1cxIyCgZsYWJlbHMYBSADKAsyIi50YWxvbi5tb2RlbHMuU2NoZWR1bGUuTGFiZWxzRW50cnkaLQoLTGFiZWxzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASK1AQoJTmFtZXNwYWNlEgwKBG5hbWUYASABKAkSDgoGcGFyZW50GAIgASgJEhIKCmlzX2RlbGV0ZWQYAyABKAgSEgoKZGVsZXRlZF9hdBgEIAEoAxIzCgZsYWJlbHMYBSADKAsyIy50YWxvbi5tb2RlbHMuTmFtZXNwYWNlLkxhYmVsc0VudHJ5Gi0KC0xhYmVsc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiXwoJS25vd2xlZGdlEgwKBHBhdGgYASABKAkSDwoHY29udGVudBgCIAEoCRISCgp1cGRhdGVkX2F0GAMgASgDEhEKCW5hbWVzcGFjZRgEIAEoCRIMCgRuYW1lGAUgASgJImsKFUtub3dsZWRnZVNlYXJjaFJlc3VsdBIMCgRwYXRoGAEgASgJEg8KB3NuaXBwZXQYAiABKAkSDQoFc2NvcmUYAyABKAISEQoJdGltZXN0YW1wGAQgASgDEhEKCW5hbWVzcGFjZRgFIAEoCSpXCgtNZXNzYWdlUm9sZRIUChBST0xFX1VOU1BFQ0lGSUVEEAASDQoJUk9MRV9VU0VSEAESEgoOUk9MRV9BU1NJU1RBTlQQAhIPCgtST0xFX1NZU1RFTRADKsEDChZTZXNzaW9uTWVzc2FnZVBhcnRUeXBlEikKJVNFU1NJT05fTUVTU0FHRV9QQVJUX1RZUEVfVU5TUEVDSUZJRUQQABIiCh5TRVNTSU9OX01FU1NBR0VfUEFSVF9UWVBFX1RFWFQQARInCiNTRVNTSU9OX01FU1NBR0VfUEFSVF9UWVBFX1JFQVNPTklORxACEicKI1NFU1NJT05fTUVTU0FHRV9QQVJUX1RZUEVfVE9PTF9DQUxMEAMSKQolU0VTU0lPTl9NRVNTQUdFX1BBUlRfVFlQRV9UT09MX1JFU1VMVBAEEiMKH1NFU1NJT05fTUVTU0FHRV9QQVJUX1RZUEVfVVNBR0UQBRIjCh9TRVNTSU9OX01FU1NBR0VfUEFSVF9UWVBFX0VSUk9SEAYSIwofU0VTU0lPTl9NRVNTQUdFX1BBUlRfVFlQRV9JTUFHRRAHEiMKH1NFU1NJT05fTUVTU0FHRV9QQVJUX1RZUEVfQVVESU8QCBIjCh9TRVNTSU9OX01FU1NBR0VfUEFSVF9UWVBFX1ZJREVPEAkSIgoeU0VTU0lPTl9NRVNTQUdFX1BBUlRfVFlQRV9GSUxFEApiBnByb3RvMw", [file_proto_manifests]);
 
 /**
  * @generated from message talon.models.Agent
@@ -57,6 +57,48 @@ export const AgentSchema: GenMessage<Agent> = /*@__PURE__*/
   messageDesc(file_proto_models, 0);
 
 /**
+ * @generated from message talon.models.ObjectRef
+ */
+export type ObjectRef = Message<"talon.models.ObjectRef"> & {
+  /**
+   * @generated from field: string key = 1;
+   */
+  key: string;
+
+  /**
+   * @generated from field: string media_type = 2;
+   */
+  mediaType: string;
+
+  /**
+   * @generated from field: uint64 size_bytes = 3;
+   */
+  sizeBytes: bigint;
+
+  /**
+   * @generated from field: string sha256 = 4;
+   */
+  sha256: string;
+
+  /**
+   * @generated from field: string filename = 5;
+   */
+  filename: string;
+
+  /**
+   * @generated from field: map<string, string> metadata = 6;
+   */
+  metadata: { [key: string]: string };
+};
+
+/**
+ * Describes the message talon.models.ObjectRef.
+ * Use `create(ObjectRefSchema)` to create a new message.
+ */
+export const ObjectRefSchema: GenMessage<ObjectRef> = /*@__PURE__*/
+  messageDesc(file_proto_models, 1);
+
+/**
  * @generated from message talon.models.SessionMessagePart
  */
 export type SessionMessagePart = Message<"talon.models.SessionMessagePart"> & {
@@ -91,6 +133,11 @@ export type SessionMessagePart = Message<"talon.models.SessionMessagePart"> & {
    * @generated from field: int64 created_at = 6;
    */
   createdAt: bigint;
+
+  /**
+   * @generated from field: talon.models.ObjectRef object = 7;
+   */
+  object?: ObjectRef;
 };
 
 /**
@@ -98,7 +145,7 @@ export type SessionMessagePart = Message<"talon.models.SessionMessagePart"> & {
  * Use `create(SessionMessagePartSchema)` to create a new message.
  */
 export const SessionMessagePartSchema: GenMessage<SessionMessagePart> = /*@__PURE__*/
-  messageDesc(file_proto_models, 1);
+  messageDesc(file_proto_models, 2);
 
 /**
  * @generated from message talon.models.SessionMessage
@@ -137,7 +184,7 @@ export type SessionMessage = Message<"talon.models.SessionMessage"> & {
  * Use `create(SessionMessageSchema)` to create a new message.
  */
 export const SessionMessageSchema: GenMessage<SessionMessage> = /*@__PURE__*/
-  messageDesc(file_proto_models, 2);
+  messageDesc(file_proto_models, 3);
 
 /**
  * @generated from message talon.models.Session
@@ -193,7 +240,7 @@ export type Session = Message<"talon.models.Session"> & {
  * Use `create(SessionSchema)` to create a new message.
  */
 export const SessionSchema: GenMessage<Session> = /*@__PURE__*/
-  messageDesc(file_proto_models, 3);
+  messageDesc(file_proto_models, 4);
 
 /**
  * @generated from message talon.models.Channel
@@ -249,7 +296,7 @@ export type Channel = Message<"talon.models.Channel"> & {
  * Use `create(ChannelSchema)` to create a new message.
  */
 export const ChannelSchema: GenMessage<Channel> = /*@__PURE__*/
-  messageDesc(file_proto_models, 4);
+  messageDesc(file_proto_models, 5);
 
 /**
  * @generated from message talon.models.ChannelMessage
@@ -313,7 +360,7 @@ export type ChannelMessage = Message<"talon.models.ChannelMessage"> & {
  * Use `create(ChannelMessageSchema)` to create a new message.
  */
 export const ChannelMessageSchema: GenMessage<ChannelMessage> = /*@__PURE__*/
-  messageDesc(file_proto_models, 5);
+  messageDesc(file_proto_models, 6);
 
 /**
  * @generated from message talon.models.ChannelContextPolicy
@@ -335,7 +382,7 @@ export type ChannelContextPolicy = Message<"talon.models.ChannelContextPolicy"> 
  * Use `create(ChannelContextPolicySchema)` to create a new message.
  */
 export const ChannelContextPolicySchema: GenMessage<ChannelContextPolicy> = /*@__PURE__*/
-  messageDesc(file_proto_models, 6);
+  messageDesc(file_proto_models, 7);
 
 /**
  * @generated from message talon.models.ChannelSubscription
@@ -399,7 +446,7 @@ export type ChannelSubscription = Message<"talon.models.ChannelSubscription"> & 
  * Use `create(ChannelSubscriptionSchema)` to create a new message.
  */
 export const ChannelSubscriptionSchema: GenMessage<ChannelSubscription> = /*@__PURE__*/
-  messageDesc(file_proto_models, 7);
+  messageDesc(file_proto_models, 8);
 
 /**
  * @generated from message talon.models.ScheduleTarget
@@ -426,7 +473,7 @@ export type ScheduleTarget = Message<"talon.models.ScheduleTarget"> & {
  * Use `create(ScheduleTargetSchema)` to create a new message.
  */
 export const ScheduleTargetSchema: GenMessage<ScheduleTarget> = /*@__PURE__*/
-  messageDesc(file_proto_models, 8);
+  messageDesc(file_proto_models, 9);
 
 /**
  * @generated from message talon.models.ScheduleSpec
@@ -478,7 +525,7 @@ export type ScheduleSpec = Message<"talon.models.ScheduleSpec"> & {
  * Use `create(ScheduleSpecSchema)` to create a new message.
  */
 export const ScheduleSpecSchema: GenMessage<ScheduleSpec> = /*@__PURE__*/
-  messageDesc(file_proto_models, 9);
+  messageDesc(file_proto_models, 10);
 
 /**
  * @generated from message talon.models.ScheduleStatus
@@ -540,7 +587,7 @@ export type ScheduleStatus = Message<"talon.models.ScheduleStatus"> & {
  * Use `create(ScheduleStatusSchema)` to create a new message.
  */
 export const ScheduleStatusSchema: GenMessage<ScheduleStatus> = /*@__PURE__*/
-  messageDesc(file_proto_models, 10);
+  messageDesc(file_proto_models, 11);
 
 /**
  * @generated from message talon.models.ScheduleEvent
@@ -572,7 +619,7 @@ export type ScheduleEvent = Message<"talon.models.ScheduleEvent"> & {
  * Use `create(ScheduleEventSchema)` to create a new message.
  */
 export const ScheduleEventSchema: GenMessage<ScheduleEvent> = /*@__PURE__*/
-  messageDesc(file_proto_models, 11);
+  messageDesc(file_proto_models, 12);
 
 /**
  * @generated from message talon.models.Schedule
@@ -609,7 +656,7 @@ export type Schedule = Message<"talon.models.Schedule"> & {
  * Use `create(ScheduleSchema)` to create a new message.
  */
 export const ScheduleSchema: GenMessage<Schedule> = /*@__PURE__*/
-  messageDesc(file_proto_models, 12);
+  messageDesc(file_proto_models, 13);
 
 /**
  * @generated from message talon.models.Namespace
@@ -650,7 +697,7 @@ export type Namespace = Message<"talon.models.Namespace"> & {
  * Use `create(NamespaceSchema)` to create a new message.
  */
 export const NamespaceSchema: GenMessage<Namespace> = /*@__PURE__*/
-  messageDesc(file_proto_models, 13);
+  messageDesc(file_proto_models, 14);
 
 /**
  * @generated from message talon.models.Knowledge
@@ -689,7 +736,7 @@ export type Knowledge = Message<"talon.models.Knowledge"> & {
  * Use `create(KnowledgeSchema)` to create a new message.
  */
 export const KnowledgeSchema: GenMessage<Knowledge> = /*@__PURE__*/
-  messageDesc(file_proto_models, 14);
+  messageDesc(file_proto_models, 15);
 
 /**
  * @generated from message talon.models.KnowledgeSearchResult
@@ -726,7 +773,7 @@ export type KnowledgeSearchResult = Message<"talon.models.KnowledgeSearchResult"
  * Use `create(KnowledgeSearchResultSchema)` to create a new message.
  */
 export const KnowledgeSearchResultSchema: GenMessage<KnowledgeSearchResult> = /*@__PURE__*/
-  messageDesc(file_proto_models, 15);
+  messageDesc(file_proto_models, 16);
 
 /**
  * @generated from enum talon.models.MessageRole
@@ -797,6 +844,26 @@ export enum SessionMessagePartType {
    * @generated from enum value: SESSION_MESSAGE_PART_TYPE_ERROR = 6;
    */
   ERROR = 6,
+
+  /**
+   * @generated from enum value: SESSION_MESSAGE_PART_TYPE_IMAGE = 7;
+   */
+  IMAGE = 7,
+
+  /**
+   * @generated from enum value: SESSION_MESSAGE_PART_TYPE_AUDIO = 8;
+   */
+  AUDIO = 8,
+
+  /**
+   * @generated from enum value: SESSION_MESSAGE_PART_TYPE_VIDEO = 9;
+   */
+  VIDEO = 9,
+
+  /**
+   * @generated from enum value: SESSION_MESSAGE_PART_TYPE_FILE = 10;
+   */
+  FILE = 10,
 }
 
 /**


### PR DESCRIPTION
## Summary
- add opt-in image attachment support to @impalasys/talon-chat via an injected onImageUpload callback returning ObjectRef
- render selected image previews and submit text plus image object parts to the UI chat endpoint
- preserve image ObjectRef parts through the gateway UI route by dispatching full SessionMessage values

## Tests
- cargo test
- cargo test gateway::ui
- cargo test scheduling::
- pnpm --filter @impalasys/talon-chat build
- pnpm --dir ui exec jest --coverage --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach and upload images with chat messages; images render as thumbnails and send alongside text.

* **Backend**
  * API stores and serves uploaded objects and returns object references usable in chat; safe retrieval and metadata support added.

* **Behavior & Limits**
  * Configurable accepted types, per-image size, and attachment count; submissions allowed with text or images; previews revoked on close; upload errors surfaced.

* **Documentation**
  * README and examples demonstrate image upload integration and usage.

* **Tests**
  * Added tests covering image upload wiring and end-to-end message submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->