### PR TITLE
[codex] Add Go client gRPC-Web transport

### DIFF
--- a/sdk/go/talon-client/client.go
+++ b/sdk/go/talon-client/client.go
@@ -1,0 +1,201 @@
+package talonclient
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/impalasys/talon/sdk/go/talon-client/talon/gateway"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	defaultConnectTimeout = 5 * time.Second
+	defaultRequestTimeout = 30 * time.Second
+)
+
+type GatewayTransport string
+
+const (
+	GatewayTransportGRPC    GatewayTransport = "grpc"
+	GatewayTransportGRPCWeb GatewayTransport = "grpc-web"
+)
+
+type GatewayClientOptions struct {
+	Endpoint       string
+	Transport      GatewayTransport
+	Authorization  string
+	ConnectTimeout time.Duration
+	RequestTimeout time.Duration
+	HTTPClient     *http.Client
+	DialOptions    []grpc.DialOption
+}
+
+type GatewayClientOption func(*GatewayClientOptions)
+
+type TalonGatewayClient struct {
+	gateway.GatewayServiceClient
+	close func() error
+}
+
+func Connect(ctx context.Context, endpoint string) (*TalonGatewayClient, error) {
+	return ConnectWithOptions(ctx, endpoint)
+}
+
+func ConnectGRPCWeb(ctx context.Context, endpoint string) (*TalonGatewayClient, error) {
+	return ConnectWithOptions(ctx, endpoint, WithGRPCWeb())
+}
+
+func ConnectWithOptions(ctx context.Context, endpoint string, options ...GatewayClientOption) (*TalonGatewayClient, error) {
+	opts := GatewayClientOptions{Endpoint: endpoint}
+	for _, option := range options {
+		if option != nil {
+			option(&opts)
+		}
+	}
+	if strings.TrimSpace(opts.Endpoint) == "" {
+		return nil, errors.New("talon gateway endpoint is required")
+	}
+	opts = opts.withDefaults()
+	switch opts.Transport {
+	case "", GatewayTransportGRPC:
+		return connectNative(ctx, opts)
+	case GatewayTransportGRPCWeb:
+		return connectGRPCWeb(opts)
+	default:
+		return nil, errors.New("unsupported talon gateway transport: " + string(opts.Transport))
+	}
+}
+
+func WithGRPC() GatewayClientOption {
+	return func(opts *GatewayClientOptions) {
+		opts.Transport = GatewayTransportGRPC
+	}
+}
+
+func WithGRPCWeb() GatewayClientOption {
+	return func(opts *GatewayClientOptions) {
+		opts.Transport = GatewayTransportGRPCWeb
+	}
+}
+
+func WithAuthorization(authorization string) GatewayClientOption {
+	return func(opts *GatewayClientOptions) {
+		opts.Authorization = authorization
+	}
+}
+
+func WithConnectTimeout(timeout time.Duration) GatewayClientOption {
+	return func(opts *GatewayClientOptions) {
+		opts.ConnectTimeout = timeout
+	}
+}
+
+func WithRequestTimeout(timeout time.Duration) GatewayClientOption {
+	return func(opts *GatewayClientOptions) {
+		opts.RequestTimeout = timeout
+	}
+}
+
+func WithHTTPClient(client *http.Client) GatewayClientOption {
+	return func(opts *GatewayClientOptions) {
+		opts.HTTPClient = client
+	}
+}
+
+func WithDialOptions(dialOptions ...grpc.DialOption) GatewayClientOption {
+	return func(opts *GatewayClientOptions) {
+		opts.DialOptions = append(opts.DialOptions, dialOptions...)
+	}
+}
+
+func (c *TalonGatewayClient) Close() error {
+	if c == nil || c.close == nil {
+		return nil
+	}
+	return c.close()
+}
+
+func (opts GatewayClientOptions) withDefaults() GatewayClientOptions {
+	if opts.Transport == "" {
+		opts.Transport = GatewayTransportGRPC
+	}
+	if opts.ConnectTimeout == 0 {
+		opts.ConnectTimeout = defaultConnectTimeout
+	}
+	if opts.RequestTimeout == 0 {
+		opts.RequestTimeout = defaultRequestTimeout
+	}
+	return opts
+}
+
+func connectNative(ctx context.Context, opts GatewayClientOptions) (*TalonGatewayClient, error) {
+	target, secure := nativeTarget(opts.Endpoint)
+	dialOptions := make([]grpc.DialOption, 0, len(opts.DialOptions)+3)
+	if secure {
+		dialOptions = append(dialOptions, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			MinVersion: tls.VersionTLS13,
+		})))
+	} else {
+		if opts.Authorization != "" {
+			return nil, errors.New("authorization requires a TLS native gRPC endpoint; use https:// or omit WithAuthorization")
+		}
+		dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	if opts.Authorization != "" {
+		dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(authorizationCredentials(opts.Authorization)))
+	}
+	dialOptions = append(dialOptions, opts.DialOptions...)
+	dialOptions = append(dialOptions, grpc.WithBlock())
+
+	if opts.ConnectTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.ConnectTimeout)
+		defer cancel()
+	}
+	conn, err := grpc.DialContext(ctx, target, dialOptions...)
+	if err != nil {
+		return nil, err
+	}
+	return &TalonGatewayClient{
+		GatewayServiceClient: gateway.NewGatewayServiceClient(conn),
+		close:                conn.Close,
+	}, nil
+}
+
+func connectGRPCWeb(opts GatewayClientOptions) (*TalonGatewayClient, error) {
+	conn, err := newGRPCWebConn(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &TalonGatewayClient{
+		GatewayServiceClient: gateway.NewGatewayServiceClient(conn),
+		close:                conn.Close,
+	}, nil
+}
+
+func nativeTarget(endpoint string) (target string, secure bool) {
+	endpoint = strings.TrimSpace(endpoint)
+	if strings.HasPrefix(endpoint, "https://") {
+		return strings.TrimPrefix(endpoint, "https://"), true
+	}
+	if strings.HasPrefix(endpoint, "http://") {
+		return strings.TrimPrefix(endpoint, "http://"), false
+	}
+	return endpoint, true
+}
+
+type authorizationCredentials string
+
+func (c authorizationCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{"authorization": string(c)}, nil
+}
+
+func (authorizationCredentials) RequireTransportSecurity() bool {
+	return true
+}

--- a/sdk/go/talon-client/client_test.go
+++ b/sdk/go/talon-client/client_test.go
@@ -1,9 +1,22 @@
 package talonclient_test
 
 import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
+	talonclient "github.com/impalasys/talon/sdk/go/talon-client"
+	"github.com/impalasys/talon/sdk/go/talon-client/talon/events"
 	"github.com/impalasys/talon/sdk/go/talon-client/talon/gateway"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -15,4 +28,378 @@ func TestGeneratedGatewayTypesAreAvailable(t *testing.T) {
 	if req.GetKind() != "Agent" {
 		t.Fatalf("unexpected kind: %q", req.GetKind())
 	}
+}
+
+func TestTalonGatewayClientUsesGeneratedGatewayInterface(t *testing.T) {
+	var _ gateway.GatewayServiceClient = (*talonclient.TalonGatewayClient)(nil)
+}
+
+func TestConnectNativeRejectsPlaintextAuthorization(t *testing.T) {
+	_, err := talonclient.ConnectWithOptions(
+		context.Background(),
+		"http://127.0.0.1:1",
+		talonclient.WithAuthorization("Bearer test-token"),
+	)
+	if err == nil {
+		t.Fatalf("expected plaintext authorization to fail")
+	}
+	if !strings.Contains(err.Error(), "authorization requires a TLS native gRPC endpoint") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSDKGenerationKeepsRootHelpers(t *testing.T) {
+	data, err := os.ReadFile("../../../scripts/sdk/generate.sh")
+	if err != nil {
+		t.Fatalf("read SDK generator: %v", err)
+	}
+	script := string(data)
+	if !strings.Contains(script, "rm -rf sdk/go/talon-client/talon") {
+		t.Fatalf("SDK generator no longer removes only the generated Go talon tree")
+	}
+	if strings.Contains(script, "rm -rf sdk/go/talon-client ") || strings.Contains(script, "rm -rf sdk/go/talon-client\n") {
+		t.Fatalf("SDK generator appears to remove the hand-written Go client root")
+	}
+}
+
+func TestConnectGRPCWebUnaryUsesHTTP1GRPCWeb(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor != 1 {
+			t.Fatalf("expected HTTP/1.x request, got %s", r.Proto)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != gateway.GatewayService_ListNamespaces_FullMethodName {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("content-type"); got != "application/grpc-web+proto" {
+			t.Fatalf("unexpected content-type: %q", got)
+		}
+		if got := r.Header.Get("x-grpc-web"); got != "1" {
+			t.Fatalf("unexpected x-grpc-web: %q", got)
+		}
+		if got := r.Header.Get("x-user-agent"); got != "talon-client-go" {
+			t.Fatalf("unexpected x-user-agent: %q", got)
+		}
+		if got := r.Header.Get("authorization"); got != "Bearer test-token" {
+			t.Fatalf("authorization header was not forwarded: %q", got)
+		}
+		if got := r.Header.Get("x-talon-test"); got != "metadata" {
+			t.Fatalf("outgoing metadata was not forwarded: %q", got)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		var request gateway.ListNamespacesRequest
+		decodeRequestFrame(t, body, &request)
+
+		w.Header().Set("content-type", "application/grpc-web+proto")
+		w.Header().Set("x-test-header", "header-value")
+		_, _ = w.Write(grpcWebBody(
+			&gateway.ListNamespacesResponse{
+				Namespaces: []*gateway.NamespaceResponse{{Name: "from-grpc-web"}},
+			},
+			"x-test-trailer: trailer-value",
+			"grpc-status: 0",
+		))
+	}))
+	defer server.Close()
+
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-talon-test", "metadata")
+	client, err := talonclient.ConnectWithOptions(
+		ctx,
+		server.URL,
+		talonclient.WithGRPCWeb(),
+		talonclient.WithAuthorization("Bearer test-token"),
+	)
+	if err != nil {
+		t.Fatalf("connect gRPC-Web client: %v", err)
+	}
+	defer client.Close()
+
+	var header metadata.MD
+	var trailer metadata.MD
+	var finished error
+	resp, err := client.ListNamespaces(
+		ctx,
+		&gateway.ListNamespacesRequest{},
+		grpc.Header(&header),
+		grpc.Trailer(&trailer),
+		grpc.OnFinish(func(err error) {
+			finished = err
+		}),
+	)
+	if err != nil {
+		t.Fatalf("list namespaces: %v", err)
+	}
+	if got := resp.GetNamespaces()[0].GetName(); got != "from-grpc-web" {
+		t.Fatalf("unexpected namespace: %q", got)
+	}
+	if got := header.Get("x-test-header"); len(got) != 1 || got[0] != "header-value" {
+		t.Fatalf("unexpected header metadata: %v", header)
+	}
+	if got := trailer.Get("x-test-trailer"); len(got) != 1 || got[0] != "trailer-value" {
+		t.Fatalf("unexpected trailer metadata: %v", trailer)
+	}
+	if got := trailer.Get("grpc-status"); len(got) != 1 || got[0] != "0" {
+		t.Fatalf("unexpected grpc-status trailer: %v", trailer)
+	}
+	if finished != nil {
+		t.Fatalf("unexpected OnFinish error: %v", finished)
+	}
+}
+
+func TestConnectGRPCWebUnaryMapsTrailerStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/grpc-web+proto")
+		_, _ = w.Write(grpcWebBody(nil, "grpc-status: 7", "grpc-message: permission%20denied"))
+	}))
+	defer server.Close()
+
+	client, err := talonclient.ConnectGRPCWeb(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("connect gRPC-Web client: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.ListNamespaces(context.Background(), &gateway.ListNamespacesRequest{})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v (%v)", status.Code(err), err)
+	}
+	if got := status.Convert(err).Message(); got != "permission denied" {
+		t.Fatalf("unexpected status message: %q", got)
+	}
+}
+
+func TestConnectGRPCWebUnaryRequiresFinalStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/grpc-web+proto")
+		message, err := proto.Marshal(&gateway.ListNamespacesResponse{})
+		if err != nil {
+			t.Fatalf("marshal response: %v", err)
+		}
+		_, _ = w.Write(grpcWebDataFrame(message))
+	}))
+	defer server.Close()
+
+	client, err := talonclient.ConnectGRPCWeb(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("connect gRPC-Web client: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.ListNamespaces(context.Background(), &gateway.ListNamespacesRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("expected unavailable for missing grpc-status, got %v (%v)", status.Code(err), err)
+	}
+	if !strings.Contains(status.Convert(err).Message(), "missing gRPC status") {
+		t.Fatalf("unexpected status message: %q", status.Convert(err).Message())
+	}
+}
+
+func TestConnectGRPCWebUnaryRejectsTruncatedFrame(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/grpc-web+proto")
+		_, _ = w.Write([]byte{0, 0})
+	}))
+	defer server.Close()
+
+	client, err := talonclient.ConnectGRPCWeb(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("connect gRPC-Web client: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.ListNamespaces(context.Background(), &gateway.ListNamespacesRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("expected unavailable for truncated frame, got %v (%v)", status.Code(err), err)
+	}
+	if !strings.Contains(status.Convert(err).Message(), "incomplete gRPC-Web frame header") {
+		t.Fatalf("unexpected status message: %q", status.Convert(err).Message())
+	}
+}
+
+func TestConnectGRPCWebUnaryRejectsOversizedMessageFrame(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/grpc-web+proto")
+		_, _ = w.Write(grpcWebDataFrame([]byte("too-large")))
+		_, _ = w.Write(grpcWebTrailerFrame("grpc-status: 0"))
+	}))
+	defer server.Close()
+
+	client, err := talonclient.ConnectGRPCWeb(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("connect gRPC-Web client: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.ListNamespaces(context.Background(), &gateway.ListNamespacesRequest{}, grpc.MaxCallRecvMsgSize(4))
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("expected resource exhausted for oversized frame, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestConnectGRPCWebServerStreamingUsesGeneratedClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != gateway.GatewayService_StreamChannelEvents_FullMethodName {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		var request gateway.StreamChannelEventsRequest
+		decodeRequestFrame(t, body, &request)
+		if request.GetNs() != "default" || request.GetChannel() != "chat" {
+			t.Fatalf("unexpected stream request: %+v", request)
+		}
+
+		w.Header().Set("content-type", "application/grpc-web+proto")
+		_, _ = w.Write(grpcWebBody(
+			&events.ChannelEvent{
+				Ns:      "default",
+				Channel: "chat",
+				Kind:    events.ChannelEventKind_CHANNEL_EVENT_KIND_MESSAGE_CREATED,
+			},
+			&events.ChannelEvent{
+				Ns:      "default",
+				Channel: "chat",
+				Kind:    events.ChannelEventKind_CHANNEL_EVENT_KIND_SESSION_ROUTED,
+			},
+			"grpc-status: 0",
+		))
+	}))
+	defer server.Close()
+
+	client, err := talonclient.ConnectGRPCWeb(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("connect gRPC-Web client: %v", err)
+	}
+	defer client.Close()
+
+	stream, err := client.StreamChannelEvents(context.Background(), &gateway.StreamChannelEventsRequest{
+		Ns:      "default",
+		Channel: "chat",
+	})
+	if err != nil {
+		t.Fatalf("stream channel events: %v", err)
+	}
+	first, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("receive first event: %v", err)
+	}
+	if first.GetKind() != events.ChannelEventKind_CHANNEL_EVENT_KIND_MESSAGE_CREATED {
+		t.Fatalf("unexpected first event: %v", first.GetKind())
+	}
+	second, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("receive second event: %v", err)
+	}
+	if second.GetKind() != events.ChannelEventKind_CHANNEL_EVENT_KIND_SESSION_ROUTED {
+		t.Fatalf("unexpected second event: %v", second.GetKind())
+	}
+	if _, err := stream.Recv(); err != io.EOF {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func TestConnectGRPCWebServerStreamingRequiresFinalStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/grpc-web+proto")
+		message, err := proto.Marshal(&events.ChannelEvent{
+			Ns:      "default",
+			Channel: "chat",
+			Kind:    events.ChannelEventKind_CHANNEL_EVENT_KIND_MESSAGE_CREATED,
+		})
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		_, _ = w.Write(grpcWebDataFrame(message))
+	}))
+	defer server.Close()
+
+	client, err := talonclient.ConnectGRPCWeb(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("connect gRPC-Web client: %v", err)
+	}
+	defer client.Close()
+
+	stream, err := client.StreamChannelEvents(context.Background(), &gateway.StreamChannelEventsRequest{
+		Ns:      "default",
+		Channel: "chat",
+	})
+	if err != nil {
+		t.Fatalf("stream channel events: %v", err)
+	}
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("receive event: %v", err)
+	}
+	_, err = stream.Recv()
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("expected unavailable for missing grpc-status, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func decodeRequestFrame(t *testing.T, body []byte, message proto.Message) {
+	t.Helper()
+	if len(body) < 5 {
+		t.Fatalf("request body too short: %d", len(body))
+	}
+	if body[0] != 0 {
+		t.Fatalf("unexpected request frame flags: 0x%x", body[0])
+	}
+	length := int(binary.BigEndian.Uint32(body[1:5]))
+	if len(body[5:]) != length {
+		t.Fatalf("unexpected request frame length: got %d want %d", len(body[5:]), length)
+	}
+	if err := proto.Unmarshal(body[5:], message); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+}
+
+func grpcWebBody(messagesAndTrailer ...any) []byte {
+	var body []byte
+	for _, item := range messagesAndTrailer {
+		switch value := item.(type) {
+		case proto.Message:
+			message, err := proto.Marshal(value)
+			if err != nil {
+				panic(err)
+			}
+			body = append(body, grpcWebDataFrame(message)...)
+		case string:
+			body = append(body, grpcWebTrailerFrame(messagesAndTrailer...)...)
+			return body
+		case nil:
+		default:
+			panic("unsupported gRPC-Web body item")
+		}
+	}
+	return append(body, grpcWebTrailerFrame("grpc-status: 0")...)
+}
+
+func grpcWebDataFrame(message []byte) []byte {
+	frame := make([]byte, 5+len(message))
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(message)))
+	copy(frame[5:], message)
+	return frame
+}
+
+func grpcWebTrailerFrame(items ...any) []byte {
+	var lines []string
+	for _, item := range items {
+		line, ok := item.(string)
+		if ok {
+			lines = append(lines, line)
+		}
+	}
+	payload := []byte(strings.Join(lines, "\r\n") + "\r\n")
+	frame := make([]byte, 5+len(payload))
+	frame[0] = 0x80
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(payload)))
+	copy(frame[5:], payload)
+	return frame
 }

