### PR TITLE
[codex] Cache runtime and Envoy image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           tags: |
             ghcr.io/impalasys/talon-runtime:latest
             ghcr.io/impalasys/talon-runtime:sha-${{ github.sha }}
+          cache-from: type=gha,scope=talon-runtime
+          cache-to: type=gha,mode=max,scope=talon-runtime
 
   envoy_image:
     name: Envoy Image
@@ -100,6 +102,8 @@ jobs:
           tags: |
             ghcr.io/impalasys/talon-envoy:latest
             ghcr.io/impalasys/talon-envoy:sha-${{ github.sha }}
+          cache-from: type=gha,scope=talon-envoy
+          cache-to: type=gha,mode=max,scope=talon-envoy
 
   ui:
     name: UI


### PR DESCRIPTION
## Summary
- add GitHub Actions BuildKit cache import/export to the runtime image build
- add a separate scoped BuildKit cache for the unified Envoy image build

## Why
The Dockerfiles already benefit from stable layers and BuildKit cache mounts, but GitHub-hosted runners are fresh for each workflow run. Exporting/importing `type=gha` caches lets runtime and Envoy builds reuse work across CI runs without sharing one noisy cache scope.

## Validation
- `ruby -ryaml -e ...` parsed `.github/workflows/ci.yml`
- asserted runtime image job has `type=gha,scope=talon-runtime`
- asserted Envoy image job has `type=gha,scope=talon-envoy`

## Notes
The benchmark workflow already had a scoped GHA Docker cache, so this PR leaves benchmark files untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal build pipeline efficiency through optimization of containerization caching mechanisms. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->