### PR TITLE
[codex] Publish Docker images to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ concurrency:
   group: talon-oss-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   cargo:
     name: Cargo
@@ -50,13 +54,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build runtime image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: dockerfiles/oss-runtime.Dockerfile
-          push: false
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           load: false
+          tags: |
+            ghcr.io/impalasys/talon-runtime:latest
+            ghcr.io/impalasys/talon-runtime:sha-${{ github.sha }}
 
   envoy_image:
     name: Envoy Image
@@ -81,13 +96,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build envoy image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: dockerfiles/envoy-cloudrun.Dockerfile
-          push: false
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           load: false
+          tags: |
+            ghcr.io/impalasys/talon-envoy-cloudrun:latest
+            ghcr.io/impalasys/talon-envoy-cloudrun:sha-${{ github.sha }}
 
   ui:
     name: UI
@@ -118,13 +144,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build UI image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: dockerfiles/oss-ui.Dockerfile
-          push: false
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           load: false
+          tags: |
+            ghcr.io/impalasys/talon-ui:latest
+            ghcr.io/impalasys/talon-ui:sha-${{ github.sha }}
           build-args: |
             NEXT_PUBLIC_GATEWAY_URL=http://localhost:18789
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,15 @@ docker build -f dockerfiles/envoy-cloudrun.Dockerfile .
 
 ## CI artifacts
 
-GitHub CI validates Cargo, runtime image, Envoy image, and UI builds. On pushes to `main`, CI also packages release binaries for:
+GitHub CI validates Cargo, runtime image, Envoy image, and UI builds. On pushes to `main`, CI publishes Docker images to GHCR:
+
+- `ghcr.io/impalasys/talon-runtime:latest`
+- `ghcr.io/impalasys/talon-envoy-cloudrun:latest`
+- `ghcr.io/impalasys/talon-ui:latest`
+
+Each image is also tagged as `sha-<commit>` for immutable references from downstream projects.
+
+On pushes to `main`, CI also packages release binaries for:
 
 - Linux `x86_64`
 - macOS `arm64`


### PR DESCRIPTION
## Summary

- Publish Talon's runtime, Envoy Cloud Run, and UI Docker images to GHCR from the existing CI image jobs when changes land on `main`.
- Tag each image as `latest` and `sha-<commit>` so downstream projects can choose moving or immutable references.
- Document the GHCR image names in the README.

## Published images

- `ghcr.io/impalasys/talon-runtime`
- `ghcr.io/impalasys/talon-envoy-cloudrun`
- `ghcr.io/impalasys/talon-ui`

## Validation

- Parsed `.github/workflows/ci.yml` with Ruby YAML.
- Confirmed referenced Docker action tags exist via `git ls-remote`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Container images (runtime, Envoy, UI) are now automatically published to GitHub Container Registry on updates to main, with stable `latest` tags and immutable commit-specific tags for reproducibility.

* **Documentation**
  * Updated CI artifacts section documenting automated image publishing and release binary packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->