### PR TITLE
[codex] Consolidate control plane construction

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -226,23 +226,12 @@ mod tests {
     use futures::StreamExt;
     use std::sync::Arc;
     use talon::control::config::Config;
-    use talon::control::{
-        keys, scheduler::NoopSchedulerBackend, ControlPlane, KeyValueStore, MessagePublisher,
-    };
+    use talon::control::{keys, ControlPlane, KeyValueStore, MessagePublisher};
     use talon::gateway::auth::AuthConfig;
     use talon::gateway::auth::AuthMode;
     use talon::test_support::{EmptyPubSub, MockKvStore};
     use tokio::sync::oneshot;
     use tokio_util::sync::CancellationToken;
-
-    fn test_control_plane() -> ControlPlane {
-        ControlPlane {
-            kv: Arc::new(MockKvStore::default()),
-            pubsub: Arc::new(EmptyPubSub),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: talon::control::object_store::default_object_store(),
-        }
-    }
 
     #[test]
     fn select_auth_config_prefers_jwt_then_token_then_password() {
@@ -298,7 +287,7 @@ mod tests {
     #[test]
     fn build_gateway_preserves_auth_and_dependencies() {
         let auth = AuthConfig::tokens(vec!["gateway-token".to_string()]);
-        let gateway = build_gateway(auth, test_control_plane());
+        let gateway = build_gateway(auth, ControlPlane::noop());
         assert_eq!(
             gateway.auth_config.as_ref().map(|cfg| cfg.mode.clone()),
             Some(AuthMode::Token)
@@ -489,7 +478,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_gateway_tasks_binds_valid_listeners() {
-        let gateway = build_gateway(AuthConfig::open(), test_control_plane());
+        let gateway = build_gateway(AuthConfig::open(), ControlPlane::noop());
         let rpc_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("rpc probe should bind");
@@ -520,7 +509,7 @@ mod tests {
     #[tokio::test]
     async fn run_gateway_with_surfaces_startup_errors() {
         let err = run_gateway_with(
-            test_control_plane(),
+            ControlPlane::noop(),
             |name| match name {
                 "GATEWAY_TOKEN" => Some("token".to_string()),
                 _ => None,
@@ -558,7 +547,7 @@ mod tests {
 
         let (tx, rx) = oneshot::channel::<()>();
         let task = tokio::spawn(run_gateway_with(
-            test_control_plane(),
+            ControlPlane::noop(),
             |_| None,
             move |name| match name {
                 "GRPC_ADDR" => Some(rpc_addr.to_string()),
@@ -581,7 +570,7 @@ mod tests {
     async fn run_server_main_with_surfaces_config_and_control_plane_errors() {
         let config_err = run_server_main_with(
             || anyhow::bail!("config failed"),
-            |_| async { Ok(test_control_plane()) },
+            |_| async { Ok(ControlPlane::noop()) },
             |_| None,
             |_| None,
             futures::future::pending::<()>(),
@@ -619,7 +608,7 @@ mod tests {
         let (tx, rx) = oneshot::channel::<()>();
         let task = tokio::spawn(run_server_main_with(
             || Ok(Arc::new(Config::default())),
-            |_| async { Ok(test_control_plane()) },
+            |_| async { Ok(ControlPlane::noop()) },
             |_| None,
             move |name| match name {
                 "GRPC_ADDR" => Some(rpc_addr.to_string()),

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -993,9 +993,7 @@ mod tests {
     use talon::control::config::Config;
     use talon::control::{
         events::{LifecycleEvent, SessionControlEvent},
-        keys,
-        scheduler::NoopSchedulerBackend,
-        ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
+        keys, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use talon::gateway::rpc::resources_proto;
     use talon::test_support::{EmptyPubSub, MockKvStore};
@@ -1010,12 +1008,7 @@ mod tests {
 
     fn handler_with_auth(authenticator: SchedulerRequestAuthenticator) -> WorkerEventHandler {
         WorkerEventHandler {
-            cp: Arc::new(ControlPlane {
-                kv: Arc::new(MockKvStore::default()),
-                pubsub: Arc::new(EmptyPubSub),
-                scheduler: Arc::new(NoopSchedulerBackend),
-                objects: talon::control::object_store::default_object_store(),
-            }),
+            cp: Arc::new(ControlPlane::noop()),
             config: Arc::new(Config::default()),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(authenticator),
@@ -1238,12 +1231,7 @@ mod tests {
             "projects/demo/subscriptions/talon-workflow-dispatch-sub"
         );
 
-        let cp = Arc::new(ControlPlane {
-            kv: Arc::new(MockKvStore::default()),
-            pubsub: Arc::new(EmptyPubSub),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: talon::control::object_store::default_object_store(),
-        });
+        let cp = Arc::new(ControlPlane::noop());
         let config = Arc::new(Config::default());
         let auth = Arc::new(SchedulerRequestAuthenticator::deny_all());
         let handler = build_worker_handler(cp.clone(), config.clone(), auth.clone());
@@ -1356,12 +1344,7 @@ mod tests {
             object_store: None,
         });
         let handler = WorkerEventHandler {
-            cp: Arc::new(ControlPlane {
-                kv: Arc::new(MockKvStore::default()),
-                pubsub: Arc::new(EmptyPubSub),
-                scheduler: Arc::new(NoopSchedulerBackend),
-                objects: talon::control::object_store::default_object_store(),
-            }),
+            cp: Arc::new(ControlPlane::noop()),
             config: Arc::new(config),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),
@@ -1703,12 +1686,7 @@ mod tests {
         .unwrap();
 
         let handler = WorkerEventHandler {
-            cp: Arc::new(ControlPlane {
-                kv,
-                pubsub: Arc::new(EmptyPubSub),
-                scheduler: Arc::new(NoopSchedulerBackend),
-                objects: talon::control::object_store::default_object_store(),
-            }),
+            cp: Arc::new(ControlPlane::builder(kv, Arc::new(EmptyPubSub)).build()),
             config: Arc::new(Config::default()),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::shared_secret(
@@ -1766,12 +1744,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_worker_with_routes_pull_mode_and_http_startup() {
-        let cp = Arc::new(ControlPlane {
-            kv: Arc::new(MockKvStore::default()),
-            pubsub: Arc::new(EmptyPubSub),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: talon::control::object_store::default_object_store(),
-        });
+        let cp = Arc::new(ControlPlane::noop());
         let config = Arc::new(Config::default());
         let auth = Arc::new(SchedulerRequestAuthenticator::deny_all());
         let spawned = Arc::new(std::sync::Mutex::new(Vec::<(bool, String)>::new()));
@@ -1813,12 +1786,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_worker_with_surfaces_http_errors_without_pull_mode() {
-        let cp = Arc::new(ControlPlane {
-            kv: Arc::new(MockKvStore::default()),
-            pubsub: Arc::new(EmptyPubSub),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: talon::control::object_store::default_object_store(),
-        });
+        let cp = Arc::new(ControlPlane::noop());
         let config = Arc::new(Config::default());
         let auth = Arc::new(SchedulerRequestAuthenticator::deny_all());
         let spawned = Arc::new(std::sync::Mutex::new(Vec::<(bool, String)>::new()));
@@ -1853,12 +1821,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_worker_with_awaits_http_shutdown_after_signal() {
-        let cp = Arc::new(ControlPlane {
-            kv: Arc::new(MockKvStore::default()),
-            pubsub: Arc::new(EmptyPubSub),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: talon::control::object_store::default_object_store(),
-        });
+        let cp = Arc::new(ControlPlane::noop());
         let config = Arc::new(Config::default());
         let auth = Arc::new(SchedulerRequestAuthenticator::deny_all());
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -1902,14 +1865,7 @@ mod tests {
     async fn run_worker_main_with_surfaces_bootstrap_failures() {
         let config_err = run_worker_main_with(
             || anyhow::bail!("config failed"),
-            |_| async {
-                Ok(Arc::new(ControlPlane {
-                    kv: Arc::new(MockKvStore::default()),
-                    pubsub: Arc::new(EmptyPubSub),
-                    scheduler: Arc::new(NoopSchedulerBackend),
-                    objects: talon::control::object_store::default_object_store(),
-                }))
-            },
+            |_| async { Ok(Arc::new(ControlPlane::noop())) },
             |_| async { Ok(Arc::new(SchedulerRequestAuthenticator::deny_all())) },
             |_| None,
             |_handler, _pull_mode, _project_id, _shutdown_token| Vec::new(),
@@ -1935,14 +1891,7 @@ mod tests {
 
         let auth_err = run_worker_main_with(
             || Ok(Arc::new(Config::default())),
-            |_| async {
-                Ok(Arc::new(ControlPlane {
-                    kv: Arc::new(MockKvStore::default()),
-                    pubsub: Arc::new(EmptyPubSub),
-                    scheduler: Arc::new(NoopSchedulerBackend),
-                    objects: talon::control::object_store::default_object_store(),
-                }))
-            },
+            |_| async { Ok(Arc::new(ControlPlane::noop())) },
             |_| async { anyhow::bail!("scheduler auth failed") },
             |_| None,
             |_handler, _pull_mode, _project_id, _shutdown_token| Vec::new(),
@@ -1959,14 +1908,7 @@ mod tests {
         let spawned = Arc::new(std::sync::Mutex::new(Vec::<(bool, String)>::new()));
         let result = run_worker_main_with(
             || Ok(Arc::new(Config::default())),
-            |_| async {
-                Ok(Arc::new(ControlPlane {
-                    kv: Arc::new(MockKvStore::default()),
-                    pubsub: Arc::new(EmptyPubSub),
-                    scheduler: Arc::new(NoopSchedulerBackend),
-                    objects: talon::control::object_store::default_object_store(),
-                }))
-            },
+            |_| async { Ok(Arc::new(ControlPlane::noop())) },
             |_| async { Ok(Arc::new(SchedulerRequestAuthenticator::deny_all())) },
             |name| match name {
                 "PULL_MODE" => Some("1".to_string()),
@@ -2256,12 +2198,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_worker_with_waits_for_pull_tasks_on_shutdown() {
-        let cp = Arc::new(ControlPlane {
-            kv: Arc::new(MockKvStore::default()),
-            pubsub: Arc::new(EmptyPubSub),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: talon::control::object_store::default_object_store(),
-        });
+        let cp = Arc::new(ControlPlane::noop());
         let config = Arc::new(Config::default());
         let auth = Arc::new(SchedulerRequestAuthenticator::deny_all());
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use std::pin::Pin;
+use std::{pin::Pin, sync::Arc};
 pub mod config;
 pub mod events;
 pub mod keys;
@@ -169,10 +169,140 @@ pub trait MessagePublisher: Send + Sync {
 
 #[derive(Clone)]
 pub struct ControlPlane {
-    pub kv: std::sync::Arc<dyn KeyValueStore + Send + Sync>,
-    pub pubsub: std::sync::Arc<dyn MessagePublisher + Send + Sync>,
-    pub scheduler: std::sync::Arc<dyn scheduler::SchedulerBackend + Send + Sync>,
-    pub objects: std::sync::Arc<dyn object_store::ObjectStore + Send + Sync>,
+    pub kv: SharedKeyValueStore,
+    pub pubsub: SharedMessagePublisher,
+    pub scheduler: SharedSchedulerBackend,
+    pub objects: SharedObjectStore,
+}
+
+pub type SharedKeyValueStore = Arc<dyn KeyValueStore + Send + Sync>;
+pub type SharedMessagePublisher = Arc<dyn MessagePublisher + Send + Sync>;
+pub type SharedSchedulerBackend = Arc<dyn scheduler::SchedulerBackend + Send + Sync>;
+pub type SharedObjectStore = Arc<dyn object_store::ObjectStore + Send + Sync>;
+
+impl ControlPlane {
+    pub fn new(
+        kv: SharedKeyValueStore,
+        pubsub: SharedMessagePublisher,
+        scheduler: SharedSchedulerBackend,
+        objects: SharedObjectStore,
+    ) -> Self {
+        Self {
+            kv,
+            pubsub,
+            scheduler,
+            objects,
+        }
+    }
+
+    /// Start a control-plane builder with lightweight defaults for services
+    /// that many tests do not exercise.
+    ///
+    /// Production wiring should prefer `ControlPlane::new` or
+    /// `build_control_plane`; this builder defaults the scheduler and object
+    /// store so tests can specify only the dependencies relevant to the case.
+    pub fn builder(kv: SharedKeyValueStore, pubsub: SharedMessagePublisher) -> ControlPlaneBuilder {
+        ControlPlaneBuilder {
+            kv,
+            pubsub,
+            scheduler: Arc::new(scheduler::NoopSchedulerBackend),
+            objects: object_store::default_object_store(),
+        }
+    }
+
+    /// Build a black-hole control plane for tests that only need to satisfy an
+    /// API shape. Writes and publishes are accepted, but stored data is not
+    /// retained.
+    pub fn noop() -> Self {
+        Self::builder(Arc::new(NoopKeyValueStore), Arc::new(NoopMessagePublisher)).build()
+    }
+}
+
+pub struct ControlPlaneBuilder {
+    kv: SharedKeyValueStore,
+    pubsub: SharedMessagePublisher,
+    scheduler: SharedSchedulerBackend,
+    objects: SharedObjectStore,
+}
+
+impl ControlPlaneBuilder {
+    pub fn scheduler(mut self, scheduler: SharedSchedulerBackend) -> Self {
+        self.scheduler = scheduler;
+        self
+    }
+
+    pub fn objects(mut self, objects: SharedObjectStore) -> Self {
+        self.objects = objects;
+        self
+    }
+
+    pub fn build(self) -> ControlPlane {
+        ControlPlane::new(self.kv, self.pubsub, self.scheduler, self.objects)
+    }
+}
+
+struct NoopKeyValueStore;
+
+#[async_trait::async_trait]
+impl KeyValueStore for NoopKeyValueStore {
+    async fn get(&self, _key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    async fn set(&self, _key: &ResourceKey, _value: &[u8]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn compare_and_swap(
+        &self,
+        _key: &ResourceKey,
+        _expected: Option<&[u8]>,
+        _value: &[u8],
+    ) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+
+    async fn delete(&self, _key: &ResourceKey) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn list_keys(&self, _list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        Ok(Vec::new())
+    }
+
+    async fn list_keys_page(
+        &self,
+        _list: &ResourceList,
+        _before_name: Option<&str>,
+        _limit: usize,
+    ) -> anyhow::Result<Vec<ResourceKey>> {
+        Ok(Vec::new())
+    }
+
+    async fn list_entries_page(
+        &self,
+        _list: &ResourceList,
+        _before_name: Option<&str>,
+        _limit: usize,
+    ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
+        Ok(Vec::new())
+    }
+}
+
+struct NoopMessagePublisher;
+
+#[async_trait::async_trait]
+impl MessagePublisher for NoopMessagePublisher {
+    async fn publish(&self, _topic: &str, _message: &[u8]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn subscribe(
+        &self,
+        _topic: &str,
+    ) -> anyhow::Result<Pin<Box<dyn futures::Stream<Item = Vec<u8>> + Send>>> {
+        Ok(Box::pin(futures::stream::empty()))
+    }
 }
 
 async fn ensure_builtin_namespaces(kv: &(dyn KeyValueStore + Send + Sync)) -> anyhow::Result<()> {
@@ -233,7 +363,7 @@ pub async fn build_control_plane(
         .database
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("control_plane.database configuration is missing"))?;
-    let kv: std::sync::Arc<dyn KeyValueStore + Send + Sync>;
+    let kv: SharedKeyValueStore;
     let scheduler_database_url: Option<String>;
     match db_config.driver.as_str() {
         "postgres" => {
@@ -243,20 +373,20 @@ pub async fn build_control_plane(
                 .ok_or_else(|| anyhow::anyhow!("Database URL secret is missing"))?;
             let pg_url: String = url_secret.resolve().await?;
             println!("Connecting to PostgresKvStore at {}...", pg_url);
-            kv = std::sync::Arc::new(kv::PostgresKvStore::new(&pg_url, "talon_kv_store").await?);
+            kv = Arc::new(kv::PostgresKvStore::new(&pg_url, "talon_kv_store").await?);
             scheduler_database_url = Some(pg_url);
         }
         "sqlite" => {
             let sqlite_url = sqlite_database_url(db_config).await?;
             println!("Connecting to SqliteKvStore at {}...", sqlite_url);
-            kv = std::sync::Arc::new(kv::SqliteKvStore::new(&sqlite_url, "talon_kv_store").await?);
+            kv = Arc::new(kv::SqliteKvStore::new(&sqlite_url, "talon_kv_store").await?);
             scheduler_database_url = Some(sqlite_url);
         }
         "d1" => {
             println!("Connecting to D1KvStore...");
             let store = kv::D1KvStore::from_env();
             store.init().await?;
-            kv = std::sync::Arc::new(store);
+            kv = Arc::new(store);
             scheduler_database_url = None;
         }
         #[cfg(feature = "rocksdb")]
@@ -266,7 +396,7 @@ pub async fn build_control_plane(
                 "Connecting to RocksDbKvStore at {}...",
                 rocksdb_path.display()
             );
-            kv = std::sync::Arc::new(kv::RocksDbKvStore::new(&rocksdb_path)?);
+            kv = Arc::new(kv::RocksDbKvStore::new(&rocksdb_path)?);
             scheduler_database_url = None;
         }
         #[cfg(not(feature = "rocksdb"))]
@@ -283,11 +413,10 @@ pub async fn build_control_plane(
     ensure_builtin_namespaces(kv.as_ref()).await?;
 
     let mb_config = message_broker_config(cp)?;
-    let pubsub: std::sync::Arc<dyn MessagePublisher + Send + Sync> = match mb_config.driver.as_str()
-    {
+    let pubsub: SharedMessagePublisher = match mb_config.driver.as_str() {
         "gcp_pubsub" => {
             println!("Initializing GcpPubSubPublisher...");
-            std::sync::Arc::new(pubsub::GcpPubSubPublisher::new().await?)
+            Arc::new(pubsub::GcpPubSubPublisher::new().await?)
         }
         "local_socket" => {
             let default_root =
@@ -301,11 +430,11 @@ pub async fn build_control_plane(
                 "Initializing LocalSocketMessagePublisher at {}...",
                 socket_path.display()
             );
-            std::sync::Arc::new(pubsub::LocalSocketMessagePublisher::new(socket_path).await?)
+            Arc::new(pubsub::LocalSocketMessagePublisher::new(socket_path).await?)
         }
         "cf_queues" => {
             println!("Initializing CfQueuesPublisher...");
-            std::sync::Arc::new(pubsub::CfQueuesPublisher::from_env())
+            Arc::new(pubsub::CfQueuesPublisher::from_env())
         }
         other => {
             return Err(anyhow::anyhow!(
@@ -315,85 +444,80 @@ pub async fn build_control_plane(
         }
     };
 
-    let scheduler: std::sync::Arc<dyn scheduler::SchedulerBackend + Send + Sync> =
-        match scheduler_driver().as_deref() {
-            Some("local_postgres") => {
-                if let Some(database_url) = scheduler_database_url.as_deref() {
-                    match scheduler::LocalPostgresSchedulerBackend::new(
-                        database_url,
-                        std::env::var("TALON_LOCAL_SCHEDULER_TABLE").ok(),
-                        std::env::var("TALON_LOCAL_SCHEDULER_TARGET_URL").ok(),
-                        std::env::var("TALON_SCHEDULER_AUTH_TOKEN").ok(),
-                        std::env::var("TALON_LOCAL_SCHEDULER_RUNNER")
-                            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-                            .unwrap_or(false),
-                    )
-                    .await
-                    {
-                        Ok(backend) => std::sync::Arc::new(backend),
-                        Err(err) => {
-                            tracing::warn!(error = %err, "Failed to initialize local_postgres scheduler; using noop");
-                            std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
-                        }
-                    }
-                } else {
-                    std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
-                }
-            }
-            Some("local_sqlite") => {
-                if let Some(database_url) = scheduler_database_url.as_deref() {
-                    match scheduler::LocalSqliteSchedulerBackend::new(
-                        database_url,
-                        std::env::var("TALON_LOCAL_SCHEDULER_TABLE").ok(),
-                        std::env::var("TALON_LOCAL_SCHEDULER_TARGET_URL").ok(),
-                        std::env::var("TALON_SCHEDULER_AUTH_TOKEN").ok(),
-                        std::env::var("TALON_LOCAL_SCHEDULER_RUNNER")
-                            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-                            .unwrap_or(false),
-                    )
-                    .await
-                    {
-                        Ok(backend) => std::sync::Arc::new(backend),
-                        Err(err) => {
-                            tracing::warn!(error = %err, "Failed to initialize local_sqlite scheduler; using noop");
-                            std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
-                        }
-                    }
-                } else {
-                    std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
-                }
-            }
-            Some("cf_alarms") => {
-                std::sync::Arc::new(scheduler::CfAlarmsSchedulerBackend::from_env())
-            }
-            _ => match configured_scheduler(cp.scheduler.as_ref()) {
-                Some(crate::control::config::proto::SchedulerConfig {
-                    backend:
-                        Some(crate::control::config::proto::scheduler_config::Backend::CloudTasks(cfg)),
-                }) => match scheduler::CloudTasksSchedulerBackend::new(&cfg).await {
-                    Ok(backend) => std::sync::Arc::new(backend),
+    let scheduler: SharedSchedulerBackend = match scheduler_driver().as_deref() {
+        Some("local_postgres") => {
+            if let Some(database_url) = scheduler_database_url.as_deref() {
+                match scheduler::LocalPostgresSchedulerBackend::new(
+                    database_url,
+                    std::env::var("TALON_LOCAL_SCHEDULER_TABLE").ok(),
+                    std::env::var("TALON_LOCAL_SCHEDULER_TARGET_URL").ok(),
+                    std::env::var("TALON_SCHEDULER_AUTH_TOKEN").ok(),
+                    std::env::var("TALON_LOCAL_SCHEDULER_RUNNER")
+                        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+                        .unwrap_or(false),
+                )
+                .await
+                {
+                    Ok(backend) => Arc::new(backend),
                     Err(err) => {
-                        tracing::warn!(error = %err, "Failed to initialize Cloud Tasks scheduler; using noop");
-                        std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
+                        return Err(anyhow::anyhow!(
+                            "Failed to initialize local_postgres scheduler: {err}"
+                        ));
                     }
-                },
-                Some(crate::control::config::proto::SchedulerConfig { backend: None }) => {
-                    std::sync::Arc::new(scheduler::NoopSchedulerBackend::default())
                 }
-                None => std::sync::Arc::new(scheduler::NoopSchedulerBackend::default()),
+            } else {
+                Arc::new(scheduler::NoopSchedulerBackend)
+            }
+        }
+        Some("local_sqlite") => {
+            if let Some(database_url) = scheduler_database_url.as_deref() {
+                match scheduler::LocalSqliteSchedulerBackend::new(
+                    database_url,
+                    std::env::var("TALON_LOCAL_SCHEDULER_TABLE").ok(),
+                    std::env::var("TALON_LOCAL_SCHEDULER_TARGET_URL").ok(),
+                    std::env::var("TALON_SCHEDULER_AUTH_TOKEN").ok(),
+                    std::env::var("TALON_LOCAL_SCHEDULER_RUNNER")
+                        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+                        .unwrap_or(false),
+                )
+                .await
+                {
+                    Ok(backend) => Arc::new(backend),
+                    Err(err) => {
+                        return Err(anyhow::anyhow!(
+                            "Failed to initialize local_sqlite scheduler: {err}"
+                        ));
+                    }
+                }
+            } else {
+                Arc::new(scheduler::NoopSchedulerBackend)
+            }
+        }
+        Some("cf_alarms") => Arc::new(scheduler::CfAlarmsSchedulerBackend::from_env()),
+        _ => match configured_scheduler(cp.scheduler.as_ref()) {
+            Some(crate::control::config::proto::SchedulerConfig {
+                backend:
+                    Some(crate::control::config::proto::scheduler_config::Backend::CloudTasks(cfg)),
+            }) => match scheduler::CloudTasksSchedulerBackend::new(&cfg).await {
+                Ok(backend) => Arc::new(backend),
+                Err(err) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to initialize Cloud Tasks scheduler: {err}"
+                    ));
+                }
             },
-        };
+            Some(crate::control::config::proto::SchedulerConfig { backend: None }) => {
+                Arc::new(scheduler::NoopSchedulerBackend)
+            }
+            None => Arc::new(scheduler::NoopSchedulerBackend),
+        },
+    };
 
     let objects =
         object_store::object_store_from_config(cp.object_store.as_ref(), &config.workspace_dir)
             .await?;
 
-    Ok(ControlPlane {
-        kv,
-        pubsub,
-        scheduler,
-        objects,
-    })
+    Ok(ControlPlane::new(kv, pubsub, scheduler, objects))
 }
 
 fn configured_scheduler(
@@ -841,6 +965,47 @@ mod tests {
         assert!(err
             .to_string()
             .contains("control_plane.message_broker configuration is missing"));
+    }
+
+    #[test]
+    fn build_control_plane_errors_when_configured_scheduler_fails_to_initialize() {
+        let _lock = crate::test_support::env_lock();
+        let _driver = EnvGuard::remove("TALON_SCHEDULER_DRIVER");
+        let _project = EnvGuard::remove("TALON_SCHEDULER_PROJECT_ID");
+        let _gcp_project = EnvGuard::remove("GCP_PROJECT_ID");
+        let _location = EnvGuard::remove("TALON_SCHEDULER_LOCATION");
+        let _queue = EnvGuard::remove("TALON_SCHEDULER_QUEUE");
+        let _target = EnvGuard::remove("TALON_SCHEDULER_TARGET_URL");
+        let dir = tempdir().unwrap();
+        let config = proto::TalonConfig {
+            workspace_dir: dir.path().display().to_string(),
+            control_plane: Some(proto::ControlPlaneConfig {
+                database: Some(proto::DatabaseConfig {
+                    data_dir: dir.path().display().to_string(),
+                    driver: "sqlite".to_string(),
+                    url: None,
+                }),
+                message_broker: Some(proto::MessageBrokerConfig {
+                    driver: "cf_queues".to_string(),
+                }),
+                scheduler: Some(proto::SchedulerConfig {
+                    backend: Some(scheduler_config::Backend::CloudTasks(
+                        proto::CloudTasksSchedulerConfig::default(),
+                    )),
+                }),
+                object_store: None,
+            }),
+            ..Default::default()
+        };
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let err = match runtime.block_on(build_control_plane(&config)) {
+            Ok(_) => panic!("expected scheduler initialization error"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("Failed to initialize Cloud Tasks scheduler"));
     }
 
     #[tokio::test]

--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -1271,12 +1271,7 @@ mod tests {
     async fn send_message_uses_atomic_session_lock() {
         let kv = Arc::new(MockKvStore::default());
         let pubsub = Arc::new(MockPubSub::default());
-        let cp = ControlPlane {
-            kv: kv.clone(),
-            pubsub: pubsub.clone(),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
-        };
+        let cp = ControlPlane::builder(kv.clone(), pubsub.clone()).build();
 
         let session = data_proto::Session {
             id: "session-1".to_string(),
@@ -1548,12 +1543,7 @@ mod tests {
     async fn create_and_dispatch_schedule_cover_session_paths() {
         let kv = Arc::new(MockKvStore::default());
         let pubsub = Arc::new(MockPubSub::default());
-        let cp = ControlPlane {
-            kv: kv.clone(),
-            pubsub: pubsub.clone(),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
-        };
+        let cp = ControlPlane::builder(kv.clone(), pubsub.clone()).build();
 
         let agent = crate::control::resource_model::agent(
             "conic:test",
@@ -1604,12 +1594,7 @@ mod tests {
     async fn dispatch_schedule_can_start_workflow_run() {
         let kv = Arc::new(MockKvStore::default());
         let pubsub = Arc::new(MockPubSub::default());
-        let cp = ControlPlane {
-            kv: kv.clone(),
-            pubsub: pubsub.clone(),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
-        };
+        let cp = ControlPlane::builder(kv.clone(), pubsub.clone()).build();
         let workflow = crate::control::resource_model::workflow(
             "conic:test",
             "retention-review",

--- a/src/gateway/rpc/channels.rs
+++ b/src/gateway/rpc/channels.rs
@@ -360,13 +360,9 @@ impl GrpcGatewayHandler {
         if channel.phase() == "closed" {
             return Err(tonic::Status::failed_precondition("channel is closed"));
         }
+        let cp = self.gateway.control_plane();
         let message = persist_channel_message(
-            &ControlPlane {
-                kv: self.gateway.kv.clone(),
-                pubsub: self.gateway.pubsub.clone(),
-                scheduler: self.gateway.scheduler.clone(),
-                objects: self.gateway.objects.clone(),
-            },
+            &cp,
             data_proto::ChannelMessage {
                 id: uuid::Uuid::now_v7().to_string(),
                 ns: req.ns.clone(),
@@ -387,17 +383,7 @@ impl GrpcGatewayHandler {
         .await
         .map_err(|e| tonic::Status::internal(format!("failed to persist channel message: {e}")))?;
 
-        let routed_sessions = route_channel_message(
-            &ControlPlane {
-                kv: self.gateway.kv.clone(),
-                pubsub: self.gateway.pubsub.clone(),
-                scheduler: self.gateway.scheduler.clone(),
-                objects: self.gateway.objects.clone(),
-            },
-            &message,
-            &req.subscription_names,
-        )
-        .await;
+        let routed_sessions = route_channel_message(&cp, &message, &req.subscription_names).await;
 
         Ok(tonic::Response::new(proto::PostChannelMessageResponse {
             message: Some(message),

--- a/src/gateway/rpc/workflows.rs
+++ b/src/gateway/rpc/workflows.rs
@@ -386,21 +386,6 @@ fn is_terminal_workflow_event(event_type: &str) -> bool {
     matches!(event_type, "run_completed" | "run_failed" | "run_cancelled")
 }
 
-trait GatewayControlPlaneExt {
-    fn control_plane(&self) -> crate::control::ControlPlane;
-}
-
-impl GatewayControlPlaneExt for crate::gateway::server::Gateway {
-    fn control_plane(&self) -> crate::control::ControlPlane {
-        crate::control::ControlPlane {
-            kv: self.kv.clone(),
-            pubsub: self.pubsub.clone(),
-            scheduler: self.scheduler.clone(),
-            objects: self.objects.clone(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use crate::control::{
-    object_store::ObjectStore, scheduler::SchedulerBackend, KeyValueStore, MessagePublisher,
+    object_store::ObjectStore, scheduler::SchedulerBackend, ControlPlane, KeyValueStore,
+    MessagePublisher,
 };
 use crate::gateway::auth::AuthConfig;
 use crate::gateway::session_streams::SessionStreamHub;
@@ -49,6 +50,15 @@ impl Gateway {
             objects: self.objects.clone(),
             session_streams: self.session_streams.clone(),
         }
+    }
+
+    pub fn control_plane(&self) -> ControlPlane {
+        ControlPlane::new(
+            self.kv.clone(),
+            self.pubsub.clone(),
+            self.scheduler.clone(),
+            self.objects.clone(),
+        )
     }
 
     pub fn http_ui_router(&self) -> Router {

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -648,9 +648,7 @@ mod tests {
         LoopMessage,
     };
     use crate::control::config::Config;
-    use crate::control::keys::{ResourceKey, ResourceList};
-    use crate::control::scheduler::{ScheduleWakeupRequest, ScheduledWakeup, SchedulerBackend};
-    use crate::control::{ControlPlane, KeyValueStore, MessagePublisher};
+    use crate::control::ControlPlane;
     use crate::gateway::rpc::{
         manifests,
         protobuf_value::{value::Kind as ProtoValueKind, ListValue, Value as ProtoValue},
@@ -667,69 +665,14 @@ mod tests {
     use crate::harness::skills::registry::ToolRegistry;
     use anyhow::Result;
     use async_trait::async_trait;
-    use futures::Stream;
     use serde_json::json;
     use std::collections::HashMap;
-    use std::pin::Pin;
     use std::sync::{Arc, Mutex};
     use tempfile::tempdir;
     use tokio_util::sync::CancellationToken;
 
     #[derive(Default)]
     struct EmptyKnowledgeBook;
-
-    struct NoopKv;
-
-    #[async_trait]
-    impl KeyValueStore for NoopKv {
-        async fn get(&self, _key: &ResourceKey) -> Result<Option<Vec<u8>>> {
-            Ok(None)
-        }
-        async fn set(&self, _key: &ResourceKey, _value: &[u8]) -> Result<()> {
-            Ok(())
-        }
-        async fn compare_and_swap(
-            &self,
-            _key: &ResourceKey,
-            _expected: Option<&[u8]>,
-            _value: &[u8],
-        ) -> Result<bool> {
-            Ok(true)
-        }
-        async fn delete(&self, _key: &ResourceKey) -> Result<()> {
-            Ok(())
-        }
-        async fn list_keys(&self, _list: &ResourceList) -> Result<Vec<ResourceKey>> {
-            Ok(Vec::new())
-        }
-    }
-
-    struct NoopPubSub;
-
-    #[async_trait]
-    impl MessagePublisher for NoopPubSub {
-        async fn publish(&self, _topic: &str, _message: &[u8]) -> Result<()> {
-            Ok(())
-        }
-        async fn subscribe(
-            &self,
-            _topic: &str,
-        ) -> Result<Pin<Box<dyn Stream<Item = Vec<u8>> + Send>>> {
-            Ok(Box::pin(futures::stream::empty()))
-        }
-    }
-
-    struct NoopScheduler;
-
-    #[async_trait]
-    impl SchedulerBackend for NoopScheduler {
-        async fn schedule(&self, _req: ScheduleWakeupRequest) -> Result<ScheduledWakeup> {
-            Ok(ScheduledWakeup::default())
-        }
-        async fn cancel(&self, _handle: &str) -> Result<()> {
-            Ok(())
-        }
-    }
 
     #[async_trait]
     impl KnowledgeBook for EmptyKnowledgeBook {
@@ -928,12 +871,7 @@ mod tests {
             Arc::new(EmptyKnowledgeBook),
             "conic:wks:13".to_string(),
             "cmo".to_string(),
-            ControlPlane {
-                kv: Arc::new(NoopKv),
-                pubsub: Arc::new(NoopPubSub),
-                scheduler: Arc::new(NoopScheduler),
-                objects: crate::control::object_store::default_object_store(),
-            },
+            ControlPlane::noop(),
             manifests::AgentSpec::default(),
             HashMap::new(),
         );
@@ -1029,12 +967,7 @@ mod tests {
             Arc::new(EmptyKnowledgeBook),
             "conic:wks:13".to_string(),
             "cmo".to_string(),
-            ControlPlane {
-                kv: Arc::new(NoopKv),
-                pubsub: Arc::new(NoopPubSub),
-                scheduler: Arc::new(NoopScheduler),
-                objects: crate::control::object_store::default_object_store(),
-            },
+            ControlPlane::noop(),
             spec.clone(),
             HashMap::new(),
         );
@@ -1122,12 +1055,7 @@ mod tests {
             Arc::new(EmptyKnowledgeBook),
             "conic:wks:13".to_string(),
             "cmo".to_string(),
-            ControlPlane {
-                kv: Arc::new(NoopKv),
-                pubsub: Arc::new(NoopPubSub),
-                scheduler: Arc::new(NoopScheduler),
-                objects: crate::control::object_store::default_object_store(),
-            },
+            ControlPlane::noop(),
             manifests::AgentSpec::default(),
             HashMap::new(),
         );
@@ -1221,12 +1149,7 @@ mod tests {
             knowledge.clone(),
             "conic:wks:13".to_string(),
             "cmo".to_string(),
-            ControlPlane {
-                kv: Arc::new(NoopKv),
-                pubsub: Arc::new(NoopPubSub),
-                scheduler: Arc::new(NoopScheduler),
-                objects: crate::control::object_store::default_object_store(),
-            },
+            ControlPlane::noop(),
             manifests::AgentSpec::default(),
             HashMap::new(),
         );

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -572,12 +572,9 @@ mod tests {
     }
 
     fn control_plane(kv: Arc<MockKvStore>, scheduler: Arc<MockScheduler>) -> ControlPlane {
-        ControlPlane {
-            kv,
-            pubsub: Arc::new(EmptyPubSub),
-            scheduler,
-            objects: crate::control::object_store::default_object_store(),
-        }
+        ControlPlane::builder(kv, Arc::new(EmptyPubSub))
+            .scheduler(scheduler)
+            .build()
     }
 
     async fn seed_agent(kv: &MockKvStore, ns: &str, name: &str) {

--- a/src/worker/controllers/deployment.rs
+++ b/src/worker/controllers/deployment.rs
@@ -648,15 +648,6 @@ mod tests {
         ))
     }
 
-    fn test_control_plane(kv: Arc<MockKvStore>, pubsub: Arc<RecordingPubSub>) -> ControlPlane {
-        ControlPlane {
-            kv,
-            pubsub,
-            scheduler: Arc::new(crate::control::scheduler::NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
-        }
-    }
-
     async fn add_namespace(cp: &ControlPlane, namespace: resources_proto::Namespace) {
         let name = namespace.name().to_string();
         let parent = namespace.parent().to_string();
@@ -912,7 +903,7 @@ mod tests {
         let pubsub = Arc::new(RecordingPubSub::default());
         let store = ResourceStore::new(kv.clone(), pubsub.clone());
         let controller = DeploymentController::new(store.clone());
-        let cp = test_control_plane(kv, pubsub);
+        let cp = ControlPlane::builder(kv, pubsub).build();
         add_namespace(&cp, labeled_target_namespace("prod")).await;
 
         let deployment = deployment_with_templates(&["coding-agent", "legacy-agent"]);
@@ -979,7 +970,7 @@ mod tests {
         let pubsub = Arc::new(RecordingPubSub::default());
         let store = ResourceStore::new(kv.clone(), pubsub.clone());
         let controller = DeploymentController::new(store.clone());
-        let cp = test_control_plane(kv, pubsub);
+        let cp = ControlPlane::builder(kv, pubsub).build();
         add_namespace(&cp, labeled_target_namespace("prod")).await;
 
         let deployment = deployment_with_templates(&["coding-agent"]);

--- a/src/worker/mcp_registry.rs
+++ b/src/worker/mcp_registry.rs
@@ -162,7 +162,6 @@ mod tests {
     use super::{filter_allowed_tools, McpRegistry};
     use crate::control::{
         keys::{ResourceKey, ResourceList},
-        scheduler::NoopSchedulerBackend,
         ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::manifests;
@@ -238,15 +237,6 @@ mod tests {
             name: name.to_string(),
             description: String::new(),
             input_schema: json!({"type": "object"}),
-        }
-    }
-
-    fn control_plane(kv: Arc<MockKvStore>) -> ControlPlane {
-        ControlPlane {
-            kv,
-            pubsub: Arc::new(MockPubSub),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
         }
     }
 
@@ -360,7 +350,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_server_errors_for_missing_binding_spec_or_server() {
         let kv = Arc::new(MockKvStore::default());
-        let cp = control_plane(kv.clone());
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
         let registry = McpRegistry::new();
 
         kv.set_msg(
@@ -399,7 +389,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_server_merges_binding_and_returns_disabled_error_before_connecting() {
         let kv = Arc::new(MockKvStore::default());
-        let cp = control_plane(kv.clone());
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
         let registry = McpRegistry::new();
 
         kv.set_msg(

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -359,7 +359,6 @@ mod tests {
     use crate::control::{
         events::{LifecycleEvent, MessageDirection, SessionControlEvent, SessionMessageEvent},
         keys::{ResourceKey, ResourceList},
-        scheduler::NoopSchedulerBackend,
         topics, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{data_proto, manifests, resources_proto};
@@ -449,12 +448,7 @@ mod tests {
 
     fn handler(kv: Arc<MockKvStore>, pubsub: Arc<MockPubSub>) -> WorkerEventHandler {
         WorkerEventHandler {
-            cp: Arc::new(ControlPlane {
-                kv,
-                pubsub,
-                scheduler: Arc::new(NoopSchedulerBackend),
-                objects: crate::control::object_store::default_object_store(),
-            }),
+            cp: Arc::new(ControlPlane::builder(kv, pubsub).build()),
             config: Arc::new(Config::default()),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -488,7 +488,6 @@ mod tests {
     use crate::control::{
         keys::{ResourceKey, ResourceList},
         object_store::{InMemoryObjectStore, ObjectMetadata, ObjectStore},
-        scheduler::NoopSchedulerBackend,
         ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{data_proto, manifests, protobuf_value, resources_proto};
@@ -618,15 +617,6 @@ mod tests {
             )]),
             default_provider: "novita".to_string(),
             ..Config::default()
-        }
-    }
-
-    fn control_plane(kv: Arc<MockKvStore>) -> ControlPlane {
-        ControlPlane {
-            kv,
-            pubsub: Arc::new(MockPubSub),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
         }
     }
 
@@ -882,7 +872,7 @@ mod tests {
     #[tokio::test]
     async fn agent_runtime_build_errors_for_missing_agent_or_spec() {
         let kv = Arc::new(MockKvStore::default());
-        let cp = control_plane(kv.clone());
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
         let config = runtime_config();
         let registry = crate::worker::mcp_registry::McpRegistry::new();
 
@@ -918,7 +908,7 @@ mod tests {
     #[tokio::test]
     async fn channel_reply_mode_none_withholds_channel_reply_tools() {
         let kv = Arc::new(MockKvStore::default());
-        let cp = control_plane(kv.clone());
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
         let config = runtime_config();
         let registry = crate::worker::mcp_registry::McpRegistry::new();
         let spec = manifests::AgentSpec {
@@ -1010,7 +1000,7 @@ mod tests {
     #[tokio::test]
     async fn agent_runtime_build_assembles_history_and_skips_bad_entries() {
         let kv = Arc::new(MockKvStore::default());
-        let cp = control_plane(kv.clone());
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
         let config = runtime_config();
         let registry = crate::worker::mcp_registry::McpRegistry::new();
         let spec = manifests::AgentSpec {
@@ -1118,7 +1108,7 @@ mod tests {
     #[tokio::test]
     async fn agent_runtime_build_rehydrates_image_parts_from_object_store() {
         let kv = Arc::new(MockKvStore::default());
-        let cp = control_plane(kv.clone());
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
         let config = runtime_config();
         let registry = crate::worker::mcp_registry::McpRegistry::new();
         let spec = manifests::AgentSpec {

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -828,7 +828,6 @@ mod tests {
     use crate::control::{
         events::{MessageDirection, SessionMessageEvent},
         keys::{ResourceKey, ResourceList},
-        scheduler::NoopSchedulerBackend,
         ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{data_proto, manifests, resources_proto};
@@ -1000,12 +999,7 @@ mod tests {
 
     fn handler_with_config(kv: Arc<MockKvStore>, config: Config) -> WorkerEventHandler {
         WorkerEventHandler {
-            cp: Arc::new(ControlPlane {
-                kv,
-                pubsub: Arc::new(MockPubSub),
-                scheduler: Arc::new(NoopSchedulerBackend),
-                objects: crate::control::object_store::default_object_store(),
-            }),
+            cp: Arc::new(ControlPlane::builder(kv, Arc::new(MockPubSub)).build()),
             config: Arc::new(config),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -1597,7 +1597,6 @@ mod tests {
     use crate::control::config::Config;
     use crate::control::{
         keys::{self, ResourceKey, ResourceList},
-        scheduler::NoopSchedulerBackend,
         ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{data_proto, manifests, resources_proto};
@@ -1707,12 +1706,7 @@ mod tests {
 
     fn handler_with_kv(kv: Arc<MockKvStore>) -> WorkerEventHandler {
         WorkerEventHandler {
-            cp: Arc::new(ControlPlane {
-                kv,
-                pubsub: Arc::new(MockPubSub),
-                scheduler: Arc::new(NoopSchedulerBackend),
-                objects: crate::control::object_store::default_object_store(),
-            }),
+            cp: Arc::new(ControlPlane::builder(kv, Arc::new(MockPubSub)).build()),
             config: Arc::new(Config::default()),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),

--- a/src/worker/workflows.rs
+++ b/src/worker/workflows.rs
@@ -2198,9 +2198,7 @@ mod tests {
     use crate::control::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::{
         events::{MessageDirection, SessionMessageEvent, WorkflowDispatchEvent},
-        scheduler::{
-            NoopSchedulerBackend, ScheduleWakeupRequest, ScheduledWakeup, SchedulerBackend,
-        },
+        scheduler::{ScheduleWakeupRequest, ScheduledWakeup, SchedulerBackend},
         ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::manifests;
@@ -2270,12 +2268,7 @@ mod tests {
 
     fn workflow_handler(kv: Arc<MockKvStore>, pubsub: Arc<RecordingPubSub>) -> WorkerEventHandler {
         WorkerEventHandler {
-            cp: Arc::new(ControlPlane {
-                kv,
-                pubsub,
-                scheduler: Arc::new(NoopSchedulerBackend),
-                objects: crate::control::object_store::default_object_store(),
-            }),
+            cp: Arc::new(ControlPlane::builder(kv, pubsub).build()),
             config: Arc::new(Config {
                 providers: HashMap::from([(
                     "novita".to_string(),
@@ -2430,12 +2423,7 @@ mod tests {
     #[tokio::test]
     async fn advance_run_completes_transform_dag_and_maps_output() {
         let kv = Arc::new(MockKvStore::new());
-        let cp = ControlPlane {
-            kv: kv.clone(),
-            pubsub: Arc::new(RecordingPubSub::default()),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
-        };
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(RecordingPubSub::default())).build();
         let workflow = workflow_fixture(
             "default",
             "copy",
@@ -2497,12 +2485,7 @@ mod tests {
     #[tokio::test]
     async fn tool_step_executes_knowledge_search_and_json_policy_failure_fails_run() {
         let kv = Arc::new(MockKvStore::new());
-        let cp = ControlPlane {
-            kv: kv.clone(),
-            pubsub: Arc::new(RecordingPubSub::default()),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
-        };
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(RecordingPubSub::default())).build();
         let book = KvKnowledgeBook::new(kv.clone());
         book.write("default", "goals.md", "ship workflow support")
             .await
@@ -2683,12 +2666,7 @@ mod tests {
     #[tokio::test]
     async fn run_uses_spec_snapshot_even_if_workflow_is_modified() {
         let kv = Arc::new(MockKvStore::new());
-        let cp = ControlPlane {
-            kv: kv.clone(),
-            pubsub: Arc::new(RecordingPubSub::default()),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
-        };
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(RecordingPubSub::default())).build();
         let mut workflow = workflow_fixture(
             "default",
             "snapshot",
@@ -2740,12 +2718,7 @@ mod tests {
     #[tokio::test]
     async fn concurrency_limit_blocks_additional_ready_agent_steps() {
         let kv = Arc::new(MockKvStore::new());
-        let cp = ControlPlane {
-            kv: kv.clone(),
-            pubsub: Arc::new(RecordingPubSub::default()),
-            scheduler: Arc::new(NoopSchedulerBackend),
-            objects: crate::control::object_store::default_object_store(),
-        };
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(RecordingPubSub::default())).build();
         for agent in ["a", "b"] {
             kv.set_msg(
                 &keys::agent("default", agent),
@@ -2823,12 +2796,9 @@ mod tests {
         let kv = Arc::new(MockKvStore::new());
         let pubsub = Arc::new(RecordingPubSub::default());
         let scheduler = Arc::new(RecordingScheduler::default());
-        let cp = ControlPlane {
-            kv: kv.clone(),
-            pubsub: pubsub.clone(),
-            scheduler: scheduler.clone(),
-            objects: crate::control::object_store::default_object_store(),
-        };
+        let cp = ControlPlane::builder(kv.clone(), pubsub.clone())
+            .scheduler(scheduler.clone())
+            .build();
         let workflow = workflow_fixture(
             "default",
             "timer",
@@ -2901,12 +2871,9 @@ mod tests {
     async fn failed_step_with_retry_schedules_durable_wakeup() {
         let kv = Arc::new(MockKvStore::new());
         let scheduler = Arc::new(RecordingScheduler::default());
-        let cp = ControlPlane {
-            kv: kv.clone(),
-            pubsub: Arc::new(RecordingPubSub::default()),
-            scheduler: scheduler.clone(),
-            objects: crate::control::object_store::default_object_store(),
-        };
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(RecordingPubSub::default()))
+            .scheduler(scheduler.clone())
+            .build();
         let workflow = workflow_fixture(
             "default",
             "retrying",


### PR DESCRIPTION
## Summary
- add shared ControlPlane constructors and a defaulting builder
- centralize Gateway-to-ControlPlane conversion
- migrate repeated test fixtures to use the builder so future control-plane services need fewer test edits

## Validation
- cargo test --no-run
- cargo test --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior when the scheduler backend is misconfigured: the server now fails fast instead of silently falling back to a no-op scheduler.
* **Refactor**
  * Standardized how shared control-plane dependencies are assembled and reused across gateway and worker runtime flows.
  * Updated gateway channel message handling to reuse the same control-plane instance for persistence and routing.
* **Tests / Chores**
  * Streamlined test fixtures to use a consistent control-plane construction pattern and reduced custom test scaffolding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->