### PR TITLE
[codex] add dynamodb store and sqs work queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,32 @@ jobs:
       - name: Run upstream A2A SDK compatibility test
         run: pytest -q tests/test_a2a_compat.py
 
+  aws_local_e2e:
+    name: AWS Local E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends pkg-config libssl-dev protobuf-compiler
+
+      - name: Check Docker daemon
+        run: docker info
+
+      - name: Run AWS local E2E
+        run: cargo test --locked --features aws-local-e2e --test aws_local_e2e -- --ignored --test-threads=1
+
   cloudflare_e2e:
     name: Cloudflare E2E
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -155,10 +155,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "astral-tokio-tar"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
 
 [[package]]
 name = "async-channel"
@@ -261,7 +286,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -315,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -342,6 +367,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-dynamodb"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c597424385739456cd04535982831c15bd58f97ca28c5bcb232c0d730d5cb39"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,14 +412,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -385,7 +434,32 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sqs"
+version = "1.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0246bf049cfc003ce44599dff955b9353758de3afa68a053da9b2c7de20a07d8"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -409,7 +483,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -433,7 +507,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -457,7 +531,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -474,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -484,16 +558,15 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
- "p256 0.11.1",
+ "p256",
  "percent-encoding",
- "ring",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -527,15 +600,15 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.20"
+version = "0.60.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -626,10 +699,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -654,15 +729,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -679,11 +755,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -695,10 +772,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -731,13 +830,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -758,7 +858,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -788,7 +888,7 @@ dependencies = [
  "hyper 1.9.0",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -806,6 +906,31 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -844,6 +969,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -930,12 +1073,6 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -1011,43 +1148,86 @@ dependencies = [
 ]
 
 [[package]]
-name = "bollard"
-version = "0.15.0"
+name = "block-buffer"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "base64 0.21.7",
+ "hybrid-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
+ "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
  "futures-core",
  "futures-util",
  "hex",
- "http 0.2.12",
- "hyper 0.14.32",
+ "home",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-named-pipe",
+ "hyper-rustls 0.27.8",
+ "hyper-util",
  "hyperlocal",
  "log",
+ "num",
  "pin-project-lite",
+ "rand 0.9.4",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "time",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tonic 0.14.5",
+ "tower-service",
  "url",
  "winapi",
 ]
 
 [[package]]
-name = "bollard-stubs"
-version = "1.43.0-rc.2"
+name = "bollard-buildkit-proto"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost 0.14.3",
  "serde",
+ "serde_json",
  "serde_repr",
- "serde_with",
+ "time",
 ]
 
 [[package]]
@@ -1177,7 +1357,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1241,6 +1421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1473,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -1363,7 +1555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rand 0.9.4",
  "regex",
  "rustversion",
@@ -1406,18 +1598,6 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -1440,12 +1620,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1457,7 +1655,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1526,21 +1724,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1561,10 +1749,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1576,6 +1776,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1598,28 +1809,16 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
- "digest",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1628,8 +1827,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -1641,7 +1840,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1657,41 +1856,21 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest",
- "ff 0.12.1",
- "generic-array",
- "group 0.12.1",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
- "digest",
- "ff 0.13.1",
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "hkdf",
  "pem-rfc7468",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1753,6 +1932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,13 +1975,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "ff"
-version = "0.12.1"
+name = "ferroid"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
 dependencies = [
- "rand_core 0.6.4",
- "subtle",
+ "portable-atomic",
+ "rand 0.10.1",
+ "web-time",
 ]
 
 [[package]]
@@ -1810,6 +2000,16 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -2106,7 +2306,7 @@ dependencies = [
  "chrono",
  "google-cloud-gax 1.9.0",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 1.4.0",
  "jsonwebtoken 10.4.0",
  "reqwest 0.13.2",
@@ -2115,7 +2315,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -2337,22 +2537,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2451,7 +2640,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2460,7 +2649,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2540,6 +2738,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,6 +2790,21 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
 ]
 
 [[package]]
@@ -2696,15 +2918,17 @@ dependencies = [
 
 [[package]]
 name = "hyperlocal"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
- "futures-util",
  "hex",
- "hyper 0.14.32",
- "pin-project",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
  "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3044,17 +3268,17 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
- "p256 0.13.2",
+ "p256",
  "p384",
  "pem",
  "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
- "sha2",
- "signature 2.2.0",
+ "sha2 0.10.9",
+ "signature",
  "simple_asn1",
  "zeroize",
 ]
@@ -3191,13 +3415,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3330,6 +3560,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3597,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3387,6 +3640,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3543,25 +3807,14 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
-dependencies = [
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2",
-]
-
-[[package]]
-name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3570,10 +3823,10 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3603,6 +3856,31 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn",
 ]
 
 [[package]]