--- a/sdk/go/talon-client/grpc_web.go
+++ b/sdk/go/talon-client/grpc_web.go
@@ -1,0 +1,478 @@
+package talonclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	defaultMaxReceiveMessageSize = 4 * 1024 * 1024
+	defaultMaxTrailerFrameSize   = 4 * 1024 * 1024
+	grpcWebContentType           = "application/grpc-web+proto"
+	grpcWebUserAgent             = "talon-client-go"
+)
+
+type grpcWebConn struct {
+	endpoint      string
+	authorization string
+	client        *http.Client
+	ownedClient   bool
+}
+
+func newGRPCWebConn(opts GatewayClientOptions) (*grpcWebConn, error) {
+	endpoint := strings.TrimRight(strings.TrimSpace(opts.Endpoint), "/")
+	if endpoint == "" {
+		return nil, errors.New("talon gateway endpoint is required")
+	}
+	client := opts.HTTPClient
+	ownedClient := false
+	if client == nil {
+		client = &http.Client{Timeout: opts.RequestTimeout}
+		ownedClient = true
+	}
+	return &grpcWebConn{
+		endpoint:      endpoint,
+		authorization: opts.Authorization,
+		client:        client,
+		ownedClient:   ownedClient,
+	}, nil
+}
+
+type grpcWebCallConfig struct {
+	maxReceiveMessageSize int
+	headerAddr            *metadata.MD
+	trailerAddr           *metadata.MD
+	onFinish              []func(error)
+}
+
+func (c *grpcWebConn) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) (err error) {
+	config := parseGRPCWebCallOptions(opts)
+	defer func() {
+		for _, onFinish := range config.onFinish {
+			onFinish(err)
+		}
+	}()
+
+	request, err := marshalMessage(args)
+	if err != nil {
+		return err
+	}
+	resp, err := c.do(ctx, method, request)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	headers := headersToMetadata(resp.Header)
+	if config.headerAddr != nil {
+		*config.headerAddr = headers.Copy()
+	}
+	reader := grpcWebFrameReader{
+		reader:                resp.Body,
+		maxReceiveMessageSize: config.maxReceiveMessageSize,
+	}
+	var trailers metadata.MD
+	for {
+		frame, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			if config.trailerAddr != nil {
+				*config.trailerAddr = trailers.Copy()
+			}
+			return requireStatus(metadata.Join(responseStatusMetadata(resp), trailers))
+		}
+		if err != nil {
+			return err
+		}
+		if frame.trailer {
+			trailers = metadata.Join(trailers, parseTrailerMetadata(frame.payload))
+			if config.trailerAddr != nil {
+				*config.trailerAddr = trailers.Copy()
+			}
+			if err := requireStatus(metadata.Join(responseStatusMetadata(resp), trailers)); err != nil {
+				return err
+			}
+			return nil
+		}
+		if err := unmarshalMessage(frame.payload, reply); err != nil {
+			return err
+		}
+	}
+}
+
+func (c *grpcWebConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	if desc.ClientStreams {
+		return nil, status.Error(codes.Unimplemented, "gRPC-Web transport does not support client-streaming or bidirectional-streaming RPCs")
+	}
+	return &grpcWebClientStream{
+		conn:   c,
+		config: parseGRPCWebCallOptions(opts),
+		ctx:    ctx,
+		method: method,
+	}, nil
+}
+
+func (c *grpcWebConn) Close() error {
+	if c.ownedClient {
+		if transport, ok := c.client.Transport.(interface{ CloseIdleConnections() }); ok {
+			transport.CloseIdleConnections()
+		}
+	}
+	return nil
+}
+
+func (c *grpcWebConn) do(ctx context.Context, method string, message []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+method, bytes.NewReader(encodeDataFrame(message)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("content-type", grpcWebContentType)
+	req.Header.Set("accept", grpcWebContentType)
+	req.Header.Set("x-grpc-web", "1")
+	req.Header.Set("x-user-agent", grpcWebUserAgent)
+	if c.authorization != "" {
+		req.Header.Set("authorization", c.authorization)
+	}
+	addOutgoingMetadata(req.Header, ctx)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		return nil, status.Errorf(codes.Unavailable, "gRPC-Web request failed: %s", resp.Status)
+	}
+	if found, err := statusFromMetadata(responseStatusMetadata(resp)); found && err != nil {
+		defer resp.Body.Close()
+		return nil, err
+	}
+	return resp, nil
+}
+
+type grpcWebClientStream struct {
+	conn    *grpcWebConn
+	config  grpcWebCallConfig
+	ctx     context.Context
+	method  string
+	request []byte
+	resp    *http.Response
+	reader  *grpcWebFrameReader
+	header  metadata.MD
+	trailer metadata.MD
+	started bool
+	done    bool
+}
+
+func (s *grpcWebClientStream) Header() (metadata.MD, error) {
+	if err := s.start(); err != nil {
+		return nil, err
+	}
+	return s.header.Copy(), nil
+}
+
+func (s *grpcWebClientStream) Trailer() metadata.MD {
+	return s.trailer.Copy()
+}
+
+func (s *grpcWebClientStream) CloseSend() error {
+	return nil
+}
+
+func (s *grpcWebClientStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *grpcWebClientStream) SendMsg(m any) error {
+	if s.started {
+		return errors.New("cannot send gRPC-Web request after stream has started")
+	}
+	if s.request != nil {
+		return errors.New("gRPC-Web server-streaming requests support exactly one request message")
+	}
+	message, err := marshalMessage(m)
+	if err != nil {
+		return err
+	}
+	s.request = message
+	return nil
+}
+
+func (s *grpcWebClientStream) RecvMsg(m any) error {
+	if s.done {
+		return io.EOF
+	}
+	if err := s.start(); err != nil {
+		return err
+	}
+	for {
+		frame, err := s.reader.Next()
+		if errors.Is(err, io.EOF) {
+			s.done = true
+			if s.resp != nil {
+				_ = s.resp.Body.Close()
+			}
+			if err := requireStatus(metadata.Join(responseStatusMetadata(s.resp), s.trailer)); err != nil {
+				s.finish(err)
+				return err
+			}
+			s.finish(nil)
+			return io.EOF
+		}
+		if err != nil {
+			s.done = true
+			if s.resp != nil {
+				_ = s.resp.Body.Close()
+			}
+			s.finish(err)
+			return err
+		}
+		if frame.trailer {
+			s.trailer = metadata.Join(s.trailer, parseTrailerMetadata(frame.payload))
+			if s.config.trailerAddr != nil {
+				*s.config.trailerAddr = s.trailer.Copy()
+			}
+			s.done = true
+			if s.resp != nil {
+				_ = s.resp.Body.Close()
+			}
+			if err := requireStatus(metadata.Join(responseStatusMetadata(s.resp), s.trailer)); err != nil {
+				s.finish(err)
+				return err
+			}
+			s.finish(nil)
+			return io.EOF
+		}
+		return unmarshalMessage(frame.payload, m)
+	}
+}
+
+func (s *grpcWebClientStream) start() error {
+	if s.started {
+		return nil
+	}
+	resp, err := s.conn.do(s.ctx, s.method, s.request)
+	if err != nil {
+		return err
+	}
+	s.resp = resp
+	reader := grpcWebFrameReader{
+		reader:                resp.Body,
+		maxReceiveMessageSize: s.config.maxReceiveMessageSize,
+	}
+	s.reader = &reader
+	s.header = headersToMetadata(resp.Header)
+	if s.config.headerAddr != nil {
+		*s.config.headerAddr = s.header.Copy()
+	}
+	s.started = true
+	return nil
+}
+
+func (s *grpcWebClientStream) finish(err error) {
+	for _, onFinish := range s.config.onFinish {
+		onFinish(err)
+	}
+	s.config.onFinish = nil
+}
+
+type grpcWebFrame struct {
+	trailer bool
+	payload []byte
+}
+
+type grpcWebFrameReader struct {
+	reader                io.Reader
+	maxReceiveMessageSize int
+}
+
+func (r *grpcWebFrameReader) Next() (grpcWebFrame, error) {
+	var header [5]byte
+	if _, err := io.ReadFull(r.reader, header[:]); err != nil {
+		if errors.Is(err, io.EOF) {
+			return grpcWebFrame{}, io.EOF
+		}
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return grpcWebFrame{}, status.Error(codes.Unavailable, "incomplete gRPC-Web frame header")
+		}
+		return grpcWebFrame{}, err
+	}
+	compressed := header[0]&0x01 != 0
+	if compressed {
+		return grpcWebFrame{}, status.Error(codes.Unimplemented, "compressed gRPC-Web frames are not supported")
+	}
+	trailer := header[0]&0x80 != 0
+	length := binary.BigEndian.Uint32(header[1:])
+	maxFrameSize := r.maxReceiveMessageSize
+	frameKind := "message"
+	if trailer {
+		maxFrameSize = defaultMaxTrailerFrameSize
+		frameKind = "trailer"
+	}
+	if maxFrameSize >= 0 && uint64(length) > uint64(maxFrameSize) {
+		return grpcWebFrame{}, status.Errorf(codes.ResourceExhausted, "gRPC-Web %s frame length %d exceeds maximum %d", frameKind, length, maxFrameSize)
+	}
+	payload := make([]byte, int(length))
+	if _, err := io.ReadFull(r.reader, payload); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return grpcWebFrame{}, status.Error(codes.Unavailable, "incomplete gRPC-Web frame payload")
+		}
+		return grpcWebFrame{}, err
+	}
+	return grpcWebFrame{
+		trailer: trailer,
+		payload: payload,
+	}, nil
+}
+
+func encodeDataFrame(message []byte) []byte {
+	frame := make([]byte, 5+len(message))
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(message)))
+	copy(frame[5:], message)
+	return frame
+}
+
+func marshalMessage(v any) ([]byte, error) {
+	message, ok := v.(proto.Message)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "gRPC-Web request %T does not implement proto.Message", v)
+	}
+	return proto.Marshal(message)
+}
+
+func unmarshalMessage(data []byte, v any) error {
+	message, ok := v.(proto.Message)
+	if !ok {
+		return status.Errorf(codes.Internal, "gRPC-Web response %T does not implement proto.Message", v)
+	}
+	return proto.Unmarshal(data, message)
+}
+
+func parseGRPCWebCallOptions(opts []grpc.CallOption) grpcWebCallConfig {
+	config := grpcWebCallConfig{maxReceiveMessageSize: defaultMaxReceiveMessageSize}
+	for _, opt := range opts {
+		switch typed := opt.(type) {
+		case grpc.HeaderCallOption:
+			config.headerAddr = typed.HeaderAddr
+		case grpc.TrailerCallOption:
+			config.trailerAddr = typed.TrailerAddr
+		case grpc.MaxRecvMsgSizeCallOption:
+			config.maxReceiveMessageSize = typed.MaxRecvMsgSize
+		case grpc.OnFinishCallOption:
+			if typed.OnFinish != nil {
+				config.onFinish = append(config.onFinish, typed.OnFinish)
+			}
+		}
+	}
+	return config
+}
+
+func addOutgoingMetadata(headers http.Header, ctx context.Context) {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return
+	}
+	for key, values := range md {
+		key = strings.ToLower(key)
+		if key == "" || strings.HasPrefix(key, ":") || strings.HasPrefix(key, "grpc-") {
+			continue
+		}
+		for _, value := range values {
+			if strings.HasSuffix(key, "-bin") {
+				value = base64.StdEncoding.EncodeToString([]byte(value))
+			}
+			headers.Add(key, value)
+		}
+	}
+}
+
+func headersToMetadata(headers http.Header) metadata.MD {
+	md := metadata.MD{}
+	for key, values := range headers {
+		key = strings.ToLower(key)
+		if key == "" || key == "content-type" {
+			continue
+		}
+		for _, value := range values {
+			md.Append(key, value)
+		}
+	}
+	return md
+}
+
+func responseStatusMetadata(resp *http.Response) metadata.MD {
+	if resp == nil {
+		return nil
+	}
+	md := metadata.MD{}
+	for _, key := range []string{"grpc-status", "grpc-message"} {
+		for _, value := range resp.Header.Values(key) {
+			md.Append(key, value)
+		}
+	}
+	return md
+}
+
+func parseTrailerMetadata(payload []byte) metadata.MD {
+	md := metadata.MD{}
+	for _, line := range strings.Split(string(payload), "\r\n") {
+		if line == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		md.Append(strings.ToLower(strings.TrimSpace(key)), strings.TrimSpace(value))
+	}
+	return md
+}
+
+func requireStatus(md metadata.MD) error {
+	found, err := statusFromMetadata(md)
+	if !found {
+		return status.Error(codes.Unavailable, "missing gRPC status in gRPC-Web response")
+	}
+	return err
+}
+
+func statusFromMetadata(md metadata.MD) (bool, error) {
+	values := md.Get("grpc-status")
+	if len(values) == 0 {
+		return false, nil
+	}
+	codeNumber, err := strconv.Atoi(values[len(values)-1])
+	if err != nil {
+		return true, status.Errorf(codes.Internal, "invalid grpc-status %q", values[len(values)-1])
+	}
+	code := codes.Code(codeNumber)
+	if code == codes.OK {
+		return true, nil
+	}
+	message := ""
+	if messages := md.Get("grpc-message"); len(messages) > 0 {
+		message = decodeGRPCMessage(messages[len(messages)-1])
+	}
+	return true, status.Error(code, message)
+}
+
+func decodeGRPCMessage(message string) string {
+	decoded, err := url.PathUnescape(message)
+	if err != nil {
+		return message
+	}
+	return decoded
+}


