### PR TITLE
[codex] Add namespace auth token command

### DIFF
--- a/docs/operations/authentication-and-access.md
+++ b/docs/operations/authentication-and-access.md
@@ -31,7 +31,7 @@ JWTs can restrict access to:
 - a channel
 - one or more browser origins
 
-JWTs without resource scope are root tokens and can access the gateway wherever JWT auth is accepted. Agent and session tokens include namespace scope; session tokens also include agent scope so a session id is not accidentally reusable across agents.
+JWTs without resource scope are root tokens and can access the gateway wherever JWT auth is accepted. Namespace tokens can access one namespace and its child namespaces. Agent and session tokens include namespace scope; session tokens also include agent scope so a session id is not accidentally reusable across agents.
 
 That makes JWT mode the most expressive option for browser or delegated access.
 
@@ -54,6 +54,7 @@ TTLs and resource scopes.
 Use the `auth` command to mint scoped tokens from `TALON_JWT_SECRET`, `GATEWAY_JWT_SECRET`, or `--jwt-secret`:
 
 - `auth root-token`
+- `auth namespace-token --namespace <ns>`
 - `auth agent-token --namespace <ns> --agent <agent>`
 - `auth session-token --namespace <ns> --agent <agent> --session <session-id>`
 - `auth channel-token --namespace <ns> --channel <channel>`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,7 @@ running with `GATEWAY_JWT_SECRET`.
 - `auth logout`: remove stored CLI auth
 - `auth whoami`: show stored CLI auth
 - `auth root-token`: unrestricted root token
+- `auth namespace-token --namespace <ns>`: namespace scoped token
 - `auth agent-token --namespace <ns> --agent <agent>`: namespace and agent scoped token
 - `auth session-token --namespace <ns> --agent <agent> --session <session-id>`: namespace, agent, and session scoped token
 - `auth channel-token --namespace <ns> --channel <channel>`: namespace and channel scoped token

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -531,6 +531,27 @@ pub(crate) fn validate_token_part<'a>(value: &'a str, name: &str) -> Result<&'a 
     Ok(value)
 }
 
