### PR TITLE
Cache Cloudflare E2E Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,22 +350,22 @@ jobs:
         run: infra/cf/worker/node_modules/.bin/wrangler deploy --dry-run --config infra/cf/worker/wrangler.jsonc --outdir /tmp/talon-cloudflare-prod-dry-run --containers-rollout=none
 
       - name: Validate Docker Compose config
-        run: docker compose -f infra/cf/dev/docker-compose.yaml config
+        run: docker compose -f infra/cf/dev/docker-compose.yaml -f infra/cf/dev/docker-compose.ci.yaml config
 
       - name: Run Cloudflare local E2E
         id: cloudflare-local-e2e
         timeout-minutes: 35
-        run: docker compose -f infra/cf/dev/docker-compose.yaml up --build --abort-on-container-exit --exit-code-from e2e-tests e2e-tests
+        run: docker compose -f infra/cf/dev/docker-compose.yaml -f infra/cf/dev/docker-compose.ci.yaml up --build --abort-on-container-exit --exit-code-from e2e-tests e2e-tests
 
       - name: Dump Cloudflare stack logs
         if: always() && steps.cloudflare-local-e2e.outcome == 'failure'
         run: |
-          docker compose -f infra/cf/dev/docker-compose.yaml ps
-          docker compose -f infra/cf/dev/docker-compose.yaml logs --no-color --tail=400
+          docker compose -f infra/cf/dev/docker-compose.yaml -f infra/cf/dev/docker-compose.ci.yaml ps
+          docker compose -f infra/cf/dev/docker-compose.yaml -f infra/cf/dev/docker-compose.ci.yaml logs --no-color --tail=400
 
       - name: Stop Cloudflare stack
         if: always()
-        run: docker compose -f infra/cf/dev/docker-compose.yaml down --volumes --remove-orphans
+        run: docker compose -f infra/cf/dev/docker-compose.yaml -f infra/cf/dev/docker-compose.ci.yaml down --volumes --remove-orphans
 
   binary_artifacts:
     name: Binary Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
+      - name: Expose GitHub Actions runtime for Docker cache
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4
+
       - name: Regenerate Wrangler configs
         run: infra/cf/gen-wrangler.sh
 

--- a/infra/cf/dev/docker-compose.ci.yaml
+++ b/infra/cf/dev/docker-compose.ci.yaml
@@ -1,0 +1,39 @@
+services:
+  cloudflare-dev:
+    build:
+      cache_from:
+        - type=gha,scope=talon-cf-cloudflare-dev
+      cache_to:
+        - type=gha,mode=max,scope=talon-cf-cloudflare-dev
+
+  gateway:
+    build:
+      cache_from:
+        - type=gha,scope=talon-cf-runtime
+        - type=gha,scope=talon-runtime
+      cache_to:
+        - type=gha,mode=max,scope=talon-cf-runtime
+
+  worker:
+    build:
+      cache_from:
+        - type=gha,scope=talon-cf-runtime
+        - type=gha,scope=talon-runtime
+      cache_to:
+        - type=gha,mode=max,scope=talon-cf-runtime
+
+  envoy:
+    build:
+      cache_from:
+        - type=gha,scope=talon-cf-envoy
+        - type=gha,scope=talon-envoy
+      cache_to:
+        - type=gha,mode=max,scope=talon-cf-envoy
+
+  e2e-tests:
+    build:
+      cache_from:
+        - type=gha,scope=talon-cf-runtime
+        - type=gha,scope=talon-runtime
+      cache_to:
+        - type=gha,mode=max,scope=talon-cf-runtime

--- a/infra/cf/dev/docker-compose.yaml
+++ b/infra/cf/dev/docker-compose.yaml
@@ -1,8 +1,32 @@
+x-cloudflare-dev-build: &cloudflare-dev-build
+  context: ../../..
+  dockerfile: infra/cf/dev/Dockerfile
+  cache_from:
+    - type=gha,scope=talon-cf-cloudflare-dev
+  cache_to:
+    - type=gha,mode=max,scope=talon-cf-cloudflare-dev
+
+x-talon-runtime-build: &talon-runtime-build
+  context: ../../..
+  dockerfile: dockerfiles/oss-runtime.Dockerfile
+  cache_from:
+    - type=gha,scope=talon-cf-runtime
+    - type=gha,scope=talon-runtime
+  cache_to:
+    - type=gha,mode=max,scope=talon-cf-runtime
+
+x-envoy-build: &envoy-build
+  context: ../../..
+  dockerfile: dockerfiles/envoy.Dockerfile
+  cache_from:
+    - type=gha,scope=talon-cf-envoy
+    - type=gha,scope=talon-envoy
+  cache_to:
+    - type=gha,mode=max,scope=talon-cf-envoy
+
 services:
   cloudflare-dev:
-    build:
-      context: ../../..
-      dockerfile: infra/cf/dev/Dockerfile
+    build: *cloudflare-dev-build
     working_dir: /repo/infra/cf/worker
     command: start-wrangler
     environment:
@@ -26,9 +50,7 @@ services:
         condition: service_healthy
 
   gateway:
-    build:
-      context: ../../..
-      dockerfile: dockerfiles/oss-runtime.Dockerfile
+    build: *talon-runtime-build
     command: sh -c 'until curl -s -o /dev/null http://talon-d1.internal:8787/__ready; do sleep 1; done; export TALON_CONFIG_INLINE_YAML="$$(cat /repo/infra/cf/dev/talon.yaml)" && exec talon-server'
     restart: on-failure
     environment:
@@ -54,9 +76,7 @@ services:
         condition: service_healthy
 
   worker:
-    build:
-      context: ../../..
-      dockerfile: dockerfiles/oss-runtime.Dockerfile
+    build: *talon-runtime-build
     command: sh -c 'until curl -s -o /dev/null http://talon-d1.internal:8787/__ready; do sleep 1; done; export TALON_CONFIG_INLINE_YAML="$$(cat /repo/infra/cf/dev/talon.yaml)" && exec talon-worker'
     restart: on-failure
     environment:
@@ -77,9 +97,7 @@ services:
         condition: service_healthy
 
   envoy:
-    build:
-      context: ../../..
-      dockerfile: dockerfiles/envoy.Dockerfile
+    build: *envoy-build
     environment:
       TALON_ENVOY_GATEWAY_GRPC_HOST: gateway.internal
       TALON_ENVOY_GATEWAY_HTTP_HOST: gateway.internal
@@ -113,9 +131,7 @@ services:
       retries: 60
 
   e2e-tests:
-    build:
-      context: ../../..
-      dockerfile: dockerfiles/oss-runtime.Dockerfile
+    build: *talon-runtime-build
     working_dir: /repo
     command: sh -c "apt-get update && apt-get install -y --no-install-recommends python3 && python3 tests/run_cloudflare_e2e.py"
     environment:

--- a/infra/cf/dev/docker-compose.yaml
+++ b/infra/cf/dev/docker-compose.yaml
@@ -1,32 +1,8 @@
-x-cloudflare-dev-build: &cloudflare-dev-build
-  context: ../../..
-  dockerfile: infra/cf/dev/Dockerfile
-  cache_from:
-    - type=gha,scope=talon-cf-cloudflare-dev
-  cache_to:
-    - type=gha,mode=max,scope=talon-cf-cloudflare-dev
-
-x-talon-runtime-build: &talon-runtime-build
-  context: ../../..
-  dockerfile: dockerfiles/oss-runtime.Dockerfile
-  cache_from:
-    - type=gha,scope=talon-cf-runtime
-    - type=gha,scope=talon-runtime
-  cache_to:
-    - type=gha,mode=max,scope=talon-cf-runtime
-
-x-envoy-build: &envoy-build
-  context: ../../..
-  dockerfile: dockerfiles/envoy.Dockerfile
-  cache_from:
-    - type=gha,scope=talon-cf-envoy
-    - type=gha,scope=talon-envoy
-  cache_to:
-    - type=gha,mode=max,scope=talon-cf-envoy
-
 services:
   cloudflare-dev:
-    build: *cloudflare-dev-build
+    build:
+      context: ../../..
+      dockerfile: infra/cf/dev/Dockerfile
     working_dir: /repo/infra/cf/worker
     command: start-wrangler
     environment:
@@ -50,7 +26,9 @@ services:
         condition: service_healthy
 
   gateway:
-    build: *talon-runtime-build
+    build:
+      context: ../../..
+      dockerfile: dockerfiles/oss-runtime.Dockerfile
     command: sh -c 'until curl -s -o /dev/null http://talon-d1.internal:8787/__ready; do sleep 1; done; export TALON_CONFIG_INLINE_YAML="$$(cat /repo/infra/cf/dev/talon.yaml)" && exec talon-server'
     restart: on-failure
     environment:
@@ -76,7 +54,9 @@ services:
         condition: service_healthy
 
   worker:
-    build: *talon-runtime-build
+    build:
+      context: ../../..
+      dockerfile: dockerfiles/oss-runtime.Dockerfile
     command: sh -c 'until curl -s -o /dev/null http://talon-d1.internal:8787/__ready; do sleep 1; done; export TALON_CONFIG_INLINE_YAML="$$(cat /repo/infra/cf/dev/talon.yaml)" && exec talon-worker'
     restart: on-failure
     environment:
@@ -97,7 +77,9 @@ services:
         condition: service_healthy
 
   envoy:
-    build: *envoy-build
+    build:
+      context: ../../..
+      dockerfile: dockerfiles/envoy.Dockerfile
     environment:
       TALON_ENVOY_GATEWAY_GRPC_HOST: gateway.internal
       TALON_ENVOY_GATEWAY_HTTP_HOST: gateway.internal
@@ -131,7 +113,9 @@ services:
       retries: 60
 
   e2e-tests:
-    build: *talon-runtime-build
+    build:
+      context: ../../..
+      dockerfile: dockerfiles/oss-runtime.Dockerfile
     working_dir: /repo
     command: sh -c "apt-get update && apt-get install -y --no-install-recommends python3 && python3 tests/run_cloudflare_e2e.py"
     environment:


### PR DESCRIPTION
## Summary
- expose the GitHub Actions runtime env in the Cloudflare E2E job so BuildKit can use the GitHub Actions cache backend
- add named GHA BuildKit cache scopes to the Cloudflare dev, Talon runtime, and Envoy Compose builds
- let the Cloudflare runtime/envoy builds read the existing image-job caches while exporting their own E2E-specific scopes

## Validation
- docker compose -f infra/cf/dev/docker-compose.yaml config
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline with improved Docker caching for faster build times in containerized test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->