### PR DESCRIPTION
## Summary

Adds a hand-written root Go client helper package for Talon gateway connections while leaving the generated `talon/gateway` SDK untouched.

## Changes

- Adds `Connect`, `ConnectGRPCWeb`, and `ConnectWithOptions` helpers around the generated `gateway.GatewayServiceClient`.
- Adds functional options including `WithGRPC`, `WithGRPCWeb`, `WithAuthorization`, timeout options, HTTP client injection, and native gRPC dial options.
- Implements a gRPC-Web `grpc.ClientConnInterface` adapter for unary and server-streaming gateway RPCs, including binary gRPC-Web framing, metadata forwarding, auth headers, trailer status parsing, and explicit unsupported errors for client/bidi streaming.
- Adds tests confirming generated gateway usage, generator safety for hand-written root files, unary gRPC-Web behavior, trailer error mapping, and server-streaming behavior.

## Validation

- `cd sdk/go/talon-client && go test ./...`

Generated files under `sdk/go/talon-client/talon/...` were not modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Go Talon gateway client to connect using native gRPC or gRPC-web.
  * Added configurable connection options (endpoint, transport selection, authorization header, connect/request timeouts, custom HTTP client, and dial options).
  * Supports unary and server-streaming RPCs with gRPC-web framing and trailer-based status/message handling, including secure-vs-insecure authorization enforcement.
* **Tests**
  * Expanded gRPC-web tests for unary/server-streaming correctness, framing robustness, required final status/trailers, error-code mapping, and authorization validation on non-TLS endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->