@@ -3708,19 +3986,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -3729,8 +3997,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3756,6 +4024,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -3819,7 +4093,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3950,6 +4224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -4362,22 +4645,11 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4466,16 +4738,16 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -4708,28 +4980,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct 0.1.1",
- "der 0.6.1",
- "generic-array",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
+ "base16ct",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -4912,7 +5170,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4923,7 +5181,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4953,21 +5222,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5050,22 +5309,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -5106,7 +5355,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -5143,7 +5392,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -5165,7 +5414,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -5175,7 +5424,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -5186,7 +5435,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5207,13 +5456,13 @@ dependencies = [
  "byteorder",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -5223,7 +5472,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5297,6 +5546,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -5395,8 +5667,10 @@ dependencies = [
  "async-stream",
  "async-trait",
  "aws-config",
+ "aws-sdk-dynamodb",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",
+ "aws-sdk-sqs",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "axum 0.7.9",
@@ -5432,11 +5706,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
  "sse-stream",
  "talon-client",
  "tempfile",
+ "testcontainers-modules",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
@@ -5482,6 +5757,46 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera 0.11.0",
+ "ferroid",
+ "futures",
+ "http 1.4.0",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -5857,8 +6172,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -5868,6 +6185,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
+ "socket2 0.6.3",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -6136,9 +6454,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typespec"
@@ -6228,7 +6546,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6251,6 +6569,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6260,6 +6605,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6273,6 +6619,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -7080,6 +7432,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 bazel = []
 cpu-profile = ["dep:pprof"]
+dynamodb = ["dep:aws-sdk-dynamodb"]
 heap-profile = [
     "dep:tikv-jemallocator",
     "tikv-jemallocator/profiling",
@@ -14,6 +15,8 @@ heap-profile = [
     "tikv-jemalloc-ctl/stats",
 ]
 rocksdb = ["dep:rocksdb"]
+sqs = ["dep:aws-sdk-sqs"]
+aws-local-e2e = ["dynamodb", "sqs"]
 
 [dependencies]
 aead = "0.5"
@@ -22,7 +25,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 async-stream = "0.3"
 base64 = "0.21"
-bollard = "0.15"
+bollard = "0.20"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 cron = "0.12"
@@ -63,8 +66,10 @@ url = "2"
 google-cloud-secretmanager-v1 = "1.7"
 google-cloud-auth = "1.8"
 aws-config = "1.8"
+aws-sdk-dynamodb = { version = "1.103", optional = true }
 aws-sdk-s3 = "1.103"
 aws-sdk-secretsmanager = "1.103"
+aws-sdk-sqs = { version = "1.102", optional = true }
 azure_identity = "0.33"
 azure_security_keyvault_secrets = "0.12"
 uuid = { version = "1.23.0", features = ["v7"] }
@@ -86,6 +91,7 @@ aws-smithy-runtime-api = "1.11"
 aws-smithy-types = "1.4"
 tempfile = "3.0"
 tokio-stream = { version = "0.1", features = ["net"] }
+testcontainers-modules = { version = "0.15", features = ["dynamodb", "localstack"] }
 
 [[bin]]
 name = "talon-server"

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -108,6 +108,34 @@ control_plane:
     driver: gcp_pubsub
 ```
 
+### AWS control plane
+
+AWS backends are compiled behind crate features so local-only builds do not pull in every AWS service client:
+
+- `dynamodb` enables `control_plane.database.driver: dynamodb`
+- `sqs` enables `control_plane.message_broker.driver: sqs`
+- `aws-local-e2e` enables both and compiles the Docker-backed AWS local integration tests
+
+```yaml
+control_plane:
+  database:
+    driver: dynamodb
+    url:
+      source: env
+      key: TALON_DYNAMODB_TABLE
+  message_broker:
+    driver: sqs
+```
+
+Notes:
+
+- DynamoDB uses one shared table with namespace-isolated partition keys. Production deployments should provision this table in infra before Talon starts.
+- `TALON_DYNAMODB_ENDPOINT_URL` and `TALON_SQS_ENDPOINT_URL` point the AWS SDK clients at local emulators such as DynamoDB Local or LocalStack.
+- `TALON_SQS_QUEUE_NAME` defaults to `talon` and names the single SQS queue used for durable worker-delivered messages. `TALON_SQS_QUEUE_PREFIX` is still accepted as a compatibility fallback.
+- `TALON_SQS_WAIT_TIME_SECONDS` is clamped to the SQS `0..=20` range, and `TALON_SQS_VISIBILITY_TIMEOUT_SECONDS` is clamped to `0..=43200`. Worker pull mode extends visibility while a dispatch is in flight.
+- SQS provides durable work-queue semantics through worker pull mode. Talon writes all worker-delivered topics to the same queue and stores the logical Talon topic in SQS message attributes for dispatch routing. Messages are deleted only after the worker dispatch succeeds.
+- The generic Talon `subscribe` stream is not available for SQS because it cannot acknowledge messages after handler completion. Live `talon.session.parts.*` token streams still require Pub/Sub, `local_socket`, `cf_queues`, or direct worker streaming.
+
 ## Local environment
 
 The local compose stack sets most runtime wiring automatically, including:

--- a/docs/wiki/key-formats.md
+++ b/docs/wiki/key-formats.md
@@ -93,6 +93,39 @@ kind = SessionMessage
 
 Recursive operations walk direct children in application code. Talon does not maintain a second recursive index in the SQL storage layer.
 
+## DynamoDB single-table layout
+
+The DynamoDB backend stores the same structured key in one shared on-demand table with only `PK` and `SK` in the key schema. The key strings are a DynamoDB-optimized projection of Talon's canonical `ResourceKey`, not a separate logical identity:
+
+```text
+PK = Namespace/<percent-encoded namespace>/Resource/<parent_path>
+SK = <kind>/<name>
+```
+
+The namespace is Talon's current isolation boundary. Every item for a namespace has that namespace embedded in `PK`, so ordinary reads and queries cannot cross namespace partitions. Talon reconstructs the structured `ResourceKey` from `PK` and `SK`; the protobuf payload is stored as binary `Value`.
+
+For session state this gives the following concrete shapes:
+
+```text
+Session:
+PK = Namespace/<namespace>/Resource/Agent/<agent_id>
+SK = Session/<session_id>
+
+Submission / lease record:
+PK = Namespace/<namespace>/Resource/Agent/<agent_id>/Session/<session_id>
+SK = SessionSubmission/<submission_id>
+
+Journal entry:
+PK = Namespace/<namespace>/Resource/Agent/<agent_id>/Session/<session_id>/SessionSubmission/<submission_id>
+SK = SessionJournalEntry/<sequence_number>
+```
+
+Leases are stored on the `SessionSubmission` record. Claim acquisition reads the current protobuf value and writes the updated submission with a DynamoDB conditional write: new submissions use `attribute_not_exists(PK)`, and existing submissions use `Value = :expected`. The submission contains a UUIDv7 `attempt_id`, `attempt_count`, and `claim_expires_at`; journal appends are fenced by checking that the active submission still has the same `attempt_id` before writing `SessionJournalEntry` items. Lease renewal uses the same expected-value condition, so a stale worker cannot renew or append after another worker has claimed a newer UUIDv7 attempt.
+
+Tables are shared across namespaces by default. New namespace onboarding does not need table creation. Production deployments should provision the shared table in infra, while local/E2E tests create their emulator table during test setup. Local development can keep using `sqlite` or filesystem-backed object storage while production sets `control_plane.database.driver: dynamodb`.
+
+The Rust backend is async and uses the official AWS SDK client directly. The SDK client is cheap to clone, internally shared, and non-blocking under Tokio, so Talon should keep one `DynamoDbKvStore` per control plane and share it behind the existing `Arc<dyn KeyValueStore + Send + Sync>` boundary instead of creating per-request clients.
+
 ## Namespace hierarchy
 
 Namespace hierarchies are not represented in the ordinary resource hierarchy. A separate `NamespaceRef` resource defines each child namespace edge:

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -15,9 +15,13 @@ use talon::control::pubsub::{
     configured_local_socket_path, fully_qualified_subscription_name, fully_qualified_topic_name,
     LocalSocketMessagePublisher,
 };
+#[cfg(feature = "sqs")]
+use talon::control::pubsub::{SqsMessagePublisher, TALON_TOPIC_ATTRIBUTE};
 use talon::control::topics;
 use talon::control::ControlPlane;
 use talon::worker::{scheduler_auth::SchedulerRequestAuthenticator, WorkerEventHandler};
+#[cfg(feature = "sqs")]
+use tokio::task::JoinSet;
 use tokio::{signal, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -30,6 +34,11 @@ static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemall
 const HEALTHY_PULL_RUNTIME_RESET: std::time::Duration = std::time::Duration::from_millis(50);
 #[cfg(not(test))]
 const HEALTHY_PULL_RUNTIME_RESET: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(feature = "sqs")]
+const SQS_RECEIVE_ERROR_INITIAL_BACKOFF: std::time::Duration =
+    std::time::Duration::from_millis(250);
+#[cfg(feature = "sqs")]
+const SQS_RECEIVE_ERROR_MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(10);
 
 fn next_pull_error_backoff(
     attempts: &mut u32,
@@ -232,6 +241,14 @@ fn local_socket_subscription_specs() -> Vec<ResolvedPullSubscriptionSpec> {
         .collect()
 }
 
+fn sqs_subscription_specs() -> Vec<ResolvedPullSubscriptionSpec> {
+    vec![ResolvedPullSubscriptionSpec {
+        topic_name: "talon-sqs-worker-queue".to_string(),
+        subscription_name: "talon-sqs-worker".to_string(),
+        event_type: "sqs_worker_queue".to_string(),
+    }]
+}
+
 fn message_broker_driver(config: &Config) -> Option<&str> {
     config
         .control_plane
@@ -281,6 +298,11 @@ struct LocalSocketPullSubscriptionBackend {
     subscription_name: String,
 }
 
+#[cfg(feature = "sqs")]
+struct SqsPullSubscriptionBackend {
+    publisher: SqsMessagePublisher,
+}
+
 impl GcpPullSubscriptionBackend {
     async fn new(
         project_id: String,
@@ -311,6 +333,15 @@ impl LocalSocketPullSubscriptionBackend {
             subscriber: publisher.subscriber(),
             topic_name,
             subscription_name,
+        })
+    }
+}
+
+#[cfg(feature = "sqs")]
+impl SqsPullSubscriptionBackend {
+    async fn new(_topic_name: String, _subscription_name: String) -> Result<Self> {
+        Ok(Self {
+            publisher: SqsMessagePublisher::from_env().await?,
         })
     }
 }
@@ -439,6 +470,270 @@ impl PullSubscriptionBackend for LocalSocketPullSubscriptionBackend {
             .await;
         Ok(())
     }
+}
+
+#[cfg(feature = "sqs")]
+#[async_trait::async_trait]
+impl PullSubscriptionBackend for SqsPullSubscriptionBackend {
+    async fn ensure_topic(&self) -> Result<()> {
+        self.publisher.queue_url().await?;
+        Ok(())
+    }
+
+    async fn ensure_subscription(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn receive(
+        &self,
+        handler: WorkerEventHandler,
+        _event_type: String,
+        cancellation_token: CancellationToken,
+    ) -> Result<()> {
+        use base64::{engine::general_purpose, Engine as _};
+
+        let client = self.publisher.client();
+        let queue_url = self.publisher.queue_url().await?;
+        let wait_time_seconds = self.publisher.wait_time_seconds();
+        let visibility_timeout_seconds = self.publisher.visibility_timeout_seconds();
+        let concurrency = session_dispatch_concurrency(|name| std::env::var(name).ok());
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
+        let mut in_flight = JoinSet::new();
+        let mut receive_error_backoff = SQS_RECEIVE_ERROR_INITIAL_BACKOFF;
+
+        tracing::info!(concurrency, "Starting SQS pull dispatch");
+        loop {
+            tokio::select! {
+                Some(result) = in_flight.join_next(), if !in_flight.is_empty() => {
+                    if let Err(err) = result {
+                        tracing::warn!(error = %err, "SQS pull dispatch task failed");
+                    }
+                }
+                _ = cancellation_token.cancelled() => break,
+                permit = semaphore.clone().acquire_owned() => {
+                    let permit = permit?;
+                    let receive = client
+                        .receive_message()
+                        .queue_url(&queue_url)
+                        .max_number_of_messages(1)
+                        .message_attribute_names(TALON_TOPIC_ATTRIBUTE)
+                        .wait_time_seconds(wait_time_seconds)
+                        .visibility_timeout(visibility_timeout_seconds)
+                        .send();
+                    let response = tokio::select! {
+                        _ = cancellation_token.cancelled() => {
+                            drop(permit);
+                            break;
+                        }
+                        response = receive => match response {
+                            Ok(response) => {
+                                receive_error_backoff = SQS_RECEIVE_ERROR_INITIAL_BACKOFF;
+                                response
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    backoff_ms = receive_error_backoff.as_millis(),
+                                    error = %err,
+                                    "SQS receive_message failed; backing off before retry"
+                                );
+                                drop(permit);
+                                tokio::select! {
+                                    _ = cancellation_token.cancelled() => break,
+                                    _ = tokio::time::sleep(receive_error_backoff) => {}
+                                }
+                                receive_error_backoff = (receive_error_backoff * 2).min(SQS_RECEIVE_ERROR_MAX_BACKOFF);
+                                continue;
+                            }
+                        }
+                    };
+                    let Some(message) = response.messages().first().cloned() else {
+                        drop(permit);
+                        continue;
+                    };
+                    let Some(receipt_handle) = message.receipt_handle().map(str::to_string) else {
+                        drop(permit);
+                        continue;
+                    };
+                    let topic_name = match sqs_message_topic(&message) {
+                        Some(topic_name) => topic_name,
+                        None => {
+                            tracing::warn!(
+                                attribute = TALON_TOPIC_ATTRIBUTE,
+                                "SQS pull message missing Talon topic attribute; deleting malformed message"
+                            );
+                            let _ = client
+                                .delete_message()
+                                .queue_url(&queue_url)
+                                .receipt_handle(receipt_handle)
+                                .send()
+                                .await;
+                            drop(permit);
+                            continue;
+                        }
+                    };
+                    let Some(event_type) =
+                        WorkerEventHandler::event_type_for_subscription(&topic_name)
+                            .map(str::to_string)
+                    else {
+                        tracing::warn!(
+                            topic = %topic_name,
+                            "SQS pull message targets unsupported Talon topic; deleting message"
+                        );
+                        let _ = client
+                            .delete_message()
+                            .queue_url(&queue_url)
+                            .receipt_handle(receipt_handle)
+                            .send()
+                            .await;
+                        drop(permit);
+                        continue;
+                    };
+                    let body = match message.body() {
+                        Some(body) => body,
+                        None => {
+                            let _ = client
+                                .delete_message()
+                                .queue_url(&queue_url)
+                                .receipt_handle(receipt_handle)
+                                .send()
+                                .await;
+                            drop(permit);
+                            continue;
+                        }
+                    };
+                    let payload = match general_purpose::STANDARD.decode(body) {
+                        Ok(payload) => payload,
+                        Err(err) => {
+                            tracing::warn!(event_type = %event_type, topic = %topic_name, error = %err, "SQS pull message body was not a Talon base64 payload");
+                            let _ = client
+                                .delete_message()
+                                .queue_url(&queue_url)
+                                .receipt_handle(receipt_handle)
+                                .send()
+                                .await;
+                            drop(permit);
+                            continue;
+                        }
+                    };
+                    let handler = handler.clone();
+                    let client = client.clone();
+                    let queue_url = queue_url.clone();
+                    let event_type = event_type.clone();
+                    let cancellation_token = cancellation_token.clone();
+                    in_flight.spawn(async move {
+                        let _permit = permit;
+                        let ack_receipt_handle = receipt_handle.clone();
+                        let heartbeat_receipt_handle = receipt_handle.clone();
+                        let nack_receipt_handle = receipt_handle;
+                        let heartbeat = (visibility_timeout_seconds > 0).then(|| {
+                            spawn_sqs_visibility_heartbeat(
+                                client.clone(),
+                                queue_url.clone(),
+                                heartbeat_receipt_handle,
+                                visibility_timeout_seconds,
+                                event_type.clone(),
+                            )
+                        });
+                        let stop_heartbeat_for_ack =
+                            heartbeat.as_ref().map(|(stop, _)| stop.clone());
+                        let stop_heartbeat_for_nack =
+                            heartbeat.as_ref().map(|(stop, _)| stop.clone());
+                        handle_pull_message(
+                            &event_type,
+                            &cancellation_token,
+                            &cancellation_token,
+                            || handler.dispatch(Some(&event_type), &payload),
+                            || async {
+                                if let Some(stop_heartbeat) = stop_heartbeat_for_ack {
+                                    stop_heartbeat.cancel();
+                                }
+                                client
+                                    .delete_message()
+                                    .queue_url(&queue_url)
+                                    .receipt_handle(ack_receipt_handle)
+                                    .send()
+                                    .await
+                                    .map(|_| ())
+                            },
+                            || async {
+                                if let Some(stop_heartbeat) = stop_heartbeat_for_nack {
+                                    stop_heartbeat.cancel();
+                                }
+                                client
+                                    .change_message_visibility()
+                                    .queue_url(&queue_url)
+                                    .receipt_handle(nack_receipt_handle)
+                                    .visibility_timeout(0)
+                                    .send()
+                                    .await
+                                    .map(|_| ())
+                            },
+                        )
+                        .await;
+                        if let Some((stop_heartbeat, heartbeat)) = heartbeat {
+                            stop_heartbeat.cancel();
+                            let _ = heartbeat.await;
+                        }
+                    });
+                }
+            }
+        }
+
+        tracing::info!(
+            in_flight = in_flight.len(),
+            "SQS pull dispatch shutting down; waiting for in-flight messages"
+        );
+        while let Some(result) = in_flight.join_next().await {
+            if let Err(err) = result {
+                tracing::warn!(error = %err, "SQS pull dispatch task failed during shutdown");
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "sqs")]
+fn sqs_message_topic(message: &aws_sdk_sqs::types::Message) -> Option<String> {
+    message
+        .message_attributes()
+        .and_then(|attributes| attributes.get(TALON_TOPIC_ATTRIBUTE))
+        .and_then(|attribute| attribute.string_value())
+        .map(str::to_string)
+}
+
+#[cfg(feature = "sqs")]
+fn spawn_sqs_visibility_heartbeat(
+    client: aws_sdk_sqs::Client,
+    queue_url: String,
+    receipt_handle: String,
+    visibility_timeout_seconds: i32,
+    event_type: String,
+) -> (CancellationToken, JoinHandle<()>) {
+    let stop_token = CancellationToken::new();
+    let task_stop_token = stop_token.clone();
+    let interval = std::time::Duration::from_secs((visibility_timeout_seconds as u64 / 2).max(1));
+    let task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = task_stop_token.cancelled() => break,
+                _ = tokio::time::sleep(interval) => {}
+            }
+            if task_stop_token.is_cancelled() {
+                break;
+            }
+            if let Err(err) = client
+                .change_message_visibility()
+                .queue_url(&queue_url)
+                .receipt_handle(&receipt_handle)
+                .visibility_timeout(visibility_timeout_seconds)
+                .send()
+                .await
+            {
+                tracing::warn!(event_type = %event_type, error = %err, "failed to extend SQS message visibility");
+            }
+        }
+    });
+    (stop_token, task)
 }
 
 async fn run_pull_subscription_with_backend(
@@ -572,10 +867,9 @@ fn spawn_pull_subscription_task(
             subscription_name: subscription_name.clone(),
             event_type,
         };
-        let use_local_socket = matches!(
-            message_broker_driver(pull_handler.config.as_ref()),
-            Some("local_socket")
-        );
+        let broker_driver = message_broker_driver(pull_handler.config.as_ref())
+            .unwrap_or("gcp_pubsub")
+            .to_string();
         let config = pull_handler.config.clone();
         run_pull_subscription_loop(
             || {
@@ -583,32 +877,44 @@ fn spawn_pull_subscription_task(
                 let topic_name = topic_name.clone();
                 let subscription_name = subscription_name.clone();
                 let config = config.clone();
+                let broker_driver = broker_driver.clone();
                 async move {
-                    if use_local_socket {
-                        let default_root = config
-                            .control_plane
-                            .as_ref()
-                            .and_then(|cp| cp.database.as_ref())
-                            .filter(|db| db.driver == "sqlite" && !db.data_dir.trim().is_empty())
-                            .map(|db| PathBuf::from(db.data_dir.trim()));
-                        let socket_path = configured_local_socket_path(default_root.as_deref());
-                        Ok::<Box<dyn PullSubscriptionBackend>, anyhow::Error>(Box::new(
-                            LocalSocketPullSubscriptionBackend::new(
-                                socket_path,
-                                topic_name,
-                                subscription_name,
-                            )
-                            .await?,
-                        ))
-                    } else {
-                        Ok::<Box<dyn PullSubscriptionBackend>, anyhow::Error>(Box::new(
+                    match broker_driver.as_str() {
+                        "local_socket" => {
+                            let default_root = config
+                                .control_plane
+                                .as_ref()
+                                .and_then(|cp| cp.database.as_ref())
+                                .filter(|db| {
+                                    db.driver == "sqlite" && !db.data_dir.trim().is_empty()
+                                })
+                                .map(|db| PathBuf::from(db.data_dir.trim()));
+                            let socket_path = configured_local_socket_path(default_root.as_deref());
+                            Ok::<Box<dyn PullSubscriptionBackend>, anyhow::Error>(Box::new(
+                                LocalSocketPullSubscriptionBackend::new(
+                                    socket_path,
+                                    topic_name,
+                                    subscription_name,
+                                )
+                                .await?,
+                            ))
+                        }
+                        #[cfg(feature = "sqs")]
+                        "sqs" => Ok::<Box<dyn PullSubscriptionBackend>, anyhow::Error>(Box::new(
+                            SqsPullSubscriptionBackend::new(topic_name, subscription_name).await?,
+                        )),
+                        #[cfg(not(feature = "sqs"))]
+                        "sqs" => Err(anyhow::anyhow!(
+                            "SQS pull subscriptions are not enabled in this build"
+                        )),
+                        _ => Ok::<Box<dyn PullSubscriptionBackend>, anyhow::Error>(Box::new(
                             GcpPullSubscriptionBackend::new(
                                 project_id,
                                 topic_name,
                                 subscription_name,
                             )
                             .await?,
-                        ))
+                        )),
                     }
                 }
             },
@@ -647,6 +953,7 @@ where
         message_broker_driver(handler.config.as_ref()),
         Some("cf_queues")
     );
+    let use_sqs = matches!(message_broker_driver(handler.config.as_ref()), Some("sqs"));
     if use_cf_queues {
         tracing::info!(
             transport = "cf_queues",
@@ -657,17 +964,21 @@ where
     tracing::info!(
         transport = if use_local_socket {
             "local_socket"
+        } else if use_sqs {
+            "sqs"
         } else {
             "gcp_pubsub"
         },
         "Starting worker background subscriptions"
     );
-    let mut tasks = Vec::new();
-    let specs = if use_local_socket {
+    let specs = if use_sqs {
+        sqs_subscription_specs()
+    } else if use_local_socket {
         local_socket_subscription_specs()
     } else {
         resolved_pull_subscription_specs(&project_id)
     };
+    let mut tasks = Vec::new();
     for spec in specs {
         tasks.push(spawn(
             handler.clone(),
@@ -1407,6 +1718,52 @@ mod tests {
         assert_eq!(spawned[0].2, "talon-session-dispatch-sub");
         assert_eq!(spawned[4].1, topics::INDEX_EVENTS_TOPIC);
         assert_eq!(spawned[4].2, "talon-index-events-sub");
+    }
+
+    #[tokio::test]
+    async fn maybe_spawn_pull_subscriptions_uses_sqs_specs_when_configured() {
+        let mut config = Config::default();
+        config.control_plane = Some(talon::control::config::proto::ControlPlaneConfig {
+            database: Some(talon::control::config::proto::DatabaseConfig {
+                data_dir: String::new(),
+                driver: "dynamodb".to_string(),
+                url: None,
+            }),
+            message_broker: Some(talon::control::config::proto::MessageBrokerConfig {
+                driver: "sqs".to_string(),
+            }),
+            scheduler: None,
+            object_store: None,
+            documents: None,
+        });
+        let handler = WorkerEventHandler {
+            cp: Arc::new(ControlPlane::noop()),
+            config: Arc::new(config),
+            mcp_registry: Arc::new(McpRegistry::new()),
+            scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),
+            session_cancellations: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let spawned = std::sync::Mutex::new(Vec::<(String, String, String)>::new());
+
+        maybe_spawn_pull_subscriptions(
+            handler,
+            true,
+            "demo".to_string(),
+            CancellationToken::new(),
+            |_h, project_id, spec, _shutdown_token| {
+                spawned.lock().expect("spawned lock poisoned").push((
+                    project_id,
+                    spec.topic_name,
+                    spec.subscription_name,
+                ));
+                tokio::spawn(async {})
+            },
+        );
+        let spawned = spawned.lock().expect("spawned lock poisoned");
+        assert_eq!(spawned.len(), 1);
+        assert_eq!(spawned[0].0, "demo");
+        assert_eq!(spawned[0].1, "talon-sqs-worker-queue");
+        assert_eq!(spawned[0].2, "talon-sqs-worker");
     }
 
     #[tokio::test]

--- a/src/control/kv/dynamodb.rs
+++ b/src/control/kv/dynamodb.rs
@@ -1,0 +1,416 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use crate::control::{
+    keys::{ResourceKey, ResourceList},
+    KeyValueStore,
+};
+use anyhow::{anyhow, Result};
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_dynamodb::{config::Credentials, primitives::Blob, types::AttributeValue, Client};
+use std::collections::HashMap;
+
+// DynamoDB table keys. `PK` encodes the Talon namespace/resource parent, while
+// `SK` encodes the direct child's kind/name. Together they are enough to
+// reconstruct the ResourceKey returned by list operations.
+const PK_ATTR: &str = "PK";
+const SK_ATTR: &str = "SK";
+
+// Serialized protobuf payload for the resource.
+const VALUE_ATTR: &str = "Value";
+
+#[derive(Clone)]
+pub struct DynamoDbKvStore {
+    client: Client,
+    table: String,
+}
+
+impl DynamoDbKvStore {
+    pub fn new(client: Client, table: impl Into<String>) -> Self {
+        Self {
+            client,
+            table: table.into(),
+        }
+    }
+
+    pub async fn from_env(table: impl Into<String>) -> Result<Self> {
+        let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(RegionProviderChain::default_provider().or_else("us-east-1"));
+        if let Ok(endpoint_url) = std::env::var("TALON_DYNAMODB_ENDPOINT_URL") {
+            if !endpoint_url.trim().is_empty() {
+                loader = loader
+                    .credentials_provider(Credentials::new("fake", "fake", None, None, "local"))
+                    .endpoint_url(endpoint_url);
+            }
+        }
+        let config = loader.load().await;
+        Ok(Self::new(Client::new(&config), table))
+    }
+
+    fn key_item(&self, key: &ResourceKey) -> HashMap<String, AttributeValue> {
+        HashMap::from([
+            (PK_ATTR.to_string(), AttributeValue::S(pk_for_key(key))),
+            (SK_ATTR.to_string(), AttributeValue::S(sk_for_key(key))),
+        ])
+    }
+
+    fn put_item(&self, key: &ResourceKey, value: &[u8]) -> HashMap<String, AttributeValue> {
+        let mut item = self.key_item(key);
+        item.insert(
+            VALUE_ATTR.to_string(),
+            AttributeValue::B(Blob::new(value.to_vec())),
+        );
+        item
+    }
+
+    async fn query_list(
+        &self,
+        list: &ResourceList,
+        before_name: Option<&str>,
+        limit: Option<usize>,
+        include_values: bool,
+    ) -> Result<Vec<(ResourceKey, Option<Vec<u8>>)>> {
+        if limit == Some(0) {
+            return Ok(Vec::new());
+        }
+
+        let pk = pk_for_list(list);
+        let mut names = HashMap::from([("#pk".to_string(), PK_ATTR.to_string())]);
+        let mut values = HashMap::from([(":pk".to_string(), AttributeValue::S(pk))]);
+        let mut key_condition = "#pk = :pk".to_string();
+        if let Some(kind) = list.kind.as_deref() {
+            names.insert("#sk".to_string(), SK_ATTR.to_string());
+            values.insert(
+                ":sk_prefix".to_string(),
+                AttributeValue::S(sk_prefix_for_kind(kind)),
+            );
+            key_condition = "#pk = :pk AND begins_with(#sk, :sk_prefix)".to_string();
+        }
+        let descending_page = before_name.is_some() || limit.is_some();
+
+        if let (Some(kind), Some(before_name)) = (list.kind.as_deref(), before_name) {
+            key_condition = "#pk = :pk AND #sk BETWEEN :sk_prefix AND :before_sk".to_string();
+            values.insert(
+                ":before_sk".to_string(),
+                AttributeValue::S(sk_for_kind_name(kind, before_name)),
+            );
+        } else if before_name.is_some() {
+            return Err(anyhow!(
+                "dynamodb list pagination requires a resource kind when before_name is set"
+            ));
+        }
+
+        let mut start_key = None;
+        let mut rows = Vec::new();
+        loop {
+            let remaining_limit = limit
+                .and_then(|limit| limit.checked_sub(rows.len()))
+                .unwrap_or(usize::MAX);
+            if remaining_limit == 0 {
+                break;
+            }
+
+            let page_limit = if limit.is_some() {
+                Some(i32::try_from(remaining_limit.min(1000))?)
+            } else {
+                None
+            };
+            let mut request = self
+                .client
+                .query()
+                .table_name(&self.table)
+                .consistent_read(true)
+                .scan_index_forward(!descending_page)
+                .key_condition_expression(key_condition.clone())
+                .set_expression_attribute_names(Some(names.clone()))
+                .set_expression_attribute_values(Some(values.clone()))
+                .set_exclusive_start_key(start_key);
+            if let Some(page_limit) = page_limit {
+                request = request.limit(page_limit);
+            }
+
+            let output = request.send().await?;
+            for item in output.items() {
+                let key = key_from_item(item)?;
+                if before_name.is_some_and(|before| key.name.as_str() >= before) {
+                    continue;
+                }
+                let value = if include_values {
+                    Some(value_from_item(item)?)
+                } else {
+                    None
+                };
+                rows.push((key, value));
+                if limit.is_some_and(|limit| rows.len() >= limit) {
+                    return Ok(rows);
+                }
+            }
+
+            start_key = output.last_evaluated_key().cloned();
+            if start_key.is_none() {
+                break;
+            }
+        }
+
+        Ok(rows)
+    }
+}
+
+#[async_trait::async_trait]
+impl KeyValueStore for DynamoDbKvStore {
+    async fn get(&self, key: &ResourceKey) -> Result<Option<Vec<u8>>> {
+        let output = self
+            .client
+            .get_item()
+            .table_name(&self.table)
+            .set_key(Some(self.key_item(key)))
+            .consistent_read(true)
+            .send()
+            .await?;
+        output.item().map(value_from_item).transpose()
+    }
+
+    async fn set(&self, key: &ResourceKey, value: &[u8]) -> Result<()> {
+        self.client
+            .put_item()
+            .table_name(&self.table)
+            .set_item(Some(self.put_item(key, value)))
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &ResourceKey,
+        expected: Option<&[u8]>,
+        value: &[u8],
+    ) -> Result<bool> {
+        let mut names = HashMap::new();
+        let mut values = HashMap::new();
+        let condition = if let Some(expected) = expected {
+            names.insert("#value".to_string(), VALUE_ATTR.to_string());
+            values.insert(
+                ":expected".to_string(),
+                AttributeValue::B(Blob::new(expected.to_vec())),
+            );
+            "#value = :expected"
+        } else {
+            names.insert("#pk".to_string(), PK_ATTR.to_string());
+            "attribute_not_exists(#pk)"
+        };
+
+        let result = self
+            .client
+            .put_item()
+            .table_name(&self.table)
+            .set_item(Some(self.put_item(key, value)))
+            .condition_expression(condition)
+            .set_expression_attribute_names(Some(names))
+            .set_expression_attribute_values((!values.is_empty()).then_some(values))
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(true),
+            Err(err)
+                if err
+                    .as_service_error()
+                    .is_some_and(|err| err.is_conditional_check_failed_exception()) =>
+            {
+                Ok(false)
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    async fn delete(&self, key: &ResourceKey) -> Result<()> {
+        self.client
+            .delete_item()
+            .table_name(&self.table)
+            .set_key(Some(self.key_item(key)))
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    async fn list_keys(&self, list: &ResourceList) -> Result<Vec<ResourceKey>> {
+        self.query_list(list, None, None, false)
+            .await
+            .map(|rows| rows.into_iter().map(|(key, _)| key).collect())
+    }
+
+    async fn list_entries(&self, list: &ResourceList) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        self.query_list(list, None, None, true).await.map(|rows| {
+            rows.into_iter()
+                .filter_map(|(key, value)| value.map(|value| (key, value)))
+                .collect()
+        })
+    }
+
+    async fn list_keys_page(
+        &self,
+        list: &ResourceList,
+        before_name: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<ResourceKey>> {
+        let _ = list
+            .kind
+            .as_ref()
+            .ok_or_else(|| anyhow!("dynamodb list_keys_page requires a resource kind"))?;
+        self.query_list(list, before_name, Some(limit), false)
+            .await
+            .map(|rows| rows.into_iter().map(|(key, _)| key).collect())
+    }
+
+    async fn list_entries_page(
+        &self,
+        list: &ResourceList,
+        before_name: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let _ = list
+            .kind
+            .as_ref()
+            .ok_or_else(|| anyhow!("dynamodb list_entries_page requires a resource kind"))?;
+        self.query_list(list, before_name, Some(limit), true)
+            .await
+            .map(|rows| {
+                rows.into_iter()
+                    .filter_map(|(key, value)| value.map(|value| (key, value)))
+                    .collect()
+            })
+    }
+}
+
+fn pk_for_key(key: &ResourceKey) -> String {
+    pk_for_parent(&key.namespace, &key.parent_path)
+}
+
+fn pk_for_list(list: &ResourceList) -> String {
+    pk_for_parent(&list.parent.namespace, &list.parent.parent_path)
+}
+
+fn pk_for_parent(namespace: &str, parent_path: &str) -> String {
+    format!(
+        "Namespace/{}/Resource/{}",
+        encode_part(namespace),
+        parent_path
+    )
+}
+
+fn sk_for_key(key: &ResourceKey) -> String {
+    sk_for_kind_name(&key.kind, &key.name)
+}
+
+fn sk_for_kind_name(kind: &str, name: &str) -> String {
+    format!("{kind}/{name}")
+}
+
+fn sk_prefix_for_kind(kind: &str) -> String {
+    format!("{kind}/")
+}
+
+fn encode_part(value: &str) -> String {
+    urlencoding::encode(value).into_owned()
+}
+
+fn key_from_item(item: &HashMap<String, AttributeValue>) -> Result<ResourceKey> {
+    let pk = string_attr(item, PK_ATTR)?;
+    let sk = string_attr(item, SK_ATTR)?;
+    resource_key_from_pk_sk(pk, sk)
+}
+
+fn resource_key_from_pk_sk(pk: &str, sk: &str) -> Result<ResourceKey> {
+    let rest = pk
+        .strip_prefix("Namespace/")
+        .ok_or_else(|| anyhow!("DynamoDB PK does not start with Namespace/: {pk}"))?;
+    let (namespace, parent_path) = rest
+        .split_once("/Resource/")
+        .ok_or_else(|| anyhow!("DynamoDB PK is missing /Resource/ separator: {pk}"))?;
+    let (kind, name) = sk
+        .split_once('/')
+        .ok_or_else(|| anyhow!("DynamoDB SK must contain kind/name: {sk}"))?;
+    Ok(ResourceKey {
+        namespace: decode_part(namespace)?,
+        parent_path: parent_path.to_string(),
+        kind: kind.to_string(),
+        name: name.to_string(),
+    })
+}
+
+fn string_attr<'a>(item: &'a HashMap<String, AttributeValue>, attr: &str) -> Result<&'a str> {
+    item.get(attr)
+        .ok_or_else(|| anyhow!("DynamoDB item missing {attr} attribute"))?
+        .as_s()
+        .map(String::as_str)
+        .map_err(|_| anyhow!("DynamoDB item attribute {attr} was not a string"))
+}
+
+fn value_from_item(item: &HashMap<String, AttributeValue>) -> Result<Vec<u8>> {
+    Ok(item
+        .get(VALUE_ATTR)
+        .ok_or_else(|| anyhow!("DynamoDB item missing {VALUE_ATTR} attribute"))?
+        .as_b()
+        .map_err(|_| anyhow!("DynamoDB item attribute {VALUE_ATTR} was not binary"))?
+        .as_ref()
+        .to_vec())
+}
+
+fn decode_part(value: &str) -> Result<String> {
+    urlencoding::decode(value)
+        .map(|value| value.into_owned())
+        .map_err(|err| anyhow!("failed to decode DynamoDB key segment '{value}': {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_keys_project_resource_parent_into_partition_key() {
+        let key = crate::control::keys::session("acme:team", "agent-1", "session-1");
+
+        assert_eq!(
+            pk_for_key(&key),
+            "Namespace/acme%3Ateam/Resource/Agent/agent-1"
+        );
+        assert_eq!(sk_for_key(&key), "Session/session-1");
+    }
+
+    #[test]
+    fn journal_keys_group_under_submission_parent() {
+        let key = crate::control::keys::session_journal_entry(
+            "acme:team",
+            "agent-1",
+            "session-1",
+            "submission-1",
+            "000001",
+        );
+
+        assert_eq!(
+            pk_for_key(&key),
+            "Namespace/acme%3Ateam/Resource/Agent/agent-1/Session/session-1/SessionSubmission/submission-1"
+        );
+        assert_eq!(sk_for_key(&key), "SessionJournalEntry/000001");
+    }
+
+    #[test]
+    fn sort_keys_preserve_raw_resource_name_order() {
+        let dash = sk_for_kind_name("Thing", "-");
+        let colon = sk_for_kind_name("Thing", ":");
+
+        assert!(dash < colon);
+        assert_eq!(colon, "Thing/:");
+    }
+
+    #[test]
+    fn resource_key_round_trips_through_pk_and_sk() {
+        let key = crate::control::keys::session("acme:team", "agent-1", "session-1");
+
+        assert_eq!(
+            resource_key_from_pk_sk(&pk_for_key(&key), &sk_for_key(&key)).unwrap(),
+            key
+        );
+    }
+}

--- a/src/control/kv/mod.rs
+++ b/src/control/kv/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 mod d1;
+#[cfg(feature = "dynamodb")]
+mod dynamodb;
 mod legacy;
 mod postgres;
 #[cfg(feature = "rocksdb")]
@@ -11,6 +13,8 @@ mod sqlite;
 mod sqlite_sql;
 
 pub use d1::D1KvStore;
+#[cfg(feature = "dynamodb")]
+pub use dynamodb::DynamoDbKvStore;
 pub use postgres::PostgresKvStore;
 #[cfg(feature = "rocksdb")]
 pub use rocksdb::RocksDbKvStore;

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -356,10 +356,11 @@ fn message_broker_config(
         .message_broker
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("control_plane.message_broker configuration is missing"))?;
-    if mb_config.driver != "gcp_pubsub"
-        && mb_config.driver != "local_socket"
-        && mb_config.driver != "cf_queues"
-    {
+    let supported = mb_config.driver == "gcp_pubsub"
+        || mb_config.driver == "local_socket"
+        || mb_config.driver == "cf_queues"
+        || mb_config.driver == "sqs";
+    if !supported {
         return Err(anyhow::anyhow!(
             "Unsupported message broker driver: {}",
             mb_config.driver
@@ -407,6 +408,20 @@ pub async fn build_control_plane(
             kv_store.init().await?;
             kv = Arc::new(kv_store);
             scheduler_database_url = None;
+        }
+        #[cfg(feature = "dynamodb")]
+        "dynamodb" => {
+            let table = dynamodb_table_name(db_config).await?;
+            println!("Connecting to DynamoDbKvStore table {}...", table);
+            let store = kv::DynamoDbKvStore::from_env(table).await?;
+            kv = Arc::new(store);
+            scheduler_database_url = None;
+        }
+        #[cfg(not(feature = "dynamodb"))]
+        "dynamodb" => {
+            return Err(anyhow::anyhow!(
+                "DynamoDB database driver is not enabled in this build"
+            ));
         }
         #[cfg(feature = "rocksdb")]
         "rocksdb" => {
@@ -457,6 +472,17 @@ pub async fn build_control_plane(
         "cf_queues" => {
             println!("Initializing CfQueuesPublisher...");
             Arc::new(pubsub::CfQueuesPublisher::from_env())
+        }
+        #[cfg(feature = "sqs")]
+        "sqs" => {
+            println!("Initializing SqsMessagePublisher...");
+            Arc::new(pubsub::SqsMessagePublisher::from_env().await?)
+        }
+        #[cfg(not(feature = "sqs"))]
+        "sqs" => {
+            return Err(anyhow::anyhow!(
+                "SQS message broker driver is not enabled in this build"
+            ));
         }
         other => {
             return Err(anyhow::anyhow!(
@@ -639,6 +665,29 @@ async fn configured_document_store(
             other
         )),
     }
+}
+
+#[cfg(feature = "dynamodb")]
+async fn dynamodb_table_name(
+    db_config: &crate::control::config::proto::DatabaseConfig,
+) -> anyhow::Result<String> {
+    use crate::control::config::SecretExt;
+
+    if let Some(url_secret) = db_config.url.as_ref() {
+        let table: String = url_secret.resolve().await?;
+        let table = table
+            .strip_prefix("dynamodb://")
+            .unwrap_or(&table)
+            .trim()
+            .to_string();
+        if !table.is_empty() {
+            return Ok(table);
+        }
+    }
+    Ok(std::env::var("TALON_DYNAMODB_TABLE")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "talon_state".to_string()))
 }
 
 #[cfg(feature = "rocksdb")]

--- a/src/control/pubsub.rs
+++ b/src/control/pubsub.rs
@@ -3,6 +3,8 @@
 
 mod cf_queues;
 mod local_socket;
+#[cfg(feature = "sqs")]
+mod sqs;
 
 use crate::control::MessagePublisher;
 use anyhow::Result;
@@ -19,6 +21,8 @@ use tokio::sync::RwLock;
 
 pub use cf_queues::CfQueuesPublisher;
 pub use local_socket::{LocalSocketMessagePublisher, LocalSocketSubscriber};
+#[cfg(feature = "sqs")]
+pub use sqs::{SqsMessagePublisher, TALON_TOPIC_ATTRIBUTE};
 
 pub struct GcpPubSubPublisher {
     backend: Arc<dyn PubSubBackend>,

--- a/src/control/pubsub/sqs.rs
+++ b/src/control/pubsub/sqs.rs
@@ -1,0 +1,283 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use crate::control::{topics, MessagePublisher};
+use anyhow::{anyhow, Result};
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_sqs::{config::Credentials, types::MessageAttributeValue, Client};
+use base64::{engine::general_purpose, Engine as _};
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub const TALON_TOPIC_ATTRIBUTE: &str = "talon_topic";
+
+// Default SQS queue name for all durable Talon worker-delivered messages.
+const DEFAULT_QUEUE_NAME: &str = "talon";
+// Default long-poll duration for ReceiveMessage; AWS allows 0-20 seconds.
+const DEFAULT_WAIT_TIME_SECONDS: i32 = 10;
+// Default time a received message stays hidden while a worker handles it.
+const DEFAULT_VISIBILITY_TIMEOUT_SECONDS: i32 = 30;
+// AWS SQS maximum ReceiveMessage long-poll duration.
+const MAX_WAIT_TIME_SECONDS: i32 = 20;
+// AWS SQS maximum message visibility timeout, in seconds.
+const MAX_VISIBILITY_TIMEOUT_SECONDS: i32 = 43_200;
+// AWS SQS queue names are capped at 80 characters.
+const QUEUE_NAME_MAX_LEN: usize = 80;
+
+#[derive(Clone)]
+pub struct SqsMessagePublisher {
+    client: Client,
+    queue_name: String,
+    queue_url: Arc<RwLock<Option<String>>>,
+    wait_time_seconds: i32,
+    visibility_timeout_seconds: i32,
+}
+
+impl SqsMessagePublisher {
+    pub async fn from_env() -> Result<Self> {
+        let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(RegionProviderChain::default_provider().or_else("us-east-1"));
+        if let Ok(endpoint_url) = std::env::var("TALON_SQS_ENDPOINT_URL") {
+            if !endpoint_url.trim().is_empty() {
+                loader = loader
+                    .credentials_provider(Credentials::new("fake", "fake", None, None, "local"))
+                    .endpoint_url(endpoint_url);
+            }
+        }
+        let config = loader.load().await;
+        let queue_name = std::env::var("TALON_SQS_QUEUE_NAME")
+            .or_else(|_| std::env::var("TALON_SQS_QUEUE_PREFIX"))
+            .unwrap_or_else(|_| DEFAULT_QUEUE_NAME.into());
+        Ok(Self::new(Client::new(&config), queue_name))
+    }
+
+    pub fn new(client: Client, queue_name: impl Into<String>) -> Self {
+        Self {
+            client,
+            queue_name: queue_name_for_config(queue_name.into()),
+            queue_url: Arc::new(RwLock::new(None)),
+            wait_time_seconds: configured_i32(
+                "TALON_SQS_WAIT_TIME_SECONDS",
+                DEFAULT_WAIT_TIME_SECONDS,
+                0,
+                MAX_WAIT_TIME_SECONDS,
+            ),
+            visibility_timeout_seconds: configured_i32(
+                "TALON_SQS_VISIBILITY_TIMEOUT_SECONDS",
+                DEFAULT_VISIBILITY_TIMEOUT_SECONDS,
+                0,
+                MAX_VISIBILITY_TIMEOUT_SECONDS,
+            ),
+        }
+    }
+
+    pub async fn queue_url(&self) -> Result<String> {
+        {
+            let cached = self.queue_url.read().await;
+            if let Some(queue_url) = cached.as_ref() {
+                return Ok(queue_url.clone());
+            }
+        }
+
+        let queue_url = match self
+            .client
+            .get_queue_url()
+            .queue_name(&self.queue_name)
+            .send()
+            .await
+        {
+            Ok(output) => output
+                .queue_url()
+                .ok_or_else(|| anyhow!("SQS get_queue_url returned no queue URL"))?
+                .to_string(),
+            Err(err)
+                if err
+                    .as_service_error()
+                    .is_some_and(|err| err.is_queue_does_not_exist()) =>
+            {
+                self.create_queue().await?
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        let mut cached = self.queue_url.write().await;
+        Ok(cached.get_or_insert(queue_url).clone())
+    }
+
+    async fn create_queue(&self) -> Result<String> {
+        let output = self
+            .client
+            .create_queue()
+            .queue_name(&self.queue_name)
+            .send()
+            .await?;
+        output
+            .queue_url()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("SQS create_queue returned no queue URL"))
+    }
+}
+
+impl SqsMessagePublisher {
+    pub fn client(&self) -> Client {
+        self.client.clone()
+    }
+
+    pub fn wait_time_seconds(&self) -> i32 {
+        self.wait_time_seconds
+    }
+
+    pub fn visibility_timeout_seconds(&self) -> i32 {
+        self.visibility_timeout_seconds
+    }
+}
+
+#[async_trait::async_trait]
+impl MessagePublisher for SqsMessagePublisher {
+    async fn publish(&self, topic: &str, message: &[u8]) -> Result<()> {
+        if !is_worker_delivered_topic(topic) {
+            return Err(anyhow!(
+                "SQS cannot publish Talon topic {topic}; SQS is a durable worker queue and only supports worker-delivered topics"
+            ));
+        }
+
+        let queue_url = self.queue_url().await?;
+        let body = general_purpose::STANDARD.encode(message);
+        self.client
+            .send_message()
+            .queue_url(queue_url)
+            .message_body(body)
+            .message_attributes(TALON_TOPIC_ATTRIBUTE, string_attribute(topic)?)
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    async fn subscribe(
+        &self,
+        topic: &str,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Vec<u8>> + Send>>> {
+        if is_live_session_stream_topic(topic) {
+            return Err(anyhow!(
+                "SQS cannot subscribe to live Talon session stream topic {topic}; SQS is a durable work queue and does not provide fanout for token deltas"
+            ));
+        }
+        Err(anyhow!(
+            "SQS generic subscriptions are not supported because the MessagePublisher stream API cannot acknowledge messages after handler completion; use Talon worker pull mode for SQS topics"
+        ))
+    }
+}
+
+fn string_attribute(value: &str) -> Result<MessageAttributeValue> {
+    Ok(MessageAttributeValue::builder()
+        .data_type("String")
+        .string_value(value)
+        .build()?)
+}
+
+fn configured_i32(name: &str, default: i32, min: i32, max: i32) -> i32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<i32>().ok())
+        .map(|value| value.clamp(min, max))
+        .unwrap_or(default)
+}
+
+fn queue_name_for_config(value: String) -> String {
+    let name = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .take(QUEUE_NAME_MAX_LEN)
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    if name.is_empty() {
+        DEFAULT_QUEUE_NAME.to_string()
+    } else {
+        name
+    }
+}
+
+fn is_live_session_stream_topic(topic: &str) -> bool {
+    topic
+        .strip_prefix(topics::SESSION_PARTS_TOPIC_PREFIX)
+        .is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+fn is_worker_delivered_topic(topic: &str) -> bool {
+    matches!(
+        topic,
+        topics::SESSION_DISPATCH_TOPIC
+            | topics::RESOURCE_LIFECYCLE_TOPIC
+            | topics::SESSION_CONTROL_TOPIC
+            | topics::WORKFLOW_DISPATCH_TOPIC
+            | topics::INDEX_EVENTS_TOPIC
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        configured_i32, is_live_session_stream_topic, is_worker_delivered_topic,
+        queue_name_for_config,
+    };
+
+    #[test]
+    fn queue_names_are_sqs_safe_and_stable() {
+        let name = queue_name_for_config("talon-dev".to_string());
+
+        assert_eq!(name, queue_name_for_config("talon-dev".to_string()));
+        assert!(name.len() <= 80);
+        assert!(name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_'));
+    }
+
+    #[test]
+    fn queue_names_truncate_to_sqs_limit() {
+        let name = queue_name_for_config(
+            "tenant-queue-name-that-is-far-too-long-for-an-sqs-queue-name-and-must-be-truncated"
+                .to_string(),
+        );
+
+        assert!(name.len() <= 80, "{name}");
+        assert!(name.starts_with("tenant-queue"));
+    }
+
+    #[test]
+    fn configured_i32_clamps_to_aws_bounds() {
+        let name = "TALON_TEST_SQS_CONFIGURED_I32";
+        std::env::set_var(name, "999");
+        assert_eq!(configured_i32(name, 10, 0, 20), 20);
+
+        std::env::set_var(name, "-10");
+        assert_eq!(configured_i32(name, 10, 0, 20), 0);
+
+        std::env::set_var(name, "not-an-int");
+        assert_eq!(configured_i32(name, 10, 0, 20), 10);
+
+        std::env::remove_var(name);
+    }
+
+    #[test]
+    fn live_session_stream_topics_are_not_sqs_subscribable() {
+        assert!(is_live_session_stream_topic("talon.session.parts.7"));
+        assert!(!is_live_session_stream_topic("talon.session.dispatch"));
+        assert!(!is_live_session_stream_topic("talon.session.parts-extra"));
+    }
+
+    #[test]
+    fn only_worker_delivered_topics_are_sqs_publishable() {
+        assert!(is_worker_delivered_topic("talon.session.dispatch"));
+        assert!(is_worker_delivered_topic("talon.workflow.dispatch"));
+        assert!(!is_worker_delivered_topic("talon.session.parts.7"));
+        assert!(!is_worker_delivered_topic("talon.channel.events.acme.main"));
+    }
+}

--- a/tests/aws_local_e2e.rs
+++ b/tests/aws_local_e2e.rs
@@ -1,0 +1,251 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#![cfg(feature = "aws-local-e2e")]
+
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_dynamodb::config::Credentials as DynamoDbCredentials;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
+};
+use aws_sdk_dynamodb::Client as DynamoDbClient;
+use base64::{engine::general_purpose, Engine as _};
+use talon::control::{
+    keys,
+    kv::DynamoDbKvStore,
+    pubsub::{SqsMessagePublisher, TALON_TOPIC_ATTRIBUTE},
+    KeyValueStore, MessagePublisher,
+};
+use testcontainers_modules::{
+    dynamodb_local::DynamoDb,
+    localstack::LocalStack,
+    testcontainers::{runners::AsyncRunner, ImageExt},
+};
+
+#[tokio::test]
+#[ignore = "requires Docker and pulls amazon/dynamodb-local"]
+async fn dynamodb_state_store_round_trips_and_compares() -> anyhow::Result<()> {
+    let _env = env_lock().lock().expect("env lock poisoned");
+    let node = DynamoDb::default().start().await?;
+    let endpoint = endpoint_for(&node, 8000).await?;
+    let client = dynamodb_local_client(&endpoint).await;
+    ensure_dynamodb_table(client.clone(), "talon_state_e2e").await?;
+    let store = DynamoDbKvStore::new(client, "talon_state_e2e");
+
+    let key = keys::session("acme:team", "agent-1", "session-1");
+    assert!(store.compare_and_swap(&key, None, b"one").await?);
+    assert_eq!(store.get(&key).await?.as_deref(), Some(&b"one"[..]));
+    assert!(!store.compare_and_swap(&key, None, b"two").await?);
+    assert!(!store.compare_and_swap(&key, Some(b"wrong"), b"two").await?);
+    assert!(store.compare_and_swap(&key, Some(b"one"), b"two").await?);
+    assert_eq!(store.get(&key).await?.as_deref(), Some(&b"two"[..]));
+
+    let keys = store
+        .list_keys(&keys::session_prefix("acme:team", "agent-1"))
+        .await?;
+    assert_eq!(keys, vec![key]);
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires Docker and pulls localstack/localstack"]
+async fn sqs_pubsub_delivers_published_message() -> anyhow::Result<()> {
+    let _env = env_lock().lock().expect("env lock poisoned");
+    let node = LocalStack::default()
+        .with_env_var("SERVICES", "sqs")
+        .start()
+        .await?;
+    let endpoint = endpoint_for(&node, 4566).await?;
+    let _endpoint = EnvGuard::set("TALON_SQS_ENDPOINT_URL", &endpoint);
+    let _queue = EnvGuard::set("TALON_SQS_QUEUE_NAME", "talon-e2e");
+    let publisher = SqsMessagePublisher::from_env().await?;
+    let queue_url = publisher.queue_url().await?;
+
+    publisher
+        .publish("talon.session.dispatch", b"dispatch-payload")
+        .await?;
+    let response = tokio::time::timeout(
+        Duration::from_secs(20),
+        publisher
+            .client()
+            .receive_message()
+            .queue_url(&queue_url)
+            .max_number_of_messages(1)
+            .message_attribute_names(TALON_TOPIC_ATTRIBUTE)
+            .wait_time_seconds(10)
+            .send(),
+    )
+    .await??;
+
+    let message = response
+        .messages()
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("SQS did not deliver the published test message"))?;
+    let body = message
+        .body()
+        .ok_or_else(|| anyhow::anyhow!("SQS delivered a message without a body"))?;
+    let topic = message
+        .message_attributes()
+        .and_then(|attributes| attributes.get(TALON_TOPIC_ATTRIBUTE))
+        .and_then(|attribute| attribute.string_value())
+        .ok_or_else(|| anyhow::anyhow!("SQS delivered a message without Talon topic metadata"))?;
+    assert_eq!(topic, "talon.session.dispatch");
+    let delivered = general_purpose::STANDARD.decode(body)?;
+    assert_eq!(delivered, b"dispatch-payload");
+
+    if let Some(receipt_handle) = message.receipt_handle() {
+        publisher
+            .client()
+            .delete_message()
+            .queue_url(queue_url)
+            .receipt_handle(receipt_handle)
+            .send()
+            .await?;
+    }
+    Ok(())
+}
+
+async fn dynamodb_local_client(endpoint: &str) -> DynamoDbClient {
+    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(RegionProviderChain::default_provider().or_else("us-east-1"))
+        .credentials_provider(DynamoDbCredentials::new(
+            "fake", "fake", None, None, "local",
+        ))
+        .endpoint_url(endpoint)
+        .load()
+        .await;
+    DynamoDbClient::new(&config)
+}
+
+async fn ensure_dynamodb_table(client: DynamoDbClient, table: &str) -> anyhow::Result<()> {
+    match client.describe_table().table_name(table).send().await {
+        Ok(output) => {
+            let status = output
+                .table()
+                .and_then(|table| table.table_status())
+                .map(|status| status.as_str());
+            if status == Some("ACTIVE") {
+                return Ok(());
+            }
+            return wait_until_dynamodb_table_active(&client, table).await;
+        }
+        Err(err)
+            if err
+                .as_service_error()
+                .is_some_and(|err| err.is_resource_not_found_exception()) => {}
+        Err(err) => return Err(err.into()),
+    }
+
+    let create_result = client
+        .create_table()
+        .table_name(table)
+        .billing_mode(BillingMode::PayPerRequest)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("PK")
+                .attribute_type(ScalarAttributeType::S)
+                .build()?,
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("SK")
+                .attribute_type(ScalarAttributeType::S)
+                .build()?,
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("PK")
+                .key_type(KeyType::Hash)
+                .build()?,
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("SK")
+                .key_type(KeyType::Range)
+                .build()?,
+        )
+        .send()
+        .await;
+    match create_result {
+        Ok(_) => {}
+        Err(err)
+            if err
+                .as_service_error()
+                .is_some_and(|err| err.is_resource_in_use_exception()) => {}
+        Err(err) => return Err(err.into()),
+    }
+
+    wait_until_dynamodb_table_active(&client, table).await
+}
+
+async fn wait_until_dynamodb_table_active(
+    client: &DynamoDbClient,
+    table: &str,
+) -> anyhow::Result<()> {
+    for _ in 0..60 {
+        let output = match client.describe_table().table_name(table).send().await {
+            Ok(output) => output,
+            Err(err) => {
+                tracing::warn!(
+                    table,
+                    error = %err,
+                    "Transient error describing DynamoDB table while waiting for ACTIVE status"
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+        };
+        let status = output
+            .table()
+            .and_then(|table| table.table_status())
+            .map(|status| status.as_str());
+        if status == Some("ACTIVE") {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    anyhow::bail!("timed out waiting for DynamoDB table {table} to become ACTIVE")
+}
+
+async fn endpoint_for<I>(
+    node: &testcontainers_modules::testcontainers::ContainerAsync<I>,
+    port: u16,
+) -> anyhow::Result<String>
+where
+    I: testcontainers_modules::testcontainers::Image,
+{
+    let host = node.get_host().await?;
+    let port = node.get_host_port_ipv4(port).await?;
+    Ok(format!("http://{host}:{port}"))
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add feature-gated DynamoDB single-table state storage for Talon KV/session state, using the canonical Talon namespace/resource-parent key shape, conditional CAS writes, and local-emulator configuration.
- Add feature-gated SQS support for a single durable Talon worker queue, including local endpoint support, logical-topic routing via SQS message attributes, in-flight visibility extension, graceful shutdown joins, and receive error backoff.
- Add AWS local E2E coverage with Testcontainers for DynamoDB Local and LocalStack SQS, and run it in CI via the new `AWS Local E2E` workflow job.
- Add docs for schema, leases, config, and operational caveats.

## DynamoDB key shape
- `PK = Namespace/<namespace>/Resource/<parent_path>`
- `SK = <kind>/<name>`
- Namespace is the current Talon isolation boundary; the backend reconstructs `ResourceKey` from `PK` and `SK` and stores the protobuf payload as binary `Value`.
- Production deployments should create the shared DynamoDB table in infra before Talon starts; AWS-local E2E provisions only its emulator table in test setup.

## SQS behavior
- SQS is treated as one durable worker queue, not one queue per Talon topic.
- `TALON_SQS_QUEUE_NAME` names that queue; `TALON_SQS_QUEUE_PREFIX` remains a compatibility fallback.
- Published worker-delivered messages keep the protobuf payload as the SQS body and carry the logical Talon topic in the `talon_topic` message attribute.
- The SQS worker starts one receive loop, derives the event type from `talon_topic`, and deletes messages only after worker dispatch succeeds; failures reset visibility for retry.
- Generic `MessagePublisher::subscribe` streams are not supported for SQS because that API cannot acknowledge messages after handler completion.
- Live/dynamic stream topics such as `talon.session.parts.*` are rejected for SQS and still require Pub/Sub/local_socket/cf_queues today or direct worker streaming in a follow-up.
- No SNS/AppSync/RabbitMQ is introduced in this PR.

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo check --features dynamodb`
- `cargo check --features sqs`
- `cargo check --features aws-local-e2e`
- `cargo test maybe_spawn_pull_subscriptions_uses_sqs_specs_when_configured --features sqs`
- `cargo test maybe_spawn_pull_subscriptions_uses_local_socket_specs_when_configured --features sqs`
- `cargo test control::pubsub::sqs --features sqs`
- `cargo test control::kv::dynamodb --features dynamodb`
- `cargo test harness::sessions`
- `cargo test --locked --features aws-local-e2e --test aws_local_e2e -- --ignored --test-threads=1`

## Review follow-up
- Resolved outstanding GitHub review threads after addressing SQS shutdown/ack/backoff/limits/cache-locking concerns and DynamoDB pagination/table-readiness concerns.
- Left journal latest-entry paging as a follow-up PR to avoid broadening this AWS backend change.

## Follow-up
- Fill `WorkerStatus.endpoints` and stream live tokens from the owning worker endpoint so `talon.session.parts.<shard>` can eventually be deprecated as a production token transport.
