### PR TITLE
[codex] Restore capabilities policy serde hook

### DIFF
--- a/src/control/manifest/agent_impls.rs
+++ b/src/control/manifest/agent_impls.rs
@@ -43,6 +43,32 @@ fn capabilities_policy_from_proto(
         .collect()
 }
 
+#[cfg(not(feature = "bazel"))]
+pub(crate) mod capabilities_policy_serde {
+    use super::*;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(crate) fn serialize<S>(
+        policy: &std::collections::HashMap<String, ListValue>,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        capabilities_policy_from_proto(policy).serialize(serializer)
+    }
+
+    pub(crate) fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> std::result::Result<std::collections::HashMap<String, ListValue>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let policy = CapabilitiesPolicyManifest::deserialize(deserializer)?;
+        Ok(capabilities_policy_into_proto(policy))
+    }
+}
+
 impl AgentSpecManifest {
     fn into_proto(self) -> Result<manifests::AgentSpec> {
         Ok(manifests::AgentSpec {


### PR DESCRIPTION
## Summary

Restore `crate::control::manifest::capabilities_policy_serde`, the serde helper module referenced by Cargo-generated `AgentSpec.capabilities` protobuf code.

The module is gated with `#[cfg(not(feature = "bazel"))]` so it fixes the Cargo path without shadowing or warning under the monorepo Bazel build, where generated proto code uses the separate `::talon_proto_serde::capabilities_policy_serde` crate.

## Root Cause

`build.rs` still annotates `.talon.resources.AgentSpec.capabilities` with `#[serde(with = "crate::control::manifest::capabilities_policy_serde", default)]`, but the prior sync removed that module from `src/control/manifest/agent_impls.rs`. That made generated `talon.resources.rs` fail to compile with `E0433`.

In `impalasys/code`, Bazel does not use `build.rs`; `talon/BUILD.bazel` applies its own prost transform and points the field attribute at `::talon_proto_serde::capabilities_policy_serde` instead.

## Validation

- `cargo fmt --check`
- `cargo build --locked --bins`
- `bazel build //talon:talon` in a temporary `~/Workspace/impalasys/code` worktree with this shim applied