### PR TITLE
Renew session leases and redispatch expired streams

### DIFF
--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -20,7 +20,7 @@ use crate::control::{
 use crate::gateway::rpc::{data_proto, resources_proto};
 
 pub const MIN_RECURRING_INTERVAL_SECONDS: u32 = 300;
-const DEFAULT_SESSION_PROCESSING_TIMEOUT_SECONDS: i64 = 30 * 60;
+const DEFAULT_SESSION_PROCESSING_TIMEOUT_SECONDS: i64 = 10;
 const DEFAULT_SCHEDULE_CLAIM_TIMEOUT_SECONDS: i64 = 60;
 const MAX_CAS_RETRIES: usize = 8;
 const MAX_RECENT_SCHEDULE_EVENTS: usize = 20;
@@ -751,7 +751,7 @@ pub async fn send_session_message(
     Ok(())
 }
 
-fn session_message_text_projection(message: &data_proto::SessionMessage) -> String {
+pub(crate) fn session_message_text_projection(message: &data_proto::SessionMessage) -> String {
     let text = message
         .parts
         .iter()
@@ -1121,7 +1121,7 @@ mod tests {
     }
 
     #[test]
-    fn session_processing_timeout_defaults_to_30_minutes() {
+    fn session_processing_timeout_defaults_to_10_seconds() {
         unsafe {
             std::env::remove_var("TALON_SESSION_PROCESSING_TIMEOUT_SECONDS");
         }

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -11,6 +11,10 @@ use prost::Message;
 use serde_json::{json, Value};
 use std::sync::OnceLock;
 
+mod watcher;
+
+use watcher::session_parts_event_stream;
+
 const LARGE_SESSION_PAYLOAD_WARNING_BYTES: usize = 128 * 1024;
 const DEFAULT_SESSION_MESSAGES_PAGE_SIZE: usize = 50;
 const MAX_SESSION_MESSAGES_PAGE_SIZE: usize = 200;
@@ -1094,6 +1098,11 @@ impl GrpcGatewayHandler {
         );
         let req = req.into_inner();
 
+        let targets = vec![SessionStreamTarget::new(
+            req.ns.clone(),
+            req.agent.clone(),
+            req.session_id.clone(),
+        )];
         let receiver = self
             .gateway
             .session_streams
@@ -1103,14 +1112,14 @@ impl GrpcGatewayHandler {
                 tonic::Status::internal(format!("Failed to subscribe to session stream: {}", e))
             })?;
 
-        let event_stream = async_stream::stream! {
-            let mut receiver = receiver;
-            while let Some(event) = receiver.recv().await {
-                yield event;
-            }
-        };
+        let event_stream = session_parts_event_stream(
+            receiver,
+            targets,
+            self.gateway.kv.clone(),
+            self.gateway.pubsub.clone(),
+        );
 
-        Ok(tonic::Response::new(Box::pin(event_stream)))
+        Ok(tonic::Response::new(event_stream))
     }
 
     pub async fn handle_stream_session_parts_batch(
@@ -1158,20 +1167,20 @@ impl GrpcGatewayHandler {
         let receiver = self
             .gateway
             .session_streams
-            .subscribe_many(targets)
+            .subscribe_many(targets.clone())
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to subscribe to session stream: {}", e))
             })?;
 
-        let event_stream = async_stream::stream! {
-            let mut receiver = receiver;
-            while let Some(event) = receiver.recv().await {
-                yield event;
-            }
-        };
+        let event_stream = session_parts_event_stream(
+            receiver,
+            targets,
+            self.gateway.kv.clone(),
+            self.gateway.pubsub.clone(),
+        );
 
-        Ok(tonic::Response::new(Box::pin(event_stream)))
+        Ok(tonic::Response::new(event_stream))
     }
 }
 

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -1,0 +1,371 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use crate::control::scheduling;
+use crate::control::topics;
+use crate::control::ProtoKeyValueStoreExt;
+use crate::control::{events, keys, KeyValueStore, MessagePublisher};
+use crate::gateway::rpc::data_proto;
+use crate::gateway::session_streams::{SessionStreamReceiver, SessionStreamTarget};
+use futures::Stream;
+use prost::Message;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+const SESSION_STREAM_LEASE_CHECK_MAX_MICROS: u64 = 5_000_000;
+const SESSION_STREAM_LEASE_CHECK_MIN_MICROS: u64 = 1_000_000;
+
+pub(super) type SessionPartEventStream = Pin<
+    Box<
+        dyn Stream<Item = std::result::Result<events::SessionMessagePartEvent, tonic::Status>>
+            + Send,
+    >,
+>;
+
+fn stream_session_lease_check_interval() -> Duration {
+    let ttl_micros = scheduling::session_processing_timeout_micros().max(1) as u64;
+    Duration::from_micros((ttl_micros / 6).clamp(
+        SESSION_STREAM_LEASE_CHECK_MIN_MICROS,
+        SESSION_STREAM_LEASE_CHECK_MAX_MICROS,
+    ))
+}
+
+fn stream_session_redispatch_throttle_micros() -> i64 {
+    scheduling::session_processing_timeout_micros().max(1)
+}
+
+pub(super) fn session_parts_event_stream(
+    mut receiver: SessionStreamReceiver,
+    targets: Vec<SessionStreamTarget>,
+    kv: Arc<dyn KeyValueStore + Send + Sync>,
+    pubsub: Arc<dyn MessagePublisher + Send + Sync>,
+) -> SessionPartEventStream {
+    Box::pin(async_stream::stream! {
+        let mut lease_check = tokio::time::interval(stream_session_lease_check_interval());
+        lease_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        lease_check.tick().await;
+
+        loop {
+            tokio::select! {
+                event = receiver.recv() => {
+                    let Some(event) = event else {
+                        break;
+                    };
+                    yield event;
+                }
+                _ = lease_check.tick() => {
+                    for target in &targets {
+                        if let Err(err) = redispatch_expired_session_lease(
+                            kv.as_ref(),
+                            pubsub.as_ref(),
+                            target,
+                            chrono::Utc::now().timestamp_micros(),
+                        ).await {
+                            tracing::warn!(
+                                namespace = %target.ns,
+                                agent = %target.agent,
+                                session = %target.session_id,
+                                error = %err,
+                                "Failed to check session submission lease while streaming"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+async fn redispatch_expired_session_lease(
+    kv: &dyn KeyValueStore,
+    pubsub: &dyn MessagePublisher,
+    target: &SessionStreamTarget,
+    now_micros: i64,
+) -> std::result::Result<bool, tonic::Status> {
+    let session_key = keys::session(&target.ns, &target.agent, &target.session_id);
+    let Some(session) = kv
+        .get_msg::<data_proto::Session>(&session_key)
+        .await
+        .map_err(|err| tonic::Status::internal(format!("Failed to fetch session: {err}")))?
+    else {
+        return Ok(false);
+    };
+    if session.status != "PROCESSING" {
+        return Ok(false);
+    }
+
+    let Some(submission) = latest_nonterminal_submission(kv, target).await? else {
+        return Ok(false);
+    };
+    if submission.status == data_proto::SessionSubmissionStatus::Claimed as i32
+        && submission
+            .claim_expires_at
+            .is_some_and(|expires_at| expires_at > now_micros)
+    {
+        return Ok(false);
+    }
+    if now_micros.saturating_sub(submission.updated_at)
+        < stream_session_redispatch_throttle_micros()
+    {
+        return Ok(false);
+    }
+
+    let submission_key = keys::session_submission(
+        &target.ns,
+        &target.agent,
+        &target.session_id,
+        &submission.submission_id,
+    );
+    let Some(current_bytes) = kv
+        .get(&submission_key)
+        .await
+        .map_err(|err| tonic::Status::internal(format!("Failed to fetch submission: {err}")))?
+    else {
+        return Ok(false);
+    };
+    let mut current = data_proto::SessionSubmission::decode(current_bytes.as_slice())
+        .map_err(|err| tonic::Status::internal(format!("Failed to decode submission: {err}")))?;
+    if crate::harness::sessions::submission_is_terminal(&current)
+        || current.status == data_proto::SessionSubmissionStatus::Claimed as i32
+            && current
+                .claim_expires_at
+                .is_some_and(|expires_at| expires_at > now_micros)
+        || now_micros.saturating_sub(current.updated_at)
+            < stream_session_redispatch_throttle_micros()
+    {
+        return Ok(false);
+    }
+
+    current.updated_at = now_micros;
+    let updated = current.encode_to_vec();
+    if !kv
+        .compare_and_swap(&submission_key, Some(current_bytes.as_slice()), &updated)
+        .await
+        .map_err(|err| tonic::Status::internal(format!("Failed to throttle redispatch: {err}")))?
+    {
+        return Ok(false);
+    }
+
+    let message_key = keys::session_message(
+        &target.ns,
+        &target.agent,
+        &target.session_id,
+        &current.user_message_id,
+    );
+    let Some(user_message) = kv
+        .get_msg::<data_proto::SessionMessage>(&message_key)
+        .await
+        .map_err(|err| tonic::Status::internal(format!("Failed to fetch user message: {err}")))?
+    else {
+        tracing::warn!(
+            namespace = %target.ns,
+            agent = %target.agent,
+            session = %target.session_id,
+            submission = %current.submission_id,
+            message = %current.user_message_id,
+            "Cannot redispatch expired session lease because the user message is missing"
+        );
+        return Ok(false);
+    };
+
+    let event = events::SessionMessageEvent {
+        session_id: target.session_id.clone(),
+        message_id: current.user_message_id.clone(),
+        direction: events::MessageDirection::Inbound as i32,
+        timestamp: session.last_active,
+        agent: target.agent.clone(),
+        message: scheduling::session_message_text_projection(&user_message),
+        ns: target.ns.clone(),
+        submission_id: current.submission_id.clone(),
+    };
+    pubsub
+        .publish(topics::SESSION_DISPATCH_TOPIC, &event.encode_to_vec())
+        .await
+        .map_err(|err| tonic::Status::internal(format!("Failed to publish redispatch: {err}")))?;
+    tracing::info!(
+        namespace = %target.ns,
+        agent = %target.agent,
+        session = %target.session_id,
+        submission = %current.submission_id,
+        "Redispatched session submission after expired lease"
+    );
+    Ok(true)
+}
+
+async fn latest_nonterminal_submission(
+    kv: &dyn KeyValueStore,
+    target: &SessionStreamTarget,
+) -> std::result::Result<Option<data_proto::SessionSubmission>, tonic::Status> {
+    let prefix = keys::session_submission_prefix(&target.ns, &target.agent, &target.session_id);
+    let entries = kv
+        .list_entries(&prefix)
+        .await
+        .map_err(|err| tonic::Status::internal(format!("Failed to list submissions: {err}")))?;
+    let mut submissions = Vec::new();
+    for (_key, bytes) in entries {
+        let submission =
+            data_proto::SessionSubmission::decode(bytes.as_slice()).map_err(|err| {
+                tonic::Status::internal(format!("Failed to decode submission: {err}"))
+            })?;
+        if !crate::harness::sessions::submission_is_terminal(&submission) {
+            submissions.push(submission);
+        }
+    }
+    Ok(submissions
+        .into_iter()
+        .max_by_key(|submission| (submission.created_at, submission.updated_at)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::ProtoKeyValueStoreExt;
+    use crate::test_support::{MockKvStore, RecordingPubSub};
+
+    #[tokio::test]
+    async fn stream_lease_check_skips_active_submission_lease() {
+        let kv = Arc::new(MockKvStore::default());
+        let pubsub = Arc::new(RecordingPubSub::default());
+        let target = SessionStreamTarget::new("conic", "infra", "session-1");
+        seed_processing_session_with_submission(
+            kv.as_ref(),
+            &target,
+            data_proto::SessionSubmission {
+                submission_id: "submission-1".to_string(),
+                session_id: "session-1".to_string(),
+                user_message_id: "user-1".to_string(),
+                status: data_proto::SessionSubmissionStatus::Claimed as i32,
+                attempt_id: "attempt-1".to_string(),
+                attempt_count: 1,
+                claim_expires_at: Some(30_000_000),
+                created_at: 1,
+                updated_at: 1,
+                completed_at: None,
+                committed_message_id: None,
+                current_phase: data_proto::SessionExecutionPhase::Unspecified as i32,
+                current_journal_entry_id: None,
+            },
+        )
+        .await;
+
+        let redispatched =
+            redispatch_expired_session_lease(kv.as_ref(), pubsub.as_ref(), &target, 20_000_000)
+                .await
+                .unwrap();
+
+        assert!(!redispatched);
+        assert!(pubsub.published.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stream_lease_check_redispatches_expired_submission_lease() {
+        let kv = Arc::new(MockKvStore::default());
+        let pubsub = Arc::new(RecordingPubSub::default());
+        let target = SessionStreamTarget::new("conic", "infra", "session-1");
+        seed_processing_session_with_submission(
+            kv.as_ref(),
+            &target,
+            data_proto::SessionSubmission {
+                submission_id: "submission-1".to_string(),
+                session_id: "session-1".to_string(),
+                user_message_id: "user-1".to_string(),
+                status: data_proto::SessionSubmissionStatus::Claimed as i32,
+                attempt_id: "attempt-1".to_string(),
+                attempt_count: 1,
+                claim_expires_at: Some(10_000_000),
+                created_at: 1,
+                updated_at: 1,
+                completed_at: None,
+                committed_message_id: None,
+                current_phase: data_proto::SessionExecutionPhase::Unspecified as i32,
+                current_journal_entry_id: None,
+            },
+        )
+        .await;
+
+        let redispatched =
+            redispatch_expired_session_lease(kv.as_ref(), pubsub.as_ref(), &target, 20_000_000)
+                .await
+                .unwrap();
+
+        assert!(redispatched);
+        let published = pubsub.published.lock().await;
+        assert_eq!(published.len(), 1);
+        assert_eq!(published[0].0, topics::SESSION_DISPATCH_TOPIC);
+        let event = events::SessionMessageEvent::decode(published[0].1.as_slice()).unwrap();
+        assert_eq!(event.ns, "conic");
+        assert_eq!(event.agent, "infra");
+        assert_eq!(event.session_id, "session-1");
+        assert_eq!(event.message_id, "user-1");
+        assert_eq!(event.submission_id, "submission-1");
+        assert_eq!(event.timestamp, 123);
+        assert_eq!(event.message, "please continue");
+        drop(published);
+
+        let submission = kv
+            .get_msg::<data_proto::SessionSubmission>(&keys::session_submission(
+                "conic",
+                "infra",
+                "session-1",
+                "submission-1",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(submission.updated_at, 20_000_000);
+    }
+
+    async fn seed_processing_session_with_submission(
+        kv: &MockKvStore,
+        target: &SessionStreamTarget,
+        submission: data_proto::SessionSubmission,
+    ) {
+        kv.set_msg(
+            &keys::session(&target.ns, &target.agent, &target.session_id),
+            &data_proto::Session {
+                id: target.session_id.clone(),
+                agent: target.agent.clone(),
+                ns: target.ns.clone(),
+                status: "PROCESSING".to_string(),
+                created_at: 1,
+                last_active: 123,
+                metadata: std::collections::HashMap::new(),
+                labels: std::collections::HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+        kv.set_msg(
+            &keys::session_message(&target.ns, &target.agent, &target.session_id, "user-1"),
+            &data_proto::SessionMessage {
+                id: "user-1".to_string(),
+                role: data_proto::MessageRole::RoleUser as i32,
+                created_at: 1,
+                labels: std::collections::HashMap::new(),
+                parts: vec![data_proto::SessionMessagePart {
+                    id: "000000".to_string(),
+                    part_type: data_proto::SessionMessagePartType::Text as i32,
+                    content: "please continue".to_string(),
+                    name: String::new(),
+                    payload_json: String::new(),
+                    created_at: 1,
+                    object: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        kv.set_msg(
+            &keys::session_submission(
+                &target.ns,
+                &target.agent,
+                &target.session_id,
+                &submission.submission_id,
+            ),
+            &submission,
+        )
+        .await
+        .unwrap();
+    }
+}

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -7,7 +7,7 @@ use crate::control::ProtoKeyValueStoreExt;
 use crate::control::{events, keys, KeyValueStore, MessagePublisher};
 use crate::gateway::rpc::data_proto;
 use crate::gateway::session_streams::{SessionStreamReceiver, SessionStreamTarget};
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use prost::Message;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 const SESSION_STREAM_LEASE_CHECK_MAX_MICROS: u64 = 5_000_000;
 const SESSION_STREAM_LEASE_CHECK_MIN_MICROS: u64 = 1_000_000;
+const SESSION_STREAM_LEASE_CHECK_CONCURRENCY: usize = 16;
 
 pub(super) type SessionPartEventStream = Pin<
     Box<
@@ -45,6 +46,7 @@ pub(super) fn session_parts_event_stream(
         let mut lease_check = tokio::time::interval(stream_session_lease_check_interval());
         lease_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         lease_check.tick().await;
+        let mut lease_check_task: Option<tokio::task::JoinHandle<()>> = None;
 
         loop {
             tokio::select! {
@@ -55,26 +57,55 @@ pub(super) fn session_parts_event_stream(
                     yield event;
                 }
                 _ = lease_check.tick() => {
-                    for target in &targets {
-                        if let Err(err) = redispatch_expired_session_lease(
-                            kv.as_ref(),
-                            pubsub.as_ref(),
-                            target,
-                            chrono::Utc::now().timestamp_micros(),
-                        ).await {
-                            tracing::warn!(
-                                namespace = %target.ns,
-                                agent = %target.agent,
-                                session = %target.session_id,
-                                error = %err,
-                                "Failed to check session submission lease while streaming"
-                            );
-                        }
+                    if lease_check_task.as_ref().is_some_and(|task| task.is_finished()) {
+                        lease_check_task = None;
+                    }
+                    if lease_check_task.is_none() {
+                        lease_check_task = Some(tokio::spawn(check_session_leases(
+                            targets.clone(),
+                            kv.clone(),
+                            pubsub.clone(),
+                        )));
                     }
                 }
             }
         }
+        if let Some(task) = lease_check_task {
+            task.abort();
+        }
     })
+}
+
+async fn check_session_leases(
+    targets: Vec<SessionStreamTarget>,
+    kv: Arc<dyn KeyValueStore + Send + Sync>,
+    pubsub: Arc<dyn MessagePublisher + Send + Sync>,
+) {
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    futures::stream::iter(targets)
+        .for_each_concurrent(SESSION_STREAM_LEASE_CHECK_CONCURRENCY, |target| {
+            let kv = kv.clone();
+            let pubsub = pubsub.clone();
+            async move {
+                if let Err(err) = redispatch_expired_session_lease(
+                    kv.as_ref(),
+                    pubsub.as_ref(),
+                    &target,
+                    now_micros,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        namespace = %target.ns,
+                        agent = %target.agent,
+                        session = %target.session_id,
+                        error = %err,
+                        "Failed to check session submission lease while streaming"
+                    );
+                }
+            }
+        })
+        .await;
 }
 
 async fn redispatch_expired_session_lease(

--- a/src/harness/sessions/lease.rs
+++ b/src/harness/sessions/lease.rs
@@ -68,8 +68,8 @@ impl SubmissionLeaseRenewer {
                         )
                         .await
                         {
-                            Ok(()) => {
-                                task_last_renewed_at.store(now_micros, Ordering::SeqCst);
+                            Ok(renewed_at) => {
+                                task_last_renewed_at.store(renewed_at, Ordering::SeqCst);
                             }
                             Err(err) => {
                                 tracing::warn!(
@@ -138,15 +138,15 @@ async fn renew_session_lock_timestamp(
     agent: &str,
     session_id: &str,
     now_micros: i64,
-) -> Result<()> {
+) -> Result<i64> {
     let key = keys::session(ns, agent, session_id);
     for _ in 0..MAX_SESSION_RENEW_CAS_RETRIES {
         let Some(current) = kv.get(&key).await? else {
-            return Ok(());
+            return Ok(now_micros);
         };
         let mut session = data_proto::Session::decode(current.as_slice())?;
         if session.status != "PROCESSING" || session.last_active >= now_micros {
-            return Ok(());
+            return Ok(session.last_active);
         }
         session.last_active = now_micros;
         let updated = session.encode_to_vec();
@@ -154,8 +154,79 @@ async fn renew_session_lock_timestamp(
             .compare_and_swap(&key, Some(current.as_slice()), &updated)
             .await?
         {
-            return Ok(());
+            return Ok(now_micros);
         }
     }
     anyhow::bail!("failed to atomically renew session processing lock")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::ProtoKeyValueStoreExt;
+    use crate::test_support::MockKvStore;
+
+    #[tokio::test]
+    async fn renew_session_lock_timestamp_returns_existing_future_timestamp() {
+        let kv = MockKvStore::default();
+        kv.set_msg(
+            &keys::session("conic", "infra", "session-1"),
+            &data_proto::Session {
+                id: "session-1".to_string(),
+                agent: "infra".to_string(),
+                ns: "conic".to_string(),
+                status: "PROCESSING".to_string(),
+                created_at: 1,
+                last_active: 200,
+                metadata: std::collections::HashMap::new(),
+                labels: std::collections::HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let renewed_at = renew_session_lock_timestamp(&kv, "conic", "infra", "session-1", 100)
+            .await
+            .unwrap();
+
+        assert_eq!(renewed_at, 200);
+        let session = kv
+            .get_msg::<data_proto::Session>(&keys::session("conic", "infra", "session-1"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.last_active, 200);
+    }
+
+    #[tokio::test]
+    async fn renew_session_lock_timestamp_returns_written_timestamp() {
+        let kv = MockKvStore::default();
+        kv.set_msg(
+            &keys::session("conic", "infra", "session-1"),
+            &data_proto::Session {
+                id: "session-1".to_string(),
+                agent: "infra".to_string(),
+                ns: "conic".to_string(),
+                status: "PROCESSING".to_string(),
+                created_at: 1,
+                last_active: 100,
+                metadata: std::collections::HashMap::new(),
+                labels: std::collections::HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let renewed_at = renew_session_lock_timestamp(&kv, "conic", "infra", "session-1", 200)
+            .await
+            .unwrap();
+
+        assert_eq!(renewed_at, 200);
+        let session = kv
+            .get_msg::<data_proto::Session>(&keys::session("conic", "infra", "session-1"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.last_active, 200);
+    }
 }

--- a/src/harness/sessions/lease.rs
+++ b/src/harness/sessions/lease.rs
@@ -1,0 +1,161 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use prost::Message;
+
+use crate::control::{keys, KeyValueStore};
+use crate::gateway::rpc::data_proto;
+
+use super::{renew_submission_claim, RenewOutcome};
+
+const MAX_SESSION_RENEW_CAS_RETRIES: usize = 8;
+
+#[derive(Debug, Clone)]
+pub struct SubmissionLease {
+    pub ns: String,
+    pub agent: String,
+    pub session_id: String,
+    pub submission_id: String,
+    pub attempt_id: String,
+    pub ttl_micros: i64,
+}
+
+pub struct SubmissionLeaseRenewer {
+    handle: tokio::task::JoinHandle<()>,
+    last_renewed_at: Arc<AtomicI64>,
+}
+
+impl SubmissionLeaseRenewer {
+    pub fn start(
+        kv: Arc<dyn KeyValueStore + Send + Sync>,
+        lease: SubmissionLease,
+        initial_renewed_at: i64,
+    ) -> Self {
+        let last_renewed_at = Arc::new(AtomicI64::new(initial_renewed_at));
+        let task_last_renewed_at = last_renewed_at.clone();
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(lease_renewal_interval(lease.ttl_micros));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            interval.tick().await;
+
+            loop {
+                interval.tick().await;
+                let now_micros = chrono::Utc::now().timestamp_micros();
+                match renew_submission_claim(
+                    kv.as_ref(),
+                    &lease.ns,
+                    &lease.agent,
+                    &lease.session_id,
+                    &lease.submission_id,
+                    &lease.attempt_id,
+                    now_micros,
+                    lease.ttl_micros,
+                )
+                .await
+                {
+                    Ok(RenewOutcome::Renewed(submission)) => {
+                        match renew_session_lock_timestamp(
+                            kv.as_ref(),
+                            &lease.ns,
+                            &lease.agent,
+                            &lease.session_id,
+                            now_micros,
+                        )
+                        .await
+                        {
+                            Ok(()) => {
+                                task_last_renewed_at.store(now_micros, Ordering::SeqCst);
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    namespace = %lease.ns,
+                                    agent = %lease.agent,
+                                    session = %lease.session_id,
+                                    submission = %submission.submission_id,
+                                    error = %err,
+                                    "Failed to renew session processing lock"
+                                );
+                            }
+                        }
+                    }
+                    Ok(RenewOutcome::NotCurrent(submission)) => {
+                        tracing::info!(
+                            namespace = %lease.ns,
+                            agent = %lease.agent,
+                            session = %lease.session_id,
+                            submission = %lease.submission_id,
+                            current_attempt = %submission.attempt_id,
+                            expected_attempt = %lease.attempt_id,
+                            "Stopping session lease renewal because claim is no longer current"
+                        );
+                        break;
+                    }
+                    Ok(RenewOutcome::AlreadyTerminal(_)) | Ok(RenewOutcome::Missing) => break,
+                    Err(err) => {
+                        tracing::warn!(
+                            namespace = %lease.ns,
+                            agent = %lease.agent,
+                            session = %lease.session_id,
+                            submission = %lease.submission_id,
+                            error = %err,
+                            "Failed to renew session submission claim"
+                        );
+                    }
+                }
+            }
+        });
+
+        Self {
+            handle,
+            last_renewed_at,
+        }
+    }
+
+    pub fn last_renewed_at(&self) -> i64 {
+        self.last_renewed_at.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for SubmissionLeaseRenewer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+fn lease_renewal_interval(ttl_micros: i64) -> Duration {
+    let ttl_micros = ttl_micros.max(1) as u64;
+    Duration::from_micros((ttl_micros / 3).max(100_000))
+}
+
+async fn renew_session_lock_timestamp(
+    kv: &dyn KeyValueStore,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+    now_micros: i64,
+) -> Result<()> {
+    let key = keys::session(ns, agent, session_id);
+    for _ in 0..MAX_SESSION_RENEW_CAS_RETRIES {
+        let Some(current) = kv.get(&key).await? else {
+            return Ok(());
+        };
+        let mut session = data_proto::Session::decode(current.as_slice())?;
+        if session.status != "PROCESSING" || session.last_active >= now_micros {
+            return Ok(());
+        }
+        session.last_active = now_micros;
+        let updated = session.encode_to_vec();
+        if kv
+            .compare_and_swap(&key, Some(current.as_slice()), &updated)
+            .await?
+        {
+            return Ok(());
+        }
+    }
+    anyhow::bail!("failed to atomically renew session processing lock")
+}

--- a/src/harness/sessions/mod.rs
+++ b/src/harness/sessions/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 mod journal;
+mod lease;
 mod submission;
 
 pub const SESSION_LABEL_SUBMISSION_ID: &str = "talon.session.submission_id";
@@ -19,7 +20,8 @@ pub use journal::{
     append_llm_response, append_tool_result, list_journal_entries, mark_terminal,
     repair_submission_pointer_to_latest,
 };
+pub use lease::{SubmissionLease, SubmissionLeaseRenewer};
 pub use submission::{
-    claim_submission, create_submission_if_absent, pending_submission, submission_is_terminal,
-    ClaimOutcome,
+    claim_submission, create_submission_if_absent, pending_submission, renew_submission_claim,
+    submission_is_terminal, ClaimOutcome, RenewOutcome,
 };

--- a/src/harness/sessions/submission.rs
+++ b/src/harness/sessions/submission.rs
@@ -15,6 +15,14 @@ pub enum ClaimOutcome {
     Busy(SessionSubmission),
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum RenewOutcome {
+    Renewed(SessionSubmission),
+    NotCurrent(SessionSubmission),
+    AlreadyTerminal(SessionSubmission),
+    Missing,
+}
+
 pub fn pending_submission(
     submission_id: impl Into<String>,
     session_id: impl Into<String>,
@@ -111,6 +119,49 @@ pub async fn claim_submission(
     Err(anyhow!("failed to atomically claim session submission"))
 }
 
+pub async fn renew_submission_claim(
+    kv: &dyn KeyValueStore,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+    submission_id: &str,
+    attempt_id: &str,
+    now_micros: i64,
+    claim_ttl_micros: i64,
+) -> Result<RenewOutcome> {
+    let key = keys::session_submission(ns, agent, session_id, submission_id);
+    for _ in 0..8 {
+        let Some(current) = kv.get(&key).await? else {
+            return Ok(RenewOutcome::Missing);
+        };
+        let mut submission = SessionSubmission::decode(current.as_slice())?;
+        if submission_is_terminal(&submission) {
+            return Ok(RenewOutcome::AlreadyTerminal(submission));
+        }
+        if submission.attempt_id != attempt_id
+            || submission.status != SessionSubmissionStatus::Claimed as i32
+            || submission
+                .claim_expires_at
+                .is_some_and(|expires_at| expires_at <= now_micros)
+        {
+            return Ok(RenewOutcome::NotCurrent(submission));
+        }
+
+        submission.claim_expires_at = Some(now_micros.saturating_add(claim_ttl_micros));
+        submission.updated_at = now_micros;
+        let updated = submission.encode_to_vec();
+        if kv
+            .compare_and_swap(&key, Some(current.as_slice()), &updated)
+            .await?
+        {
+            return Ok(RenewOutcome::Renewed(submission));
+        }
+    }
+    Err(anyhow!(
+        "failed to atomically renew session submission claim"
+    ))
+}
+
 pub(super) async fn ensure_submission_attempt_current(
     kv: &dyn KeyValueStore,
     ns: &str,
@@ -129,6 +180,13 @@ pub(super) async fn ensure_submission_attempt_current(
     let submission = SessionSubmission::decode(current.as_slice())?;
     if submission_is_terminal(&submission) {
         return Err(anyhow!("session submission already terminal"));
+    }
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    if submission
+        .claim_expires_at
+        .is_some_and(|expires_at| expires_at <= now_micros)
+    {
+        return Err(anyhow!("session submission claim expired"));
     }
     if submission.attempt_id != attempt_id {
         return Err(anyhow!(
@@ -168,6 +226,12 @@ pub(super) async fn update_submission_from_entry(
                 submission.attempt_id,
                 entry.attempt_id
             ));
+        }
+        if submission
+            .claim_expires_at
+            .is_some_and(|expires_at| expires_at <= now_micros)
+        {
+            return Err(anyhow!("session submission claim expired"));
         }
         if submission_is_terminal(&submission) {
             if terminal_update {

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -338,8 +338,20 @@ impl WorkerEventHandler {
             }
         };
 
-        // Build the deterministic assistant reply sink. The sink owns live UI
-        // fanout plus mutable SessionMessage projection writes for this attempt.
+        // Keep this claimed submission and its user-visible session lock alive
+        // while the attempt is executing.
+        let lease_renewal = sessions::SubmissionLeaseRenewer::start(
+            self.cp.kv.clone(),
+            sessions::SubmissionLease {
+                ns: ns.to_string(),
+                agent: event.agent.clone(),
+                session_id: event.session_id.clone(),
+                submission_id: submission.submission_id.clone(),
+                attempt_id: submission.attempt_id.clone(),
+                ttl_micros: crate::control::scheduling::session_processing_timeout_micros(),
+            },
+            event.timestamp,
+        );
         let cancellation_token = CancellationToken::new();
         self.session_cancellations
             .lock()
@@ -352,6 +364,9 @@ impl WorkerEventHandler {
             &event.session_id,
             &reply_msg_id,
         );
+
+        // Build the deterministic assistant reply sink. The sink owns live UI
+        // fanout plus mutable SessionMessage projection writes for this attempt.
         let sink = PubSubSessionSink::new(
             self.cp.kv.clone(),
             self.cp.pubsub.clone(),
@@ -438,7 +453,7 @@ impl WorkerEventHandler {
                 ns,
                 &event.agent,
                 &event.session_id,
-                event.timestamp,
+                lease_renewal.last_renewed_at(),
                 SessionCompletionStatus::Completed,
             )
             .await;
@@ -615,7 +630,7 @@ impl WorkerEventHandler {
             ns,
             &event.agent,
             &event.session_id,
-            event.timestamp,
+            lease_renewal.last_renewed_at(),
             completion_status,
         )
         .instrument(tracing::info_span!(

--- a/tests/test_durable_sessions_stress.py
+++ b/tests/test_durable_sessions_stress.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import json
 import os
 import shutil
@@ -34,8 +33,6 @@ from proto.data.session_journal_entry_pb2 import (
     SessionJournalEntry,
 )
 from proto.events_pb2 import (
-    MESSAGE_DIRECTION_INBOUND,
-    SessionMessageEvent,
     SessionMessagePartEvent,
 )
 from proto.gateway_pb2 import (
@@ -55,7 +52,6 @@ from proto.resources.resource_pb2 import ResourceManifest, ResourceSpec
 import conftest
 
 
-SESSION_DISPATCH_TOPIC = "talon.session.dispatch"
 BLOCKING_MCP_SERVER = "durable-slow"
 BLOCKING_MCP_TOOL = "mcp_durable_slow_blocking_lookup"
 BLOCKING_TOOL_CALL_ID = "call_blocking_lookup_1"
@@ -302,37 +298,6 @@ control_plane:
     def restart_worker(self) -> subprocess.Popen:
         self.kill_worker()
         return self.start_worker()
-
-    def republish_session_dispatch(
-        self,
-        namespace: str,
-        agent: str,
-        session_id: str,
-        submission: SubmissionRecord,
-        message: str = "durable stress redelivery",
-    ) -> None:
-        event = SessionMessageEvent(
-            session_id=session_id,
-            message_id=submission["userMessageId"],
-            submission_id=submission["submissionId"],
-            direction=MESSAGE_DIRECTION_INBOUND,
-            timestamp=submission["createdAt"],
-            agent=agent,
-            message=message,
-            ns=namespace,
-        )
-        response = requests.post(
-            f"http://127.0.0.1:{self.worker_port}/pubsub/push",
-            json={
-                "message": {
-                    "data": base64.b64encode(event.SerializeToString()).decode("ascii"),
-                    "messageId": f"redelivery-{submission['submissionId']}",
-                },
-                "subscription": f"projects/test/subscriptions/{SESSION_DISPATCH_TOPIC}",
-            },
-            timeout=20,
-        )
-        response.raise_for_status()
 
 
 class SessionStreamBuffer:
@@ -758,6 +723,24 @@ class SessionSnooper:
             lambda: self.kv.read_submission(self.namespace, self.agent, self.session_id),
         )
 
+    def wait_for_reclaimed_submission(
+        self, submission_id: str, previous_attempt_count: int
+    ) -> SubmissionRecord:
+        def reclaimed_submission() -> SubmissionRecord | None:
+            submission = self.kv.read_submission(
+                self.namespace, self.agent, self.session_id, submission_id
+            )
+            if submission and submission["attemptCount"] > previous_attempt_count:
+                return submission
+            return None
+
+        return self._wait_for_condition(
+            "stream-triggered session submission reclaim",
+            reclaimed_submission,
+            attempts=120,
+            delay=0.1,
+        )
+
     def wait_for_in_progress_projection(self) -> SessionMessage:
         return self._wait_for_condition(
             "in-progress assistant projection",
@@ -900,9 +883,16 @@ def test_provider_started_worker_kill_restart_redelivery_is_non_polluting(
     infra.restart_worker()
     time.sleep(1.3)
     mock_control("POST", "/__control/unblock_stream")
-    infra.republish_session_dispatch(namespace, agent, session_id, submission)
-
-    session = snooper.wait_for_completed_session("session completion after worker restart")
+    with SessionStreamBuffer(
+        grpc_port=infra.grpc_port,
+        namespace=namespace,
+        agent=agent,
+        session_id=session_id,
+    ):
+        snooper.wait_for_reclaimed_submission(
+            submission_id, submission["attemptCount"]
+        )
+        session = snooper.wait_for_completed_session("session completion after worker restart")
     assistants = [message for message in session.messages if message.role == ROLE_ASSISTANT]
     users = [message for message in session.messages if message.role == ROLE_USER]
     assert len(users) == 1
@@ -1002,13 +992,18 @@ def test_tool_call_recorded_worker_kill_restart_recovers_from_journal(
     time.sleep(1.3)
     mock_control("POST", "/__control/unblock_mcp_tool")
     infra.start_worker()
-    infra.republish_session_dispatch(
-        namespace, agent, session_id, submission, message=message
-    )
-
-    session = snooper.wait_for_completed_session(
-        "tool-call journal recovery after worker restart"
-    )
+    with SessionStreamBuffer(
+        grpc_port=infra.grpc_port,
+        namespace=namespace,
+        agent=agent,
+        session_id=session_id,
+    ):
+        snooper.wait_for_reclaimed_submission(
+            submission_id, submission["attemptCount"]
+        )
+        session = snooper.wait_for_completed_session(
+            "tool-call journal recovery after worker restart"
+        )
     assistants = [message for message in session.messages if message.role == ROLE_ASSISTANT]
     assert len(assistants) == 1
     assistant_parts = text_parts_for(assistants[0])
@@ -1074,12 +1069,13 @@ def test_tool_result_recorded_worker_kill_restart_does_not_duplicate_message_par
     mock_control("POST", "/__control/block_mcp_tool")
     mock_control("POST", "/__control/block_stream_after_chunks", {"chunks": 1})
 
-    with SessionStreamBuffer(
+    stream = SessionStreamBuffer(
         grpc_port=infra.grpc_port,
         namespace=namespace,
         agent=agent,
         session_id=session_id,
-    ) as stream:
+    )
+    with stream:
         message = "Please run a blocking lookup docs.example.com and summarize what you found."
         stub.SendMessage(
             SendMessageRequest(
@@ -1118,11 +1114,17 @@ def test_tool_result_recorded_worker_kill_restart_does_not_duplicate_message_par
         assert mock_state_at_crash["mcp_tool_call_count"] == 1
 
         infra.kill_worker()
-        time.sleep(1.3)
-        mock_control("POST", "/__control/unblock_stream")
-        infra.start_worker()
-        infra.republish_session_dispatch(
-            namespace, agent, session_id, submission, message=message
+    time.sleep(1.3)
+    mock_control("POST", "/__control/unblock_stream")
+    infra.start_worker()
+    with SessionStreamBuffer(
+        grpc_port=infra.grpc_port,
+        namespace=namespace,
+        agent=agent,
+        session_id=session_id,
+    ):
+        snooper.wait_for_reclaimed_submission(
+            submission_id, submission["attemptCount"]
         )
 
         session = snooper.wait_for_completed_session(
@@ -1146,8 +1148,8 @@ def test_tool_result_recorded_worker_kill_restart_does_not_duplicate_message_par
             tool_call_id=BLOCKING_TOOL_CALL_ID,
         )
 
-        assert len(entries_with_phase(final_entries, SESSION_EXECUTION_PHASE_TOOL_RESULT)) == 1
-        assert len(entries_with_phase(final_entries, SESSION_EXECUTION_PHASE_COMMITTED)) == 1
-        assert final_mock_state["mcp_tool_call_count"] == 1
-        assert len(streamed_tool_calls) == 1
-        assert len(streamed_tool_results) == 1
+    assert len(entries_with_phase(final_entries, SESSION_EXECUTION_PHASE_TOOL_RESULT)) == 1
+    assert len(entries_with_phase(final_entries, SESSION_EXECUTION_PHASE_COMMITTED)) == 1
+    assert final_mock_state["mcp_tool_call_count"] == 1
+    assert len(streamed_tool_calls) == 1
+    assert len(streamed_tool_results) == 1


### PR DESCRIPTION
## Summary

Adds active lease renewal for durable agent session execution and lets gateway session streams recover abandoned claimed submissions.

- Adds `SubmissionLeaseRenewer`, which periodically extends the current `SessionSubmission` claim and keeps the parent `Session.last_active` processing lock fresh while a worker attempt is executing.
- Rejects journal/projection writes from attempts whose submission claim has expired, so an old worker cannot keep mutating durable state after its lease is lost.
- Wraps gateway session part streams with a watcher that checks active streamed sessions for expired submission leases and republishes the original inbound session dispatch when recovery is needed.
- Throttles stream-triggered redispatches to at most once per full lease period per submission to avoid rapid duplicate publishes while a stream remains connected.
- Refactors session RPC code into `src/gateway/rpc/sessions/mod.rs` plus `src/gateway/rpc/sessions/watcher.rs` so the stream watcher logic is isolated.
- Updates durable E2E recovery tests to rely on the connected session stream lease checks instead of manually posting redispatch messages to Pub/Sub.

## Why

PR #58 added the durable session journal, but a worker that died mid-session could leave a claimed submission waiting for an external redispatch. The gateway already has the user-visible stream attached to the session, so that stream can be the lightweight recovery trigger: if the claim stops renewing and expires, the stream asks the control plane to redispatch the existing submission.

The worker now renews on a short cadence against the 10 second default lease. The gateway checks streams on a bounded interval and only redispatches after the claim is expired and the submission has not been redispatched within a whole lease window.

## Validation

- `cargo fmt`
- `cargo test`
- `cargo test stream_lease_check`
- `cargo test worker::sessions`
- `cargo test session_processing_timeout_defaults_to_10_seconds`
- `.venv/bin/python -m pytest tests/test_durable_sessions_stress.py -k "provider_started_worker_kill_restart_redelivery_is_non_polluting or tool_call_recorded_worker_kill_restart_recovers_from_journal or tool_result_recorded_worker_kill_restart_does_not_duplicate_message_parts" -q`
- `git diff --check`
- `docker compose up --build -d`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added session lease renewal functionality to keep claimed submissions alive during processing.
* Implemented automatic redispatching of expired submission leases to improve session recovery.

**Bug Fixes**
* Adjusted default session processing timeout from 30 minutes to 10 seconds.

**Chores**
* Refactored session event streaming to use a dedicated watcher module for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->