### PR TITLE
[codex] Prefetch gateway session part streams

### DIFF
--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -16,6 +16,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UnixStream;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 use url::Url;
@@ -23,6 +25,7 @@ use url::Url;
 const SESSION_STREAM_LEASE_CHECK_MAX_MICROS: u64 = 5_000_000;
 const SESSION_STREAM_LEASE_CHECK_MIN_MICROS: u64 = 100_000;
 const WORKER_FANOUT_NOT_FOUND_RETRY_DELAY: Duration = Duration::from_millis(50);
+const SESSION_PART_PREFETCH_BUFFER: usize = 64;
 
 pub(crate) type SessionPartEventStream = Pin<
     Box<
@@ -48,20 +51,21 @@ pub(crate) fn session_parts_event_stream(
     kv: Arc<dyn KeyValueStore + Send + Sync>,
     pubsub: Arc<dyn MessagePublisher + Send + Sync>,
 ) -> SessionPartEventStream {
-    if targets.len() > 1 {
-        return batch_session_parts_event_stream(targets, kv, pubsub);
+    if targets.is_empty() {
+        return Box::pin(futures::stream::empty());
     }
 
-    let mut streams: SelectAll<SessionPartEventStream> = SelectAll::new();
-    for target in targets {
-        streams.push(single_session_parts_event_stream(
-            target,
+    let stream = if targets.len() > 1 {
+        batch_session_parts_event_stream(targets, kv, pubsub)
+    } else {
+        single_session_parts_event_stream(
+            targets.into_iter().next().expect("target"),
             None,
-            kv.clone(),
-            pubsub.clone(),
-        ));
-    }
-    Box::pin(streams)
+            kv,
+            pubsub,
+        )
+    };
+    eager_buffer_session_part_stream(stream)
 }
 
 pub(crate) fn session_submission_event_stream(
@@ -70,7 +74,52 @@ pub(crate) fn session_submission_event_stream(
     kv: Arc<dyn KeyValueStore + Send + Sync>,
     pubsub: Arc<dyn MessagePublisher + Send + Sync>,
 ) -> SessionPartEventStream {
-    single_session_parts_event_stream(target, Some(submission_id), kv, pubsub)
+    eager_buffer_session_part_stream(single_session_parts_event_stream(
+        target,
+        Some(submission_id),
+        kv,
+        pubsub,
+    ))
+}
+
+// Start each returned gateway stream's upstream watcher immediately and isolate it
+// behind a private bounded queue. That lets the gateway attach to worker fanout
+// before the client polls the response stream, while keeping concurrent watchers
+// independent: no shared receiver or fanout cursor can let one stream consume,
+// block, or advance another stream's events.
+fn eager_buffer_session_part_stream(mut source: SessionPartEventStream) -> SessionPartEventStream {
+    let (sender, receiver) = mpsc::channel(SESSION_PART_PREFETCH_BUFFER);
+    let cancel = CancellationToken::new();
+    let task_cancel = cancel.clone();
+    tokio::spawn(async move {
+        loop {
+            let item = tokio::select! {
+                _ = task_cancel.cancelled() => break,
+                item = source.next() => item,
+            };
+            let Some(item) = item else {
+                break;
+            };
+            tokio::select! {
+                _ = task_cancel.cancelled() => break,
+                result = sender.send(item) => {
+                    if result.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+    let cancel_on_drop = cancel.drop_guard();
+    Box::pin(futures::stream::unfold(
+        (receiver, cancel_on_drop),
+        |(mut receiver, cancel_on_drop)| async move {
+            receiver
+                .recv()
+                .await
+                .map(|item| (item, (receiver, cancel_on_drop)))
+        },
+    ))
 }
 
 fn single_session_parts_event_stream(
@@ -738,8 +787,10 @@ mod tests {
     use super::*;
     use crate::control::events::SessionMessagePartEventKind;
     use crate::worker::fanout::{FanoutHub, SessionFanoutKey};
+    use futures::StreamExt;
     use tempfile::tempdir;
     use tokio::net::UnixListener;
+    use tokio::sync::oneshot;
     use tokio_stream::wrappers::UnixListenerStream;
     use tokio_util::sync::CancellationToken;
     use tonic::transport::Server;
@@ -760,6 +811,36 @@ mod tests {
             ns: "ns".to_string(),
             message_id: "message-1".to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn eager_buffer_polls_and_buffers_before_consumer_poll() {
+        let (started_tx, started_rx) = oneshot::channel();
+        let (event_tx, event_rx) = oneshot::channel();
+        let source: SessionPartEventStream = Box::pin(async_stream::stream! {
+            let _ = started_tx.send(());
+            if let Ok(event) = event_rx.await {
+                yield Ok(event);
+            }
+        });
+
+        let mut stream = eager_buffer_session_part_stream(source);
+        tokio::time::timeout(Duration::from_secs(1), started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(event_tx
+            .send(part_event(SessionMessagePartEventKind::Delta, "prefetched"))
+            .is_ok());
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let event = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.part.unwrap().content, "prefetched");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- start gateway session part followers eagerly when `StreamParts`, `StreamPartsBatch`, or `SubmitTurn` creates a response stream
- buffer worker fanout events in a bounded gateway-side queue while the client/gateway finishes consuming setup work
- cancel the background follower when the returned stream is dropped
- refresh `Cargo.lock` for the current `origin/main` dependency graph so `cargo check --locked` passes

## Why

This trims the delay between worker fanout attachment and client-visible streaming. The gateway can now drain tokens from the worker into a small local buffer while downstream response hydration or polling catches up, instead of waiting until the client first polls the returned stream.

## Validation

- `cargo test gateway::rpc::sessions::watcher::tests --lib`
- `cargo check --locked -q`
- `git diff --check`
- `/tmp/talon-e2e-venv-9052/bin/python -m pytest -q tests/test_chat.py::test_worker_registers_local_endpoint tests/test_chat_sqlite.py::test_worker_registers_sqlite_local_endpoint tests/test_chat.py::test_streaming_chat tests/test_chat_sqlite.py::test_streaming_chat_sqlite_local_socket tests/test_chat_sqlite.py::test_cli_streaming_chat_sqlite_local_socket`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session event delivery by preloading upcoming events in the background, helping streams remain responsive even when consumers read slowly.
  * Stream handling now starts buffering immediately, reducing the chance of delays when opening session updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->