+pub(crate) fn mint_namespace_jwt(
+    secret: &str,
+    namespace: &str,
+    subject: &str,
+    ttl_seconds: u64,
+    origins: &[String],
+) -> Result<String> {
+    let namespace = validate_token_part(namespace, "namespace")?;
+    mint_scoped_jwt(
+        secret,
+        subject,
+        ttl_seconds,
+        Some(namespace),
+        None,
+        None,
+        None,
+        origins,
+    )
+    .context("Failed to sign Talon namespace JWT")
+}
+
 pub(crate) fn mint_agent_jwt(
     secret: &str,
     namespace: &str,
@@ -663,9 +684,10 @@ pub(crate) async fn connect_gateway(cli: &Cli) -> Result<TalonClient> {
 #[cfg(test)]
 mod tests {
     use super::{
-        google_token_request_form, parse_ttl_seconds, resolve_token_ttl_seconds,
-        DEFAULT_GOOGLE_CLI_CLIENT_SECRET, DEFAULT_TOKEN_TTL,
+        google_token_request_form, mint_namespace_jwt, parse_ttl_seconds,
+        resolve_token_ttl_seconds, DEFAULT_GOOGLE_CLI_CLIENT_SECRET, DEFAULT_TOKEN_TTL,
     };
+    use crate::gateway::auth::verify_jwt;
 
     #[test]
     fn google_token_request_form_includes_client_secret_when_present() {
@@ -719,5 +741,18 @@ mod tests {
         assert!(resolve_token_ttl_seconds("1wk", Some(123)).is_err());
         assert!(parse_ttl_seconds("0min").is_err());
         assert!(parse_ttl_seconds("1fortnight").is_err());
+    }
+
+    #[test]
+    fn mint_namespace_jwt_sets_only_namespace_scope() {
+        let token =
+            mint_namespace_jwt("secret", " customers:acme ", "tenant-client", 60, &[]).unwrap();
+        let claims = verify_jwt(&token, "secret").unwrap();
+
+        assert_eq!(claims.sub, "tenant-client");
+        assert_eq!(claims.ns.as_deref(), Some("customers:acme"));
+        assert_eq!(claims.agent, None);
+        assert_eq!(claims.session, None);
+        assert_eq!(claims.channel, None);
     }
 }

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -7,9 +7,9 @@ use clap::{Args, Subcommand};
 use super::{Cli, RunOutcome};
 use crate::cli::{
     clear_stored_gateway_auth, describe_stored_auth, exchange_oidc_id_token,
-    login_with_google_loopback, mint_agent_jwt, mint_channel_jwt, mint_root_jwt, mint_session_jwt,
-    resolve_gateway_jwt_secret, resolve_token_ttl_seconds, save_stored_gateway_auth,
-    DEFAULT_TOKEN_TTL,
+    login_with_google_loopback, mint_agent_jwt, mint_channel_jwt, mint_namespace_jwt,
+    mint_root_jwt, mint_session_jwt, resolve_gateway_jwt_secret, resolve_token_ttl_seconds,
+    save_stored_gateway_auth, DEFAULT_TOKEN_TTL,
 };
 
 #[derive(Args)]
@@ -44,6 +44,22 @@ enum AuthCommands {
     /// Mint a root JWT with unrestricted gateway scope.
     RootToken {
         #[arg(long, default_value = "talon-root-client")]
+        subject: String,
+        /// Token lifetime, such as 5min, 1wk, 3mo, or 1yr.
+        #[arg(long, default_value = DEFAULT_TOKEN_TTL)]
+        ttl: String,
+        /// Token lifetime in seconds. Kept for script compatibility.
+        #[arg(long)]
+        ttl_seconds: Option<u64>,
+        /// Browser origin allowed to use this token. Repeat for multiple origins.
+        #[arg(long = "origin")]
+        origins: Vec<String>,
+    },
+    /// Mint a JWT that can access one namespace and its child namespaces.
+    NamespaceToken {
+        #[arg(short, long)]
+        namespace: String,
+        #[arg(long, default_value = "talon-namespace-client")]
         subject: String,
         /// Token lifetime, such as 5min, 1wk, 3mo, or 1yr.
         #[arg(long, default_value = DEFAULT_TOKEN_TTL)]
@@ -166,6 +182,18 @@ pub(super) async fn run(cli: &Cli, command: &AuthCommand) -> Result<RunOutcome> 
                 .context("TALON_JWT_SECRET or GATEWAY_JWT_SECRET is required")?;
             let ttl_seconds = resolve_token_ttl_seconds(ttl, *ttl_seconds)?;
             mint_root_jwt(&secret, subject, ttl_seconds, origins)?
+        }
+        AuthCommands::NamespaceToken {
+            namespace,
+            subject,
+            ttl,
+            ttl_seconds,
+            origins,
+        } => {
+            let secret = resolve_gateway_jwt_secret(cli)
+                .context("TALON_JWT_SECRET or GATEWAY_JWT_SECRET is required")?;
+            let ttl_seconds = resolve_token_ttl_seconds(ttl, *ttl_seconds)?;
+            mint_namespace_jwt(&secret, namespace, subject, ttl_seconds, origins)?
         }
         AuthCommands::AgentToken {
             namespace,

--- a/src/cli/prelude.rs
+++ b/src/cli/prelude.rs
@@ -16,7 +16,7 @@ use commands::Cli;
 
 pub(super) use auth::{
     clear_stored_gateway_auth, connect_gateway, describe_stored_auth, exchange_oidc_id_token,
-    login_with_google_loopback, mint_agent_jwt, mint_channel_jwt, mint_root_jwt, mint_session_jwt,
-    resolve_gateway_jwt_secret, resolve_gateway_password, resolve_token_ttl_seconds,
-    save_stored_gateway_auth, DEFAULT_TOKEN_TTL,
+    login_with_google_loopback, mint_agent_jwt, mint_channel_jwt, mint_namespace_jwt,
+    mint_root_jwt, mint_session_jwt, resolve_gateway_jwt_secret, resolve_gateway_password,
+    resolve_token_ttl_seconds, save_stored_gateway_auth, DEFAULT_TOKEN_TTL,
 };


### PR DESCRIPTION
## Summary

Adds a `talon-cli auth namespace-token` subcommand for minting JWTs scoped only to a namespace, without binding them to an agent, session, or channel.

## Details

- Adds `mint_namespace_jwt`, which signs tokens containing `talon:ns` only.
- Wires the helper into the auth CLI as `auth namespace-token --namespace <ns>`.
- Carries through the current token options from `main`: `--ttl`, compatibility `--ttl-seconds`, and repeatable `--origin`.
- Documents namespace-scoped tokens in the CLI reference and authentication guide.

## Impact

Clients can now request a namespace-scoped token for access across a namespace and its child namespaces without using a broader root token or a narrower agent/session token.

## Validation

- `cargo test mint_namespace_jwt_sets_only_namespace_scope`
- `cargo test resolve_token_ttl_seconds_keeps_legacy_seconds_escape_hatch`
- `cargo run --quiet --bin talon-cli -- auth namespace-token --help`
- `cargo run --quiet --bin talon-cli -- --jwt-secret test-secret auth namespace-token --namespace customers:acme --subject tenant-client --ttl 10min --origin https://app.example.com`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for minting namespace-scoped JWTs from the CLI.
  * Expanded CLI docs with a new token variant example and updated command reference.

* **Documentation**
  * Clarified JWT scoping rules, including namespace access behavior and token inheritance details.

* **Bug Fixes**
  * Improved validation for namespace token creation to require a non-empty namespace value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->