### PR TITLE
Add direct worker fanout streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5687,6 +5687,7 @@ dependencies = [
  "google-cloud-googleapis",
  "google-cloud-pubsub",
  "google-cloud-secretmanager-v1",
+ "hyper-util",
  "jsonwebtoken 10.4.0",
  "minijinja",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ chrono-tz = "0.10"
 cron = "0.12"
 jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 futures = "0.3"
+hyper-util = { version = "0.1", features = ["tokio"] }
 opentelemetry = "0.31"
 opentelemetry-otlp = { version = "0.31", default-features = false, features = ["grpc-tonic", "trace"] }
 opentelemetry_sdk = "0.31"
@@ -77,6 +78,7 @@ sqlx = { version = "0.8.6", features = ["postgres", "sqlite", "runtime-tokio"] }
 google-cloud-pubsub = "0.25.0"
 google-cloud-googleapis = { version = "0.13.0", features = ["pubsub"] }
 clap = { version = "4.6.0", features = ["derive"] }
+tokio-stream = { version = "0.1", features = ["net"] }
 tokio-util = "0.7.18"
 talon-client = { path = "sdk/rust/talon-client" }
 
@@ -90,7 +92,6 @@ protoc-gen-tonic = "0.4.0"
 aws-smithy-runtime-api = "1.11"
 aws-smithy-types = "1.4"
 tempfile = "3.0"
-tokio-stream = { version = "0.1", features = ["net"] }
 testcontainers-modules = { version = "0.15", features = ["dynamodb", "localstack"] }
 
 [[bin]]

--- a/bench/benchmark_1000_agents.py
+++ b/bench/benchmark_1000_agents.py
@@ -1749,7 +1749,12 @@ async def amain() -> None:
     parser.add_argument("--postgres-cpus", type=float, default=None)
     parser.add_argument("--postgres-memory", default=None)
     parser.add_argument("--rocksdb-disable-wal", action="store_true")
-    parser.add_argument("--rocksdb-compression", choices=("lz4", "none"), default=None)
+    parser.add_argument(
+        "--rocksdb-compression",
+        choices=("lz4", "none"),
+        default="none",
+        help="RocksDB compression setting for benchmark containers.",
+    )
     parser.add_argument("--rocksdb-write-buffer-size-mb", type=int, default=None)
     parser.add_argument("--rocksdb-max-write-buffer-number", type=int, default=None)
     parser.add_argument("--rocksdb-block-cache-size-mb", type=int, default=None)

--- a/bench/benchmark_1000_agents.py
+++ b/bench/benchmark_1000_agents.py
@@ -504,6 +504,7 @@ services:
       PORT: "8081"
       TALON_TOKEN_BATCH_MS: "10000"
       TALON_WORKER_SESSION_CONCURRENCY: "{worker_concurrency}"
+      TALON_WORKER_FANOUT_SUBSCRIBER_GRACE_MS: "500"
       TALON_LOCAL_SOCKET_SUBSCRIBER_BUFFER_SIZE: "{local_socket_buffer_size}"
       TALON_SQLITE_MAX_CONNECTIONS: "{sqlite_pool_size}"
       TALON_SQLITE_BUSY_TIMEOUT_MS: "{sqlite_busy_timeout_ms}"

--- a/bench/runtime.Dockerfile
+++ b/bench/runtime.Dockerfile
@@ -16,13 +16,16 @@ ARG CARGO_FEATURES="rocksdb"
 COPY Cargo.toml Cargo.lock build.rs ./
 COPY third_party ./third_party
 COPY proto ./proto
+COPY sdk/rust/talon-client ./sdk/rust/talon-client
 COPY src ./src
 COPY talon.yaml ./talon.yaml
 
 RUN if [ -n "$CARGO_FEATURES" ]; then \
-        cargo build --release --locked --bins --features "$CARGO_FEATURES"; \
+        cargo build --release --locked --features "$CARGO_FEATURES" \
+          --bin talon-server --bin talon-worker --bin talon-cli --bin talon-node; \
     else \
-        cargo build --release --locked --bins; \
+        cargo build --release --locked \
+          --bin talon-server --bin talon-worker --bin talon-cli --bin talon-node; \
     fi && \
     mkdir -p /usr/src/talon/dist && \
     cp /usr/src/talon/target/release/talon-server /usr/src/talon/dist/talon-server && \

--- a/build.rs
+++ b/build.rs
@@ -188,6 +188,7 @@ fn main() -> std::io::Result<()> {
             "proto/talon/v1/search.proto",
             "proto/talon/v1/sessions.proto",
             "proto/talon/v1/workflows.proto",
+            "proto/talon/worker/v1/fanout.proto",
         ],
         &[".", "third_party/googleapis/"],
     )?;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,6 +65,8 @@ services:
       - TALON_GOOGLE_WEB_CLIENT_ID
       - PULL_MODE=1
       - TALON_CONFIG_PATH=/data/talon/talon.docker-compose.yaml
+      - TALON_WORKER_ENDPOINT_URL=http://worker:8081
+      - TALON_WORKER_ENDPOINT_PROTOCOL=grpc
     env_file:
       - .env
     volumes:

--- a/dockerfiles/oss-runtime.Dockerfile
+++ b/dockerfiles/oss-runtime.Dockerfile
@@ -44,7 +44,8 @@ COPY src ./src
 COPY talon.yaml ./talon.yaml
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release --locked --bins --features rocksdb && \
+    cargo build --release --locked --features rocksdb \
+      --bin talon-server --bin talon-worker --bin talon-cli --bin talon-node && \
     mkdir -p /usr/src/talon/dist && \
     cp /usr/src/talon/target/release/talon-server /usr/src/talon/dist/talon-server && \
     cp /usr/src/talon/target/release/talon-worker /usr/src/talon/dist/talon-worker && \

--- a/docs/operations/deployment-model.md
+++ b/docs/operations/deployment-model.md
@@ -17,6 +17,18 @@ The runtime is centered on:
 - the worker
 - the control plane backing services
 
+## Worker endpoint registration
+
+Workers publish a `Worker` resource in the Talon system namespace and refresh its status on a heartbeat. When the worker has an address that another Talon component can call, it includes that address in `status.endpoints`.
+
+Endpoint discovery is override-first. Set `TALON_WORKER_ENDPOINT_URL` only when it names the specific worker instance that is registering. Optional `TALON_WORKER_ENDPOINT_AUDIENCE` and `TALON_WORKER_ENDPOINT_PROTOCOL` values are copied into the registered endpoint.
+
+Platform behavior:
+
+- AWS ECS tasks with `ECS_CONTAINER_METADATA_URI_V4` register the task's first IPv4 address and the worker `PORT`.
+- Cloudflare Containers receive a per-instance internal endpoint from the Worker wrapper, such as `http://default.worker.internal` or `http://worker-7.worker.internal`.
+- Cloud Run worker pools do not have a load-balanced endpoint. Use `TALON_WORKER_ENDPOINT_URL` only when you intentionally front the worker with another reachable service.
+
 ## Local deployment shape
 
 The local stack in this repo uses Docker Compose to start:

--- a/infra/cf/dev/docker-compose.yaml
+++ b/infra/cf/dev/docker-compose.yaml
@@ -67,6 +67,8 @@ services:
       TALON_SCHEDULER_DRIVER: cf_alarms
       TALON_SCHEDULER_AUTH_TOKEN: cloudflare-local-scheduler-token
       MOCK_LLM_API_KEY: local-cloudflare-e2e
+      TALON_WORKER_ENDPOINT_URL: http://worker:8081
+      TALON_WORKER_ENDPOINT_PROTOCOL: grpc
     volumes:
       - ../../..:/repo:ro
     depends_on:

--- a/infra/cf/worker/src/index.ts
+++ b/infra/cf/worker/src/index.ts
@@ -92,7 +92,7 @@ function gatewayContainerStartProfile(env: Env): ContainerStartProfile {
   };
 }
 
