### PR TITLE
[codex] Fix agent system prompt propagation

### DIFF
--- a/src/harness/acp.rs
+++ b/src/harness/acp.rs
@@ -45,6 +45,7 @@ pub struct AcpAgentRuntime {
     ns: String,
     agent_id: String,
     session_id: String,
+    system_prompt: String,
     acp: manifests::AcpRuntime,
     cp: ControlPlane,
     _config: Arc<Config>,
@@ -88,10 +89,12 @@ impl AcpAgentRuntime {
             .acp
             .clone()
             .ok_or_else(|| anyhow!("Agent '{}' ACP runtime config is missing", agent_id))?;
+        let system_prompt = spec.system_prompt.clone();
         Ok(Self {
             ns: ns.to_string(),
             agent_id: agent_id.to_string(),
             session_id: session_id.to_string(),
+            system_prompt,
             acp,
             cp: cp.clone(),
             _config: config.clone(),
@@ -188,6 +191,7 @@ impl AcpAgentRuntime {
         .await?;
         let _ = read_optional_capability_response(&mut lines, 2).await?;
         let mut open_request_id = 3;
+        let mut opened_new_session = false;
         let open_response = if effective_acp.persist_session {
             send_request(
                 &mut stdin,
@@ -200,6 +204,7 @@ impl AcpAgentRuntime {
                 Ok(response) => response,
                 Err(err) if is_acp_resource_not_found(&err) => {
                     open_request_id += 1;
+                    opened_new_session = true;
                     let mut new_session_acp = effective_acp.clone();
                     new_session_acp.persist_session = false;
                     send_request(
@@ -214,6 +219,7 @@ impl AcpAgentRuntime {
                 Err(err) => return Err(err),
             }
         } else {
+            opened_new_session = true;
             send_request(
                 &mut stdin,
                 open_request_id,
@@ -244,10 +250,12 @@ impl AcpAgentRuntime {
             &mut stdin,
             prompt_request_id,
             "session/prompt",
-            json!({
-                "sessionId": acp_session_id,
-                "prompt": [{ "type": "text", "text": prompt }],
-            }),
+            session_prompt_params(
+                &acp_session_id,
+                prompt,
+                &self.system_prompt,
+                opened_new_session,
+            ),
         )
         .await?;
 
@@ -849,6 +857,27 @@ fn session_open_params(session_id: &str, acp: &manifests::AcpRuntime) -> Value {
     }
 }
 
+fn session_prompt_params(
+    session_id: &str,
+    prompt: &str,
+    system_prompt: &str,
+    include_system_prompt: bool,
+) -> Value {
+    let text = if include_system_prompt && !system_prompt.trim().is_empty() {
+        format!(
+            "System instructions from Talon agent spec:\n{}\n\nUser message:\n{}",
+            system_prompt.trim(),
+            prompt
+        )
+    } else {
+        prompt.to_string()
+    };
+    json!({
+        "sessionId": session_id,
+        "prompt": [{ "type": "text", "text": text }],
+    })
+}
+
 fn acp_auth_method(acp: &manifests::AcpRuntime) -> &'static str {
     if acp.env.contains_key("CODEX_API_KEY") {
         "codex-api-key"
@@ -960,6 +989,31 @@ mod tests {
         assert_eq!(
             effective.env.get("CODEX_API_KEY").map(String::as_str),
             Some("test-openai-key")
+        );
+    }
+
+    #[test]
+    fn session_prompt_params_includes_system_prompt_for_new_sessions() {
+        let params = session_prompt_params("session-1", "Fix the bug", "Stay concise.", true);
+
+        let text = params
+            .pointer("/prompt/0/text")
+            .and_then(|value| value.as_str())
+            .unwrap();
+        assert!(text.contains("System instructions from Talon agent spec:"));
+        assert!(text.contains("Stay concise."));
+        assert!(text.contains("User message:\nFix the bug"));
+    }
+
+    #[test]
+    fn session_prompt_params_omits_system_prompt_for_loaded_sessions() {
+        let params = session_prompt_params("session-1", "Continue", "Stay concise.", false);
+
+        assert_eq!(
+            params
+                .pointer("/prompt/0/text")
+                .and_then(|value| value.as_str()),
+            Some("Continue")
         );
     }
 

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -448,6 +448,24 @@ impl AgentExecutor {
         ))
     }
 
+    fn messages_for_llm(&self, context: &ExecutionContext) -> Vec<ChatMessage> {
+        let mut history = context.history.clone();
+        let system_prompt = self.agent_spec.system_prompt.trim();
+        if !system_prompt.is_empty() && !context.has_system_message() {
+            history.insert(0, LoopMessage::text("system", system_prompt));
+        }
+
+        compact_history_for_llm(&history)
+            .iter()
+            .map(|m| ChatMessage {
+                role: m.role.clone(),
+                content_parts: m.content_parts.clone(),
+                tool_calls: m.tool_calls.clone().unwrap_or_default(),
+                tool_call_id: m.tool_call_id.clone(),
+            })
+            .collect()
+    }
+
     /// Run the prepared execution context to completion, emitting events to
     /// `sink` along the way.
     /// Returns the final reply text.
@@ -471,15 +489,7 @@ impl AgentExecutor {
             }
             turn_limit -= 1;
 
-            let messages: Vec<ChatMessage> = compact_history_for_llm(&context.history)
-                .iter()
-                .map(|m| ChatMessage {
-                    role: m.role.clone(),
-                    content_parts: m.content_parts.clone(),
-                    tool_calls: m.tool_calls.clone().unwrap_or_default(),
-                    tool_call_id: m.tool_call_id.clone(),
-                })
-                .collect();
+            let messages = self.messages_for_llm(context);
 
             let tools = {
                 let reg = self.registry.read().await;
@@ -999,6 +1009,89 @@ mod tests {
         assert!(messages.iter().any(|message| {
             message.role == "system" && message.text_content().contains("earlier messages omitted")
         }));
+    }
+
+    #[tokio::test]
+    async fn executor_injects_agent_system_prompt_into_llm_request() {
+        let llm = Arc::new(RecordingLlmProvider::default());
+        let registry = Arc::new(tokio::sync::RwLock::new(ToolRegistry::new()));
+        let mut spec = manifests::AgentSpec::default();
+        spec.system_prompt = "Answer like the configured agent.".to_string();
+        let executor = AgentExecutor::new(
+            llm.clone(),
+            "test-provider".to_string(),
+            "test-model".to_string(),
+            ContextAssembler::new("."),
+            registry,
+            Arc::new(Config::default()),
+            Arc::new(EmptyKnowledgeBook),
+            "conic:wks:13".to_string(),
+            "cmo".to_string(),
+            ControlPlane::noop(),
+            spec,
+            HashMap::new(),
+        );
+
+        let mut context = ExecutionContext::new("cmo");
+        context.push(LoopMessage::text("user", "Hello"));
+
+        let reply = executor
+            .execute(&mut context, &CaptureSink::new(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(reply, "resolved");
+        let seen = llm.seen_messages.lock().unwrap();
+        let messages = seen.last().unwrap();
+        assert_eq!(messages[0].role, "system");
+        assert_eq!(
+            messages[0].text_content(),
+            "Answer like the configured agent."
+        );
+        assert_eq!(messages[1].role, "user");
+        assert_eq!(messages[1].text_content(), "Hello");
+    }
+
+    #[tokio::test]
+    async fn executor_does_not_duplicate_existing_system_message() {
+        let llm = Arc::new(RecordingLlmProvider::default());
+        let registry = Arc::new(tokio::sync::RwLock::new(ToolRegistry::new()));
+        let mut spec = manifests::AgentSpec::default();
+        spec.system_prompt = "Configured prompt".to_string();
+        let executor = AgentExecutor::new(
+            llm.clone(),
+            "test-provider".to_string(),
+            "test-model".to_string(),
+            ContextAssembler::new("."),
+            registry,
+            Arc::new(Config::default()),
+            Arc::new(EmptyKnowledgeBook),
+            "conic:wks:13".to_string(),
+            "cmo".to_string(),
+            ControlPlane::noop(),
+            spec,
+            HashMap::new(),
+        );
+
+        let mut context = ExecutionContext::new("cmo");
+        context.push(LoopMessage::text("system", "Existing prompt"));
+        context.push(LoopMessage::text("user", "Hello"));
+
+        executor
+            .execute(&mut context, &CaptureSink::new(), None)
+            .await
+            .unwrap();
+
+        let seen = llm.seen_messages.lock().unwrap();
+        let messages = seen.last().unwrap();
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| message.role == "system")
+                .count(),
+            1
+        );
+        assert_eq!(messages[0].text_content(), "Existing prompt");
     }
 
     #[tokio::test]

--- a/src/harness/llm/anthropic.rs
+++ b/src/harness/llm/anthropic.rs
@@ -105,6 +105,35 @@ impl AnthropicProvider {
             "content": content,
         })
     }
+
+    fn request_system_prompt(messages: &[ChatMessage]) -> Option<String> {
+        let system_parts = messages
+            .iter()
+            .filter(|message| message.role == "system")
+            .map(|message| {
+                message
+                    .content_parts
+                    .iter()
+                    .filter_map(|part| match part.content.as_ref() {
+                        Some(chat_content_part::Content::Text(text)) => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+            .filter(|text| !text.trim().is_empty())
+            .collect::<Vec<_>>();
+
+        (!system_parts.is_empty()).then(|| system_parts.join("\n\n"))
+    }
+
+    fn request_messages(messages: &[ChatMessage]) -> Vec<serde_json::Value> {
+        messages
+            .iter()
+            .filter(|message| message.role != "system")
+            .map(Self::serialize_message)
+            .collect()
+    }
 }
 
 fn anthropic_content_part(part: &ChatContentPart) -> serde_json::Value {
@@ -145,8 +174,11 @@ impl LlmProvider for AnthropicProvider {
         let mut payload = json!({
             "model": self.model,
             "max_tokens": max_tokens,
-            "messages": request.messages.iter().filter(|message| message.role != "system").map(Self::serialize_message).collect::<Vec<_>>(),
+            "messages": Self::request_messages(&request.messages),
         });
+        if let Some(system_prompt) = Self::request_system_prompt(&request.messages) {
+            payload["system"] = json!(system_prompt);
+        }
         if let Some(thinking_payload) = thinking_payload {
             payload["thinking"] = thinking_payload;
         }
@@ -185,9 +217,12 @@ impl LlmProvider for AnthropicProvider {
         let mut payload = json!({
             "model": self.model,
             "max_tokens": max_tokens,
-            "messages": request.messages.iter().filter(|message| message.role != "system").map(Self::serialize_message).collect::<Vec<_>>(),
+            "messages": Self::request_messages(&request.messages),
             "stream": true,
         });
+        if let Some(system_prompt) = Self::request_system_prompt(&request.messages) {
+            payload["system"] = json!(system_prompt);
+        }
         if let Some(thinking_payload) = thinking_payload {
             payload["thinking"] = thinking_payload;
         }
@@ -568,6 +603,9 @@ mod tests {
                     .iter()
                     .all(|message| message["role"] != "system"));
                 let content = body["messages"][0]["content"].as_str().unwrap_or_default();
+                if content == "hello" {
+                    assert_eq!(body["system"].as_str(), Some("top-level system prompt"));
+                }
                 if content == "cause-error" {
                     return (
                         axum::http::StatusCode::BAD_REQUEST,
@@ -637,6 +675,12 @@ mod tests {
         let app = Router::new().route(
             "/v1/messages",
             post(|Json(body): Json<serde_json::Value>| async move {
+                if body["messages"][0]["content"].as_str().unwrap_or_default() == "stream" {
+                    assert_eq!(
+                        body["system"].as_str(),
+                        Some("top-level system prompt")
+                    );
+                }
                 assert!(body["messages"]
                     .as_array()
                     .unwrap()


### PR DESCRIPTION
## Summary

This fixes Talon agent system prompts being dropped before they reach the model or ACP harness.

## Root Cause

The native executor built provider requests from session loop history only, so `AgentSpec.system_prompt` was never injected unless a system message already happened to exist in the persisted history. The ACP runtime also discarded the agent spec after reading the ACP runtime config, and the Anthropic provider filtered system messages out without forwarding them to Anthropic's top-level `system` field.

## Changes

- Inject `AgentSpec.system_prompt` as a leading system message at the native LLM request boundary, without duplicating existing system messages.
- Preserve the agent system prompt in ACP runtimes and include it in the first prompt for newly opened ACP sessions.
- Map system messages to Anthropic's top-level `system` payload field.
- Add focused regression coverage for native executor injection, ACP prompt params, and Anthropic system forwarding.

## Validation

- `cargo fmt`
- `cargo test harness::executor::runtime::tests::executor_`
- `cargo test harness::acp::tests::session_prompt_params`
- `cargo test harness::llm::anthropic::tests::`
- `cargo test system_prompt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System instructions are now included in chat requests when a new session is created, improving first-run behavior.
  * Support for top-level system prompts has been added for supported AI requests, keeping system guidance separate from user messages.

* **Bug Fixes**
  * Existing sessions no longer receive duplicated system instructions.
  * Request formatting now better matches provider expectations when system messages are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->