-function workerContainerStartProfile(env: Env): ContainerStartProfile {
+function workerContainerStartProfile(env: Env, instance: string): ContainerStartProfile {
   return {
     ports: WORKER_CONTAINER_PORTS,
     startOptions: {
@@ -101,6 +101,8 @@ function workerContainerStartProfile(env: Env): ContainerStartProfile {
       envVars: {
         ...forwardedWorkerEnv(env),
         PORT: "8081",
+        TALON_CLOUDFLARE_CONTAINER_NAME: instance,
+        TALON_WORKER_ENDPOINT_URL: workerContainerInternalUrl(instance),
         ...(env.TALON_CONFIG_INLINE_YAML ? { TALON_CONFIG_INLINE_YAML: env.TALON_CONFIG_INLINE_YAML } : {}),
         TALON_SCHEDULER_DRIVER: "cf_alarms",
         ...(env.TALON_SCHEDULER_AUTH_TOKEN ? { TALON_SCHEDULER_AUTH_TOKEN: env.TALON_SCHEDULER_AUTH_TOKEN } : {}),
@@ -147,23 +149,46 @@ function instanceName(prefix: string, count: number, key?: string): string {
 
 function containerFor(
   namespace: WorkerContainerNamespace,
-  prefix: string,
-  count: number,
-  key?: string,
+  name: string,
 ): DurableObjectStub<Container<Env>> {
-  return namespace.get(namespace.idFromName(instanceName(prefix, count, key)));
+  return namespace.get(namespace.idFromName(name));
 }
 
 function gatewayContainer(env: Env, key?: string) {
-  return containerFor(env.GATEWAY_CONTAINER, "gateway", configuredCount(env.TALON_GATEWAY_CONTAINER_COUNT), key);
+  return containerFor(env.GATEWAY_CONTAINER, instanceName("gateway", configuredCount(env.TALON_GATEWAY_CONTAINER_COUNT), key));
+}
+
+function workerContainerName(env: Env, key?: string): string {
+  return instanceName("worker", configuredCount(env.TALON_WORKER_CONTAINER_COUNT), key);
+}
+
+function workerContainerByName(env: Env, name: string) {
+  return containerFor(env.WORKER_CONTAINER, name);
+}
+
+function workerContainerRef(env: Env, key?: string): { name: string; container: DurableObjectStub<Container<Env>> } {
+  const name = workerContainerName(env, key);
+  return { name, container: workerContainerByName(env, name) };
 }
 
 function workerContainer(env: Env, key?: string) {
-  return containerFor(env.WORKER_CONTAINER, "worker", configuredCount(env.TALON_WORKER_CONTAINER_COUNT), key);
+  return workerContainerRef(env, key).container;
 }
 
 function externalContainersEnabled(env: Env): boolean {
   return env.TALON_CF_DEV_EXTERNAL_CONTAINERS === "true";
+}
+
+function workerContainerInternalUrl(instance: string): string {
+  return `http://${instance}.worker.internal`;
+}
+
+function workerInstanceFromHost(hostname: string): string | undefined {
+  const suffix = ".worker.internal";
+  if (!hostname.endsWith(suffix)) return undefined;
+  const instance = hostname.slice(0, -suffix.length);
+  if (instance === "default" || /^worker-\d+$/.test(instance)) return instance;
+  return undefined;
 }
 
 function requestToOrigin(request: Request, origin: string): Request {
@@ -250,6 +275,14 @@ async function fetchGateway(env: Env, request: Request): Promise<Response> {
   );
 }
 
+async function fetchWorkerInstance(env: Env, instance: string, request: Request): Promise<Response> {
+  return fetchStartedContainer(
+    workerContainerByName(env, instance),
+    switchPort(request, WORKER_CONTAINER_PORTS[0]),
+    workerContainerStartProfile(env, instance),
+  );
+}
+
 const CORS_ALLOW_METHODS = "GET,PUT,DELETE,POST,OPTIONS";
 const CORS_ALLOW_HEADERS =
   "keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms,authorization";
@@ -279,7 +312,7 @@ function withCors(response: Response, request: Request): Response {
   });
 }
 
-const outboundByHost = {
+const outboundByHost: Record<string, (request: Request, env: Env) => Promise<Response> | Response> = {
   "talon-d1.internal": (request: Request, env: Env) => handleD1(request, env),
   "talon-r2.internal": (request: Request, env: Env) => handleR2(request, env),
   "talon-queues.internal": (request: Request, env: Env) => handleQueues(request, env),
@@ -300,6 +333,11 @@ const outboundByHost = {
     );
   },
 };
+
+for (const instance of ["default", ...Array.from({ length: 128 }, (_, index) => `worker-${index}`)]) {
+  outboundByHost[`${instance}.worker.internal`] = (request: Request, env: Env) =>
+    fetchWorkerInstance(env, instance, request);
+}
 
 export class GatewayContainer extends Container<Env> {
   defaultPort = 50051;
@@ -333,6 +371,10 @@ export default {
     const outboundHandler = outboundByHost[url.hostname as keyof typeof outboundByHost];
     if (outboundHandler) {
       return withCors(await outboundHandler(request, env), request);
+    }
+    const workerInstance = workerInstanceFromHost(url.hostname);
+    if (workerInstance) {
+      return withCors(await fetchWorkerInstance(env, workerInstance, request), request);
     }
 
     if (url.pathname === "/healthz") {
@@ -368,16 +410,19 @@ export default {
           new Request("https://talon-health.internal/"),
           gatewayContainerStartProfile(env),
         ),
-        containerReady(
-          "worker",
-          workerContainer(env),
-          new Request("https://talon-health.internal/cloudflare/queues/dispatch", {
-            method: "POST",
-            headers: TEXT_JSON,
-            body: "{}",
-          }),
-          workerContainerStartProfile(env),
-        ),
+        (() => {
+          const worker = workerContainerRef(env);
+          return containerReady(
+            "worker",
+            worker.container,
+            new Request("https://talon-health.internal/cloudflare/queues/dispatch", {
+              method: "POST",
+              headers: TEXT_JSON,
+              body: "{}",
+            }),
+            workerContainerStartProfile(env, worker.name),
+          );
+        })(),
       ]);
       const ok = gateway.ready && worker.ready;
       return withCors(
@@ -415,13 +460,13 @@ export default {
       if (externalContainersEnabled(env)) {
         return fetcherForOrigin(env.TALON_CF_DEV_WORKER_URL ?? "http://worker:8081");
       }
-      const container = workerContainer(env, message.id);
+      const { name, container } = workerContainerRef(env, message.id);
       return {
         fetch(input: RequestInfo | URL, init?: RequestInit) {
           return fetchStartedContainer(
             container,
             new Request(input, init),
-            workerContainerStartProfile(env),
+            workerContainerStartProfile(env, name),
           );
         },
       };

--- a/proto/data/session_submission.proto
+++ b/proto/data/session_submission.proto
@@ -44,6 +44,11 @@ message SessionSubmission {
   // workers cannot move the submission pointer backward.
   string attempt_id = 5;
 
+  // Worker that owns the current claim. Gateways use this to connect to the
+  // exact worker process that can stream in-process session parts for the
+  // attempt.
+  string claim_worker_id = 14;
+
   // Number of successful claims/reclaims for this submission.
   uint32 attempt_count = 6;
 

--- a/proto/talon/worker/v1/fanout.proto
+++ b/proto/talon/worker/v1/fanout.proto
@@ -6,6 +6,7 @@ import "proto/events.proto";
 
 service FanoutService {
   rpc StreamSessionParts(StreamSessionPartsRequest) returns (stream StreamSessionPartsResponse);
+  rpc StreamSessionPartsBatch(StreamSessionPartsBatchRequest) returns (stream StreamSessionPartsResponse);
 }
 
 message StreamSessionPartsRequest {
@@ -20,4 +21,8 @@ message StreamSessionPartsRequest {
 message StreamSessionPartsResponse {
   uint64 sequence = 1;
   talon.events.SessionMessagePartEvent event = 2;
+}
+
+message StreamSessionPartsBatchRequest {
+  repeated StreamSessionPartsRequest streams = 1;
 }

--- a/proto/talon/worker/v1/fanout.proto
+++ b/proto/talon/worker/v1/fanout.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package talon.worker.v1;
+
+import "proto/events.proto";
+
+service FanoutService {
+  rpc StreamSessionParts(StreamSessionPartsRequest) returns (stream StreamSessionPartsResponse);
+}
+
+message StreamSessionPartsRequest {
+  string ns = 1;
+  string agent = 2;
+  string session_id = 3;
+  string submission_id = 4;
+  string attempt_id = 5;
+  uint64 after_sequence = 6;
+}
+
+message StreamSessionPartsResponse {
+  uint64 sequence = 1;
+  talon.events.SessionMessagePartEvent event = 2;
+}

--- a/sdk/go/talon-client/talon/data/session_submission.pb.go
+++ b/sdk/go/talon-client/talon/data/session_submission.pb.go
@@ -101,6 +101,10 @@ type SessionSubmission struct {
 	// Current lease owner. Journal appends are fenced by this value so stale
 	// workers cannot move the submission pointer backward.
 	AttemptId string `protobuf:"bytes,5,opt,name=attempt_id,json=attemptId,proto3" json:"attempt_id,omitempty"`
+	// Worker that owns the current claim. Gateways use this to connect to the
+	// exact worker process that can stream in-process session parts for the
+	// attempt.
+	ClaimWorkerId string `protobuf:"bytes,14,opt,name=claim_worker_id,json=claimWorkerId,proto3" json:"claim_worker_id,omitempty"`
 	// Number of successful claims/reclaims for this submission.
 	AttemptCount uint32 `protobuf:"varint,6,opt,name=attempt_count,json=attemptCount,proto3" json:"attempt_count,omitempty"`
 	// Lease expiration for the current claim. Cleared when the submission becomes
@@ -193,6 +197,13 @@ func (x *SessionSubmission) GetAttemptId() string {
 	return ""
 }
 
+func (x *SessionSubmission) GetClaimWorkerId() string {
+	if x != nil {
+		return x.ClaimWorkerId
+	}
+	return ""
+}
+
 func (x *SessionSubmission) GetAttemptCount() uint32 {
 	if x != nil {
 		return x.AttemptCount
@@ -254,7 +265,7 @@ var File_proto_data_session_submission_proto protoreflect.FileDescriptor
 const file_proto_data_session_submission_proto_rawDesc = "" +
 	"\n" +
 	"#proto/data/session_submission.proto\x12\n" +
-	"talon.data\x1a&proto/data/session_journal_entry.proto\"\xae\x05\n" +
+	"talon.data\x1a&proto/data/session_journal_entry.proto\"\xd6\x05\n" +
 	"\x11SessionSubmission\x12#\n" +
 	"\rsubmission_id\x18\x01 \x01(\tR\fsubmissionId\x12\x1d\n" +
 	"\n" +
@@ -262,7 +273,8 @@ const file_proto_data_session_submission_proto_rawDesc = "" +
 	"\x0fuser_message_id\x18\x03 \x01(\tR\ruserMessageId\x12;\n" +
 	"\x06status\x18\x04 \x01(\x0e2#.talon.data.SessionSubmissionStatusR\x06status\x12\x1d\n" +
 	"\n" +
-	"attempt_id\x18\x05 \x01(\tR\tattemptId\x12#\n" +
+	"attempt_id\x18\x05 \x01(\tR\tattemptId\x12&\n" +
+	"\x0fclaim_worker_id\x18\x0e \x01(\tR\rclaimWorkerId\x12#\n" +
 	"\rattempt_count\x18\x06 \x01(\rR\fattemptCount\x12-\n" +
 	"\x10claim_expires_at\x18\a \x01(\x03H\x00R\x0eclaimExpiresAt\x88\x01\x01\x12\x1d\n" +
 	"\n" +

--- a/sdk/java/talon-client/src/main/java/talon/data/SessionSubmissionOuterClass.java
+++ b/sdk/java/talon-client/src/main/java/talon/data/SessionSubmissionOuterClass.java
@@ -334,6 +334,30 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
 
     /**
      * <pre>
+     * Worker that owns the current claim. Gateways use this to connect to the
+     * exact worker process that can stream in-process session parts for the
+     * attempt.
+     * </pre>
+     *
+     * <code>string claim_worker_id = 14;</code>
+     * @return The claimWorkerId.
+     */
+    java.lang.String getClaimWorkerId();
+    /**
+     * <pre>
+     * Worker that owns the current claim. Gateways use this to connect to the
+     * exact worker process that can stream in-process session parts for the
+     * attempt.
+     * </pre>
+     *
+     * <code>string claim_worker_id = 14;</code>
+     * @return The bytes for claimWorkerId.
+     */
+    com.google.protobuf.ByteString
+        getClaimWorkerIdBytes();
+
+    /**
+     * <pre>
      * Number of successful claims/reclaims for this submission.
      * </pre>
      *
@@ -521,6 +545,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       userMessageId_ = "";
       status_ = 0;
       attemptId_ = "";
+      claimWorkerId_ = "";
       committedMessageId_ = "";
       currentPhase_ = 0;
       currentJournalEntryId_ = "";
@@ -747,6 +772,57 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         attemptId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CLAIM_WORKER_ID_FIELD_NUMBER = 14;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object claimWorkerId_ = "";
+    /**
+     * <pre>
+     * Worker that owns the current claim. Gateways use this to connect to the
+     * exact worker process that can stream in-process session parts for the
+     * attempt.
+     * </pre>
+     *
+     * <code>string claim_worker_id = 14;</code>
+     * @return The claimWorkerId.
+     */
+    @java.lang.Override
+    public java.lang.String getClaimWorkerId() {
+      java.lang.Object ref = claimWorkerId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        claimWorkerId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Worker that owns the current claim. Gateways use this to connect to the
+     * exact worker process that can stream in-process session parts for the
+     * attempt.
+     * </pre>
+     *
+     * <code>string claim_worker_id = 14;</code>
+     * @return The bytes for claimWorkerId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getClaimWorkerIdBytes() {
+      java.lang.Object ref = claimWorkerId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        claimWorkerId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -1066,6 +1142,9 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       if (((bitField0_ & 0x00000008) != 0)) {
         com.google.protobuf.GeneratedMessage.writeString(output, 13, currentJournalEntryId_);
       }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(claimWorkerId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 14, claimWorkerId_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -1121,6 +1200,9 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.GeneratedMessage.computeStringSize(13, currentJournalEntryId_);
       }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(claimWorkerId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(14, claimWorkerId_);
+      }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
@@ -1145,6 +1227,8 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       if (status_ != other.status_) return false;
       if (!getAttemptId()
           .equals(other.getAttemptId())) return false;
+      if (!getClaimWorkerId()
+          .equals(other.getClaimWorkerId())) return false;
       if (getAttemptCount()
           != other.getAttemptCount()) return false;
       if (hasClaimExpiresAt() != other.hasClaimExpiresAt()) return false;
@@ -1193,6 +1277,8 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       hash = (53 * hash) + status_;
       hash = (37 * hash) + ATTEMPT_ID_FIELD_NUMBER;
       hash = (53 * hash) + getAttemptId().hashCode();
+      hash = (37 * hash) + CLAIM_WORKER_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getClaimWorkerId().hashCode();
       hash = (37 * hash) + ATTEMPT_COUNT_FIELD_NUMBER;
       hash = (53 * hash) + getAttemptCount();
       if (hasClaimExpiresAt()) {
@@ -1357,6 +1443,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
         userMessageId_ = "";
         status_ = 0;
         attemptId_ = "";
+        claimWorkerId_ = "";
         attemptCount_ = 0;
         claimExpiresAt_ = 0L;
         createdAt_ = 0L;
@@ -1414,31 +1501,34 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
           result.attemptId_ = attemptId_;
         }
         if (((from_bitField0_ & 0x00000020) != 0)) {
+          result.claimWorkerId_ = claimWorkerId_;
+        }
+        if (((from_bitField0_ & 0x00000040) != 0)) {
           result.attemptCount_ = attemptCount_;
         }
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000040) != 0)) {
+        if (((from_bitField0_ & 0x00000080) != 0)) {
           result.claimExpiresAt_ = claimExpiresAt_;
           to_bitField0_ |= 0x00000001;
         }
-        if (((from_bitField0_ & 0x00000080) != 0)) {
+        if (((from_bitField0_ & 0x00000100) != 0)) {
           result.createdAt_ = createdAt_;
         }
-        if (((from_bitField0_ & 0x00000100) != 0)) {
+        if (((from_bitField0_ & 0x00000200) != 0)) {
           result.updatedAt_ = updatedAt_;
         }
-        if (((from_bitField0_ & 0x00000200) != 0)) {
+        if (((from_bitField0_ & 0x00000400) != 0)) {
           result.completedAt_ = completedAt_;
           to_bitField0_ |= 0x00000002;
         }
-        if (((from_bitField0_ & 0x00000400) != 0)) {
+        if (((from_bitField0_ & 0x00000800) != 0)) {
           result.committedMessageId_ = committedMessageId_;
           to_bitField0_ |= 0x00000004;
         }
-        if (((from_bitField0_ & 0x00000800) != 0)) {
+        if (((from_bitField0_ & 0x00001000) != 0)) {
           result.currentPhase_ = currentPhase_;
         }
-        if (((from_bitField0_ & 0x00001000) != 0)) {
+        if (((from_bitField0_ & 0x00002000) != 0)) {
           result.currentJournalEntryId_ = currentJournalEntryId_;
           to_bitField0_ |= 0x00000008;
         }
@@ -1480,6 +1570,11 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
           bitField0_ |= 0x00000010;
           onChanged();
         }
+        if (!other.getClaimWorkerId().isEmpty()) {
+          claimWorkerId_ = other.claimWorkerId_;
+          bitField0_ |= 0x00000020;
+          onChanged();
+        }
         if (other.getAttemptCount() != 0) {
           setAttemptCount(other.getAttemptCount());
         }
@@ -1497,7 +1592,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
         }
         if (other.hasCommittedMessageId()) {
           committedMessageId_ = other.committedMessageId_;
-          bitField0_ |= 0x00000400;
+          bitField0_ |= 0x00000800;
           onChanged();
         }
         if (other.currentPhase_ != 0) {
@@ -1505,7 +1600,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
         }
         if (other.hasCurrentJournalEntryId()) {
           currentJournalEntryId_ = other.currentJournalEntryId_;
-          bitField0_ |= 0x00001000;
+          bitField0_ |= 0x00002000;
           onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
@@ -1561,44 +1656,49 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
               } // case 42
               case 48: {
                 attemptCount_ = input.readUInt32();
-                bitField0_ |= 0x00000020;
+                bitField0_ |= 0x00000040;
                 break;
               } // case 48
               case 56: {
                 claimExpiresAt_ = input.readInt64();
-                bitField0_ |= 0x00000040;
+                bitField0_ |= 0x00000080;
                 break;
               } // case 56
               case 64: {
                 createdAt_ = input.readInt64();
-                bitField0_ |= 0x00000080;
+                bitField0_ |= 0x00000100;
                 break;
               } // case 64
               case 72: {
                 updatedAt_ = input.readInt64();
-                bitField0_ |= 0x00000100;
+                bitField0_ |= 0x00000200;
                 break;
               } // case 72
               case 80: {
                 completedAt_ = input.readInt64();
-                bitField0_ |= 0x00000200;
+                bitField0_ |= 0x00000400;
                 break;
               } // case 80
               case 90: {
                 committedMessageId_ = input.readStringRequireUtf8();
-                bitField0_ |= 0x00000400;
+                bitField0_ |= 0x00000800;
                 break;
               } // case 90
               case 96: {
                 currentPhase_ = input.readEnum();
-                bitField0_ |= 0x00000800;
+                bitField0_ |= 0x00001000;
                 break;
               } // case 96
               case 106: {
                 currentJournalEntryId_ = input.readStringRequireUtf8();
-                bitField0_ |= 0x00001000;
+                bitField0_ |= 0x00002000;
                 break;
               } // case 106
+              case 114: {
+                claimWorkerId_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000020;
+                break;
+              } // case 114
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -2041,6 +2141,108 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
         return this;
       }
 
+      private java.lang.Object claimWorkerId_ = "";
+      /**
+       * <pre>
+       * Worker that owns the current claim. Gateways use this to connect to the
+       * exact worker process that can stream in-process session parts for the
+       * attempt.
+       * </pre>
+       *
+       * <code>string claim_worker_id = 14;</code>
+       * @return The claimWorkerId.
+       */
+      public java.lang.String getClaimWorkerId() {
+        java.lang.Object ref = claimWorkerId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          claimWorkerId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Worker that owns the current claim. Gateways use this to connect to the
+       * exact worker process that can stream in-process session parts for the
+       * attempt.
+       * </pre>
+       *
+       * <code>string claim_worker_id = 14;</code>
+       * @return The bytes for claimWorkerId.
+       */
+      public com.google.protobuf.ByteString
+          getClaimWorkerIdBytes() {
+        java.lang.Object ref = claimWorkerId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          claimWorkerId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Worker that owns the current claim. Gateways use this to connect to the
+       * exact worker process that can stream in-process session parts for the
+       * attempt.
+       * </pre>
+       *
+       * <code>string claim_worker_id = 14;</code>
+       * @param value The claimWorkerId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClaimWorkerId(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        claimWorkerId_ = value;
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Worker that owns the current claim. Gateways use this to connect to the
+       * exact worker process that can stream in-process session parts for the
+       * attempt.
+       * </pre>
+       *
+       * <code>string claim_worker_id = 14;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearClaimWorkerId() {
+        claimWorkerId_ = getDefaultInstance().getClaimWorkerId();
+        bitField0_ = (bitField0_ & ~0x00000020);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Worker that owns the current claim. Gateways use this to connect to the
+       * exact worker process that can stream in-process session parts for the
+       * attempt.
+       * </pre>
+       *
+       * <code>string claim_worker_id = 14;</code>
+       * @param value The bytes for claimWorkerId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClaimWorkerIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        claimWorkerId_ = value;
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return this;
+      }
+
       private int attemptCount_ ;
       /**
        * <pre>
@@ -2066,7 +2268,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       public Builder setAttemptCount(int value) {
 
         attemptCount_ = value;
-        bitField0_ |= 0x00000020;
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -2079,7 +2281,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        * @return This builder for chaining.
        */
       public Builder clearAttemptCount() {
-        bitField0_ = (bitField0_ & ~0x00000020);
+        bitField0_ = (bitField0_ & ~0x00000040);
         attemptCount_ = 0;
         onChanged();
         return this;
@@ -2098,7 +2300,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        */
       @java.lang.Override
       public boolean hasClaimExpiresAt() {
-        return ((bitField0_ & 0x00000040) != 0);
+        return ((bitField0_ & 0x00000080) != 0);
       }
       /**
        * <pre>
@@ -2128,7 +2330,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       public Builder setClaimExpiresAt(long value) {
 
         claimExpiresAt_ = value;
-        bitField0_ |= 0x00000040;
+        bitField0_ |= 0x00000080;
         onChanged();
         return this;
       }
@@ -2143,7 +2345,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        * @return This builder for chaining.
        */
       public Builder clearClaimExpiresAt() {
-        bitField0_ = (bitField0_ & ~0x00000040);
+        bitField0_ = (bitField0_ & ~0x00000080);
         claimExpiresAt_ = 0L;
         onChanged();
         return this;
@@ -2174,7 +2376,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       public Builder setCreatedAt(long value) {
 
         createdAt_ = value;
-        bitField0_ |= 0x00000080;
+        bitField0_ |= 0x00000100;
         onChanged();
         return this;
       }
@@ -2187,7 +2389,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        * @return This builder for chaining.
        */
       public Builder clearCreatedAt() {
-        bitField0_ = (bitField0_ & ~0x00000080);
+        bitField0_ = (bitField0_ & ~0x00000100);
         createdAt_ = 0L;
         onChanged();
         return this;
@@ -2218,7 +2420,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       public Builder setUpdatedAt(long value) {
 
         updatedAt_ = value;
-        bitField0_ |= 0x00000100;
+        bitField0_ |= 0x00000200;
         onChanged();
         return this;
       }
@@ -2231,7 +2433,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        * @return This builder for chaining.
        */
       public Builder clearUpdatedAt() {
-        bitField0_ = (bitField0_ & ~0x00000100);
+        bitField0_ = (bitField0_ & ~0x00000200);
         updatedAt_ = 0L;
         onChanged();
         return this;
@@ -2249,7 +2451,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        */
       @java.lang.Override
       public boolean hasCompletedAt() {
-        return ((bitField0_ & 0x00000200) != 0);
+        return ((bitField0_ & 0x00000400) != 0);
       }
       /**
        * <pre>
@@ -2277,7 +2479,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
       public Builder setCompletedAt(long value) {
 
         completedAt_ = value;
-        bitField0_ |= 0x00000200;
+        bitField0_ |= 0x00000400;
         onChanged();
         return this;
       }
@@ -2291,7 +2493,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        * @return This builder for chaining.
        */
       public Builder clearCompletedAt() {
-        bitField0_ = (bitField0_ & ~0x00000200);
+        bitField0_ = (bitField0_ & ~0x00000400);
         completedAt_ = 0L;
         onChanged();
         return this;
@@ -2308,7 +2510,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        * @return Whether the committedMessageId field is set.
        */
       public boolean hasCommittedMessageId() {
-        return ((bitField0_ & 0x00000400) != 0);
+        return ((bitField0_ & 0x00000800) != 0);
       }
       /**
        * <pre>
@@ -2367,7 +2569,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
           java.lang.String value) {
         if (value == null) { throw new NullPointerException(); }
         committedMessageId_ = value;
-        bitField0_ |= 0x00000400;
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -2382,7 +2584,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        */
       public Builder clearCommittedMessageId() {
         committedMessageId_ = getDefaultInstance().getCommittedMessageId();
-        bitField0_ = (bitField0_ & ~0x00000400);
+        bitField0_ = (bitField0_ & ~0x00000800);
         onChanged();
         return this;
       }
@@ -2401,7 +2603,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
         if (value == null) { throw new NullPointerException(); }
         checkByteStringIsUtf8(value);
         committedMessageId_ = value;
-        bitField0_ |= 0x00000400;
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -2432,7 +2634,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        */
       public Builder setCurrentPhaseValue(int value) {
         currentPhase_ = value;
-        bitField0_ |= 0x00000800;
+        bitField0_ |= 0x00001000;
         onChanged();
         return this;
       }
@@ -2462,7 +2664,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        */
       public Builder setCurrentPhase(talon.data.SessionJournalEntryOuterClass.SessionExecutionPhase value) {
         if (value == null) { throw new NullPointerException(); }
-        bitField0_ |= 0x00000800;
+        bitField0_ |= 0x00001000;
         currentPhase_ = value.getNumber();
         onChanged();
         return this;
@@ -2477,7 +2679,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        * @return This builder for chaining.
        */
       public Builder clearCurrentPhase() {
-        bitField0_ = (bitField0_ & ~0x00000800);
+        bitField0_ = (bitField0_ & ~0x00001000);
         currentPhase_ = 0;
         onChanged();
         return this;
@@ -2495,7 +2697,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        * @return Whether the currentJournalEntryId field is set.
        */
       public boolean hasCurrentJournalEntryId() {
-        return ((bitField0_ & 0x00001000) != 0);
+        return ((bitField0_ & 0x00002000) != 0);
       }
       /**
        * <pre>
@@ -2557,7 +2759,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
           java.lang.String value) {
         if (value == null) { throw new NullPointerException(); }
         currentJournalEntryId_ = value;
-        bitField0_ |= 0x00001000;
+        bitField0_ |= 0x00002000;
         onChanged();
         return this;
       }
@@ -2573,7 +2775,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
        */
       public Builder clearCurrentJournalEntryId() {
         currentJournalEntryId_ = getDefaultInstance().getCurrentJournalEntryId();
-        bitField0_ = (bitField0_ & ~0x00001000);
+        bitField0_ = (bitField0_ & ~0x00002000);
         onChanged();
         return this;
       }
@@ -2593,7 +2795,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
         if (value == null) { throw new NullPointerException(); }
         checkByteStringIsUtf8(value);
         currentJournalEntryId_ = value;
-        bitField0_ |= 0x00001000;
+        bitField0_ |= 0x00002000;
         onChanged();
         return this;
       }
@@ -2665,26 +2867,27 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
     java.lang.String[] descriptorData = {
       "\n#proto/data/session_submission.proto\022\nt" +
       "alon.data\032&proto/data/session_journal_en" +
-      "try.proto\"\371\003\n\021SessionSubmission\022\025\n\rsubmi" +
+      "try.proto\"\222\004\n\021SessionSubmission\022\025\n\rsubmi" +
       "ssion_id\030\001 \001(\t\022\022\n\nsession_id\030\002 \001(\t\022\027\n\017us" +
       "er_message_id\030\003 \001(\t\0223\n\006status\030\004 \001(\0162#.ta" +
       "lon.data.SessionSubmissionStatus\022\022\n\natte" +
-      "mpt_id\030\005 \001(\t\022\025\n\rattempt_count\030\006 \001(\r\022\035\n\020c" +
-      "laim_expires_at\030\007 \001(\003H\000\210\001\001\022\022\n\ncreated_at" +
-      "\030\010 \001(\003\022\022\n\nupdated_at\030\t \001(\003\022\031\n\014completed_" +
-      "at\030\n \001(\003H\001\210\001\001\022!\n\024committed_message_id\030\013 " +
-      "\001(\tH\002\210\001\001\0228\n\rcurrent_phase\030\014 \001(\0162!.talon." +
-      "data.SessionExecutionPhase\022%\n\030current_jo" +
-      "urnal_entry_id\030\r \001(\tH\003\210\001\001B\023\n\021_claim_expi" +
-      "res_atB\017\n\r_completed_atB\027\n\025_committed_me" +
-      "ssage_idB\033\n\031_current_journal_entry_id*\214\002" +
-      "\n\027SessionSubmissionStatus\022)\n%SESSION_SUB" +
-      "MISSION_STATUS_UNSPECIFIED\020\000\022%\n!SESSION_" +
-      "SUBMISSION_STATUS_PENDING\020\001\022%\n!SESSION_S" +
-      "UBMISSION_STATUS_CLAIMED\020\002\022\'\n#SESSION_SU" +
-      "BMISSION_STATUS_COMMITTED\020\003\022$\n SESSION_S" +
-      "UBMISSION_STATUS_FAILED\020\004\022)\n%SESSION_SUB" +
-      "MISSION_STATUS_INTERRUPTED\020\005b\006proto3"
+      "mpt_id\030\005 \001(\t\022\027\n\017claim_worker_id\030\016 \001(\t\022\025\n" +
+      "\rattempt_count\030\006 \001(\r\022\035\n\020claim_expires_at" +
+      "\030\007 \001(\003H\000\210\001\001\022\022\n\ncreated_at\030\010 \001(\003\022\022\n\nupdat" +
+      "ed_at\030\t \001(\003\022\031\n\014completed_at\030\n \001(\003H\001\210\001\001\022!" +
+      "\n\024committed_message_id\030\013 \001(\tH\002\210\001\001\0228\n\rcur" +
+      "rent_phase\030\014 \001(\0162!.talon.data.SessionExe" +
+      "cutionPhase\022%\n\030current_journal_entry_id\030" +
+      "\r \001(\tH\003\210\001\001B\023\n\021_claim_expires_atB\017\n\r_comp" +
+      "leted_atB\027\n\025_committed_message_idB\033\n\031_cu" +
+      "rrent_journal_entry_id*\214\002\n\027SessionSubmis" +
+      "sionStatus\022)\n%SESSION_SUBMISSION_STATUS_" +
+      "UNSPECIFIED\020\000\022%\n!SESSION_SUBMISSION_STAT" +
+      "US_PENDING\020\001\022%\n!SESSION_SUBMISSION_STATU" +
+      "S_CLAIMED\020\002\022\'\n#SESSION_SUBMISSION_STATUS" +
+      "_COMMITTED\020\003\022$\n SESSION_SUBMISSION_STATU" +
+      "S_FAILED\020\004\022)\n%SESSION_SUBMISSION_STATUS_" +
+      "INTERRUPTED\020\005b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -2696,7 +2899,7 @@ public final class SessionSubmissionOuterClass extends com.google.protobuf.Gener
     internal_static_talon_data_SessionSubmission_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_talon_data_SessionSubmission_descriptor,
-        new java.lang.String[] { "SubmissionId", "SessionId", "UserMessageId", "Status", "AttemptId", "AttemptCount", "ClaimExpiresAt", "CreatedAt", "UpdatedAt", "CompletedAt", "CommittedMessageId", "CurrentPhase", "CurrentJournalEntryId", });
+        new java.lang.String[] { "SubmissionId", "SessionId", "UserMessageId", "Status", "AttemptId", "ClaimWorkerId", "AttemptCount", "ClaimExpiresAt", "CreatedAt", "UpdatedAt", "CompletedAt", "CommittedMessageId", "CurrentPhase", "CurrentJournalEntryId", });
     descriptor.resolveAllFeaturesImmutable();
     talon.data.SessionJournalEntryOuterClass.getDescriptor();
   }

--- a/sdk/js/talon-client/src/gen/proto/data/session_submission_pb.ts
+++ b/sdk/js/talon-client/src/gen/proto/data/session_submission_pb.ts
@@ -106,6 +106,15 @@ export class SessionSubmission extends Message<SessionSubmission> {
   attemptId = "";
 
   /**
+   * Worker that owns the current claim. Gateways use this to connect to the
+   * exact worker process that can stream in-process session parts for the
+   * attempt.
+   *
+   * @generated from field: string claim_worker_id = 14;
+   */
+  claimWorkerId = "";
+
+  /**
    * Number of successful claims/reclaims for this submission.
    *
    * @generated from field: uint32 attempt_count = 6;
@@ -181,6 +190,7 @@ export class SessionSubmission extends Message<SessionSubmission> {
     { no: 3, name: "user_message_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "status", kind: "enum", T: proto3.getEnumType(SessionSubmissionStatus) },
     { no: 5, name: "attempt_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 14, name: "claim_worker_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 6, name: "attempt_count", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
     { no: 7, name: "claim_expires_at", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
     { no: 8, name: "created_at", kind: "scalar", T: 3 /* ScalarType.INT64 */ },

--- a/sdk/python/talon-client/src/talon_client/proto/data/session_submission_pb2.py
+++ b/sdk/python/talon-client/src/talon_client/proto/data/session_submission_pb2.py
@@ -25,15 +25,15 @@ _sym_db = _symbol_database.Default()
 from talon_client.proto.data import session_journal_entry_pb2 as proto_dot_data_dot_session__journal__entry__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n#proto/data/session_submission.proto\x12\ntalon.data\x1a&proto/data/session_journal_entry.proto\"\xf9\x03\n\x11SessionSubmission\x12\x15\n\rsubmission_id\x18\x01 \x01(\t\x12\x12\n\nsession_id\x18\x02 \x01(\t\x12\x17\n\x0fuser_message_id\x18\x03 \x01(\t\x12\x33\n\x06status\x18\x04 \x01(\x0e\x32#.talon.data.SessionSubmissionStatus\x12\x12\n\nattempt_id\x18\x05 \x01(\t\x12\x15\n\rattempt_count\x18\x06 \x01(\r\x12\x1d\n\x10\x63laim_expires_at\x18\x07 \x01(\x03H\x00\x88\x01\x01\x12\x12\n\ncreated_at\x18\x08 \x01(\x03\x12\x12\n\nupdated_at\x18\t \x01(\x03\x12\x19\n\x0c\x63ompleted_at\x18\n \x01(\x03H\x01\x88\x01\x01\x12!\n\x14\x63ommitted_message_id\x18\x0b \x01(\tH\x02\x88\x01\x01\x12\x38\n\rcurrent_phase\x18\x0c \x01(\x0e\x32!.talon.data.SessionExecutionPhase\x12%\n\x18\x63urrent_journal_entry_id\x18\r \x01(\tH\x03\x88\x01\x01\x42\x13\n\x11_claim_expires_atB\x0f\n\r_completed_atB\x17\n\x15_committed_message_idB\x1b\n\x19_current_journal_entry_id*\x8c\x02\n\x17SessionSubmissionStatus\x12)\n%SESSION_SUBMISSION_STATUS_UNSPECIFIED\x10\x00\x12%\n!SESSION_SUBMISSION_STATUS_PENDING\x10\x01\x12%\n!SESSION_SUBMISSION_STATUS_CLAIMED\x10\x02\x12\'\n#SESSION_SUBMISSION_STATUS_COMMITTED\x10\x03\x12$\n SESSION_SUBMISSION_STATUS_FAILED\x10\x04\x12)\n%SESSION_SUBMISSION_STATUS_INTERRUPTED\x10\x05\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n#proto/data/session_submission.proto\x12\ntalon.data\x1a&proto/data/session_journal_entry.proto\"\x92\x04\n\x11SessionSubmission\x12\x15\n\rsubmission_id\x18\x01 \x01(\t\x12\x12\n\nsession_id\x18\x02 \x01(\t\x12\x17\n\x0fuser_message_id\x18\x03 \x01(\t\x12\x33\n\x06status\x18\x04 \x01(\x0e\x32#.talon.data.SessionSubmissionStatus\x12\x12\n\nattempt_id\x18\x05 \x01(\t\x12\x17\n\x0f\x63laim_worker_id\x18\x0e \x01(\t\x12\x15\n\rattempt_count\x18\x06 \x01(\r\x12\x1d\n\x10\x63laim_expires_at\x18\x07 \x01(\x03H\x00\x88\x01\x01\x12\x12\n\ncreated_at\x18\x08 \x01(\x03\x12\x12\n\nupdated_at\x18\t \x01(\x03\x12\x19\n\x0c\x63ompleted_at\x18\n \x01(\x03H\x01\x88\x01\x01\x12!\n\x14\x63ommitted_message_id\x18\x0b \x01(\tH\x02\x88\x01\x01\x12\x38\n\rcurrent_phase\x18\x0c \x01(\x0e\x32!.talon.data.SessionExecutionPhase\x12%\n\x18\x63urrent_journal_entry_id\x18\r \x01(\tH\x03\x88\x01\x01\x42\x13\n\x11_claim_expires_atB\x0f\n\r_completed_atB\x17\n\x15_committed_message_idB\x1b\n\x19_current_journal_entry_id*\x8c\x02\n\x17SessionSubmissionStatus\x12)\n%SESSION_SUBMISSION_STATUS_UNSPECIFIED\x10\x00\x12%\n!SESSION_SUBMISSION_STATUS_PENDING\x10\x01\x12%\n!SESSION_SUBMISSION_STATUS_CLAIMED\x10\x02\x12\'\n#SESSION_SUBMISSION_STATUS_COMMITTED\x10\x03\x12$\n SESSION_SUBMISSION_STATUS_FAILED\x10\x04\x12)\n%SESSION_SUBMISSION_STATUS_INTERRUPTED\x10\x05\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'proto.data.session_submission_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_SESSIONSUBMISSIONSTATUS']._serialized_start=600
-  _globals['_SESSIONSUBMISSIONSTATUS']._serialized_end=868
+  _globals['_SESSIONSUBMISSIONSTATUS']._serialized_start=625
+  _globals['_SESSIONSUBMISSIONSTATUS']._serialized_end=893
   _globals['_SESSIONSUBMISSION']._serialized_start=92
-  _globals['_SESSIONSUBMISSION']._serialized_end=597
+  _globals['_SESSIONSUBMISSION']._serialized_end=622
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/talon-client/src/talon_client/proto/data/session_submission_pb2.pyi
+++ b/sdk/python/talon-client/src/talon_client/proto/data/session_submission_pb2.pyi
@@ -22,12 +22,13 @@ SESSION_SUBMISSION_STATUS_FAILED: SessionSubmissionStatus
 SESSION_SUBMISSION_STATUS_INTERRUPTED: SessionSubmissionStatus
 
 class SessionSubmission(_message.Message):
-    __slots__ = ("submission_id", "session_id", "user_message_id", "status", "attempt_id", "attempt_count", "claim_expires_at", "created_at", "updated_at", "completed_at", "committed_message_id", "current_phase", "current_journal_entry_id")
+    __slots__ = ("submission_id", "session_id", "user_message_id", "status", "attempt_id", "claim_worker_id", "attempt_count", "claim_expires_at", "created_at", "updated_at", "completed_at", "committed_message_id", "current_phase", "current_journal_entry_id")
     SUBMISSION_ID_FIELD_NUMBER: _ClassVar[int]
     SESSION_ID_FIELD_NUMBER: _ClassVar[int]
     USER_MESSAGE_ID_FIELD_NUMBER: _ClassVar[int]
     STATUS_FIELD_NUMBER: _ClassVar[int]
     ATTEMPT_ID_FIELD_NUMBER: _ClassVar[int]
+    CLAIM_WORKER_ID_FIELD_NUMBER: _ClassVar[int]
     ATTEMPT_COUNT_FIELD_NUMBER: _ClassVar[int]
     CLAIM_EXPIRES_AT_FIELD_NUMBER: _ClassVar[int]
     CREATED_AT_FIELD_NUMBER: _ClassVar[int]
@@ -41,6 +42,7 @@ class SessionSubmission(_message.Message):
     user_message_id: str
     status: SessionSubmissionStatus
     attempt_id: str
+    claim_worker_id: str
     attempt_count: int
     claim_expires_at: int
     created_at: int
@@ -49,4 +51,4 @@ class SessionSubmission(_message.Message):
     committed_message_id: str
     current_phase: _session_journal_entry_pb2.SessionExecutionPhase
     current_journal_entry_id: str
-    def __init__(self, submission_id: _Optional[str] = ..., session_id: _Optional[str] = ..., user_message_id: _Optional[str] = ..., status: _Optional[_Union[SessionSubmissionStatus, str]] = ..., attempt_id: _Optional[str] = ..., attempt_count: _Optional[int] = ..., claim_expires_at: _Optional[int] = ..., created_at: _Optional[int] = ..., updated_at: _Optional[int] = ..., completed_at: _Optional[int] = ..., committed_message_id: _Optional[str] = ..., current_phase: _Optional[_Union[_session_journal_entry_pb2.SessionExecutionPhase, str]] = ..., current_journal_entry_id: _Optional[str] = ...) -> None: ...
+    def __init__(self, submission_id: _Optional[str] = ..., session_id: _Optional[str] = ..., user_message_id: _Optional[str] = ..., status: _Optional[_Union[SessionSubmissionStatus, str]] = ..., attempt_id: _Optional[str] = ..., claim_worker_id: _Optional[str] = ..., attempt_count: _Optional[int] = ..., claim_expires_at: _Optional[int] = ..., created_at: _Optional[int] = ..., updated_at: _Optional[int] = ..., completed_at: _Optional[int] = ..., committed_message_id: _Optional[str] = ..., current_phase: _Optional[_Union[_session_journal_entry_pb2.SessionExecutionPhase, str]] = ..., current_journal_entry_id: _Optional[str] = ...) -> None: ...

--- a/sdk/rust/talon-client/src/generated/talon.data.rs
+++ b/sdk/rust/talon-client/src/generated/talon.data.rs
@@ -452,6 +452,11 @@ pub struct SessionSubmission {
     /// workers cannot move the submission pointer backward.
     #[prost(string, tag = "5")]
     pub attempt_id: ::prost::alloc::string::String,
+    /// Worker that owns the current claim. Gateways use this to connect to the
+    /// exact worker process that can stream in-process session parts for the
+    /// attempt.
+    #[prost(string, tag = "14")]
+    pub claim_worker_id: ::prost::alloc::string::String,
     /// Number of successful claims/reclaims for this submission.
     #[prost(uint32, tag = "6")]
     pub attempt_count: u32,

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -1,8 +1,9 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use futures::StreamExt;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use talon::{
     control::{
@@ -10,15 +11,22 @@ use talon::{
         config::{Config, ConfigExt},
         topics, ControlPlane, MessagePublisher,
     },
+    gateway::rpc::resources_proto,
     gateway::{auth::AuthConfig, server::Gateway},
     worker::{
-        mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator,
-        WorkerEventHandler,
+        fanout::FanoutHub, mcp_registry::McpRegistry,
+        scheduler_auth::SchedulerRequestAuthenticator, WorkerEventHandler,
     },
 };
-use tokio::{signal, task::JoinHandle};
+use tokio::{net::UnixListener, signal, task::JoinHandle};
+use tokio_stream::wrappers::UnixListenerStream;
 use tokio_util::sync::CancellationToken;
+use tonic::transport::Server;
 use tracing::Instrument;
+use url::Url;
+
+#[cfg(unix)]
+use std::os::unix::fs::FileTypeExt;
 
 #[cfg(feature = "heap-profile")]
 #[global_allocator]
@@ -52,16 +60,110 @@ fn worker_handler(
     cp: Arc<ControlPlane>,
     config: Arc<Config>,
     scheduler_authenticator: Arc<SchedulerRequestAuthenticator>,
+    worker_id: String,
+    fanout_hub: Arc<FanoutHub>,
 ) -> WorkerEventHandler {
     WorkerEventHandler {
         cp,
         config,
         mcp_registry: Arc::new(McpRegistry::new()),
         scheduler_authenticator,
-        worker_id: talon::worker::registration::worker_id(),
-        fanout_hub: Arc::new(talon::worker::fanout::FanoutHub::new()),
+        worker_id,
+        fanout_hub,
         session_cancellations: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
     }
+}
+
+fn node_worker_socket_path(worker_id: &str) -> Result<PathBuf> {
+    if let Ok(raw_url) = std::env::var("TALON_WORKER_ENDPOINT_URL") {
+        let url = Url::parse(raw_url.trim()).context("invalid TALON_WORKER_ENDPOINT_URL")?;
+        if url.scheme() == "unix" {
+            let path = urlencoding::decode(url.path())
+                .context("invalid unix worker endpoint path")?
+                .into_owned();
+            return Ok(PathBuf::from(path));
+        }
+    }
+    if let Ok(path) = std::env::var("TALON_WORKER_UNIX_SOCKET_PATH") {
+        let path = path.trim();
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    Ok(std::env::temp_dir().join(format!("talon-node-worker-{worker_id}.sock")))
+}
+
+fn node_worker_endpoint(socket_path: &Path) -> resources_proto::WorkerEndpoint {
+    resources_proto::WorkerEndpoint {
+        url: format!("unix://{}", socket_path.display()),
+        protocol: "grpc".to_string(),
+        audience: std::env::var("TALON_WORKER_ENDPOINT_AUDIENCE").unwrap_or_default(),
+    }
+}
+
+async fn prepare_worker_socket(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.with_context(|| {
+            format!(
+                "failed to create worker socket directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    match tokio::fs::metadata(path).await {
+        Ok(metadata) if metadata.file_type().is_socket() => {
+            tokio::fs::remove_file(path).await.with_context(|| {
+                format!("failed to remove stale worker socket {}", path.display())
+            })?;
+        }
+        Ok(_) => {
+            anyhow::bail!(
+                "refusing to replace non-socket worker endpoint path {}",
+                path.display()
+            );
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!("failed to inspect worker socket path {}", path.display())
+            });
+        }
+    }
+    Ok(())
+}
+
+async fn serve_worker_fanout_socket(
+    socket_path: PathBuf,
+    fanout_hub: Arc<FanoutHub>,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    prepare_worker_socket(&socket_path).await?;
+    let listener = UnixListener::bind(&socket_path).with_context(|| {
+        format!(
+            "failed to bind worker fanout socket {}",
+            socket_path.display()
+        )
+    })?;
+    let incoming = UnixListenerStream::new(listener);
+    let service =
+        talon::gateway::rpc::worker_proto::fanout_service_server::FanoutServiceServer::new(
+            talon::worker::fanout::FanoutServiceImpl::new(fanout_hub),
+        );
+    tracing::info!(
+        endpoint = %format!("unix://{}", socket_path.display()),
+        "Starting node worker fanout service"
+    );
+    let result = Server::builder()
+        .add_service(service)
+        .serve_with_incoming_shutdown(incoming, shutdown.cancelled_owned())
+        .await
+        .context("node worker fanout service failed");
+    if let Err(err) = tokio::fs::remove_file(&socket_path).await {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(path = %socket_path.display(), error = %err, "Failed to remove worker fanout socket");
+        }
+    }
+    result
 }
 
 async fn spawn_subscription(
@@ -117,18 +219,47 @@ async fn join_with_grace(task: &mut JoinHandle<Result<()>>) -> Result<()> {
     }
 }
 
+async fn join_unit_with_grace(task: &mut JoinHandle<()>) {
+    if tokio::time::timeout(std::time::Duration::from_secs(1), &mut *task)
+        .await
+        .is_err()
+    {
+        task.abort();
+        let _ = task.await;
+    }
+}
+
 async fn run() -> Result<()> {
     let config = Arc::new(Config::load_default()?);
     let cp = Arc::new(build_control_plane(&config).await?);
     let scheduler_authenticator =
         Arc::new(SchedulerRequestAuthenticator::from_config(&config).await?);
+    let worker_id = talon::worker::registration::worker_id();
+    let fanout_hub = Arc::new(FanoutHub::new());
     let handler = worker_handler(
         Arc::clone(&cp),
         Arc::clone(&config),
         scheduler_authenticator,
+        worker_id.clone(),
+        fanout_hub.clone(),
     );
     let shutdown = CancellationToken::new();
     let session_concurrency = worker_session_concurrency();
+    let worker_socket_path = node_worker_socket_path(&worker_id)?;
+    let worker_endpoint = node_worker_endpoint(&worker_socket_path);
+    let worker_registration =
+        talon::worker::registration::WorkerRegistration::new(&worker_id, env!("CARGO_PKG_VERSION"))
+            .with_endpoints(vec![worker_endpoint]);
+    let mut heartbeat_task = tokio::spawn(talon::worker::registration::run_worker_heartbeat(
+        Arc::clone(&cp),
+        worker_registration,
+        shutdown.child_token(),
+    ));
+    let mut fanout_task = tokio::spawn(serve_worker_fanout_socket(
+        worker_socket_path,
+        fanout_hub,
+        shutdown.child_token(),
+    ));
 
     let mut subscription_tasks = vec![
         spawn_subscription(
@@ -188,11 +319,16 @@ async fn run() -> Result<()> {
 
     enum Exit {
         Rpc(Result<()>),
+        Fanout(Result<()>),
         Shutdown,
     }
 
     let exit = tokio::select! {
         result = &mut rpc_task => Exit::Rpc(match result {
+            Ok(inner) => inner,
+            Err(err) => Err(err.into()),
+        }),
+        result = &mut fanout_task => Exit::Fanout(match result {
             Ok(inner) => inner,
             Err(err) => Err(err.into()),
         }),
@@ -205,8 +341,11 @@ async fn run() -> Result<()> {
     shutdown.cancel();
     let result = match exit {
         Exit::Rpc(result) => result,
+        Exit::Fanout(result) => result,
         Exit::Shutdown => join_with_grace(&mut rpc_task).await,
     };
+    let _ = join_with_grace(&mut fanout_task).await;
+    join_unit_with_grace(&mut heartbeat_task).await;
     for task in &mut subscription_tasks {
         let _ = join_with_grace(task).await;
     }
@@ -221,4 +360,54 @@ async fn main() -> Result<()> {
     talon::control::profiling::init_heap_profiler_from_env(|name| std::env::var(name).ok())?;
     tracing::info!("Starting Talon node runtime...");
     run().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon::control::{keys, ns, ProtoKeyValueStoreExt};
+    use talon::test_support::{EmptyPubSub, MockKvStore};
+    use tempfile::tempdir;
+
+    #[test]
+    fn node_worker_endpoint_uses_unix_uri() {
+        let endpoint = node_worker_endpoint(Path::new("/tmp/talon-node-worker.sock"));
+        assert_eq!(endpoint.url, "unix:///tmp/talon-node-worker.sock");
+        assert_eq!(endpoint.protocol, "grpc");
+    }
+
+    #[tokio::test]
+    async fn node_worker_fanout_registration_publishes_unix_endpoint() {
+        let dir = tempdir().unwrap();
+        let socket_path = dir.path().join("fanout.sock");
+        let endpoint = node_worker_endpoint(&socket_path);
+        let cp =
+            ControlPlane::builder(Arc::new(MockKvStore::default()), Arc::new(EmptyPubSub)).build();
+        let registration =
+            talon::worker::registration::WorkerRegistration::new("node-worker", "1.2.3")
+                .with_endpoints(vec![endpoint.clone()]);
+
+        talon::worker::registration::upsert_worker(&cp, &registration)
+            .await
+            .unwrap();
+        talon::worker::registration::patch_worker_status(&cp, &registration, "ready")
+            .await
+            .unwrap();
+
+        let worker = cp
+            .kv
+            .get_msg::<resources_proto::Worker>(&keys::ResourceKey::new(
+                ns::TALON_SYSTEM,
+                &[],
+                "Worker",
+                "node-worker",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        let endpoints = worker.status.unwrap().endpoints;
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].url, endpoint.url);
+        assert_eq!(endpoints[0].protocol, "grpc");
+    }
 }

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -58,6 +58,8 @@ fn worker_handler(
         config,
         mcp_registry: Arc::new(McpRegistry::new()),
         scheduler_authenticator,
+        worker_id: talon::worker::registration::worker_id(),
+        fanout_hub: Arc::new(talon::worker::fanout::FanoutHub::new()),
         session_cancellations: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
     }
 }

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -288,7 +288,7 @@ fn worker_router(handler: WorkerEventHandler) -> Router {
         talon::gateway::rpc::worker_proto::fanout_service_server::FanoutServiceServer::new(
             talon::worker::fanout::FanoutServiceImpl::new(handler.fanout_hub.clone()),
         );
-    let grpc_service = Server::builder()
+    let tonic_service = Server::builder()
         .accept_http1(true)
         .add_service(fanout_service)
         .into_service::<BoxBody>();
@@ -304,11 +304,11 @@ fn worker_router(handler: WorkerEventHandler) -> Router {
             "/mcp/talon-ops",
             talon::worker::talon_ops::talon_ops_router(handler.clone()),
         )
-        .fallback_service(grpc_fallback_service(grpc_service))
+        .fallback_service(grpc_service(tonic_service))
         .with_state(handler)
 }
 
-fn grpc_fallback_service<S>(grpc_service: S) -> axum::routing::RouterIntoService<Body, ()>
+fn grpc_service<S>(service: S) -> axum::routing::RouterIntoService<Body, ()>
 where
     S: Service<Request<BoxBody>, Response = Response<BoxBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
@@ -316,10 +316,10 @@ where
 {
     Router::new()
         .fallback_service(tower::service_fn(move |request: Request<Body>| {
-            let mut grpc_service = grpc_service.clone();
+            let mut service = service.clone();
             async move {
                 let request = request.map(tonic::body::boxed);
-                let response = match grpc_service.ready().await {
+                let response = match service.ready().await {
                     Ok(ready_service) => ready_service.call(request).await,
                     Err(err) => {
                         tracing::error!(%err, "worker gRPC service was not ready");

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -3,8 +3,12 @@
 
 use anyhow::Result;
 use axum::{
-    body::Bytes, extract::State, http::HeaderMap, response::IntoResponse, routing::post, Json,
-    Router,
+    body::{Body, Bytes},
+    extract::State,
+    http::{HeaderMap, Request, Response, StatusCode},
+    response::IntoResponse,
+    routing::post,
+    Json, Router,
 };
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -20,6 +24,8 @@ use talon::control::ControlPlane;
 use talon::worker::{scheduler_auth::SchedulerRequestAuthenticator, WorkerEventHandler};
 use tokio::{signal, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
+use tonic::body::BoxBody;
+use tower::{Service, ServiceExt};
 use tracing::Instrument;
 
 #[cfg(feature = "heap-profile")]
@@ -244,17 +250,32 @@ fn build_worker_handler(
     cp: Arc<ControlPlane>,
     config: Arc<Config>,
     scheduler_authenticator: Arc<SchedulerRequestAuthenticator>,
+    worker_id: String,
+    fanout_hub: Arc<talon::worker::fanout::FanoutHub>,
 ) -> WorkerEventHandler {
     WorkerEventHandler {
         cp,
         config,
         mcp_registry: Arc::new(talon::worker::mcp_registry::McpRegistry::new()),
         scheduler_authenticator,
+        worker_id,
+        fanout_hub,
         session_cancellations: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
     }
 }
 
 fn worker_router(handler: WorkerEventHandler) -> Router {
+    use tonic::transport::Server;
+
+    let fanout_service =
+        talon::gateway::rpc::worker_proto::fanout_service_server::FanoutServiceServer::new(
+            talon::worker::fanout::FanoutServiceImpl::new(handler.fanout_hub.clone()),
+        );
+    let grpc_service = Server::builder()
+        .accept_http1(true)
+        .add_service(fanout_service)
+        .into_service::<BoxBody>();
+
     Router::new()
         .route("/pubsub/push", post(push_webhook))
         .route(
@@ -266,7 +287,42 @@ fn worker_router(handler: WorkerEventHandler) -> Router {
             "/mcp/talon-ops",
             talon::worker::talon_ops::talon_ops_router(handler.clone()),
         )
+        .fallback_service(grpc_fallback_service(grpc_service))
         .with_state(handler)
+}
+
+fn grpc_fallback_service<S>(grpc_service: S) -> axum::routing::RouterIntoService<Body, ()>
+where
+    S: Service<Request<BoxBody>, Response = Response<BoxBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    Router::new()
+        .fallback_service(tower::service_fn(move |request: Request<Body>| {
+            let mut grpc_service = grpc_service.clone();
+            async move {
+                let request = request.map(tonic::body::boxed);
+                let response = match grpc_service.ready().await {
+                    Ok(ready_service) => ready_service.call(request).await,
+                    Err(err) => {
+                        tracing::error!(%err, "worker gRPC service was not ready");
+                        return Ok::<_, std::convert::Infallible>(internal_server_error());
+                    }
+                };
+                match response {
+                    Ok(response) => Ok(response.into_response()),
+                    Err(err) => {
+                        tracing::error!(%err, "worker gRPC service failed");
+                        Ok(internal_server_error())
+                    }
+                }
+            }
+        }))
+        .into_service()
+}
+
+fn internal_server_error() -> axum::response::Response {
+    StatusCode::INTERNAL_SERVER_ERROR.into_response()
 }
 
 struct GcpPullSubscriptionBackend {
@@ -725,14 +781,23 @@ where
     Fut: std::future::Future<Output = Result<()>>,
     FShutdown: std::future::Future,
 {
-    let handler = build_worker_handler(cp, config, scheduler_authenticator);
+    let worker_id = talon::worker::registration::worker_id();
+    let fanout_hub = Arc::new(talon::worker::fanout::FanoutHub::new());
+    let handler = build_worker_handler(
+        cp,
+        config,
+        scheduler_authenticator,
+        worker_id.clone(),
+        fanout_hub,
+    );
     let pull_mode = pull_mode_enabled(&env_get);
     let project_id = pubsub_project_id(&env_get);
+    let port = worker_port(&env_get);
+    let endpoints = talon::worker::registration::discover_worker_endpoints(&env_get, &port).await;
     let shutdown_token = CancellationToken::new();
-    let worker_registration = talon::worker::registration::WorkerRegistration::new(
-        talon::worker::registration::worker_id(),
-        env!("CARGO_PKG_VERSION"),
-    );
+    let worker_registration =
+        talon::worker::registration::WorkerRegistration::new(worker_id, env!("CARGO_PKG_VERSION"))
+            .with_endpoints(endpoints);
     let heartbeat_task = tokio::spawn(talon::worker::registration::run_worker_heartbeat(
         handler.cp.clone(),
         worker_registration,
@@ -745,7 +810,7 @@ where
         shutdown_token.child_token(),
     );
     tokio::pin!(shutdown);
-    let serve_future = serve(handler, worker_port(env_get), shutdown_token.child_token());
+    let serve_future = serve(handler, port, shutdown_token.child_token());
     tokio::pin!(serve_future);
     let result = tokio::select! {
         res = &mut serve_future => res,
@@ -1027,6 +1092,8 @@ mod tests {
             config: Arc::new(Config::default()),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(authenticator),
+            worker_id: "test-worker".to_string(),
+            fanout_hub: Arc::new(talon::worker::fanout::FanoutHub::new()),
             session_cancellations: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -1263,10 +1330,19 @@ mod tests {
         let cp = Arc::new(ControlPlane::noop());
         let config = Arc::new(Config::default());
         let auth = Arc::new(SchedulerRequestAuthenticator::deny_all());
-        let handler = build_worker_handler(cp.clone(), config.clone(), auth.clone());
+        let fanout_hub = Arc::new(talon::worker::fanout::FanoutHub::new());
+        let handler = build_worker_handler(
+            cp.clone(),
+            config.clone(),
+            auth.clone(),
+            "worker-test".to_string(),
+            fanout_hub.clone(),
+        );
         assert!(Arc::ptr_eq(&handler.cp, &cp));
         assert!(Arc::ptr_eq(&handler.config, &config));
         assert!(Arc::ptr_eq(&handler.scheduler_authenticator, &auth));
+        assert_eq!(handler.worker_id, "worker-test");
+        assert!(Arc::ptr_eq(&handler.fanout_hub, &fanout_hub));
         assert!(handler.session_cancellations.blocking_lock().is_empty());
     }
 
@@ -1382,6 +1458,8 @@ mod tests {
             config: Arc::new(config),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),
+            worker_id: "test-worker".to_string(),
+            fanout_hub: Arc::new(talon::worker::fanout::FanoutHub::new()),
             session_cancellations: Arc::new(Mutex::new(HashMap::new())),
         };
         let spawned = std::sync::Mutex::new(Vec::<(String, String, String)>::new());
@@ -1728,6 +1806,8 @@ mod tests {
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::shared_secret(
                 "secret".to_string(),
             )),
+            worker_id: "test-worker".to_string(),
+            fanout_hub: Arc::new(talon::worker::fanout::FanoutHub::new()),
             session_cancellations: Arc::new(Mutex::new(HashMap::new())),
         };
 

--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -631,7 +631,9 @@ pub async fn send_message(
         }],
     };
 
-    send_session_message(kv, pubsub, ns, agent, session_id, user_msg, now).await
+    send_session_message(kv, pubsub, ns, agent, session_id, user_msg, now)
+        .await
+        .map(|_| ())
 }
 
 pub async fn send_session_message(
@@ -642,7 +644,7 @@ pub async fn send_session_message(
     session_id: &str,
     mut user_msg: data_proto::SessionMessage,
     now: DateTime<Utc>,
-) -> Result<()> {
+) -> Result<String> {
     if user_msg.parts.is_empty() {
         return Err(EmptyMessageError.into());
     }
@@ -786,7 +788,7 @@ pub async fn send_session_message(
         message_id = %message_id,
         "Queued scheduled message for session dispatch"
     );
-    Ok(())
+    Ok(message_id)
 }
 
 pub(crate) fn session_message_text_projection(message: &data_proto::SessionMessage) -> String {

--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -162,6 +162,34 @@ async fn stream_message(
         return response;
     }
 
+    let mut receiver = crate::gateway::rpc::sessions::watcher::session_parts_event_stream(
+        vec![SessionStreamTarget::new(
+            route.ns.clone(),
+            route.agent.clone(),
+            context_id.clone(),
+        )],
+        gateway.kv.clone(),
+        gateway.pubsub.clone(),
+    );
+    let (event_sender, mut event_receiver) = tokio::sync::mpsc::channel(32);
+    let watcher_cancel = tokio_util::sync::CancellationToken::new();
+    let watcher_cancel_task = watcher_cancel.clone();
+    let _watcher_task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = watcher_cancel_task.cancelled() => break,
+                event = receiver.next() => {
+                    let Some(event) = event else {
+                        break;
+                    };
+                    if event_sender.send(event).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
     if let Err(err) = scheduling::send_session_message(
         gateway.kv.as_ref(),
         gateway.pubsub.as_ref(),
@@ -173,18 +201,9 @@ async fn stream_message(
     )
     .await
     {
+        watcher_cancel.cancel();
         return scheduling_error_response(err);
     }
-
-    let mut receiver = crate::gateway::rpc::sessions::watcher::session_parts_event_stream(
-        vec![SessionStreamTarget::new(
-            route.ns.clone(),
-            route.agent.clone(),
-            context_id.clone(),
-        )],
-        gateway.kv.clone(),
-        gateway.pubsub.clone(),
-    );
 
     let stream_gateway = gateway.clone();
     let stream_route = route.clone();
@@ -241,9 +260,10 @@ async fn stream_message(
                             "final": true
                         }
                     })));
+                    watcher_cancel.cancel();
                     return;
                 }
-                event_result = receiver.next() => {
+                event_result = event_receiver.recv() => {
                     timeout.as_mut().reset(tokio::time::Instant::now() + A2A_STREAM_IDLE_TIMEOUT);
                     let Some(event_result) = event_result else {
                         break;
@@ -258,6 +278,7 @@ async fn stream_message(
                                 Some(status.message()),
                                 true,
                             )));
+                            watcher_cancel.cancel();
                             return;
                         }
                     };
@@ -266,6 +287,14 @@ async fn stream_message(
                     let part_type = part.map(|part| part.part_type).unwrap_or_default();
                     let content = part.map(|part| part.content.as_str()).unwrap_or_default();
                     if event.kind == SessionMessagePartEventKind::Done as i32 {
+                        if !stream_artifact_started
+                            && part_type == data_proto::SessionMessagePartType::Text as i32
+                            && !content.is_empty()
+                            && (pending_artifact_text.is_empty()
+                                || content.ends_with(&pending_artifact_text))
+                        {
+                            pending_artifact_text = content.to_string();
+                        }
                         break;
                     } else if event.kind == SessionMessagePartEventKind::Error as i32 {
                         if !pending_artifact_text.is_empty() {
@@ -286,6 +315,7 @@ async fn stream_message(
                             Some(error_text),
                             true,
                         )));
+                        watcher_cancel.cancel();
                         return;
                     } else if part_type == data_proto::SessionMessagePartType::Text as i32 && !content.is_empty() {
                         pending_artifact_text.push_str(content);
@@ -332,6 +362,7 @@ async fn stream_message(
                 "final": true
             }
         })));
+        watcher_cancel.cancel();
     };
 
     (

--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -11,6 +11,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use futures::StreamExt;
 use serde_json::{json, Value};
 use tonic::Code;
 use uuid::Uuid;
@@ -24,6 +25,7 @@ use crate::control::{
 use crate::gateway::auth::{self, AuthConfig};
 use crate::gateway::rpc::data_proto;
 use crate::gateway::server::Gateway;
+use crate::gateway::session_streams::SessionStreamTarget;
 
 use super::card::{
     agent_card_json, external_host_from_headers, resolve_agent_card_route, scheme_from_headers,
@@ -160,21 +162,6 @@ async fn stream_message(
         return response;
     }
 
-    let mut receiver = match gateway
-        .session_streams
-        .subscribe(&route.ns, &route.agent, &context_id)
-        .await
-    {
-        Ok(receiver) => receiver,
-        Err(err) => {
-            tracing::error!(%err, "Failed to subscribe to A2A stream");
-            return a2a_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed to subscribe to task stream",
-            );
-        }
-    };
-
     if let Err(err) = scheduling::send_session_message(
         gateway.kv.as_ref(),
         gateway.pubsub.as_ref(),
@@ -188,6 +175,16 @@ async fn stream_message(
     {
         return scheduling_error_response(err);
     }
+
+    let mut receiver = crate::gateway::rpc::sessions::watcher::session_parts_event_stream(
+        vec![SessionStreamTarget::new(
+            route.ns.clone(),
+            route.agent.clone(),
+            context_id.clone(),
+        )],
+        gateway.kv.clone(),
+        gateway.pubsub.clone(),
+    );
 
     let stream_gateway = gateway.clone();
     let stream_route = route.clone();
@@ -246,7 +243,7 @@ async fn stream_message(
                     })));
                     return;
                 }
-                event_result = receiver.recv() => {
+                event_result = receiver.next() => {
                     timeout.as_mut().reset(tokio::time::Instant::now() + A2A_STREAM_IDLE_TIMEOUT);
                     let Some(event_result) = event_result else {
                         break;

--- a/src/gateway/rpc/mod.rs
+++ b/src/gateway/rpc/mod.rs
@@ -32,6 +32,9 @@ pub mod generated {
     pub mod proto {
         tonic::include_proto!("talon.v1");
     }
+    pub mod worker_proto {
+        tonic::include_proto!("talon.worker.v1");
+    }
 }
 
 #[cfg(feature = "bazel")]
@@ -47,6 +50,9 @@ pub mod generated {
     }
     pub mod proto {
         pub use talon_api_proto::talon::v1::*;
+    }
+    pub mod worker_proto {
+        pub use talon_api_proto::talon::worker::v1::*;
     }
 }
 
@@ -64,6 +70,10 @@ pub mod harness_proto {
 
 pub mod resources_proto {
     pub use super::generated::resources::*;
+}
+
+pub mod worker_proto {
+    pub use super::generated::worker_proto::*;
 }
 
 pub mod manifests {

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -11,9 +11,9 @@ use prost::Message;
 use serde_json::{json, Value};
 use std::sync::OnceLock;
 
-mod watcher;
+pub(crate) mod watcher;
 
-use watcher::session_parts_event_stream;
+use watcher::{session_parts_event_stream, session_submission_event_stream};
 
 const LARGE_SESSION_PAYLOAD_WARNING_BYTES: usize = 128 * 1024;
 const DEFAULT_SESSION_MESSAGES_PAGE_SIZE: usize = 50;
@@ -1198,17 +1198,7 @@ impl GrpcGatewayHandler {
             req.agent.clone(),
             req.session_id.clone(),
         )];
-        let receiver = self
-            .gateway
-            .session_streams
-            .subscribe(&req.ns, &req.agent, &req.session_id)
-            .await
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to subscribe to session stream: {}", e))
-            })?;
-
         let event_stream = session_parts_event_stream(
-            receiver,
             targets,
             self.gateway.kv.clone(),
             self.gateway.pubsub.clone(),
@@ -1260,17 +1250,7 @@ impl GrpcGatewayHandler {
             }
         }
 
-        let receiver = self
-            .gateway
-            .session_streams
-            .subscribe_many(targets.clone())
-            .await
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to subscribe to session stream: {}", e))
-            })?;
-
         let event_stream = session_parts_event_stream(
-            receiver,
             targets,
             self.gateway.kv.clone(),
             self.gateway.pubsub.clone(),
@@ -1296,27 +1276,13 @@ impl GrpcGatewayHandler {
             &req.get_ref().session_id
         );
         let req = req.into_inner();
-        let targets = vec![SessionStreamTarget::new(
-            req.ns.clone(),
-            req.agent.clone(),
-            req.session_id.clone(),
-        )];
-        let receiver = self
-            .gateway
-            .session_streams
-            .subscribe(&req.ns, &req.agent, &req.session_id)
-            .await
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to subscribe to session stream: {}", e))
-            })?;
-
         let mut message = req
             .message
             .ok_or_else(|| tonic::Status::invalid_argument("message is required"))?;
         message.labels.extend(req.labels);
         let message = normalize_appended_session_message(message);
         let now = chrono::Utc::now();
-        scheduling::send_session_message(
+        let submission_id = scheduling::send_session_message(
             self.gateway.kv.as_ref(),
             self.gateway.pubsub.as_ref(),
             &req.ns,
@@ -1327,10 +1293,12 @@ impl GrpcGatewayHandler {
         )
         .await
         .map_err(map_session_submit_error)?;
+        let target =
+            SessionStreamTarget::new(req.ns.clone(), req.agent.clone(), req.session_id.clone());
 
-        let event_stream = session_parts_event_stream(
-            receiver,
-            targets,
+        let event_stream = session_submission_event_stream(
+            target,
+            submission_id,
             self.gateway.kv.clone(),
             self.gateway.pubsub.clone(),
         );

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -89,7 +89,7 @@ fn single_session_parts_event_stream(
             tick.tick().await;
             let Some(submission) = (match submission_id.as_deref() {
                 Some(submission_id) => load_session_submission(kv.as_ref(), &target, submission_id).await?,
-                None => latest_nonterminal_submission(kv.as_ref(), &target).await?,
+                None => latest_submission(kv.as_ref(), &target).await?,
             }) else {
                 continue;
             };
@@ -101,21 +101,24 @@ fn single_session_parts_event_stream(
 
             let now_micros = chrono::Utc::now().timestamp_micros();
             let terminal = crate::harness::sessions::submission_is_terminal(&submission);
-            if !terminal {
-                if submission.status != data_proto::SessionSubmissionStatus::Claimed as i32
-                    || submission
-                        .claim_expires_at
-                        .is_some_and(|expires_at| expires_at <= now_micros)
-                {
-                    redispatch_expired_session_lease(
-                        kv.as_ref(),
-                        pubsub.as_ref(),
-                        &target,
-                        now_micros,
-                    )
-                    .await?;
-                    continue;
-                }
+            if terminal {
+                yield Ok(terminal_event_from_submission(&target, &submission));
+                break 'outer;
+            }
+
+            if submission.status != data_proto::SessionSubmissionStatus::Claimed as i32
+                || submission
+                    .claim_expires_at
+                    .is_some_and(|expires_at| expires_at <= now_micros)
+            {
+                redispatch_expired_session_lease(
+                    kv.as_ref(),
+                    pubsub.as_ref(),
+                    &target,
+                    now_micros,
+                )
+                .await?;
+                continue;
             }
 
             if submission.claim_worker_id.is_empty() {
@@ -156,10 +159,6 @@ fn single_session_parts_event_stream(
                     if status.code() == tonic::Code::NotFound
                         || status.code() == tonic::Code::Unavailable =>
                 {
-                    if terminal {
-                        yield Err(status);
-                        break;
-                    }
                     tokio::time::sleep(WORKER_FANOUT_NOT_FOUND_RETRY_DELAY).await;
                 }
                 Err(status) => {
@@ -240,7 +239,7 @@ fn batch_session_parts_event_stream(
                     continue;
                 }
 
-                let Some(submission) = latest_nonterminal_submission(kv.as_ref(), &state.target).await? else {
+                let Some(submission) = latest_submission(kv.as_ref(), &state.target).await? else {
                     continue;
                 };
 
@@ -250,21 +249,25 @@ fn batch_session_parts_event_stream(
                 }
 
                 let terminal = crate::harness::sessions::submission_is_terminal(&submission);
-                if !terminal {
-                    if submission.status != data_proto::SessionSubmissionStatus::Claimed as i32
-                        || submission
-                            .claim_expires_at
-                            .is_some_and(|expires_at| expires_at <= now_micros)
-                    {
-                        redispatch_expired_session_lease(
-                            kv.as_ref(),
-                            pubsub.as_ref(),
-                            &state.target,
-                            now_micros,
-                        )
-                        .await?;
-                        continue;
-                    }
+                if terminal {
+                    state.done = true;
+                    yield Ok(terminal_event_from_submission(&state.target, &submission));
+                    continue;
+                }
+
+                if submission.status != data_proto::SessionSubmissionStatus::Claimed as i32
+                    || submission
+                        .claim_expires_at
+                        .is_some_and(|expires_at| expires_at <= now_micros)
+                {
+                    redispatch_expired_session_lease(
+                        kv.as_ref(),
+                        pubsub.as_ref(),
+                        &state.target,
+                        now_micros,
+                    )
+                    .await?;
+                    continue;
                 }
 
                 if submission.claim_worker_id.is_empty() {
@@ -679,6 +682,56 @@ async fn latest_nonterminal_submission(
     Ok(submissions
         .into_iter()
         .max_by_key(|submission| (submission.created_at, submission.updated_at)))
+}
+
+async fn latest_submission(
+    kv: &dyn KeyValueStore,
+    target: &SessionStreamTarget,
+) -> std::result::Result<Option<data_proto::SessionSubmission>, tonic::Status> {
+    let prefix = keys::session_submission_prefix(&target.ns, &target.agent, &target.session_id);
+    let entries = kv
+        .list_entries(&prefix)
+        .await
+        .map_err(|err| tonic::Status::internal(format!("Failed to list submissions: {err}")))?;
+    let mut submissions = Vec::new();
+    for (_key, bytes) in entries {
+        let submission =
+            data_proto::SessionSubmission::decode(bytes.as_slice()).map_err(|err| {
+                tonic::Status::internal(format!("Failed to decode submission: {err}"))
+            })?;
+        submissions.push(submission);
+    }
+    Ok(submissions
+        .into_iter()
+        .max_by_key(|submission| (submission.created_at, submission.updated_at)))
+}
+
+fn terminal_event_from_submission(
+    target: &SessionStreamTarget,
+    submission: &data_proto::SessionSubmission,
+) -> events::SessionMessagePartEvent {
+    let failed = submission.status == data_proto::SessionSubmissionStatus::Failed as i32
+        || submission.status == data_proto::SessionSubmissionStatus::Interrupted as i32;
+    events::SessionMessagePartEvent {
+        session_id: target.session_id.clone(),
+        kind: if failed {
+            events::SessionMessagePartEventKind::Error as i32
+        } else {
+            events::SessionMessagePartEventKind::Done as i32
+        },
+        part: Some(data_proto::SessionMessagePart {
+            part_type: if failed {
+                data_proto::SessionMessagePartType::Error as i32
+            } else {
+                data_proto::SessionMessagePartType::Text as i32
+            },
+            ..Default::default()
+        }),
+        timestamp: submission.updated_at,
+        agent: target.agent.clone(),
+        ns: target.ns.clone(),
+        message_id: String::new(),
+    }
 }
 
 #[cfg(test)]

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -8,11 +8,16 @@ use crate::control::{events, keys, ns, KeyValueStore, MessagePublisher};
 use crate::gateway::rpc::{data_proto, resources_proto, worker_proto};
 use crate::gateway::session_streams::SessionStreamTarget;
 use futures::{stream::SelectAll, Stream, StreamExt};
+use hyper_util::rt::TokioIo;
 use prost::Message;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
-use tonic::transport::Channel;
+use tokio::net::UnixStream;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+use url::Url;
 
 const SESSION_STREAM_LEASE_CHECK_MAX_MICROS: u64 = 5_000_000;
 const SESSION_STREAM_LEASE_CHECK_MIN_MICROS: u64 = 100_000;
@@ -187,11 +192,7 @@ async fn stream_from_endpoint(
     after_sequence: u64,
 ) -> std::result::Result<tonic::Streaming<worker_proto::StreamSessionPartsResponse>, tonic::Status>
 {
-    let channel = Channel::from_shared(endpoint.url.clone())
-        .map_err(|err| tonic::Status::unavailable(format!("invalid worker endpoint: {err}")))?
-        .connect()
-        .await
-        .map_err(|err| tonic::Status::unavailable(format!("failed to connect to worker: {err}")))?;
+    let channel = worker_endpoint_channel(endpoint).await?;
     let mut client = worker_proto::fanout_service_client::FanoutServiceClient::new(channel);
     let response = client
         .stream_session_parts(worker_proto::StreamSessionPartsRequest {
@@ -204,6 +205,47 @@ async fn stream_from_endpoint(
         })
         .await?;
     Ok(response.into_inner())
+}
+
+async fn worker_endpoint_channel(
+    endpoint: &resources_proto::WorkerEndpoint,
+) -> std::result::Result<Channel, tonic::Status> {
+    if let Some(path) = unix_endpoint_path(&endpoint.url)? {
+        let path = Arc::new(path);
+        return Endpoint::try_from("http://[::]:50051")
+            .map_err(|err| tonic::Status::unavailable(format!("invalid worker endpoint: {err}")))?
+            .connect_with_connector(service_fn(move |_uri: Uri| {
+                let path = path.clone();
+                async move { UnixStream::connect(path.as_ref()).await.map(TokioIo::new) }
+            }))
+            .await
+            .map_err(|err| {
+                tonic::Status::unavailable(format!("failed to connect to worker: {err}"))
+            });
+    }
+
+    Channel::from_shared(endpoint.url.clone())
+        .map_err(|err| tonic::Status::unavailable(format!("invalid worker endpoint: {err}")))?
+        .connect()
+        .await
+        .map_err(|err| tonic::Status::unavailable(format!("failed to connect to worker: {err}")))
+}
+
+fn unix_endpoint_path(url: &str) -> std::result::Result<Option<PathBuf>, tonic::Status> {
+    let parsed = Url::parse(url)
+        .map_err(|err| tonic::Status::unavailable(format!("invalid worker endpoint: {err}")))?;
+    if parsed.scheme() != "unix" {
+        return Ok(None);
+    }
+    if parsed.path().is_empty() {
+        return Err(tonic::Status::unavailable(
+            "unix worker endpoint is missing a socket path",
+        ));
+    }
+    let path = urlencoding::decode(parsed.path()).map_err(|err| {
+        tonic::Status::unavailable(format!("invalid unix worker endpoint path: {err}"))
+    })?;
+    Ok(Some(PathBuf::from(path.into_owned())))
 }
 
 async fn worker_endpoints(
@@ -395,4 +437,97 @@ async fn latest_nonterminal_submission(
     Ok(submissions
         .into_iter()
         .max_by_key(|submission| (submission.created_at, submission.updated_at)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::events::SessionMessagePartEventKind;
+    use crate::worker::fanout::{FanoutHub, SessionFanoutKey};
+    use tempfile::tempdir;
+    use tokio::net::UnixListener;
+    use tokio_stream::wrappers::UnixListenerStream;
+    use tokio_util::sync::CancellationToken;
+    use tonic::transport::Server;
+
+    fn part_event(
+        kind: SessionMessagePartEventKind,
+        content: &str,
+    ) -> events::SessionMessagePartEvent {
+        events::SessionMessagePartEvent {
+            session_id: "session-1".to_string(),
+            kind: kind as i32,
+            part: Some(data_proto::SessionMessagePart {
+                content: content.to_string(),
+                ..Default::default()
+            }),
+            timestamp: 1,
+            agent: "agent".to_string(),
+            ns: "ns".to_string(),
+            message_id: "message-1".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_from_endpoint_connects_to_unix_fanout_service() {
+        let dir = tempdir().unwrap();
+        let socket_path = dir.path().join("fanout.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let shutdown = CancellationToken::new();
+        let hub = Arc::new(FanoutHub::new());
+        let service = worker_proto::fanout_service_server::FanoutServiceServer::new(
+            crate::worker::fanout::FanoutServiceImpl::new(hub.clone()),
+        );
+        let server = tokio::spawn(
+            Server::builder()
+                .add_service(service)
+                .serve_with_incoming_shutdown(
+                    UnixListenerStream::new(listener),
+                    shutdown.clone().cancelled_owned(),
+                ),
+        );
+
+        let key = SessionFanoutKey::new("ns", "agent", "session-1", "submission-1", "attempt-1");
+        hub.create_session_attempt(key.clone()).await;
+
+        let endpoint = resources_proto::WorkerEndpoint {
+            url: format!("unix://{}", socket_path.display()),
+            protocol: "grpc".to_string(),
+            audience: String::new(),
+        };
+        let target = SessionStreamTarget::new("ns", "agent", "session-1");
+        let submission = data_proto::SessionSubmission {
+            submission_id: "submission-1".to_string(),
+            attempt_id: "attempt-1".to_string(),
+            ..Default::default()
+        };
+
+        let mut stream = tokio::time::timeout(
+            Duration::from_secs(5),
+            stream_from_endpoint(&endpoint, &target, &submission, 0),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        hub.publish_session_part(
+            &key,
+            part_event(SessionMessagePartEventKind::Delta, "hello"),
+        )
+        .await;
+        let response = tokio::time::timeout(Duration::from_secs(5), stream.message())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.sequence, 1);
+        assert_eq!(response.event.unwrap().part.unwrap().content, "hello");
+
+        drop(stream);
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
 }

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -10,6 +10,7 @@ use crate::gateway::session_streams::SessionStreamTarget;
 use futures::{stream::SelectAll, Stream, StreamExt};
 use hyper_util::rt::TokioIo;
 use prost::Message;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -47,6 +48,10 @@ pub(crate) fn session_parts_event_stream(
     kv: Arc<dyn KeyValueStore + Send + Sync>,
     pubsub: Arc<dyn MessagePublisher + Send + Sync>,
 ) -> SessionPartEventStream {
+    if targets.len() > 1 {
+        return batch_session_parts_event_stream(targets, kv, pubsub);
+    }
+
     let mut streams: SelectAll<SessionPartEventStream> = SelectAll::new();
     for target in targets {
         streams.push(single_session_parts_event_stream(
@@ -166,6 +171,200 @@ fn single_session_parts_event_stream(
     })
 }
 
+#[derive(Clone)]
+struct BatchSessionState {
+    target: SessionStreamTarget,
+    after_sequence: u64,
+    active_attempt_id: String,
+    done: bool,
+}
+
+#[derive(Clone)]
+struct ClaimedBatchStream {
+    target: SessionStreamTarget,
+    submission: data_proto::SessionSubmission,
+    after_sequence: u64,
+}
+
+type WorkerFanoutStream = Pin<
+    Box<
+        dyn Stream<
+                Item = std::result::Result<worker_proto::StreamSessionPartsResponse, tonic::Status>,
+            > + Send,
+    >,
+>;
+
+fn batch_session_parts_event_stream(
+    targets: Vec<SessionStreamTarget>,
+    kv: Arc<dyn KeyValueStore + Send + Sync>,
+    pubsub: Arc<dyn MessagePublisher + Send + Sync>,
+) -> SessionPartEventStream {
+    Box::pin(async_stream::stream! {
+        let mut states: Vec<BatchSessionState> = targets
+            .into_iter()
+            .map(|target| BatchSessionState {
+                target,
+                after_sequence: 0,
+                active_attempt_id: String::new(),
+                done: false,
+            })
+            .collect();
+        let mut tick = tokio::time::interval(stream_session_lease_check_interval());
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        'outer: loop {
+            if states.iter().all(|state| state.done) {
+                break;
+            }
+
+            tick.tick().await;
+            let now_micros = chrono::Utc::now().timestamp_micros();
+            let mut by_worker: HashMap<String, Vec<ClaimedBatchStream>> = HashMap::new();
+            let target_indexes: HashMap<(String, String, String), usize> = states
+                .iter()
+                .enumerate()
+                .map(|(index, state)| {
+                    (
+                        (
+                            state.target.ns.clone(),
+                            state.target.agent.clone(),
+                            state.target.session_id.clone(),
+                        ),
+                        index,
+                    )
+                })
+                .collect();
+
+            for state in &mut states {
+                if state.done {
+                    continue;
+                }
+
+                let Some(submission) = latest_nonterminal_submission(kv.as_ref(), &state.target).await? else {
+                    continue;
+                };
+
+                if submission.attempt_id != state.active_attempt_id {
+                    state.active_attempt_id = submission.attempt_id.clone();
+                    state.after_sequence = 0;
+                }
+
+                let terminal = crate::harness::sessions::submission_is_terminal(&submission);
+                if !terminal {
+                    if submission.status != data_proto::SessionSubmissionStatus::Claimed as i32
+                        || submission
+                            .claim_expires_at
+                            .is_some_and(|expires_at| expires_at <= now_micros)
+                    {
+                        redispatch_expired_session_lease(
+                            kv.as_ref(),
+                            pubsub.as_ref(),
+                            &state.target,
+                            now_micros,
+                        )
+                        .await?;
+                        continue;
+                    }
+                }
+
+                if submission.claim_worker_id.is_empty() {
+                    continue;
+                }
+
+                by_worker
+                    .entry(submission.claim_worker_id.clone())
+                    .or_default()
+                    .push(ClaimedBatchStream {
+                        target: state.target.clone(),
+                        submission,
+                        after_sequence: state.after_sequence,
+                    });
+            }
+
+            if by_worker.is_empty() {
+                continue;
+            }
+
+            let mut worker_streams: SelectAll<WorkerFanoutStream> = SelectAll::new();
+            for (worker_id, streams) in by_worker {
+                let terminal_batch = streams
+                    .iter()
+                    .all(|stream| crate::harness::sessions::submission_is_terminal(&stream.submission));
+                match connect_worker_batch_stream(
+                    kv.as_ref(),
+                    pubsub.as_ref(),
+                    &worker_id,
+                    &streams,
+                )
+                .await
+                {
+                    Ok(stream) => worker_streams.push(Box::pin(stream)),
+                    Err(status)
+                        if status.code() == tonic::Code::NotFound
+                            || status.code() == tonic::Code::Unavailable =>
+                    {
+                        if terminal_batch {
+                            yield Err(status);
+                            break 'outer;
+                        }
+                        tokio::time::sleep(WORKER_FANOUT_NOT_FOUND_RETRY_DELAY).await;
+                        continue 'outer;
+                    }
+                    Err(status) => {
+                        yield Err(status);
+                        break 'outer;
+                    }
+                }
+            }
+
+            loop {
+                let item = tokio::select! {
+                    item = worker_streams.next() => item,
+                    _ = tick.tick() => break,
+                };
+                let Some(item) = item else {
+                    break;
+                };
+                match item {
+                    Ok(response) => {
+                        let Some(event) = response.event else {
+                            continue;
+                        };
+                        let target_key = (
+                            event.ns.clone(),
+                            event.agent.clone(),
+                            event.session_id.clone(),
+                        );
+                        if let Some(index) = target_indexes.get(&target_key).copied() {
+                            states[index].after_sequence = response.sequence;
+                            let terminal = event.kind
+                                == events::SessionMessagePartEventKind::Done as i32
+                                || event.kind
+                                    == events::SessionMessagePartEventKind::Error as i32;
+                            if terminal {
+                                states[index].done = true;
+                            }
+                        }
+                        yield Ok(event);
+                        if states.iter().all(|state| state.done) {
+                            break 'outer;
+                        }
+                    }
+                    Err(status) => {
+                        if status.code() == tonic::Code::NotFound
+                            || status.code() == tonic::Code::Unavailable
+                        {
+                            break;
+                        }
+                        yield Err(status);
+                        break 'outer;
+                    }
+                }
+            }
+        }
+    })
+}
+
 async fn connect_worker_stream(
     kv: &dyn KeyValueStore,
     pubsub: &dyn MessagePublisher,
@@ -178,6 +377,24 @@ async fn connect_worker_stream(
     let mut last_status = None;
     for endpoint in endpoints {
         match stream_from_endpoint(&endpoint, target, submission, after_sequence).await {
+            Ok(stream) => return Ok(stream),
+            Err(status) => last_status = Some(status),
+        }
+    }
+    Err(last_status.unwrap_or_else(|| tonic::Status::unavailable("worker has no endpoints")))
+}
+
+async fn connect_worker_batch_stream(
+    kv: &dyn KeyValueStore,
+    pubsub: &dyn MessagePublisher,
+    worker_id: &str,
+    streams: &[ClaimedBatchStream],
+) -> std::result::Result<tonic::Streaming<worker_proto::StreamSessionPartsResponse>, tonic::Status>
+{
+    let endpoints = worker_endpoints(kv, pubsub, worker_id).await?;
+    let mut last_status = None;
+    for endpoint in endpoints {
+        match stream_batch_from_endpoint(&endpoint, streams).await {
             Ok(stream) => return Ok(stream),
             Err(status) => last_status = Some(status),
         }
@@ -202,6 +419,31 @@ async fn stream_from_endpoint(
             submission_id: submission.submission_id.clone(),
             attempt_id: submission.attempt_id.clone(),
             after_sequence,
+        })
+        .await?;
+    Ok(response.into_inner())
+}
+
+async fn stream_batch_from_endpoint(
+    endpoint: &resources_proto::WorkerEndpoint,
+    streams: &[ClaimedBatchStream],
+) -> std::result::Result<tonic::Streaming<worker_proto::StreamSessionPartsResponse>, tonic::Status>
+{
+    let channel = worker_endpoint_channel(endpoint).await?;
+    let mut client = worker_proto::fanout_service_client::FanoutServiceClient::new(channel);
+    let response = client
+        .stream_session_parts_batch(worker_proto::StreamSessionPartsBatchRequest {
+            streams: streams
+                .iter()
+                .map(|stream| worker_proto::StreamSessionPartsRequest {
+                    ns: stream.target.ns.clone(),
+                    agent: stream.target.agent.clone(),
+                    session_id: stream.target.session_id.clone(),
+                    submission_id: stream.submission.submission_id.clone(),
+                    attempt_id: stream.submission.attempt_id.clone(),
+                    after_sequence: stream.after_sequence,
+                })
+                .collect(),
         })
         .await?;
     Ok(response.into_inner())

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -33,7 +33,7 @@ pub(crate) type SessionPartEventStream = Pin<
 
 fn stream_session_lease_check_interval() -> Duration {
     let ttl_micros = scheduling::session_processing_timeout_micros().max(1) as u64;
-    Duration::from_micros((ttl_micros / 10).clamp(
+    Duration::from_micros((ttl_micros / 100).clamp(
         SESSION_STREAM_LEASE_CHECK_MIN_MICROS,
         SESSION_STREAM_LEASE_CHECK_MAX_MICROS,
     ))

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -4,20 +4,21 @@
 use crate::control::scheduling;
 use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{events, keys, KeyValueStore, MessagePublisher};
-use crate::gateway::rpc::data_proto;
-use crate::gateway::session_streams::{SessionStreamReceiver, SessionStreamTarget};
-use futures::{Stream, StreamExt};
+use crate::control::{events, keys, ns, KeyValueStore, MessagePublisher};
+use crate::gateway::rpc::{data_proto, resources_proto, worker_proto};
+use crate::gateway::session_streams::SessionStreamTarget;
+use futures::{stream::SelectAll, Stream, StreamExt};
 use prost::Message;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
+use tonic::transport::Channel;
 
 const SESSION_STREAM_LEASE_CHECK_MAX_MICROS: u64 = 5_000_000;
-const SESSION_STREAM_LEASE_CHECK_MIN_MICROS: u64 = 1_000_000;
-const SESSION_STREAM_LEASE_CHECK_CONCURRENCY: usize = 16;
+const SESSION_STREAM_LEASE_CHECK_MIN_MICROS: u64 = 100_000;
+const WORKER_FANOUT_NOT_FOUND_RETRY_DELAY: Duration = Duration::from_millis(50);
 
-pub(super) type SessionPartEventStream = Pin<
+pub(crate) type SessionPartEventStream = Pin<
     Box<
         dyn Stream<Item = std::result::Result<events::SessionMessagePartEvent, tonic::Status>>
             + Send,
@@ -26,7 +27,7 @@ pub(super) type SessionPartEventStream = Pin<
 
 fn stream_session_lease_check_interval() -> Duration {
     let ttl_micros = scheduling::session_processing_timeout_micros().max(1) as u64;
-    Duration::from_micros((ttl_micros / 6).clamp(
+    Duration::from_micros((ttl_micros / 10).clamp(
         SESSION_STREAM_LEASE_CHECK_MIN_MICROS,
         SESSION_STREAM_LEASE_CHECK_MAX_MICROS,
     ))
@@ -36,76 +37,205 @@ fn stream_session_redispatch_throttle_micros() -> i64 {
     scheduling::session_processing_timeout_micros().max(1)
 }
 
-pub(super) fn session_parts_event_stream(
-    mut receiver: SessionStreamReceiver,
+pub(crate) fn session_parts_event_stream(
     targets: Vec<SessionStreamTarget>,
     kv: Arc<dyn KeyValueStore + Send + Sync>,
     pubsub: Arc<dyn MessagePublisher + Send + Sync>,
 ) -> SessionPartEventStream {
-    Box::pin(async_stream::stream! {
-        let mut lease_check = tokio::time::interval(stream_session_lease_check_interval());
-        lease_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        lease_check.tick().await;
-        let mut lease_check_task: Option<tokio::task::JoinHandle<()>> = None;
+    let mut streams: SelectAll<SessionPartEventStream> = SelectAll::new();
+    for target in targets {
+        streams.push(single_session_parts_event_stream(
+            target,
+            None,
+            kv.clone(),
+            pubsub.clone(),
+        ));
+    }
+    Box::pin(streams)
+}
 
-        loop {
-            tokio::select! {
-                event = receiver.recv() => {
-                    let Some(event) = event else {
-                        break;
-                    };
-                    yield event;
-                }
-                _ = lease_check.tick() => {
-                    if lease_check_task.as_ref().is_some_and(|task| task.is_finished()) {
-                        lease_check_task = None;
-                    }
-                    if lease_check_task.is_none() {
-                        lease_check_task = Some(tokio::spawn(check_session_leases(
-                            targets.clone(),
-                            kv.clone(),
-                            pubsub.clone(),
-                        )));
-                    }
+pub(crate) fn session_submission_event_stream(
+    target: SessionStreamTarget,
+    submission_id: String,
+    kv: Arc<dyn KeyValueStore + Send + Sync>,
+    pubsub: Arc<dyn MessagePublisher + Send + Sync>,
+) -> SessionPartEventStream {
+    single_session_parts_event_stream(target, Some(submission_id), kv, pubsub)
+}
+
+fn single_session_parts_event_stream(
+    target: SessionStreamTarget,
+    submission_id: Option<String>,
+    kv: Arc<dyn KeyValueStore + Send + Sync>,
+    pubsub: Arc<dyn MessagePublisher + Send + Sync>,
+) -> SessionPartEventStream {
+    Box::pin(async_stream::stream! {
+        let mut after_sequence = 0u64;
+        let mut active_attempt_id = String::new();
+        let mut tick = tokio::time::interval(stream_session_lease_check_interval());
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        'outer: loop {
+            tick.tick().await;
+            let Some(submission) = (match submission_id.as_deref() {
+                Some(submission_id) => load_session_submission(kv.as_ref(), &target, submission_id).await?,
+                None => latest_nonterminal_submission(kv.as_ref(), &target).await?,
+            }) else {
+                continue;
+            };
+
+            if submission.attempt_id != active_attempt_id {
+                active_attempt_id = submission.attempt_id.clone();
+                after_sequence = 0;
+            }
+
+            let now_micros = chrono::Utc::now().timestamp_micros();
+            let terminal = crate::harness::sessions::submission_is_terminal(&submission);
+            if !terminal {
+                if submission.status != data_proto::SessionSubmissionStatus::Claimed as i32
+                    || submission
+                        .claim_expires_at
+                        .is_some_and(|expires_at| expires_at <= now_micros)
+                {
+                    redispatch_expired_session_lease(
+                        kv.as_ref(),
+                        pubsub.as_ref(),
+                        &target,
+                        now_micros,
+                    )
+                    .await?;
+                    continue;
                 }
             }
-        }
-        if let Some(task) = lease_check_task {
-            task.abort();
+
+            if submission.claim_worker_id.is_empty() {
+                continue;
+            }
+
+            match connect_worker_stream(kv.as_ref(), pubsub.as_ref(), &target, &submission, after_sequence).await {
+                Ok(mut stream) => {
+                    while let Some(item) = stream.next().await {
+                        match item {
+                            Ok(response) => {
+                                after_sequence = response.sequence;
+                                let Some(event) = response.event else {
+                                    continue;
+                                };
+                                let terminal = event.kind
+                                    == events::SessionMessagePartEventKind::Done as i32
+                                    || event.kind
+                                        == events::SessionMessagePartEventKind::Error as i32;
+                                yield Ok(event);
+                                if terminal {
+                                    break 'outer;
+                                }
+                            }
+                            Err(status) => {
+                                if status.code() == tonic::Code::NotFound
+                                    || status.code() == tonic::Code::Unavailable
+                                {
+                                    break;
+                                }
+                                yield Err(status);
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(status)
+                    if status.code() == tonic::Code::NotFound
+                        || status.code() == tonic::Code::Unavailable =>
+                {
+                    if terminal {
+                        yield Err(status);
+                        break;
+                    }
+                    tokio::time::sleep(WORKER_FANOUT_NOT_FOUND_RETRY_DELAY).await;
+                }
+                Err(status) => {
+                    yield Err(status);
+                    break;
+                }
+            }
         }
     })
 }
 
-async fn check_session_leases(
-    targets: Vec<SessionStreamTarget>,
-    kv: Arc<dyn KeyValueStore + Send + Sync>,
-    pubsub: Arc<dyn MessagePublisher + Send + Sync>,
-) {
-    let now_micros = chrono::Utc::now().timestamp_micros();
-    futures::stream::iter(targets)
-        .for_each_concurrent(SESSION_STREAM_LEASE_CHECK_CONCURRENCY, |target| {
-            let kv = kv.clone();
-            let pubsub = pubsub.clone();
-            async move {
-                if let Err(err) = redispatch_expired_session_lease(
-                    kv.as_ref(),
-                    pubsub.as_ref(),
-                    &target,
-                    now_micros,
-                )
-                .await
-                {
-                    tracing::warn!(
-                        namespace = %target.ns,
-                        agent = %target.agent,
-                        session = %target.session_id,
-                        error = %err,
-                        "Failed to check session submission lease while streaming"
-                    );
-                }
-            }
+async fn connect_worker_stream(
+    kv: &dyn KeyValueStore,
+    pubsub: &dyn MessagePublisher,
+    target: &SessionStreamTarget,
+    submission: &data_proto::SessionSubmission,
+    after_sequence: u64,
+) -> std::result::Result<tonic::Streaming<worker_proto::StreamSessionPartsResponse>, tonic::Status>
+{
+    let endpoints = worker_endpoints(kv, pubsub, &submission.claim_worker_id).await?;
+    let mut last_status = None;
+    for endpoint in endpoints {
+        match stream_from_endpoint(&endpoint, target, submission, after_sequence).await {
+            Ok(stream) => return Ok(stream),
+            Err(status) => last_status = Some(status),
+        }
+    }
+    Err(last_status.unwrap_or_else(|| tonic::Status::unavailable("worker has no endpoints")))
+}
+
+async fn stream_from_endpoint(
+    endpoint: &resources_proto::WorkerEndpoint,
+    target: &SessionStreamTarget,
+    submission: &data_proto::SessionSubmission,
+    after_sequence: u64,
+) -> std::result::Result<tonic::Streaming<worker_proto::StreamSessionPartsResponse>, tonic::Status>
+{
+    let channel = Channel::from_shared(endpoint.url.clone())
+        .map_err(|err| tonic::Status::unavailable(format!("invalid worker endpoint: {err}")))?
+        .connect()
+        .await
+        .map_err(|err| tonic::Status::unavailable(format!("failed to connect to worker: {err}")))?;
+    let mut client = worker_proto::fanout_service_client::FanoutServiceClient::new(channel);
+    let response = client
+        .stream_session_parts(worker_proto::StreamSessionPartsRequest {
+            ns: target.ns.clone(),
+            agent: target.agent.clone(),
+            session_id: target.session_id.clone(),
+            submission_id: submission.submission_id.clone(),
+            attempt_id: submission.attempt_id.clone(),
+            after_sequence,
         })
-        .await;
+        .await?;
+    Ok(response.into_inner())
+}
+
+async fn worker_endpoints(
+    kv: &dyn KeyValueStore,
+    _pubsub: &dyn MessagePublisher,
+    worker_id: &str,
+) -> std::result::Result<Vec<resources_proto::WorkerEndpoint>, tonic::Status> {
+    let key = keys::ResourceKey::new(ns::TALON_SYSTEM, &[], "Worker", worker_id);
+    let Some(bytes) = kv
+        .get(&key)
+        .await
+        .map_err(|err| tonic::Status::internal(format!("Failed to fetch worker: {err}")))?
+    else {
+        return Err(tonic::Status::not_found("claim worker not found"));
+    };
+    let worker = resources_proto::Worker::decode(bytes.as_slice())
+        .map_err(|err| tonic::Status::internal(format!("Failed to decode worker: {err}")))?;
+    let Some(status) = worker.status else {
+        return Err(tonic::Status::unavailable("worker status is missing"));
+    };
+    if status.phase != "ready" {
+        return Err(tonic::Status::unavailable("worker is not ready"));
+    }
+    let endpoints: Vec<_> = status
+        .endpoints
+        .into_iter()
+        .filter(|endpoint| !endpoint.url.trim().is_empty())
+        .collect();
+    if endpoints.is_empty() {
+        return Err(tonic::Status::unavailable("worker has no endpoints"));
+    }
+    Ok(endpoints)
 }
 
 async fn redispatch_expired_session_lease(
@@ -224,6 +354,25 @@ async fn redispatch_expired_session_lease(
     Ok(true)
 }
 
+async fn load_session_submission(
+    kv: &dyn KeyValueStore,
+    target: &SessionStreamTarget,
+    submission_id: &str,
+) -> std::result::Result<Option<data_proto::SessionSubmission>, tonic::Status> {
+    let key =
+        keys::session_submission(&target.ns, &target.agent, &target.session_id, submission_id);
+    let Some(bytes) = kv
+        .get(&key)
+        .await
+        .map_err(|err| tonic::Status::internal(format!("Failed to fetch submission: {err}")))?
+    else {
+        return Ok(None);
+    };
+    data_proto::SessionSubmission::decode(bytes.as_slice())
+        .map(Some)
+        .map_err(|err| tonic::Status::internal(format!("Failed to decode submission: {err}")))
+}
+
 async fn latest_nonterminal_submission(
     kv: &dyn KeyValueStore,
     target: &SessionStreamTarget,
@@ -246,157 +395,4 @@ async fn latest_nonterminal_submission(
     Ok(submissions
         .into_iter()
         .max_by_key(|submission| (submission.created_at, submission.updated_at)))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::control::ProtoKeyValueStoreExt;
-    use crate::test_support::{MockKvStore, RecordingPubSub};
-
-    #[tokio::test]
-    async fn stream_lease_check_skips_active_submission_lease() {
-        let kv = Arc::new(MockKvStore::default());
-        let pubsub = Arc::new(RecordingPubSub::default());
-        let target = SessionStreamTarget::new("conic", "infra", "session-1");
-        seed_processing_session_with_submission(
-            kv.as_ref(),
-            &target,
-            data_proto::SessionSubmission {
-                submission_id: "submission-1".to_string(),
-                session_id: "session-1".to_string(),
-                user_message_id: "user-1".to_string(),
-                status: data_proto::SessionSubmissionStatus::Claimed as i32,
-                attempt_id: "attempt-1".to_string(),
-                attempt_count: 1,
-                claim_expires_at: Some(30_000_000),
-                created_at: 1,
-                updated_at: 1,
-                completed_at: None,
-                committed_message_id: None,
-                current_phase: data_proto::SessionExecutionPhase::Unspecified as i32,
-                current_journal_entry_id: None,
-            },
-        )
-        .await;
-
-        let redispatched =
-            redispatch_expired_session_lease(kv.as_ref(), pubsub.as_ref(), &target, 20_000_000)
-                .await
-                .unwrap();
-
-        assert!(!redispatched);
-        assert!(pubsub.published.lock().await.is_empty());
-    }
-
-    #[tokio::test]
-    async fn stream_lease_check_redispatches_expired_submission_lease() {
-        let kv = Arc::new(MockKvStore::default());
-        let pubsub = Arc::new(RecordingPubSub::default());
-        let target = SessionStreamTarget::new("conic", "infra", "session-1");
-        seed_processing_session_with_submission(
-            kv.as_ref(),
-            &target,
-            data_proto::SessionSubmission {
-                submission_id: "submission-1".to_string(),
-                session_id: "session-1".to_string(),
-                user_message_id: "user-1".to_string(),
-                status: data_proto::SessionSubmissionStatus::Claimed as i32,
-                attempt_id: "attempt-1".to_string(),
-                attempt_count: 1,
-                claim_expires_at: Some(10_000_000),
-                created_at: 1,
-                updated_at: 1,
-                completed_at: None,
-                committed_message_id: None,
-                current_phase: data_proto::SessionExecutionPhase::Unspecified as i32,
-                current_journal_entry_id: None,
-            },
-        )
-        .await;
-
-        let redispatched =
-            redispatch_expired_session_lease(kv.as_ref(), pubsub.as_ref(), &target, 20_000_000)
-                .await
-                .unwrap();
-
-        assert!(redispatched);
-        let published = pubsub.published.lock().await;
-        assert_eq!(published.len(), 1);
-        assert_eq!(published[0].0, topics::SESSION_DISPATCH_TOPIC);
-        let event = events::SessionMessageEvent::decode(published[0].1.as_slice()).unwrap();
-        assert_eq!(event.ns, "conic");
-        assert_eq!(event.agent, "infra");
-        assert_eq!(event.session_id, "session-1");
-        assert_eq!(event.message_id, "user-1");
-        assert_eq!(event.submission_id, "submission-1");
-        assert_eq!(event.timestamp, 123);
-        assert_eq!(event.message, "please continue");
-        drop(published);
-
-        let submission = kv
-            .get_msg::<data_proto::SessionSubmission>(&keys::session_submission(
-                "conic",
-                "infra",
-                "session-1",
-                "submission-1",
-            ))
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(submission.updated_at, 20_000_000);
-    }
-
-    async fn seed_processing_session_with_submission(
-        kv: &MockKvStore,
-        target: &SessionStreamTarget,
-        submission: data_proto::SessionSubmission,
-    ) {
-        kv.set_msg(
-            &keys::session(&target.ns, &target.agent, &target.session_id),
-            &data_proto::Session {
-                id: target.session_id.clone(),
-                agent: target.agent.clone(),
-                ns: target.ns.clone(),
-                status: "PROCESSING".to_string(),
-                created_at: 1,
-                last_active: 123,
-                metadata: std::collections::HashMap::new(),
-                labels: std::collections::HashMap::new(),
-            },
-        )
-        .await
-        .unwrap();
-        kv.set_msg(
-            &keys::session_message(&target.ns, &target.agent, &target.session_id, "user-1"),
-            &data_proto::SessionMessage {
-                id: "user-1".to_string(),
-                role: data_proto::MessageRole::RoleUser as i32,
-                created_at: 1,
-                labels: std::collections::HashMap::new(),
-                parts: vec![data_proto::SessionMessagePart {
-                    id: "000000".to_string(),
-                    part_type: data_proto::SessionMessagePartType::Text as i32,
-                    content: "please continue".to_string(),
-                    name: String::new(),
-                    payload_json: String::new(),
-                    created_at: 1,
-                    object: None,
-                }],
-            },
-        )
-        .await
-        .unwrap();
-        kv.set_msg(
-            &keys::session_submission(
-                &target.ns,
-                &target.agent,
-                &target.session_id,
-                &submission.submission_id,
-            ),
-            &submission,
-        )
-        .await
-        .unwrap();
-    }
 }

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -7,7 +7,6 @@ use crate::control::{
     ControlPlane, KeyValueStore, MessagePublisher,
 };
 use crate::gateway::auth::AuthConfig;
-use crate::gateway::session_streams::SessionStreamHub;
 use anyhow::Result;
 use axum::{
     body::Body,
@@ -31,7 +30,6 @@ pub struct Gateway {
     pub scheduler: Arc<dyn SchedulerBackend + Send + Sync>,
     pub objects: Arc<dyn ObjectStore + Send + Sync>,
     pub documents: Arc<dyn DocumentStore + Send + Sync>,
-    pub session_streams: Arc<SessionStreamHub>,
 }
 
 impl Gateway {
@@ -55,7 +53,6 @@ impl Gateway {
         objects: Arc<dyn ObjectStore + Send + Sync>,
         documents: Arc<dyn DocumentStore + Send + Sync>,
     ) -> Self {
-        let session_streams = Arc::new(SessionStreamHub::new(pubsub.clone()));
         Self {
             auth_config,
             trust_config,
@@ -64,7 +61,6 @@ impl Gateway {
             scheduler,
             objects,
             documents,
-            session_streams,
         }
     }
 
@@ -91,7 +87,6 @@ impl Gateway {
             scheduler: self.scheduler.clone(),
             objects: self.objects.clone(),
             documents: self.documents.clone(),
-            session_streams: self.session_streams.clone(),
         }
     }
 

--- a/src/harness/sessions/submission.rs
+++ b/src/harness/sessions/submission.rs
@@ -35,6 +35,7 @@ pub fn pending_submission(
         user_message_id: user_message_id.into(),
         status: SessionSubmissionStatus::Pending as i32,
         attempt_id: String::new(),
+        claim_worker_id: String::new(),
         attempt_count: 0,
         claim_expires_at: None,
         created_at: now_micros,
@@ -80,6 +81,7 @@ pub async fn claim_submission(
     session_id: &str,
     submission_id: &str,
     user_message_id: &str,
+    worker_id: &str,
     now_micros: i64,
     claim_ttl_micros: i64,
 ) -> Result<ClaimOutcome> {
@@ -105,6 +107,7 @@ pub async fn claim_submission(
 
         submission.status = SessionSubmissionStatus::Claimed as i32;
         submission.attempt_id = uuid::Uuid::now_v7().to_string();
+        submission.claim_worker_id = worker_id.to_string();
         submission.attempt_count = submission.attempt_count.saturating_add(1);
         submission.claim_expires_at = Some(now_micros.saturating_add(claim_ttl_micros));
         submission.updated_at = now_micros;
@@ -272,4 +275,32 @@ pub(super) async fn update_submission_from_entry(
 
 fn journal_entry_order(journal_entry_id: &str) -> u64 {
     journal_entry_id.parse::<u64>().unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::MockKvStore;
+
+    #[tokio::test]
+    async fn claim_submission_records_claim_worker_id() {
+        let kv = MockKvStore::default();
+        let outcome = claim_submission(
+            &kv,
+            "ns",
+            "agent",
+            "session-1",
+            "submission-1",
+            "user-1",
+            "worker-1",
+            1_000,
+            10_000,
+        )
+        .await
+        .unwrap();
+        let ClaimOutcome::Claimed(submission) = outcome else {
+            panic!("expected claim");
+        };
+        assert_eq!(submission.claim_worker_id, "worker-1");
+    }
 }

--- a/src/worker/fanout.rs
+++ b/src/worker/fanout.rs
@@ -11,7 +11,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::{
     mpsc::{self, error::TrySendError},
-    Mutex,
+    Mutex, Notify,
 };
 use tonic::{Request, Response, Status};
 
@@ -58,6 +58,7 @@ struct FanoutSubscriber {
 struct SessionAttemptFanout {
     subscribers: Vec<u64>,
     next_sequence: u64,
+    subscriber_notify: Arc<Notify>,
 }
 
 impl SessionAttemptFanout {
@@ -65,6 +66,7 @@ impl SessionAttemptFanout {
         Self {
             subscribers: Vec::new(),
             next_sequence: 1,
+            subscriber_notify: Arc::new(Notify::new()),
         }
     }
 }
@@ -92,6 +94,32 @@ impl FanoutHub {
             .attempts
             .entry(key)
             .or_insert_with(SessionAttemptFanout::new);
+    }
+
+    pub async fn wait_for_subscriber(
+        &self,
+        key: &SessionFanoutKey,
+        timeout: std::time::Duration,
+    ) -> bool {
+        loop {
+            let notify = {
+                let state = self.state.lock().await;
+                let Some(fanout) = state.attempts.get(key) else {
+                    return false;
+                };
+                if !fanout.subscribers.is_empty() {
+                    return true;
+                }
+                fanout.subscriber_notify.clone()
+            };
+
+            if tokio::time::timeout(timeout, notify.notified())
+                .await
+                .is_err()
+            {
+                return false;
+            }
+        }
     }
 
     pub async fn publish_session_part(
@@ -182,14 +210,19 @@ impl FanoutHub {
             .map(|(key, _after_sequence)| key)
             .collect::<Vec<_>>();
         let (sender, receiver) = mpsc::channel(subscriber_queue_capacity(keys.len()));
+        let mut subscriber_notifies = Vec::new();
         for key in &keys {
             if let Some(fanout) = state.attempts.get_mut(key) {
                 fanout.subscribers.push(subscriber_id);
+                subscriber_notifies.push(fanout.subscriber_notify.clone());
             }
         }
         state
             .subscribers
             .insert(subscriber_id, FanoutSubscriber { keys, sender });
+        for notify in subscriber_notifies {
+            notify.notify_waiters();
+        }
 
         Ok(FanoutSubscription {
             receiver,
@@ -450,6 +483,38 @@ mod tests {
             hub.subscribe_session_parts(&key(), 0).await,
             Err(FanoutSubscribeError::NotFound)
         ));
+    }
+
+    #[tokio::test]
+    async fn wait_for_subscriber_returns_when_stream_attaches() {
+        let hub = Arc::new(FanoutHub::new());
+        let key = key();
+        hub.create_session_attempt(key.clone()).await;
+
+        let waiter = {
+            let hub = hub.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                hub.wait_for_subscriber(&key, std::time::Duration::from_secs(5))
+                    .await
+            })
+        };
+
+        assert!(
+            !hub.wait_for_subscriber(&key, std::time::Duration::from_millis(1))
+                .await
+        );
+        let _stream = hub
+            .subscribe_session_parts(&key, 0)
+            .await
+            .unwrap()
+            .into_stream();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+                .await
+                .unwrap()
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/src/worker/fanout.rs
+++ b/src/worker/fanout.rs
@@ -221,7 +221,7 @@ impl FanoutHub {
             .subscribers
             .insert(subscriber_id, FanoutSubscriber { keys, sender });
         for notify in subscriber_notifies {
-            notify.notify_waiters();
+            notify.notify_one();
         }
 
         Ok(FanoutSubscription {

--- a/src/worker/fanout.rs
+++ b/src/worker/fanout.rs
@@ -3,8 +3,10 @@
 
 use crate::control::events::{SessionMessagePartEvent, SessionMessagePartEventKind};
 use crate::gateway::rpc::worker_proto::{
-    fanout_service_server::FanoutService, StreamSessionPartsRequest, StreamSessionPartsResponse,
+    fanout_service_server::FanoutService, StreamSessionPartsBatchRequest,
+    StreamSessionPartsRequest, StreamSessionPartsResponse,
 };
+use futures::stream::SelectAll;
 use std::collections::{HashMap, VecDeque};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -220,6 +222,12 @@ impl FanoutService for FanoutServiceImpl {
                 + Send,
         >,
     >;
+    type StreamSessionPartsBatchStream = Pin<
+        Box<
+            dyn futures::Stream<Item = std::result::Result<StreamSessionPartsResponse, Status>>
+                + Send,
+        >,
+    >;
 
     async fn stream_session_parts(
         &self,
@@ -245,6 +253,44 @@ impl FanoutService for FanoutServiceImpl {
             })?;
         Ok(Response::new(subscription.into_stream()))
     }
+
+    async fn stream_session_parts_batch(
+        &self,
+        request: Request<StreamSessionPartsBatchRequest>,
+    ) -> std::result::Result<Response<Self::StreamSessionPartsBatchStream>, Status> {
+        let request = request.into_inner();
+        if request.streams.is_empty() {
+            return Err(Status::invalid_argument(
+                "streams must contain at least one session",
+            ));
+        }
+
+        let mut streams: SelectAll<Self::StreamSessionPartsBatchStream> = SelectAll::new();
+        for request in request.streams {
+            let key = SessionFanoutKey::new(
+                request.ns,
+                request.agent,
+                request.session_id,
+                request.submission_id,
+                request.attempt_id,
+            );
+            let subscription = self
+                .hub
+                .subscribe_session_parts(&key, request.after_sequence)
+                .await
+                .map_err(|err| match err {
+                    FanoutSubscribeError::NotFound => {
+                        Status::not_found("session attempt not found")
+                    }
+                    FanoutSubscribeError::ReplayGap => {
+                        Status::out_of_range("session fanout replay gap")
+                    }
+                })?;
+            streams.push(subscription.into_stream());
+        }
+
+        Ok(Response::new(Box::pin(streams)))
+    }
 }
 
 fn session_part_event_is_terminal(event: &SessionMessagePartEvent) -> bool {
@@ -256,10 +302,19 @@ fn session_part_event_is_terminal(event: &SessionMessagePartEvent) -> bool {
 mod tests {
     use super::*;
     use crate::control::events::SessionMessagePartEventKind;
+    use futures::StreamExt;
 
     fn event(kind: SessionMessagePartEventKind, content: &str) -> SessionMessagePartEvent {
+        event_for_session("session-1", kind, content)
+    }
+
+    fn event_for_session(
+        session_id: &str,
+        kind: SessionMessagePartEventKind,
+        content: &str,
+    ) -> SessionMessagePartEvent {
         SessionMessagePartEvent {
-            session_id: "session-1".to_string(),
+            session_id: session_id.to_string(),
             kind: kind as i32,
             part: Some(crate::gateway::rpc::data_proto::SessionMessagePart {
                 content: content.to_string(),
@@ -274,6 +329,10 @@ mod tests {
 
     fn key() -> SessionFanoutKey {
         SessionFanoutKey::new("ns", "agent", "session-1", "submission-1", "attempt-1")
+    }
+
+    fn key_for_session(session_id: &str) -> SessionFanoutKey {
+        SessionFanoutKey::new("ns", "agent", session_id, "submission-1", "attempt-1")
     }
 
     #[tokio::test]
@@ -298,5 +357,63 @@ mod tests {
             hub.subscribe_session_parts(&key(), 0).await,
             Err(FanoutSubscribeError::NotFound)
         ));
+    }
+
+    #[tokio::test]
+    async fn fanout_batch_streams_multiple_attempts() {
+        let hub = Arc::new(FanoutHub::new());
+        let service = FanoutServiceImpl::new(hub.clone());
+        let key_one = key_for_session("session-1");
+        let key_two = key_for_session("session-2");
+        hub.create_session_attempt(key_one.clone()).await;
+        hub.create_session_attempt(key_two.clone()).await;
+
+        let mut stream = service
+            .stream_session_parts_batch(Request::new(StreamSessionPartsBatchRequest {
+                streams: vec![
+                    StreamSessionPartsRequest {
+                        ns: "ns".to_string(),
+                        agent: "agent".to_string(),
+                        session_id: "session-1".to_string(),
+                        submission_id: "submission-1".to_string(),
+                        attempt_id: "attempt-1".to_string(),
+                        after_sequence: 0,
+                    },
+                    StreamSessionPartsRequest {
+                        ns: "ns".to_string(),
+                        agent: "agent".to_string(),
+                        session_id: "session-2".to_string(),
+                        submission_id: "submission-1".to_string(),
+                        attempt_id: "attempt-1".to_string(),
+                        after_sequence: 0,
+                    },
+                ],
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        hub.publish_session_part(
+            &key_one,
+            event_for_session("session-1", SessionMessagePartEventKind::Delta, "one"),
+        )
+        .await;
+        hub.publish_session_part(
+            &key_two,
+            event_for_session("session-2", SessionMessagePartEventKind::Delta, "two"),
+        )
+        .await;
+
+        let mut contents = Vec::new();
+        for _ in 0..2 {
+            let response = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            contents.push(response.event.unwrap().part.unwrap().content);
+        }
+        contents.sort();
+        assert_eq!(contents, ["one", "two"]);
     }
 }

--- a/src/worker/fanout.rs
+++ b/src/worker/fanout.rs
@@ -6,15 +6,17 @@ use crate::gateway::rpc::worker_proto::{
     fanout_service_server::FanoutService, StreamSessionPartsBatchRequest,
     StreamSessionPartsRequest, StreamSessionPartsResponse,
 };
-use futures::stream::SelectAll;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{
+    mpsc::{self, error::TrySendError},
+    Mutex,
+};
 use tonic::{Request, Response, Status};
 
-const DEFAULT_REPLAY_CAPACITY: usize = 256;
-const DEFAULT_BROADCAST_CAPACITY: usize = 512;
+const MAX_SUBSCRIBER_QUEUE_CAPACITY: usize = 1_048_576;
+const SUBSCRIBER_QUEUE_EVENTS_PER_STREAM: usize = 96;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SessionFanoutKey {
@@ -46,78 +48,37 @@ impl SessionFanoutKey {
 #[derive(Debug)]
 pub enum FanoutSubscribeError {
     NotFound,
-    ReplayGap,
 }
 
-pub struct FanoutSubscription {
-    replay: Vec<StreamSessionPartsResponse>,
-    receiver: broadcast::Receiver<StreamSessionPartsResponse>,
-}
-
-impl FanoutSubscription {
-    pub fn into_stream(
-        mut self,
-    ) -> Pin<
-        Box<
-            dyn futures::Stream<Item = std::result::Result<StreamSessionPartsResponse, Status>>
-                + Send,
-        >,
-    > {
-        Box::pin(async_stream::stream! {
-            for event in self.replay {
-                let terminal = event
-                    .event
-                    .as_ref()
-                    .is_some_and(session_part_event_is_terminal);
-                yield Ok(event);
-                if terminal {
-                    return;
-                }
-            }
-
-            loop {
-                match self.receiver.recv().await {
-                    Ok(event) => {
-                        let terminal = event
-                            .event
-                            .as_ref()
-                            .is_some_and(session_part_event_is_terminal);
-                        yield Ok(event);
-                        if terminal {
-                            break;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        yield Err(Status::out_of_range("session fanout replay gap"));
-                        break;
-                    }
-                    Err(broadcast::error::RecvError::Closed) => break,
-                }
-            }
-        })
-    }
+struct FanoutSubscriber {
+    keys: Vec<SessionFanoutKey>,
+    sender: mpsc::Sender<StreamSessionPartsResponse>,
 }
 
 struct SessionAttemptFanout {
-    sender: broadcast::Sender<StreamSessionPartsResponse>,
-    replay: VecDeque<StreamSessionPartsResponse>,
+    subscribers: Vec<u64>,
     next_sequence: u64,
 }
 
 impl SessionAttemptFanout {
     fn new() -> Self {
-        let (sender, _) = broadcast::channel(DEFAULT_BROADCAST_CAPACITY);
         Self {
-            sender,
-            replay: VecDeque::with_capacity(DEFAULT_REPLAY_CAPACITY),
+            subscribers: Vec::new(),
             next_sequence: 1,
         }
     }
 }
 
 #[derive(Default)]
+struct FanoutState {
+    attempts: HashMap<SessionFanoutKey, SessionAttemptFanout>,
+    subscribers: HashMap<u64, FanoutSubscriber>,
+    next_subscriber_id: u64,
+}
+
+#[derive(Clone, Default)]
 pub struct FanoutHub {
-    sessions: Mutex<HashMap<SessionFanoutKey, SessionAttemptFanout>>,
+    state: Arc<Mutex<FanoutState>>,
 }
 
 impl FanoutHub {
@@ -126,8 +87,9 @@ impl FanoutHub {
     }
 
     pub async fn create_session_attempt(&self, key: SessionFanoutKey) {
-        let mut sessions = self.sessions.lock().await;
-        sessions
+        let mut state = self.state.lock().await;
+        state
+            .attempts
             .entry(key)
             .or_insert_with(SessionAttemptFanout::new);
     }
@@ -137,20 +99,60 @@ impl FanoutHub {
         key: &SessionFanoutKey,
         event: SessionMessagePartEvent,
     ) {
-        let mut sessions = self.sessions.lock().await;
-        let fanout = sessions
-            .entry(key.clone())
-            .or_insert_with(SessionAttemptFanout::new);
-        let response = StreamSessionPartsResponse {
-            sequence: fanout.next_sequence,
-            event: Some(event),
+        let terminal = session_part_event_is_terminal(&event);
+        let (response, subscribers) = {
+            let mut state = self.state.lock().await;
+            let fanout = state
+                .attempts
+                .entry(key.clone())
+                .or_insert_with(SessionAttemptFanout::new);
+            let response = StreamSessionPartsResponse {
+                sequence: fanout.next_sequence,
+                event: Some(event),
+            };
+            fanout.next_sequence = fanout.next_sequence.saturating_add(1);
+
+            let subscriber_ids = fanout.subscribers.clone();
+            let subscribers = subscriber_ids
+                .into_iter()
+                .filter_map(|subscriber_id| {
+                    state
+                        .subscribers
+                        .get(&subscriber_id)
+                        .map(|subscriber| (subscriber_id, subscriber.sender.clone()))
+                })
+                .collect::<Vec<_>>();
+            (response, subscribers)
         };
-        fanout.next_sequence = fanout.next_sequence.saturating_add(1);
-        fanout.replay.push_back(response.clone());
-        while fanout.replay.len() > DEFAULT_REPLAY_CAPACITY {
-            fanout.replay.pop_front();
+
+        let mut stale_subscribers = Vec::new();
+        for (subscriber_id, sender) in subscribers {
+            match sender.try_send(response.clone()) {
+                Ok(()) => {}
+                Err(TrySendError::Full(response)) => {
+                    if sender.send(response).await.is_err() {
+                        stale_subscribers.push(subscriber_id);
+                    }
+                }
+                Err(TrySendError::Closed(_)) => stale_subscribers.push(subscriber_id),
+            }
         }
-        let _ = fanout.sender.send(response);
+
+        let mut state = self.state.lock().await;
+        for subscriber_id in stale_subscribers {
+            remove_subscriber(&mut state, subscriber_id);
+        }
+        if terminal {
+            for subscriber_id in state
+                .attempts
+                .get(key)
+                .map(|fanout| fanout.subscribers.clone())
+                .unwrap_or_default()
+            {
+                remove_subscriber_from_key(&mut state, subscriber_id, key);
+            }
+            state.attempts.remove(key);
+        }
     }
 
     pub async fn subscribe_session_parts(
@@ -158,48 +160,133 @@ impl FanoutHub {
         key: &SessionFanoutKey,
         after_sequence: u64,
     ) -> std::result::Result<FanoutSubscription, FanoutSubscribeError> {
-        let sessions = self.sessions.lock().await;
-        let Some(fanout) = sessions.get(key) else {
-            return Err(FanoutSubscribeError::NotFound);
-        };
+        self.subscribe_session_parts_batch(vec![(key.clone(), after_sequence)])
+            .await
+    }
 
-        if after_sequence > 0 {
-            if let Some(first) = fanout.replay.front() {
-                if first.sequence > after_sequence.saturating_add(1) {
-                    return Err(FanoutSubscribeError::ReplayGap);
-                }
+    pub async fn subscribe_session_parts_batch(
+        &self,
+        streams: Vec<(SessionFanoutKey, u64)>,
+    ) -> std::result::Result<FanoutSubscription, FanoutSubscribeError> {
+        let mut state = self.state.lock().await;
+        for (key, _) in &streams {
+            if !state.attempts.contains_key(key) {
+                return Err(FanoutSubscribeError::NotFound);
             }
         }
 
-        let replay = fanout
-            .replay
-            .iter()
-            .filter(|event| event.sequence > after_sequence)
-            .cloned()
-            .collect();
+        let subscriber_id = state.next_subscriber_id;
+        state.next_subscriber_id = state.next_subscriber_id.saturating_add(1);
+        let keys = streams
+            .into_iter()
+            .map(|(key, _after_sequence)| key)
+            .collect::<Vec<_>>();
+        let (sender, receiver) = mpsc::channel(subscriber_queue_capacity(keys.len()));
+        for key in &keys {
+            if let Some(fanout) = state.attempts.get_mut(key) {
+                fanout.subscribers.push(subscriber_id);
+            }
+        }
+        state
+            .subscribers
+            .insert(subscriber_id, FanoutSubscriber { keys, sender });
+
         Ok(FanoutSubscription {
-            replay,
-            receiver: fanout.sender.subscribe(),
+            receiver,
+            cleanup: FanoutSubscriptionCleanup {
+                state: Some(self.state.clone()),
+                subscriber_id,
+            },
         })
     }
 
     #[cfg(test)]
-    pub async fn replay_session_part_events(
-        &self,
-        key: &SessionFanoutKey,
-    ) -> Vec<SessionMessagePartEvent> {
-        self.sessions
-            .lock()
-            .await
-            .get(key)
-            .map(|fanout| {
-                fanout
-                    .replay
-                    .iter()
-                    .filter_map(|response| response.event.clone())
-                    .collect()
-            })
-            .unwrap_or_default()
+    pub async fn attempt_count(&self) -> usize {
+        self.state.lock().await.attempts.len()
+    }
+
+    #[cfg(test)]
+    pub async fn subscriber_count(&self) -> usize {
+        self.state.lock().await.subscribers.len()
+    }
+}
+
+fn subscriber_queue_capacity(stream_count: usize) -> usize {
+    stream_count
+        .saturating_mul(SUBSCRIBER_QUEUE_EVENTS_PER_STREAM)
+        .max(2)
+        .min(MAX_SUBSCRIBER_QUEUE_CAPACITY)
+}
+
+fn remove_subscriber(state: &mut FanoutState, subscriber_id: u64) {
+    let Some(subscriber) = state.subscribers.remove(&subscriber_id) else {
+        return;
+    };
+    for key in subscriber.keys {
+        if let Some(fanout) = state.attempts.get_mut(&key) {
+            fanout
+                .subscribers
+                .retain(|existing_id| *existing_id != subscriber_id);
+        }
+    }
+}
+
+fn remove_subscriber_from_key(state: &mut FanoutState, subscriber_id: u64, key: &SessionFanoutKey) {
+    if let Some(fanout) = state.attempts.get_mut(key) {
+        fanout
+            .subscribers
+            .retain(|existing_id| *existing_id != subscriber_id);
+    }
+
+    let Some(subscriber) = state.subscribers.get_mut(&subscriber_id) else {
+        return;
+    };
+    subscriber.keys.retain(|existing_key| existing_key != key);
+    if subscriber.keys.is_empty() {
+        state.subscribers.remove(&subscriber_id);
+    }
+}
+
+pub struct FanoutSubscription {
+    receiver: mpsc::Receiver<StreamSessionPartsResponse>,
+    cleanup: FanoutSubscriptionCleanup,
+}
+
+impl FanoutSubscription {
+    pub fn into_stream(
+        self,
+    ) -> Pin<
+        Box<
+            dyn futures::Stream<Item = std::result::Result<StreamSessionPartsResponse, Status>>
+                + Send,
+        >,
+    > {
+        let mut receiver = self.receiver;
+        let cleanup = self.cleanup;
+        Box::pin(async_stream::stream! {
+            let _cleanup = cleanup;
+            while let Some(event) = receiver.recv().await {
+                yield Ok(event);
+            }
+        })
+    }
+}
+
+struct FanoutSubscriptionCleanup {
+    state: Option<Arc<Mutex<FanoutState>>>,
+    subscriber_id: u64,
+}
+
+impl Drop for FanoutSubscriptionCleanup {
+    fn drop(&mut self) {
+        let Some(state) = self.state.take() else {
+            return;
+        };
+        let subscriber_id = self.subscriber_id;
+        tokio::spawn(async move {
+            let mut state = state.lock().await;
+            remove_subscriber(&mut state, subscriber_id);
+        });
     }
 }
 
@@ -247,9 +334,6 @@ impl FanoutService for FanoutServiceImpl {
             .await
             .map_err(|err| match err {
                 FanoutSubscribeError::NotFound => Status::not_found("session attempt not found"),
-                FanoutSubscribeError::ReplayGap => {
-                    Status::out_of_range("session fanout replay gap")
-                }
             })?;
         Ok(Response::new(subscription.into_stream()))
     }
@@ -265,31 +349,30 @@ impl FanoutService for FanoutServiceImpl {
             ));
         }
 
-        let mut streams: SelectAll<Self::StreamSessionPartsBatchStream> = SelectAll::new();
-        for request in request.streams {
-            let key = SessionFanoutKey::new(
-                request.ns,
-                request.agent,
-                request.session_id,
-                request.submission_id,
-                request.attempt_id,
-            );
-            let subscription = self
-                .hub
-                .subscribe_session_parts(&key, request.after_sequence)
-                .await
-                .map_err(|err| match err {
-                    FanoutSubscribeError::NotFound => {
-                        Status::not_found("session attempt not found")
-                    }
-                    FanoutSubscribeError::ReplayGap => {
-                        Status::out_of_range("session fanout replay gap")
-                    }
-                })?;
-            streams.push(subscription.into_stream());
-        }
-
-        Ok(Response::new(Box::pin(streams)))
+        let streams = request
+            .streams
+            .into_iter()
+            .map(|request| {
+                (
+                    SessionFanoutKey::new(
+                        request.ns,
+                        request.agent,
+                        request.session_id,
+                        request.submission_id,
+                        request.attempt_id,
+                    ),
+                    request.after_sequence,
+                )
+            })
+            .collect();
+        let subscription = self
+            .hub
+            .subscribe_session_parts_batch(streams)
+            .await
+            .map_err(|err| match err {
+                FanoutSubscribeError::NotFound => Status::not_found("session attempt not found"),
+            })?;
+        Ok(Response::new(subscription.into_stream()))
     }
 }
 
@@ -336,18 +419,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fanout_replays_events_after_sequence() {
+    async fn fanout_streams_live_events_without_replay() {
         let hub = FanoutHub::new();
         let key = key();
         hub.create_session_attempt(key.clone()).await;
-        hub.publish_session_part(&key, event(SessionMessagePartEventKind::Delta, "one"))
-            .await;
-        hub.publish_session_part(&key, event(SessionMessagePartEventKind::Delta, "two"))
+        hub.publish_session_part(&key, event(SessionMessagePartEventKind::Delta, "missed"))
             .await;
 
-        let subscription = hub.subscribe_session_parts(&key, 1).await.unwrap();
-        assert_eq!(subscription.replay.len(), 1);
-        assert_eq!(subscription.replay[0].sequence, 2);
+        let mut subscription = hub
+            .subscribe_session_parts(&key, 0)
+            .await
+            .unwrap()
+            .into_stream();
+        hub.publish_session_part(&key, event(SessionMessagePartEventKind::Delta, "live"))
+            .await;
+
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), subscription.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.sequence, 2);
+        assert_eq!(response.event.unwrap().part.unwrap().content, "live");
     }
 
     #[tokio::test]
@@ -415,5 +508,72 @@ mod tests {
         }
         contents.sort();
         assert_eq!(contents, ["one", "two"]);
+    }
+
+    #[tokio::test]
+    async fn batch_subscription_survives_one_attempt_terminal_event() {
+        let hub = FanoutHub::new();
+        let key_one = key_for_session("session-1");
+        let key_two = key_for_session("session-2");
+        hub.create_session_attempt(key_one.clone()).await;
+        hub.create_session_attempt(key_two.clone()).await;
+
+        let mut stream = hub
+            .subscribe_session_parts_batch(vec![(key_one.clone(), 0), (key_two.clone(), 0)])
+            .await
+            .unwrap()
+            .into_stream();
+
+        hub.publish_session_part(
+            &key_one,
+            event_for_session("session-1", SessionMessagePartEventKind::Done, "one"),
+        )
+        .await;
+        hub.publish_session_part(
+            &key_two,
+            event_for_session("session-2", SessionMessagePartEventKind::Delta, "two-delta"),
+        )
+        .await;
+        hub.publish_session_part(
+            &key_two,
+            event_for_session("session-2", SessionMessagePartEventKind::Done, "two-done"),
+        )
+        .await;
+
+        let mut contents = Vec::new();
+        for _ in 0..3 {
+            let response = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            contents.push(response.event.unwrap().part.unwrap().content);
+        }
+        assert_eq!(contents, ["one", "two-delta", "two-done"]);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn terminal_event_removes_attempt_and_subscriber() {
+        let hub = FanoutHub::new();
+        let key = key();
+        hub.create_session_attempt(key.clone()).await;
+        let mut stream = hub
+            .subscribe_session_parts(&key, 0)
+            .await
+            .unwrap()
+            .into_stream();
+
+        hub.publish_session_part(&key, event(SessionMessagePartEventKind::Done, "done"))
+            .await;
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.event.unwrap().part.unwrap().content, "done");
+        assert!(stream.next().await.is_none());
+        assert_eq!(hub.attempt_count().await, 0);
+        assert_eq!(hub.subscriber_count().await, 0);
     }
 }

--- a/src/worker/fanout.rs
+++ b/src/worker/fanout.rs
@@ -1,0 +1,302 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use crate::control::events::{SessionMessagePartEvent, SessionMessagePartEventKind};
+use crate::gateway::rpc::worker_proto::{
+    fanout_service_server::FanoutService, StreamSessionPartsRequest, StreamSessionPartsResponse,
+};
+use std::collections::{HashMap, VecDeque};
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::{broadcast, Mutex};
+use tonic::{Request, Response, Status};
+
+const DEFAULT_REPLAY_CAPACITY: usize = 256;
+const DEFAULT_BROADCAST_CAPACITY: usize = 512;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SessionFanoutKey {
+    pub ns: String,
+    pub agent: String,
+    pub session_id: String,
+    pub submission_id: String,
+    pub attempt_id: String,
+}
+
+impl SessionFanoutKey {
+    pub fn new(
+        ns: impl Into<String>,
+        agent: impl Into<String>,
+        session_id: impl Into<String>,
+        submission_id: impl Into<String>,
+        attempt_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            ns: ns.into(),
+            agent: agent.into(),
+            session_id: session_id.into(),
+            submission_id: submission_id.into(),
+            attempt_id: attempt_id.into(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FanoutSubscribeError {
+    NotFound,
+    ReplayGap,
+}
+
+pub struct FanoutSubscription {
+    replay: Vec<StreamSessionPartsResponse>,
+    receiver: broadcast::Receiver<StreamSessionPartsResponse>,
+}
+
+impl FanoutSubscription {
+    pub fn into_stream(
+        mut self,
+    ) -> Pin<
+        Box<
+            dyn futures::Stream<Item = std::result::Result<StreamSessionPartsResponse, Status>>
+                + Send,
+        >,
+    > {
+        Box::pin(async_stream::stream! {
+            for event in self.replay {
+                let terminal = event
+                    .event
+                    .as_ref()
+                    .is_some_and(session_part_event_is_terminal);
+                yield Ok(event);
+                if terminal {
+                    return;
+                }
+            }
+
+            loop {
+                match self.receiver.recv().await {
+                    Ok(event) => {
+                        let terminal = event
+                            .event
+                            .as_ref()
+                            .is_some_and(session_part_event_is_terminal);
+                        yield Ok(event);
+                        if terminal {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        yield Err(Status::out_of_range("session fanout replay gap"));
+                        break;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        })
+    }
+}
+
+struct SessionAttemptFanout {
+    sender: broadcast::Sender<StreamSessionPartsResponse>,
+    replay: VecDeque<StreamSessionPartsResponse>,
+    next_sequence: u64,
+}
+
+impl SessionAttemptFanout {
+    fn new() -> Self {
+        let (sender, _) = broadcast::channel(DEFAULT_BROADCAST_CAPACITY);
+        Self {
+            sender,
+            replay: VecDeque::with_capacity(DEFAULT_REPLAY_CAPACITY),
+            next_sequence: 1,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct FanoutHub {
+    sessions: Mutex<HashMap<SessionFanoutKey, SessionAttemptFanout>>,
+}
+
+impl FanoutHub {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn create_session_attempt(&self, key: SessionFanoutKey) {
+        let mut sessions = self.sessions.lock().await;
+        sessions
+            .entry(key)
+            .or_insert_with(SessionAttemptFanout::new);
+    }
+
+    pub async fn publish_session_part(
+        &self,
+        key: &SessionFanoutKey,
+        event: SessionMessagePartEvent,
+    ) {
+        let mut sessions = self.sessions.lock().await;
+        let fanout = sessions
+            .entry(key.clone())
+            .or_insert_with(SessionAttemptFanout::new);
+        let response = StreamSessionPartsResponse {
+            sequence: fanout.next_sequence,
+            event: Some(event),
+        };
+        fanout.next_sequence = fanout.next_sequence.saturating_add(1);
+        fanout.replay.push_back(response.clone());
+        while fanout.replay.len() > DEFAULT_REPLAY_CAPACITY {
+            fanout.replay.pop_front();
+        }
+        let _ = fanout.sender.send(response);
+    }
+
+    pub async fn subscribe_session_parts(
+        &self,
+        key: &SessionFanoutKey,
+        after_sequence: u64,
+    ) -> std::result::Result<FanoutSubscription, FanoutSubscribeError> {
+        let sessions = self.sessions.lock().await;
+        let Some(fanout) = sessions.get(key) else {
+            return Err(FanoutSubscribeError::NotFound);
+        };
+
+        if after_sequence > 0 {
+            if let Some(first) = fanout.replay.front() {
+                if first.sequence > after_sequence.saturating_add(1) {
+                    return Err(FanoutSubscribeError::ReplayGap);
+                }
+            }
+        }
+
+        let replay = fanout
+            .replay
+            .iter()
+            .filter(|event| event.sequence > after_sequence)
+            .cloned()
+            .collect();
+        Ok(FanoutSubscription {
+            replay,
+            receiver: fanout.sender.subscribe(),
+        })
+    }
+
+    #[cfg(test)]
+    pub async fn replay_session_part_events(
+        &self,
+        key: &SessionFanoutKey,
+    ) -> Vec<SessionMessagePartEvent> {
+        self.sessions
+            .lock()
+            .await
+            .get(key)
+            .map(|fanout| {
+                fanout
+                    .replay
+                    .iter()
+                    .filter_map(|response| response.event.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Clone)]
+pub struct FanoutServiceImpl {
+    hub: Arc<FanoutHub>,
+}
+
+impl FanoutServiceImpl {
+    pub fn new(hub: Arc<FanoutHub>) -> Self {
+        Self { hub }
+    }
+}
+
+#[tonic::async_trait]
+impl FanoutService for FanoutServiceImpl {
+    type StreamSessionPartsStream = Pin<
+        Box<
+            dyn futures::Stream<Item = std::result::Result<StreamSessionPartsResponse, Status>>
+                + Send,
+        >,
+    >;
+
+    async fn stream_session_parts(
+        &self,
+        request: Request<StreamSessionPartsRequest>,
+    ) -> std::result::Result<Response<Self::StreamSessionPartsStream>, Status> {
+        let request = request.into_inner();
+        let key = SessionFanoutKey::new(
+            request.ns,
+            request.agent,
+            request.session_id,
+            request.submission_id,
+            request.attempt_id,
+        );
+        let subscription = self
+            .hub
+            .subscribe_session_parts(&key, request.after_sequence)
+            .await
+            .map_err(|err| match err {
+                FanoutSubscribeError::NotFound => Status::not_found("session attempt not found"),
+                FanoutSubscribeError::ReplayGap => {
+                    Status::out_of_range("session fanout replay gap")
+                }
+            })?;
+        Ok(Response::new(subscription.into_stream()))
+    }
+}
+
+fn session_part_event_is_terminal(event: &SessionMessagePartEvent) -> bool {
+    event.kind == SessionMessagePartEventKind::Done as i32
+        || event.kind == SessionMessagePartEventKind::Error as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::events::SessionMessagePartEventKind;
+
+    fn event(kind: SessionMessagePartEventKind, content: &str) -> SessionMessagePartEvent {
+        SessionMessagePartEvent {
+            session_id: "session-1".to_string(),
+            kind: kind as i32,
+            part: Some(crate::gateway::rpc::data_proto::SessionMessagePart {
+                content: content.to_string(),
+                ..Default::default()
+            }),
+            timestamp: 1,
+            agent: "agent".to_string(),
+            ns: "ns".to_string(),
+            message_id: "message-1".to_string(),
+        }
+    }
+
+    fn key() -> SessionFanoutKey {
+        SessionFanoutKey::new("ns", "agent", "session-1", "submission-1", "attempt-1")
+    }
+
+    #[tokio::test]
+    async fn fanout_replays_events_after_sequence() {
+        let hub = FanoutHub::new();
+        let key = key();
+        hub.create_session_attempt(key.clone()).await;
+        hub.publish_session_part(&key, event(SessionMessagePartEventKind::Delta, "one"))
+            .await;
+        hub.publish_session_part(&key, event(SessionMessagePartEventKind::Delta, "two"))
+            .await;
+
+        let subscription = hub.subscribe_session_parts(&key, 1).await.unwrap();
+        assert_eq!(subscription.replay.len(), 1);
+        assert_eq!(subscription.replay[0].sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn fanout_returns_not_found_for_unknown_attempt() {
+        let hub = FanoutHub::new();
+        assert!(matches!(
+            hub.subscribe_session_parts(&key(), 0).await,
+            Err(FanoutSubscribeError::NotFound)
+        ));
+    }
+}

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -11,6 +11,7 @@ use prost::Message;
 use std::sync::Arc;
 
 pub mod controllers;
+pub mod fanout;
 pub mod mcp_registry;
 pub mod registration;
 pub mod runtime;
@@ -28,6 +29,8 @@ pub struct WorkerEventHandler {
     pub config: Arc<Config>,
     pub mcp_registry: Arc<mcp_registry::McpRegistry>,
     pub scheduler_authenticator: Arc<scheduler_auth::SchedulerRequestAuthenticator>,
+    pub worker_id: String,
+    pub fanout_hub: Arc<fanout::FanoutHub>,
     pub session_cancellations: Arc<
         tokio::sync::Mutex<std::collections::HashMap<String, tokio_util::sync::CancellationToken>>,
     >,
@@ -467,6 +470,8 @@ mod tests {
             config: Arc::new(Config::default()),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),
+            worker_id: "test-worker".to_string(),
+            fanout_hub: Arc::new(crate::worker::fanout::FanoutHub::new()),
             session_cancellations: Arc::new(Mutex::new(HashMap::new())),
         }
     }

--- a/src/worker/registration.rs
+++ b/src/worker/registration.rs
@@ -4,8 +4,10 @@
 use crate::control::{ns, ControlPlane};
 use crate::gateway::rpc::resources_proto;
 use anyhow::{Context, Result};
+use serde_json::Value;
 use std::sync::{Arc, OnceLock};
 use tokio_util::sync::CancellationToken;
+use url::Url;
 
 pub const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 pub const HEARTBEAT_TTL: chrono::Duration = chrono::Duration::seconds(30);
@@ -17,6 +19,7 @@ pub struct WorkerRegistration {
     pub worker_id: String,
     pub started_at: i64,
     pub version: String,
+    pub endpoints: Vec<resources_proto::WorkerEndpoint>,
 }
 
 impl WorkerRegistration {
@@ -25,7 +28,13 @@ impl WorkerRegistration {
             worker_id: worker_id.into(),
             started_at: chrono::Utc::now().timestamp_micros(),
             version: version.into(),
+            endpoints: Vec::new(),
         }
+    }
+
+    pub fn with_endpoints(mut self, endpoints: Vec<resources_proto::WorkerEndpoint>) -> Self {
+        self.endpoints = endpoints;
+        self
     }
 }
 
@@ -97,8 +106,100 @@ pub fn worker_status(
         heartbeat_at: now.timestamp_micros(),
         expires_at: (now + HEARTBEAT_TTL).timestamp_micros(),
         version: registration.version.clone(),
-        endpoints: Vec::new(),
+        endpoints: if phase == "ready" {
+            registration.endpoints.clone()
+        } else {
+            Vec::new()
+        },
     }
+}
+
+pub async fn discover_worker_endpoints<F>(
+    get: F,
+    port: &str,
+) -> Vec<resources_proto::WorkerEndpoint>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if let Some(endpoint) = explicit_worker_endpoint(&get) {
+        return vec![endpoint];
+    }
+
+    if let Some(endpoint) = ecs_worker_endpoint(&get, port).await {
+        return vec![endpoint];
+    }
+
+    Vec::new()
+}
+
+fn explicit_worker_endpoint<F>(get: &F) -> Option<resources_proto::WorkerEndpoint>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    [
+        "TALON_WORKER_ENDPOINT_URL",
+        "TALON_WORKER_PUBLIC_URL",
+        "TALON_WORKER_URL",
+        "CLOUD_RUN_SERVICE_URL",
+    ]
+    .into_iter()
+    .find_map(|name| get(name))
+    .and_then(|url| worker_endpoint_from_url(&url, get))
+}
+
+fn worker_endpoint_from_url<F>(raw_url: &str, get: &F) -> Option<resources_proto::WorkerEndpoint>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let url = raw_url.trim().trim_end_matches('/');
+    if url.is_empty() || Url::parse(url).is_err() {
+        return None;
+    }
+    Some(resources_proto::WorkerEndpoint {
+        url: url.to_string(),
+        protocol: get("TALON_WORKER_ENDPOINT_PROTOCOL")
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "http".to_string()),
+        audience: get("TALON_WORKER_ENDPOINT_AUDIENCE").unwrap_or_default(),
+    })
+}
+
+async fn ecs_worker_endpoint<F>(get: &F, port: &str) -> Option<resources_proto::WorkerEndpoint>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let metadata_uri = get("ECS_CONTAINER_METADATA_URI_V4")?;
+    let metadata = fetch_json_metadata(&metadata_uri).await?;
+    let address = first_ecs_ipv4_address(&metadata)?;
+    worker_endpoint_from_url(&format!("http://{}:{}", address, port), get)
+}
+
+async fn fetch_json_metadata(url: &str) -> Option<Value> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(750))
+        .build()
+        .ok()?;
+    let response = client.get(url).send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    response.json::<Value>().await.ok()
+}
+
+fn first_ecs_ipv4_address(metadata: &Value) -> Option<&str> {
+    metadata
+        .get("Networks")?
+        .as_array()?
+        .iter()
+        .flat_map(|network| {
+            network
+                .get("IPv4Addresses")
+                .and_then(|addresses| addresses.as_array())
+                .into_iter()
+                .flatten()
+        })
+        .filter_map(|address| address.as_str())
+        .find(|address| !address.trim().is_empty())
 }
 
 pub fn worker_is_live(status: &resources_proto::WorkerStatus, now_micros: i64) -> bool {
@@ -209,12 +310,65 @@ mod tests {
 
     #[test]
     fn draining_status_clears_endpoints() {
-        let registration = WorkerRegistration::new("worker-a", "1.2.3");
+        let registration = WorkerRegistration::new("worker-a", "1.2.3").with_endpoints(vec![
+            resources_proto::WorkerEndpoint {
+                url: "https://worker.example.com".to_string(),
+                protocol: "http".to_string(),
+                audience: "talon".to_string(),
+            },
+        ]);
         let ready = worker_status(&registration, "ready");
-        assert!(ready.endpoints.is_empty());
+        assert_eq!(ready.endpoints.len(), 1);
         let draining = worker_status(&registration, "draining");
         assert_eq!(draining.phase, "draining");
         assert!(draining.endpoints.is_empty());
+    }
+
+    #[tokio::test]
+    async fn worker_endpoint_discovery_prefers_explicit_url() {
+        let endpoints = discover_worker_endpoints(
+            |name| match name {
+                "TALON_WORKER_ENDPOINT_URL" => Some("https://worker.example.com/".to_string()),
+                "TALON_WORKER_ENDPOINT_AUDIENCE" => Some("scheduler".to_string()),
+                _ => None,
+            },
+            "8081",
+        )
+        .await;
+
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].url, "https://worker.example.com");
+        assert_eq!(endpoints[0].protocol, "http");
+        assert_eq!(endpoints[0].audience, "scheduler");
+    }
+
+    #[tokio::test]
+    async fn worker_endpoint_discovery_ignores_cloud_run_worker_pool_without_url() {
+        let endpoints = discover_worker_endpoints(
+            |name| match name {
+                "K_CONFIGURATION" => Some("worker-pool-a".to_string()),
+                "K_REVISION" => Some("worker-pool-a-00001".to_string()),
+                _ => None,
+            },
+            "8081",
+        )
+        .await;
+
+        assert!(endpoints.is_empty());
+    }
+
+    #[test]
+    fn first_ecs_ipv4_address_reads_container_metadata() {
+        let metadata = serde_json::json!({
+            "Networks": [
+                {
+                    "NetworkMode": "awsvpc",
+                    "IPv4Addresses": ["10.0.12.34"]
+                }
+            ]
+        });
+
+        assert_eq!(first_ecs_ipv4_address(&metadata), Some("10.0.12.34"));
     }
 
     #[tokio::test]

--- a/src/worker/registration.rs
+++ b/src/worker/registration.rs
@@ -152,14 +152,20 @@ where
     F: Fn(&str) -> Option<String>,
 {
     let url = raw_url.trim().trim_end_matches('/');
-    if url.is_empty() || Url::parse(url).is_err() {
+    let parsed = Url::parse(url).ok()?;
+    if url.is_empty() {
         return None;
     }
+    let default_protocol = if parsed.scheme() == "unix" {
+        "grpc"
+    } else {
+        "http"
+    };
     Some(resources_proto::WorkerEndpoint {
         url: url.to_string(),
         protocol: get("TALON_WORKER_ENDPOINT_PROTOCOL")
             .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "http".to_string()),
+            .unwrap_or_else(|| default_protocol.to_string()),
         audience: get("TALON_WORKER_ENDPOINT_AUDIENCE").unwrap_or_default(),
     })
 }
@@ -340,6 +346,22 @@ mod tests {
         assert_eq!(endpoints[0].url, "https://worker.example.com");
         assert_eq!(endpoints[0].protocol, "http");
         assert_eq!(endpoints[0].audience, "scheduler");
+    }
+
+    #[tokio::test]
+    async fn worker_endpoint_discovery_accepts_unix_socket_urls() {
+        let endpoints = discover_worker_endpoints(
+            |name| match name {
+                "TALON_WORKER_ENDPOINT_URL" => Some("unix:///tmp/talon-worker.sock".to_string()),
+                _ => None,
+            },
+            "8081",
+        )
+        .await;
+
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].url, "unix:///tmp/talon-worker.sock");
+        assert_eq!(endpoints[0].protocol, "grpc");
     }
 
     #[tokio::test]

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -298,6 +298,7 @@ impl WorkerEventHandler {
             &event.session_id,
             submission_id,
             &event.message_id,
+            &self.worker_id,
             now_micros,
             crate::control::scheduling::session_processing_timeout_micros(),
         )
@@ -364,12 +365,24 @@ impl WorkerEventHandler {
             &event.session_id,
             &reply_msg_id,
         );
+        let fanout_key = crate::worker::fanout::SessionFanoutKey::new(
+            event.ns.clone(),
+            event.agent.clone(),
+            event.session_id.clone(),
+            submission.submission_id.clone(),
+            submission.attempt_id.clone(),
+        );
+        self.fanout_hub
+            .create_session_attempt(fanout_key.clone())
+            .await;
 
         // Build the deterministic assistant reply sink. The sink owns live UI
         // fanout plus mutable SessionMessage projection writes for this attempt.
-        let sink = PubSubSessionSink::new(
+        let sink = PubSubSessionSink::new_with_fanout(
             self.cp.kv.clone(),
             self.cp.pubsub.clone(),
+            self.fanout_hub.clone(),
+            fanout_key,
             event.ns.clone(),
             event.session_id.clone(),
             event.agent.clone(),
@@ -1067,6 +1080,8 @@ mod tests {
             config: Arc::new(config),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),
+            worker_id: "test-worker".to_string(),
+            fanout_hub: Arc::new(crate::worker::fanout::FanoutHub::new()),
             session_cancellations: Arc::new(AsyncMutex::new(HashMap::new())),
         }
     }

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -22,6 +22,7 @@ use tracing::Instrument;
 
 const MAX_SESSION_RELEASE_CAS_RETRIES: usize = 8;
 const SESSION_RELEASE_CAS_BACKOFF_MS: u64 = 10;
+const FANOUT_SUBSCRIBER_GRACE_MS: u64 = 500;
 
 async fn execute_with_panic_boundary<F>(
     future: F,
@@ -374,6 +375,12 @@ impl WorkerEventHandler {
         );
         self.fanout_hub
             .create_session_attempt(fanout_key.clone())
+            .await;
+        self.fanout_hub
+            .wait_for_subscriber(
+                &fanout_key,
+                std::time::Duration::from_millis(FANOUT_SUBSCRIBER_GRACE_MS),
+            )
             .await;
 
         // Build the deterministic assistant reply sink. The sink owns live UI

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -22,7 +22,26 @@ use tracing::Instrument;
 
 const MAX_SESSION_RELEASE_CAS_RETRIES: usize = 8;
 const SESSION_RELEASE_CAS_BACKOFF_MS: u64 = 10;
-const FANOUT_SUBSCRIBER_GRACE_MS: u64 = 500;
+const DEFAULT_FANOUT_SUBSCRIBER_GRACE_MS: u64 = 100;
+
+fn fanout_subscriber_grace() -> std::time::Duration {
+    let millis = match std::env::var("TALON_WORKER_FANOUT_SUBSCRIBER_GRACE_MS") {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::warn!(
+                    value = %raw,
+                    error = %error,
+                    default_ms = DEFAULT_FANOUT_SUBSCRIBER_GRACE_MS,
+                    "Ignoring invalid TALON_WORKER_FANOUT_SUBSCRIBER_GRACE_MS"
+                );
+                DEFAULT_FANOUT_SUBSCRIBER_GRACE_MS
+            }
+        },
+        Err(_) => DEFAULT_FANOUT_SUBSCRIBER_GRACE_MS,
+    };
+    std::time::Duration::from_millis(millis)
+}
 
 async fn execute_with_panic_boundary<F>(
     future: F,
@@ -377,10 +396,7 @@ impl WorkerEventHandler {
             .create_session_attempt(fanout_key.clone())
             .await;
         self.fanout_hub
-            .wait_for_subscriber(
-                &fanout_key,
-                std::time::Duration::from_millis(FANOUT_SUBSCRIBER_GRACE_MS),
-            )
+            .wait_for_subscriber(&fanout_key, fanout_subscriber_grace())
             .await;
 
         // Build the deterministic assistant reply sink. The sink owns live UI

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -996,8 +996,11 @@ impl ExecutionSink for PubSubSessionSink {
         self.flush_token_event_buffer().await;
         self.flush_reasoning_part_and_event().await;
         // Final KV write (complete message)
-        let reply = if reply.is_empty() {
-            self.accumulated.lock().unwrap().clone()
+        let accumulated = self.accumulated.lock().unwrap().clone();
+        let reply = if accumulated.is_empty() {
+            reply.to_string()
+        } else if reply.is_empty() || accumulated.ends_with(reply) {
+            accumulated
         } else {
             reply.to_string()
         };
@@ -1390,6 +1393,46 @@ mod tests {
             .map(|part| part.content.as_str())
             .collect::<String>();
         assert_eq!(reply_text, "The answer is 12.");
+    }
+
+    #[tokio::test]
+    async fn final_message_persists_accumulated_streamed_text_when_done_reply_is_tail() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let kv = Arc::new(MockKvStore::default());
+        let sink = PubSubSessionSink::new_with_token_publish_interval(
+            kv.clone(),
+            Arc::new(MockPubSub { events }),
+            "conic",
+            "session-1",
+            "infra",
+            "reply-1",
+            reply_key(),
+            "submission-1",
+            "attempt-1",
+            Duration::from_secs(10),
+        );
+
+        sink.on_token("Hello! I am a mock LLM. How can ").await;
+        sink.on_token("I assist you today?").await;
+        sink.on_done("I assist you today?").await;
+
+        let entries = kv.entries.lock().await.clone();
+        let reply = entries
+            .iter()
+            .rev()
+            .filter_map(|(_, value)| data_proto::SessionMessage::decode(value.as_slice()).ok())
+            .find(|message| message.id == "reply-1")
+            .expect("reply message should be persisted");
+        let reply_text = reply
+            .parts
+            .iter()
+            .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+            .map(|part| part.content.as_str())
+            .collect::<String>();
+        assert_eq!(
+            reply_text,
+            "Hello! I am a mock LLM. How can I assist you today?"
+        );
     }
 
     #[tokio::test]

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -3,7 +3,6 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use prost::Message;
 use serde_json::Value;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -16,7 +15,18 @@ use crate::harness::executor::context_budget::tool_result_preview;
 use crate::harness::executor::{AgentEvent, ExecutionSink};
 use crate::harness::llm::{ChatResponse, ChatUsage};
 use crate::harness::sessions::{self, SessionSubmission};
+use crate::worker::fanout::{FanoutHub, SessionFanoutKey};
 use tracing::Instrument;
+
+fn chat_usage_payload_json(usage: &ChatUsage) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "reasoning_tokens": usage.reasoning_tokens,
+        "total_tokens": usage.total_tokens,
+    }))
+    .unwrap_or_else(|_| "{}".to_string())
+}
 
 #[derive(Debug, Clone)]
 pub struct SessionRunSummary {
@@ -44,6 +54,8 @@ pub struct PubSubSessionSink {
     // Shared IO handles and session identity.
     pub kv: Arc<dyn KeyValueStore>,
     pub pubsub: Arc<dyn MessagePublisher>,
+    pub fanout_hub: Arc<FanoutHub>,
+    pub fanout_key: SessionFanoutKey,
     pub ns: String,
     pub session_id: String,
     pub agent_id: String,
@@ -109,6 +121,37 @@ impl PubSubSessionSink {
         Self::new_inner(
             kv,
             pubsub,
+            None,
+            None,
+            ns,
+            session_id,
+            agent_id,
+            reply_msg_id,
+            reply_msg_key,
+            submission_id,
+            attempt_id,
+            token_publish_interval(),
+        )
+    }
+
+    pub fn new_with_fanout(
+        kv: Arc<dyn KeyValueStore>,
+        pubsub: Arc<dyn MessagePublisher>,
+        fanout_hub: Arc<FanoutHub>,
+        fanout_key: SessionFanoutKey,
+        ns: impl Into<String>,
+        session_id: impl Into<String>,
+        agent_id: impl Into<String>,
+        reply_msg_id: impl Into<String>,
+        reply_msg_key: ResourceKey,
+        submission_id: impl Into<String>,
+        attempt_id: impl Into<String>,
+    ) -> Self {
+        Self::new_inner(
+            kv,
+            pubsub,
+            Some(fanout_hub),
+            Some(fanout_key),
             ns,
             session_id,
             agent_id,
@@ -136,6 +179,8 @@ impl PubSubSessionSink {
         Self::new_inner(
             kv,
             pubsub,
+            None,
+            None,
             ns,
             session_id,
             agent_id,
@@ -150,6 +195,8 @@ impl PubSubSessionSink {
     fn new_inner(
         kv: Arc<dyn KeyValueStore>,
         pubsub: Arc<dyn MessagePublisher>,
+        fanout_hub: Option<Arc<FanoutHub>>,
+        fanout_key: Option<SessionFanoutKey>,
         ns: impl Into<String>,
         session_id: impl Into<String>,
         agent_id: impl Into<String>,
@@ -159,18 +206,33 @@ impl PubSubSessionSink {
         attempt_id: impl Into<String>,
         token_publish_interval: Duration,
     ) -> Self {
+        let ns = ns.into();
         let session_id = session_id.into();
+        let agent_id = agent_id.into();
+        let submission_id = submission_id.into();
+        let attempt_id = attempt_id.into();
         let status_topic = topics::session_part_topic_for_session(&session_id);
+        let fanout_key = fanout_key.unwrap_or_else(|| {
+            SessionFanoutKey::new(
+                ns.clone(),
+                agent_id.clone(),
+                session_id.clone(),
+                submission_id.clone(),
+                attempt_id.clone(),
+            )
+        });
         Self {
             kv,
             pubsub,
-            ns: ns.into(),
+            fanout_hub: fanout_hub.unwrap_or_else(|| Arc::new(FanoutHub::new())),
+            fanout_key,
+            ns,
             session_id,
-            agent_id: agent_id.into(),
+            agent_id,
             reply_msg_id: reply_msg_id.into(),
             reply_msg_key,
-            submission_id: submission_id.into(),
-            attempt_id: attempt_id.into(),
+            submission_id,
+            attempt_id,
             status_topic,
             token_publish_interval,
             started_at: Instant::now(),
@@ -468,7 +530,7 @@ impl PubSubSessionSink {
                 data_proto::SessionMessagePartType::Usage,
                 String::new(),
                 String::new(),
-                serde_json::to_string(&usage).unwrap_or_else(|_| "{}".to_string()),
+                chat_usage_payload_json(&usage),
             ),
             AgentEvent::Done(reply) => (
                 SessionMessagePartEventKind::Done,
@@ -503,25 +565,20 @@ impl PubSubSessionSink {
             ns: self.ns.clone(),
             message_id: self.reply_msg_id.clone(),
         };
-        let payload = event.encode_to_vec();
-        if let Err(err) = async { self.pubsub.publish(&self.status_topic, &payload).await }
-            .instrument(tracing::info_span!(
-                "PubSubSessionSink.publish_event",
-                namespace = %self.ns,
-                agent = %self.agent_id,
-                session = %self.session_id,
-                kind = ?kind,
-                part_type = ?part_type,
-                payload_bytes = payload.len(),
-            ))
-            .await
-        {
-            tracing::warn!(
-                error = %err,
-                topic = %self.status_topic,
-                "Failed to publish session stream event"
-            );
+        async {
+            self.fanout_hub
+                .publish_session_part(&self.fanout_key, event)
+                .await
         }
+        .instrument(tracing::info_span!(
+            "PubSubSessionSink.publish_event",
+            namespace = %self.ns,
+            agent = %self.agent_id,
+            session = %self.session_id,
+            kind = ?kind,
+            part_type = ?part_type,
+        ))
+        .await;
     }
 
     fn projection_labels(&self, state: &str) -> std::collections::HashMap<String, String> {
@@ -930,7 +987,7 @@ impl ExecutionSink for PubSubSessionSink {
             data_proto::SessionMessagePartType::Usage,
             String::new(),
             String::new(),
-            serde_json::to_string(usage).unwrap_or_else(|_| "{}".to_string()),
+            chat_usage_payload_json(usage),
         );
         self.publish_event(AgentEvent::Usage(usage.clone())).await;
     }
@@ -1172,6 +1229,12 @@ mod tests {
         event.part.as_ref().expect("event part")
     }
 
+    async fn fanout_events(sink: &PubSubSessionSink) -> Vec<SessionMessagePartEvent> {
+        sink.fanout_hub
+            .replay_session_part_events(&sink.fanout_key)
+            .await
+    }
+
     #[async_trait]
     impl MessagePublisher for MockPubSub {
         async fn publish(&self, topic: &str, message: &[u8]) -> anyhow::Result<()> {
@@ -1235,7 +1298,7 @@ mod tests {
         sink.on_token(" world").await;
         sink.on_done("hello world").await;
 
-        let events = events.lock().await.clone();
+        let events = fanout_events(&sink).await;
         let token_events = events
             .iter()
             .filter(|event| event.kind == SessionMessagePartEventKind::Delta as i32)
@@ -1351,7 +1414,7 @@ mod tests {
         sink.on_tool_call("tool-1", "create_prompt", &json!({"content": "x"}))
             .await;
 
-        let events = events.lock().await.clone();
+        let events = fanout_events(&sink).await;
         assert_eq!(
             event_part(&events[0]).part_type,
             data_proto::SessionMessagePartType::Text as i32
@@ -1406,7 +1469,7 @@ mod tests {
         sink.on_reasoning(" second").await;
         sink.on_done("final reply").await;
 
-        let events = events.lock().await.clone();
+        let events = fanout_events(&sink).await;
         let reasoning_events = events
             .iter()
             .filter(|event| {
@@ -1714,7 +1777,7 @@ mod tests {
         sink.on_done("final reply").await;
         tokio::time::sleep(Duration::from_millis(25)).await;
 
-        let events = events.lock().await.clone();
+        let events = fanout_events(&sink).await;
         assert!(events.iter().any(
             |event| event.kind == SessionMessagePartEventKind::Error as i32
                 && event_part(event).content == "tool failed"
@@ -1782,7 +1845,7 @@ mod tests {
 
         sink.on_done("final reply").await;
 
-        let events = events.lock().await.clone();
+        let events = fanout_events(&sink).await;
         assert!(events.iter().any(
             |event| event.kind == SessionMessagePartEventKind::Error as i32
                 && event_part(event).content == "Error: failed to mark session submission terminal"
@@ -1827,7 +1890,7 @@ mod tests {
 
         sink.on_done("final reply").await;
 
-        let events = events.lock().await.clone();
+        let events = fanout_events(&sink).await;
         assert!(events.iter().any(
             |event| event.kind == SessionMessagePartEventKind::Error as i32
                 && event_part(event).content

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1146,6 +1146,7 @@ mod tests {
     use crate::harness::executor::ExecutionSink;
     use crate::harness::sessions;
     use async_trait::async_trait;
+    use futures::StreamExt;
     use prost::Message;
     use serde_json::json;
     use std::sync::Arc;
@@ -1229,10 +1230,52 @@ mod tests {
         event.part.as_ref().expect("event part")
     }
 
-    async fn fanout_events(sink: &PubSubSessionSink) -> Vec<SessionMessagePartEvent> {
+    type TestFanoutStream = std::pin::Pin<
+        Box<
+            dyn futures::Stream<
+                    Item = std::result::Result<
+                        crate::gateway::rpc::worker_proto::StreamSessionPartsResponse,
+                        tonic::Status,
+                    >,
+                > + Send,
+        >,
+    >;
+
+    async fn fanout_stream(sink: &PubSubSessionSink) -> TestFanoutStream {
         sink.fanout_hub
-            .replay_session_part_events(&sink.fanout_key)
+            .create_session_attempt(sink.fanout_key.clone())
+            .await;
+        sink.fanout_hub
+            .subscribe_session_parts(&sink.fanout_key, 0)
             .await
+            .expect("fanout subscription")
+            .into_stream()
+    }
+
+    async fn next_fanout_event(stream: &mut TestFanoutStream) -> SessionMessagePartEvent {
+        tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("fanout event timed out")
+            .expect("fanout stream ended")
+            .expect("fanout stream error")
+            .event
+            .expect("fanout event")
+    }
+
+    async fn fanout_events_until_terminal(
+        stream: &mut TestFanoutStream,
+    ) -> Vec<SessionMessagePartEvent> {
+        let mut events = Vec::new();
+        loop {
+            let event = next_fanout_event(stream).await;
+            let terminal = event.kind == SessionMessagePartEventKind::Done as i32
+                || event.kind == SessionMessagePartEventKind::Error as i32;
+            events.push(event);
+            if terminal {
+                break;
+            }
+        }
+        events
     }
 
     #[async_trait]
@@ -1293,12 +1336,13 @@ mod tests {
             Duration::from_millis(5),
         );
 
+        let mut fanout = fanout_stream(&sink).await;
         sink.on_token("hello").await;
         tokio::time::sleep(Duration::from_millis(10)).await;
         sink.on_token(" world").await;
         sink.on_done("hello world").await;
 
-        let events = fanout_events(&sink).await;
+        let events = fanout_events_until_terminal(&mut fanout).await;
         let token_events = events
             .iter()
             .filter(|event| event.kind == SessionMessagePartEventKind::Delta as i32)
@@ -1409,12 +1453,16 @@ mod tests {
             Duration::from_secs(10),
         );
 
+        let mut fanout = fanout_stream(&sink).await;
         sink.on_token("drafting ").await;
         sink.on_token("request").await;
         sink.on_tool_call("tool-1", "create_prompt", &json!({"content": "x"}))
             .await;
 
-        let events = fanout_events(&sink).await;
+        let events = vec![
+            next_fanout_event(&mut fanout).await,
+            next_fanout_event(&mut fanout).await,
+        ];
         assert_eq!(
             event_part(&events[0]).part_type,
             data_proto::SessionMessagePartType::Text as i32
@@ -1464,12 +1512,13 @@ mod tests {
             Duration::from_millis(5),
         );
 
+        let mut fanout = fanout_stream(&sink).await;
         sink.on_reasoning("first").await;
         tokio::time::sleep(Duration::from_millis(10)).await;
         sink.on_reasoning(" second").await;
         sink.on_done("final reply").await;
 
-        let events = fanout_events(&sink).await;
+        let events = fanout_events_until_terminal(&mut fanout).await;
         let reasoning_events = events
             .iter()
             .filter(|event| {
@@ -1772,20 +1821,20 @@ mod tests {
             Duration::from_secs(10),
         );
 
+        let mut fanout = fanout_stream(&sink).await;
         sink.on_token("partial ").await;
         sink.on_error("tool failed").await;
         sink.on_done("final reply").await;
         tokio::time::sleep(Duration::from_millis(25)).await;
 
-        let events = fanout_events(&sink).await;
+        let events = fanout_events_until_terminal(&mut fanout).await;
         assert!(events.iter().any(
             |event| event.kind == SessionMessagePartEventKind::Error as i32
                 && event_part(event).content == "tool failed"
         ));
-        assert!(events.iter().any(
-            |event| event.kind == SessionMessagePartEventKind::Done as i32
-                && event_part(event).content == "final reply"
-        ));
+        assert!(!events
+            .iter()
+            .any(|event| event.kind == SessionMessagePartEventKind::Done as i32));
 
         let entries = kv.entries.lock().await.clone();
         let persisted_messages = entries
@@ -1843,9 +1892,10 @@ mod tests {
             Duration::from_secs(10),
         );
 
+        let mut fanout = fanout_stream(&sink).await;
         sink.on_done("final reply").await;
 
-        let events = fanout_events(&sink).await;
+        let events = fanout_events_until_terminal(&mut fanout).await;
         assert!(events.iter().any(
             |event| event.kind == SessionMessagePartEventKind::Error as i32
                 && event_part(event).content == "Error: failed to mark session submission terminal"
@@ -1888,9 +1938,10 @@ mod tests {
             Duration::from_secs(10),
         );
 
+        let mut fanout = fanout_stream(&sink).await;
         sink.on_done("final reply").await;
 
-        let events = fanout_events(&sink).await;
+        let events = fanout_events_until_terminal(&mut fanout).await;
         assert!(events.iter().any(
             |event| event.kind == SessionMessagePartEventKind::Error as i32
                 && event_part(event).content

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -1710,6 +1710,8 @@ mod tests {
             config: Arc::new(Config::default()),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),
+            worker_id: "test-worker".to_string(),
+            fanout_hub: Arc::new(crate::worker::fanout::FanoutHub::new()),
             session_cancellations: Arc::new(AsyncMutex::new(HashMap::new())),
         }
     }

--- a/src/worker/workflows.rs
+++ b/src/worker/workflows.rs
@@ -2289,6 +2289,8 @@ mod tests {
             }),
             mcp_registry: Arc::new(McpRegistry::new()),
             scheduler_authenticator: Arc::new(SchedulerRequestAuthenticator::deny_all()),
+            worker_id: "test-worker".to_string(),
+            fanout_hub: Arc::new(crate::worker::fanout::FanoutHub::new()),
             session_cancellations: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,11 @@ def start_talon_server_and_worker(env, grpc_port, worker_pull_mode=False):
     worker_env = env.copy()
     if worker_pull_mode:
         worker_env["PULL_MODE"] = "1"
+    worker_env.setdefault(
+        "TALON_WORKER_ENDPOINT_URL",
+        f"http://127.0.0.1:{worker_env.get('PORT', '8081')}",
+    )
+    worker_env.setdefault("TALON_WORKER_ENDPOINT_PROTOCOL", "grpc")
 
     worker_proc = subprocess.Popen(
         [worker_bin],

--- a/tests/run_e2e_stack.py
+++ b/tests/run_e2e_stack.py
@@ -174,6 +174,8 @@ control_plane:
     time.sleep(3)
     env_worker = env.copy()
     env_worker["PULL_MODE"] = "1"
+    env_worker["TALON_WORKER_ENDPOINT_URL"] = "http://127.0.0.1:8081"
+    env_worker["TALON_WORKER_ENDPOINT_PROTOCOL"] = "grpc"
     worker_proc = subprocess.Popen([worker_bin], env=env_worker, stdout=sys.stdout, stderr=sys.stderr)
 
     print("--- E2E STACK READY ---")

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -67,9 +67,34 @@ def create_agent_resource(stub, ns, name, spec):
         ResourceSpec(agent=spec),
     )
 
+
+def wait_for_worker_endpoint(stub, expected_url, attempts=30, delay=1):
+    last_urls = []
+    for _ in range(attempts):
+        resources = list(stub.resources.List(ListResourcesRequest(ns="Sys", kind="Worker")).resources)
+        last_urls = [
+            endpoint.url
+            for resource in resources
+            if resource.status and resource.status.worker.phase == "ready"
+            for endpoint in resource.status.worker.endpoints
+        ]
+        if expected_url in last_urls:
+            return
+        time.sleep(delay)
+    raise AssertionError(
+        f"Timed out waiting for worker endpoint {expected_url!r}; saw {last_urls!r}"
+    )
+
+
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+def test_worker_registers_local_endpoint(gateway_channel, talon_infrastructure):
+    stub = TalonClient(gateway_channel)
+    wait_for_worker_endpoint(stub, "http://127.0.0.1:8081")
+
 
 def test_single_turn_chat(gateway_channel, mock_llm_server):
     stub = TalonClient(gateway_channel)

--- a/tests/test_chat_sqlite.py
+++ b/tests/test_chat_sqlite.py
@@ -63,6 +63,32 @@ def create_agent_resource(stub, ns, name, spec):
     ).resource
 
 
+def wait_for_worker_endpoint(stub, expected_url, attempts=30, delay=1):
+    last_urls = []
+    for _ in range(attempts):
+        resources = list(stub.resources.List(ListResourcesRequest(ns="Sys", kind="Worker")).resources)
+        last_urls = [
+            endpoint.url
+            for resource in resources
+            if resource.status and resource.status.worker.phase == "ready"
+            for endpoint in resource.status.worker.endpoints
+        ]
+        if expected_url in last_urls:
+            return
+        time.sleep(delay)
+    raise AssertionError(
+        f"Timed out waiting for worker endpoint {expected_url!r}; saw {last_urls!r}"
+    )
+
+
+def test_worker_registers_sqlite_local_endpoint(
+    gateway_channel_sqlite,
+    talon_infrastructure_sqlite,
+):
+    stub = TalonClient(gateway_channel_sqlite)
+    wait_for_worker_endpoint(stub, "http://127.0.0.1:18082")
+
+
 def test_single_turn_chat_sqlite_local_socket(gateway_channel_sqlite, mock_llm_server):
     stub = TalonClient(gateway_channel_sqlite)
 

--- a/tests/test_durable_sessions_stress.py
+++ b/tests/test_durable_sessions_stress.py
@@ -167,7 +167,7 @@ class DurableSessionKvProbe:
                 (
                     "Sys",
                     "",
-                    "MCPServer",
+                    "McpServer",
                     BLOCKING_MCP_SERVER,
                     server.SerializeToString(),
                 ),

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1125,6 +1125,12 @@ function DebuggerPageContent() {
   useEffect(() => {
     if (!storageHydrated) return;
 
+    const wantsConnected = searchParams.get('connected') === 'true';
+    const queryHasSelection = searchParams.has('ns');
+    if ((wantsConnected && !isConnected) || (queryHasSelection && !selectedNamespace)) {
+      return;
+    }
+
     const nextQuery = buildSearchParams(isConnected, selectedNamespace, searchParams).toString();
     if (nextQuery === lastSyncedQueryRef.current) return;
 

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -57,13 +57,10 @@ async function provisionSession(page: Page) {
 
   const { sessionId, gatewayUrl, client, testNs, testAgent } = await createTestSession();
 
-  await page.goto('/');
-  const connectButton = page.locator('button', { hasText: 'Initialize Connection' });
-  const gatewayInput = page.locator('input[type="url"]');
-  await expect(gatewayInput).toBeVisible();
-  await gatewayInput.fill(gatewayUrl);
-  await connectButton.click();
-  await expect(page.locator('text=Connected')).toBeVisible({ timeout: 15000 });
+  await page.addInitScript((url) => {
+    localStorage.setItem('talon_gateway_url', url);
+  }, gatewayUrl);
+  await page.goto('/?connected=true');
 
   const nsNode = page.locator('.truncate', { hasText: testNs }).first();
   await expect(nsNode).toBeVisible({ timeout: 15000 });
@@ -78,7 +75,7 @@ async function provisionSession(page: Page) {
   await sessionLink.click();
 
   const chatInput = page.locator('textarea[placeholder="Ask Talon to perform a task..."]');
-  const sendButton = page.locator('form').filter({ has: chatInput }).getByRole('button');
+  const sendButton = page.locator('form').filter({ has: chatInput }).getByRole('button', { name: 'Send message' });
   await expect(chatInput).toBeVisible({ timeout: 5000 });
 
   return { chatInput, sendButton, sessionId, gatewayUrl, client, testNs, testAgent };
@@ -115,6 +112,29 @@ function sessionMessageText(message: any): string {
   return typeof message?.content === 'string' ? message.content : '';
 }
 
+function sessionMessageProjectionState(message: any): string {
+  return message?.labels?.['talon.session.projection_state'] ?? '';
+}
+
+async function waitForCommittedSessionText(
+  client: any,
+  target: { ns: string; agent: string; sessionId: string },
+  expectedText: string,
+) {
+  await expect(async () => {
+    const history = await client.sessions.listMessages({
+      ...target,
+      pageSize: 50,
+    });
+    const match = (history.items ?? [])
+      .map((item: any) => item.message)
+      .find((message: any) => sessionMessageText(message) === expectedText);
+    expect(match).toBeTruthy();
+    expect(sessionMessageProjectionState(match)).toBe('committed');
+    expect(history.state).toBe('IDLE');
+  }).toPass({ timeout: 60000 });
+}
+
 function hasReasoningPart(message: any): boolean {
   return Array.isArray(message?.parts) && message.parts.some((part: any) => {
     const type = part?.partType ?? part?.part_type ?? part?.type;
@@ -127,6 +147,10 @@ async function rootCssVar(page: Page, name: string) {
   return page.evaluate((variableName) => {
     return getComputedStyle(document.documentElement).getPropertyValue(variableName).trim();
   }, name);
+}
+
+function cssVarPattern(...values: string[]) {
+  return new RegExp(`^(?:${values.map((value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})$`);
 }
 
 async function annotatePaginationProof(page: Page, label: string) {
@@ -173,7 +197,7 @@ test.describe('Sightline theme tokens', () => {
     }).toMatchObject({
       className: expect.stringContaining('light'),
       titleColor: '#0f172a',
-      inputBg: 'rgba(255, 255, 255, 0.96)',
+      inputBg: expect.stringMatching(cssVarPattern('rgba(255, 255, 255, 0.96)', '#fffffff5')),
       bubbleFg: '#0f172a',
     });
   });
@@ -186,7 +210,7 @@ test.describe('Sightline theme tokens', () => {
       document.documentElement.classList.add('light');
     });
     await expect.poll(() => rootCssVar(page, '--color-title-50')).toBe('#0f172a');
-    await expect.poll(() => rootCssVar(page, '--copilot-input-bg')).toBe('rgba(255, 255, 255, 0.96)');
+    await expect.poll(() => rootCssVar(page, '--copilot-input-bg')).toMatch(cssVarPattern('rgba(255, 255, 255, 0.96)', '#fffffff5'));
     await expect.poll(() => rootCssVar(page, '--talon-chat-user-bubble-fg')).toBe('#0f172a');
 
     await page.evaluate(() => {
@@ -194,7 +218,7 @@ test.describe('Sightline theme tokens', () => {
       document.documentElement.classList.add('dark');
     });
     await expect.poll(() => rootCssVar(page, '--color-title-50')).toBe('#f4f7ff');
-    await expect.poll(() => rootCssVar(page, '--copilot-input-bg')).toBe('rgba(15, 23, 42, 0.92)');
+    await expect.poll(() => rootCssVar(page, '--copilot-input-bg')).toMatch(cssVarPattern('rgba(15, 23, 42, 0.92)', '#0f172aeb'));
     await expect.poll(() => rootCssVar(page, '--talon-chat-user-bubble-fg')).toBe('#e6edf3');
   });
 });
@@ -232,7 +256,8 @@ test.describe('Chat Streaming', () => {
     const clearOption = page.getByRole('option', { name: /\/clear/i });
     await expect(clearOption).toBeVisible();
     await clearOption.hover();
-    await expect(clearOption).toHaveCSS('background-color', 'rgba(148, 163, 184, 0.16)');
+    await expect.poll(async () => clearOption.evaluate((element) => getComputedStyle(element).backgroundColor))
+      .toMatch(cssVarPattern('rgba(148, 163, 184, 0.16)', 'rgba(15, 23, 42, 0.06)'));
     await clearOption.click();
 
     await expect(chatInput).toHaveValue('/clear');
@@ -267,8 +292,12 @@ test.describe('Chat Streaming', () => {
         sessionId,
         pageSize: 50,
       }) as any;
-      expect((history.items ?? []).some((item: any) => sessionMessageText(item.message) === 'Hello! I am a mock LLM. How can I assist you today?')).toBeTruthy();
-      expect((history.items ?? []).some((item: any) => hasReasoningPart(item.message))).toBeTruthy();
+      const message = (history.items ?? [])
+        .map((item: any) => item.message)
+        .find((candidate: any) => sessionMessageText(candidate) === 'Hello! I am a mock LLM. How can I assist you today?');
+      expect(message).toBeTruthy();
+      expect(hasReasoningPart(message)).toBeTruthy();
+      expect(sessionMessageProjectionState(message)).toBe('committed');
     }).toPass({ timeout: 30000 });
 
     await page.reload();
@@ -333,7 +362,7 @@ test.describe('Copilot history pagination', () => {
         message: prompt,
         labels: {},
       });
-      await waitForSessionText(client, target, `I received your message: ${prompt}`);
+      await waitForCommittedSessionText(client, target, `I received your message: ${prompt}`);
     }
 
     const webPort = process.env.WEB_PORT || '3000';

--- a/ui/e2e/explorer.spec.ts
+++ b/ui/e2e/explorer.spec.ts
@@ -50,6 +50,10 @@ test.describe('Explorer navigation', () => {
       session: sessionRes.sessionId,
     });
 
+    await page.addInitScript((url) => {
+      localStorage.setItem('talon_gateway_url', url);
+    }, gatewayUrl);
+
     await page.goto(`/?${params.toString()}`);
 
     await expect(page.locator('text=Connected')).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
## Summary
- add worker claim routing via claim_worker_id and direct gateway-to-worker FanoutService streaming
- serve worker-local in-process FanoutHub over the existing worker port and stop session token pubsub streaming
- register per-worker endpoints for local, Cloudflare dev, subprocess, and generated SDK/test paths
- update UI/deep-link and E2E coverage for direct streaming and worker endpoint registration

## Local validation
- cargo fmt --all
- git diff --check
- cargo test --lib
- .tools/e2e-venv/bin/python -m pytest -q tests
- env CI=1 PYTHON_BIN=/Users/shukant/.codex/worktrees/9052/talon/.tools/e2e-venv/bin/python REUSE_EXISTING_SERVER=false WEB_PORT=3017 pnpm --dir ui test:e2e
- docker compose -f infra/cf/dev/docker-compose.yaml -f infra/cf/dev/docker-compose.ci.yaml config
- docker compose -f infra/cf/dev/docker-compose.yaml -f infra/cf/dev/docker-compose.ci.yaml up --build --abort-on-container-exit --exit-code-from e2e-tests e2e-tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workers now register and advertise endpoints more precisely, including local endpoint discovery and environment-driven protocol/URL overrides.
  * Added worker fanout streaming for session message parts to route streaming to the correct owning worker.
* **Bug Fixes**
  * Improved session streaming/routing so event delivery and SSE projections follow the correct session attempt/worker.
  * Enhanced worker readiness/health signaling and startup/shutdown coordination.
* **Documentation**
  * Added “Worker endpoint registration” deployment guidance.
* **Tests**
  * Expanded E2E polling to validate local worker endpoint registration for both chat and SQLite setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->