### PR TITLE
[codex] Refactor Sightline explorer state

### DIFF
--- a/dockerfiles/oss-ui.Dockerfile
+++ b/dockerfiles/oss-ui.Dockerfile
@@ -24,6 +24,7 @@ ENV NEXT_PUBLIC_GATEWAY_URL=$NEXT_PUBLIC_GATEWAY_URL
 
 COPY ui/app ./app
 COPY ui/components ./components
+COPY ui/hooks ./hooks
 COPY ui/lib ./lib
 COPY ui/proto ./proto
 COPY ui/utils ./utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.13
         version: 4.3.0
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.3)
       ai:
         specifier: ^5.0.52
         version: 5.0.188(zod@3.25.76)
@@ -1792,6 +1795,14 @@ packages:
 
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/react-query@5.101.2':
+    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5844,6 +5855,13 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       postcss: 8.5.14
       tailwindcss: 4.3.0
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/react-query@5.101.2(react@19.2.3)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      react: 19.2.3
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "../components/theme-provider";
+import { TalonQueryProvider } from "../components/query-provider";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 const jetBrainsMono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
@@ -20,7 +21,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} ${jetBrainsMono.variable} font-sans antialiased`}>
         <ThemeProvider>
-          {children}
+          <TalonQueryProvider>{children}</TalonQueryProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Suspense, useState, useRef, useEffect, useCallback } from 'react';
+import { Suspense, useMemo, useState, useRef, useEffect, useCallback } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { dump } from 'js-yaml';
+import { useQueryClient } from '@tanstack/react-query';
 import { 
   Terminal, 
   Activity, 
@@ -30,11 +30,11 @@ import {
   ShieldCheck,
   Container,
 } from 'lucide-react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { TalonChannel, TalonCopilot, type TalonChatObjectRef, type TalonImageUploadContext } from '@impalasys/talon-chat';
-import { NamespaceExplorer, type Selection } from '../components/Namespaces/NamespaceExplorer';
+import { NamespaceExplorer } from '../components/Namespaces/NamespaceExplorer';
 import { WorkspaceCommandPalette } from '../components/Search/WorkspaceCommandPalette';
 import {
   getDefaultGatewayUrl,
@@ -43,11 +43,23 @@ import {
   normalizeGatewayUrl,
   updateGatewayClient,
 } from '../lib/grpc';
-import { resourceToManifestDocument, yamlSafeValue } from '../lib/resourceManifest';
+import {
+  areSelectionsEqual,
+  buildSearchParams,
+  getSelectionSubtitle,
+  getSelectionTitle,
+  selectionFromSearchParams,
+  SYSTEM_NAMESPACE,
+  type Selection,
+} from '../lib/selection';
+import {
+  channelSubscriptionDocumentFromResource,
+  type ResourceEnvelope,
+} from '../lib/talon/resourceMappers';
+import { useResourceDocument } from '../hooks/useResourceDocument';
 
 const isStaticExport = process.env.NEXT_PUBLIC_TALON_STATIC_EXPORT === '1';
-const SYSTEM_NAMESPACE = 'Sys';
-
+const CONNECT_TIMEOUT_MS = 8000;
 declare global {
   interface Window {
     google?: {
@@ -61,296 +73,8 @@ declare global {
   }
 }
 
-const RESOURCE_KIND_BY_SELECTION: Partial<Record<Selection['type'], string>> = {
-  agent: 'Agent',
-  channel: 'Channel',
-  'channel-subscription': 'ChannelSubscription',
-  workflow: 'Workflow',
-  schedule: 'Schedule',
-  template: 'Template',
-  deployment: 'Deployment',
-  'deployment-replica': 'DeploymentReplica',
-  'sandbox-class': 'SandboxClass',
-  'sandbox-policy': 'SandboxPolicy',
-  sandbox: 'Sandbox',
-  'mcp-server': 'McpServer',
-  knowledge: 'Knowledge',
-};
-
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
-}
-
-type ResourceEnvelope = {
-  apiVersion?: string;
-  kind?: string;
-  metadata?: {
-    name?: string;
-    namespace?: string;
-    labels?: Record<string, string>;
-  };
-  spec?: {
-    kind?: {
-      case?: string;
-      value?: any;
-    };
-  };
-  status?: {
-    kind?: {
-      case?: string;
-      value?: any;
-    };
-  };
-};
-
-function resourceSpec(resource: ResourceEnvelope, caseName: string) {
-  return resource.spec?.kind?.case === caseName ? resource.spec.kind.value || {} : {};
-}
-
-function resourceStatus(resource: ResourceEnvelope, caseName: string) {
-  return resource.status?.kind?.case === caseName ? resource.status.kind.value || {} : {};
-}
-
-function isV2ResourceDocument(document: any): document is ResourceEnvelope {
-  return Boolean(
-    document &&
-      typeof document === 'object' &&
-      typeof document.apiVersion === 'string' &&
-      typeof document.kind === 'string' &&
-      document.metadata &&
-      document.spec?.kind?.case,
-  );
-}
-
-function channelDocumentFromResource(resource: ResourceEnvelope): ChannelDocument {
-  const spec = resourceSpec(resource, 'channel');
-  const status = resourceStatus(resource, 'channel');
-  return {
-    name: resource.metadata?.name,
-    ns: resource.metadata?.namespace,
-    title: spec.title,
-    status: status.phase,
-    metadata: spec.metadata,
-    labels: resource.metadata?.labels,
-  };
-}
-
-function channelSubscriptionDocumentFromResource(resource: ResourceEnvelope): ChannelSubscriptionDocument {
-  const spec = resourceSpec(resource, 'channelSubscription');
-  return {
-    name: resource.metadata?.name,
-    ns: resource.metadata?.namespace,
-    channel: spec.channel,
-    agent: spec.agent,
-    enabled: spec.enabled,
-    trigger: spec.trigger,
-    replyMode: spec.replyMode,
-    contextPolicy: spec.contextPolicy,
-  };
-}
-
-function scheduleDocumentFromResource(resource: ResourceEnvelope): ScheduleDocument {
-  return {
-    name: resource.metadata?.name,
-    ns: resource.metadata?.namespace,
-    labels: resource.metadata?.labels,
-    spec: resourceSpec(resource, 'schedule'),
-    status: resourceStatus(resource, 'schedule'),
-  };
-}
-
-function areSelectionsEqual(left: Selection | null, right: Selection | null) {
-  if (left === right) return true;
-  if (!left || !right) return false;
-  return (
-    left.type === right.type &&
-    left.ns === right.ns &&
-    left.agent === right.agent &&
-    left.channel === right.channel &&
-    left.sessionId === right.sessionId &&
-    left.resourceName === right.resourceName
-  );
-}
-
-function selectionFromSearchParams(searchParams: URLSearchParams): Selection | null {
-  const type = searchParams.get('type');
-  const ns = searchParams.get('ns');
-  const agent = searchParams.get('agent');
-  const channel = searchParams.get('channel');
-  const sessionId = searchParams.get('session');
-  const resourceName = searchParams.get('name');
-
-  if (type === 'template' && resourceName) {
-    return {
-      type: 'template',
-      ns: ns || SYSTEM_NAMESPACE,
-      resourceName,
-      fullPath: `${ns || SYSTEM_NAMESPACE}:template:${resourceName}`,
-    };
-  }
-
-  if (!ns) return null;
-
-  if (sessionId && agent) {
-    return {
-      type: 'session',
-      ns,
-      agent,
-      sessionId,
-      fullPath: `${ns}/${agent}/${sessionId}`,
-    };
-  }
-
-  if (agent) {
-    return {
-      type: 'agent',
-      ns,
-      agent,
-      fullPath: `${ns}/${agent}`,
-    };
-  }
-
-  if (type === 'channel-subscription' && channel && resourceName) {
-    return {
-      type: 'channel-subscription',
-      ns,
-      channel,
-      resourceName,
-      fullPath: `${ns}:channel:${channel}:subscription:${resourceName}`,
-    };
-  }
-
-  if (type === 'channel' && (resourceName || channel)) {
-    const channelName = resourceName || channel || '';
-    return {
-      type: 'channel',
-      ns,
-      channel: channelName,
-      resourceName: channelName,
-      fullPath: `${ns}:channel:${channelName}`,
-    };
-  }
-
-  if (type === 'schedule' && resourceName) {
-    return {
-      type: 'schedule',
-      ns,
-      resourceName,
-      fullPath: `${ns}:schedule:${resourceName}`,
-    };
-  }
-
-  if (type === 'mcp-server' && resourceName) {
-    return {
-      type: 'mcp-server',
-      ns,
-      resourceName,
-      fullPath: `${ns}:mcp-server:${resourceName}`,
-    };
-  }
-
-  if (type === 'knowledge' && resourceName) {
-    return {
-      type: 'knowledge',
-      ns,
-      resourceName,
-      fullPath: `${ns}:knowledge:${resourceName}`,
-    };
-  }
-
-  if (
-    (
-      type === 'deployment' ||
-      type === 'workflow' ||
-      type === 'deployment-replica' ||
-      type === 'sandbox-class' ||
-      type === 'sandbox-policy' ||
-      type === 'sandbox'
-    ) &&
-    ns &&
-    resourceName
-  ) {
-    return {
-      type,
-      ns,
-      resourceName,
-      fullPath: `${ns}:${type}:${resourceName}`,
-    };
-  }
-
-  return {
-    type: 'namespace',
-    ns,
-    fullPath: ns,
-  };
-}
-
-function buildSearchParams(isConnected: boolean, selection: Selection | null, currentSearchParams?: URLSearchParams) {
-  const params = new URLSearchParams();
-  const historyPageSize = currentSearchParams?.get('historyPageSize');
-
-  if (isConnected) {
-    params.set('connected', 'true');
-  }
-
-  if (historyPageSize && /^\d+$/.test(historyPageSize) && Number(historyPageSize) > 0) {
-    params.set('historyPageSize', historyPageSize);
-  }
-
-  if (selection?.ns) {
-    params.set('ns', selection.ns);
-  }
-
-  if (selection?.type) {
-    params.set('type', selection.type);
-  }
-
-  if (selection?.agent) {
-    params.set('agent', selection.agent);
-  }
-
-  if (selection?.channel) {
-    params.set('channel', selection.channel);
-  }
-
-  if (selection?.sessionId) {
-    params.set('session', selection.sessionId);
-  }
-
-  if (selection?.resourceName) {
-    params.set('name', selection.resourceName);
-  }
-
-  return params;
-}
-
-function getSelectionTitle(selection: Selection | null) {
-  if (!selection) return 'No Resource Selected';
-  if (selection.type === 'namespace') return selection.ns;
-  if (selection.type === 'agent') return selection.agent || 'Agent';
-  if (selection.type === 'session') return selection.sessionId || 'Session';
-  if (selection.type === 'channel') return selection.channel || selection.resourceName || 'Channel';
-  return selection.resourceName || selection.type;
-}
-
-function getSelectionSubtitle(selection: Selection | null) {
-  if (!selection) return 'Select a namespace, agent, deployment, sandbox, template, MCP server, or session.';
-  if (selection.type === 'namespace') return 'Namespace';
-  if (selection.type === 'agent') return `${selection.ns} / Agent`;
-  if (selection.type === 'session') return `${selection.ns} / ${selection.agent}`;
-  if (selection.type === 'channel') return `${selection.ns} / Channel`;
-  if (selection.type === 'channel-subscription') return `${selection.ns} / ${selection.channel} / ChannelSubscription`;
-  if (selection.type === 'workflow') return `${selection.ns} / Workflow`;
-  if (selection.type === 'schedule') return `${selection.ns} / Schedule`;
-  if (selection.type === 'mcp-server') return `${selection.ns} / MCPServer`;
-  if (selection.type === 'knowledge') return `${selection.ns} / Knowledge`;
-  if (selection.type === 'template') return `${selection.ns} / Template`;
-  if (selection.type === 'deployment') return `${selection.ns} / Deployment`;
-  if (selection.type === 'deployment-replica') return `${selection.ns} / DeploymentReplica`;
-  if (selection.type === 'sandbox-class') return `${selection.ns} / SandboxClass`;
-  if (selection.type === 'sandbox-policy') return `${selection.ns} / SandboxPolicy`;
-  if (selection.type === 'sandbox') return `${selection.ns} / Sandbox`;
-  return 'Sys / MCPServer';
 }
 
 function positiveIntParam(searchParams: URLSearchParams, name: string) {
@@ -503,6 +227,209 @@ function formatMicros(value: unknown) {
 
 function scheduleField<T>(primary: T | undefined, fallback: T | undefined): T | undefined {
   return primary ?? fallback;
+}
+
+function formatConnectionError(error: unknown) {
+  if (error instanceof Error && error.message === 'connection-timeout') {
+    return 'Could not connect to gateway: the request timed out.';
+  }
+
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return 'Could not connect to gateway: the request timed out.';
+  }
+
+  const candidate = error as {
+    message?: string;
+    rawMessage?: string;
+    code?: string | number;
+    codeName?: string;
+    cause?: { message?: string };
+  };
+  const lowerMessage = `${candidate?.rawMessage || candidate?.message || candidate?.cause?.message || ''}`.toLowerCase();
+  if (lowerMessage.includes('signal is aborted') || lowerMessage.includes('aborterror')) {
+    return 'Could not connect to gateway: the request timed out.';
+  }
+
+  const code = candidate?.codeName || candidate?.code;
+  const message =
+    candidate?.rawMessage ||
+    candidate?.message ||
+    candidate?.cause?.message ||
+    'The gateway did not respond.';
+  return `Could not connect to gateway${code ? ` (${code})` : ''}: ${message}`;
+}
+
+function timeoutSignal(timeoutMs: number) {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    abort: () => controller.abort(),
+    clear: () => window.clearTimeout(timeoutId),
+  };
+}
+
+function withConnectionTimeout<T>(promise: Promise<T>, timeoutMs: number, onTimeout: () => void) {
+  let timeoutId: number | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = window.setTimeout(() => {
+      onTimeout();
+      reject(new Error('connection-timeout'));
+    }, timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+  });
+}
+
+function decodeJwtPayload(token: string) {
+  const [, payload] = token.split('.');
+  if (!payload) return null;
+  try {
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    return JSON.parse(window.atob(padded)) as { exp?: number };
+  } catch {
+    return null;
+  }
+}
+
+function tokenExpiryError(token: string) {
+  const payload = decodeJwtPayload(token);
+  if (!payload?.exp) return null;
+  const expiresAt = payload.exp * 1000;
+  if (expiresAt > Date.now()) return null;
+  return `Authorization token expired at ${new Date(expiresAt).toLocaleString()}.`;
+}
+
+function AuthScreen({
+  gatewayUrl,
+  authToken,
+  isConnecting,
+  googleSsoEnabled,
+  googleSsoError,
+  connectionError,
+  onGatewayUrlChange,
+  onAuthTokenChange,
+  onGoogleSignIn,
+  onConnect,
+}: {
+  gatewayUrl: string;
+  authToken: string;
+  isConnecting: boolean;
+  googleSsoEnabled: boolean;
+  googleSsoError: string | null;
+  connectionError: string | null;
+  onGatewayUrlChange: (value: string) => void;
+  onAuthTokenChange: (value: string) => void;
+  onGoogleSignIn: () => void;
+  onConnect: (values: { gatewayUrl: string; authToken: string }) => void;
+}) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const submitConnection = () => {
+    const form = formRef.current;
+    if (!form) return;
+    const formData = new FormData(form);
+    onConnect({
+      gatewayUrl: String(formData.get('gatewayUrl') || ''),
+      authToken: String(formData.get('authToken') || ''),
+    });
+  };
+
+  return (
+    <main className="grid min-h-screen min-w-0 grid-cols-1 overflow-hidden bg-background text-foreground lg:grid-cols-2">
+        <section className="hidden min-h-0 flex-col border-r border-border/70 bg-muted/20 px-12 py-12 lg:flex">
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="max-w-2xl"
+          >
+            <div className="mb-8 flex h-12 w-12 items-center justify-center rounded-lg border border-border/70 bg-background">
+              <Activity className="h-6 w-6 text-foreground stroke-[1.5]" />
+            </div>
+            <h1 className="max-w-xl text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              Connect to Talon Engine
+            </h1>
+            <p className="mt-4 max-w-xl text-sm leading-6 text-muted-foreground">
+              Choose the gateway endpoint for this Sightline workspace.
+            </p>
+          </motion.div>
+        </section>
+
+        <section className="flex min-h-screen items-center px-5 py-8 sm:px-8 lg:min-h-0 lg:px-12">
+          <motion.form
+            ref={formRef}
+            initial={{ opacity: 0, x: 10 }}
+            animate={{ opacity: 1, x: 0 }}
+            noValidate
+            onSubmit={(event) => {
+              event.preventDefault();
+              submitConnection();
+            }}
+            className="w-full max-w-[460px] space-y-6"
+          >
+            <div>
+              <h2 className="text-base font-semibold text-foreground">Connection</h2>
+              <p className="mt-1 text-[13px] text-muted-foreground">Enter the endpoint and credentials for this session.</p>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="gateway-url-input" className="text-[12px] font-medium text-foreground">Gateway URL</label>
+              <input
+                id="gateway-url-input"
+                name="gatewayUrl"
+                type="text"
+                inputMode="url"
+                required
+                defaultValue={gatewayUrl}
+                onChange={(event) => onGatewayUrlChange(event.target.value)}
+                className="w-full rounded-lg border border-border/70 bg-background px-3 py-2.5 font-mono text-sm text-foreground transition-shadow focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="https://talon.impala.systems"
+                disabled={isConnecting}
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="auth-token-input" className="text-[12px] font-medium text-foreground">Authorization Token (Optional)</label>
+              <input
+                id="auth-token-input"
+                name="authToken"
+                type="password"
+                defaultValue={authToken}
+                onChange={(event) => onAuthTokenChange(event.target.value)}
+                className="w-full rounded-lg border border-border/70 bg-background px-3 py-2.5 font-mono text-sm text-foreground transition-shadow focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="Enter bearer token"
+                disabled={isConnecting}
+              />
+            </div>
+            {googleSsoEnabled ? (
+              <div className="space-y-2">
+                <button
+                  type="button"
+                  onClick={onGoogleSignIn}
+                  disabled={isConnecting}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-border/70 bg-background py-2.5 text-[13px] font-medium text-foreground transition-all hover:bg-muted/45"
+                >
+                  <ShieldCheck className="h-4 w-4 stroke-[2]" />
+                  Sign in with Google
+                </button>
+                {googleSsoError ? <p className="text-[12px] text-red-400">{googleSsoError}</p> : null}
+              </div>
+            ) : null}
+            {connectionError ? <p className="text-[12px] leading-5 text-red-400">{connectionError}</p> : null}
+            <button
+              type="button"
+              onClick={submitConnection}
+              disabled={isConnecting}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-foreground py-2.5 text-[13px] font-medium text-background transition-all hover:opacity-90 disabled:opacity-50"
+            >
+              <Settings2 className="h-4 w-4 stroke-[2]" />
+              {isConnecting ? 'Connecting...' : 'Initialize Connection'}
+            </button>
+          </motion.form>
+        </section>
+    </main>
+  );
 }
 
 function ScheduleInspector({
@@ -940,26 +867,46 @@ function DebuggerPageContent() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
   const nextHistoryModeRef = useRef<'push' | 'replace'>('replace');
+  const explicitConnectRef = useRef(false);
   const [gatewayUrl, setGatewayUrl] = useState('');
   const [authToken, setAuthToken] = useState('');
   const [googleSsoEnabled, setGoogleSsoEnabled] = useState(false);
   const [googleWebClientId, setGoogleWebClientId] = useState<string | null>(null);
   const [googleSsoError, setGoogleSsoError] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
+  const [authScreenOpen, setAuthScreenOpen] = useState(false);
   const [isHoveringConnection, setIsHoveringConnection] = useState(false);
   const [selectedNamespace, setSelectedNamespace] = useState<Selection | null>(null);
   const [isSidebarPinned, setIsSidebarPinned] = useState(true);
   const [isSidebarHovered, setIsSidebarHovered] = useState(false);
   const [isRightSidebarPinned, setIsRightSidebarPinned] = useState(true);
   const [isRightSidebarHovered, setIsRightSidebarHovered] = useState(false);
-  const [resourceYaml, setResourceYaml] = useState<string>('');
-  const [resourceDocument, setResourceDocument] = useState<any | null>(null);
-  const [resourceLoading, setResourceLoading] = useState(false);
-  const [resourceError, setResourceError] = useState<string | null>(null);
   const [storageHydrated, setStorageHydrated] = useState(false);
   const lastSyncedQueryRef = useRef<string | null>(null);
+  const queryScope = useMemo(
+    () => ({
+      gatewayUrl: normalizeGatewayUrl(gatewayUrl || getDefaultGatewayUrl()),
+      authToken: authToken || null,
+    }),
+    [authToken, gatewayUrl],
+  );
+  const resourceQuery = useResourceDocument({
+    isConnected,
+    scope: queryScope,
+    selection: selectedNamespace,
+  });
+  const resourceYaml = resourceQuery.yaml;
+  const resourceDocument = resourceQuery.document;
+  const resourceLoading = resourceQuery.isLoading || resourceQuery.isFetching;
+  const resourceError = resourceQuery.error
+    ? resourceQuery.error instanceof Error
+      ? resourceQuery.error.message
+      : 'Failed to load resource'
+    : null;
 
   const handleSelectionChange = useCallback(
     (selection: Selection | null, historyMode: 'push' | 'replace' = 'push') => {
@@ -1006,6 +953,7 @@ function DebuggerPageContent() {
       localStorage.setItem('talon_gateway_url', talonGatewayUrl);
       updateGatewayClient(talonGatewayUrl);
       setIsConnected(true);
+      setAuthScreenOpen(false);
       currentParams.delete('talon_gateway_url');
     }
     if (talonGatewayHttpUrl) {
@@ -1015,6 +963,7 @@ function DebuggerPageContent() {
       localStorage.removeItem('talon_gateway_http_url');
       updateGatewayClient(normalizedGatewayUrl);
       setIsConnected(true);
+      setAuthScreenOpen(false);
       currentParams.delete('talon_gateway_http_url');
     }
     if (hasTalonHandoff) {
@@ -1032,22 +981,34 @@ function DebuggerPageContent() {
     setSelectedNamespace(prev => areSelectionsEqual(prev, nextSelection) ? prev : nextSelection);
 
     const wantsConnected = searchParams.get('connected') === 'true';
+    if (wantsConnected) {
+      explicitConnectRef.current = false;
+    }
+    if (authScreenOpen) {
+      return;
+    }
     if (wantsConnected && gatewayUrl.trim()) {
       if (isBlockedMixedContentGatewayUrl(gatewayUrl)) {
         setConnectionError('Sightline is running over HTTPS, so the gateway URL must also use HTTPS or the same origin.');
         setIsConnected(false);
+        setAuthScreenOpen(true);
         return;
       }
       updateGatewayClient(normalizeGatewayUrl(gatewayUrl));
       setConnectionError(null);
       setIsConnected(true);
+      setAuthScreenOpen(false);
       return;
     }
 
     if (!wantsConnected) {
+      if (explicitConnectRef.current) {
+        return;
+      }
       setIsConnected(false);
+      setAuthScreenOpen(true);
     }
-  }, [storageHydrated, searchParams, gatewayUrl, pathname, router]);
+  }, [authScreenOpen, storageHydrated, searchParams, gatewayUrl, pathname, router]);
 
   const effectiveGatewayHttpUrl = gatewayUrl.trim();
 
@@ -1133,7 +1094,13 @@ function DebuggerPageContent() {
               localStorage.setItem('talon_gateway_url', normalizedGatewayUrl);
               updateGatewayClient(normalizedGatewayUrl);
               setConnectionError(null);
+              explicitConnectRef.current = true;
+              const connectedQuery = buildSearchParams(true, selectedNamespace, searchParams).toString();
+              lastSyncedQueryRef.current = connectedQuery;
+              router.replace(connectedQuery ? `${pathname}?${connectedQuery}` : pathname, { scroll: false });
+              queryClient.removeQueries({ queryKey: ['talon'] });
               setIsConnected(true);
+              setAuthScreenOpen(false);
             }
           } catch (err: any) {
             setGoogleSsoError(err?.message || 'Google sign-in failed');
@@ -1144,14 +1111,14 @@ function DebuggerPageContent() {
     } catch (err: any) {
       setGoogleSsoError(err?.message || 'Google sign-in failed');
     }
-  }, [effectiveGatewayHttpUrl, gatewayUrl, googleWebClientId]);
+  }, [effectiveGatewayHttpUrl, gatewayUrl, googleWebClientId, pathname, queryClient, router, searchParams, selectedNamespace]);
 
   useEffect(() => {
     if (!storageHydrated) return;
 
     const wantsConnected = searchParams.get('connected') === 'true';
     const queryHasSelection = searchParams.has('ns');
-    if ((wantsConnected && !isConnected) || (queryHasSelection && !selectedNamespace)) {
+    if ((wantsConnected && !isConnected && !authScreenOpen) || (queryHasSelection && !selectedNamespace)) {
       return;
     }
 
@@ -1167,128 +1134,111 @@ function DebuggerPageContent() {
     } else {
       router.replace(nextUrl, { scroll: false });
     }
-  }, [storageHydrated, isConnected, selectedNamespace, pathname, router, searchParams]);
+  }, [authScreenOpen, storageHydrated, isConnected, selectedNamespace, pathname, router, searchParams]);
 
-  useEffect(() => {
-    if (!isConnected || !selectedNamespace || selectedNamespace.type === 'session') {
-      setResourceYaml('');
-      setResourceDocument(null);
-      setResourceLoading(false);
-      setResourceError(null);
-      return;
-    }
+  const handleConnect = async ({ gatewayUrl: submittedGatewayUrlValue, authToken: submittedAuthTokenValue }: { gatewayUrl: string; authToken: string }) => {
+    const submittedGatewayUrl = (submittedGatewayUrlValue || gatewayUrl).trim();
+    const submittedAuthToken = (submittedAuthTokenValue || authToken).trim();
+    setGatewayUrl(submittedGatewayUrl);
+    setAuthToken(submittedAuthToken);
 
-    const selection = selectedNamespace;
-    let cancelled = false;
-    const fetchResource = async () => {
-      setResourceLoading(true);
-      setResourceError(null);
-
-      try {
-        let document: any;
-        switch (selection.type) {
-          case 'namespace':
-            document = await getGatewayClient().namespaces.get({ name: selection.ns });
-            break;
-          case 'agent':
-            document = (await getGatewayClient().resources.get({
-              ns: selection.ns,
-              kind: 'Agent',
-              name: selection.agent || '',
-            })).resource;
-            break;
-          case 'channel':
-            document = channelDocumentFromResource(((await getGatewayClient().resources.get({
-              ns: selection.ns,
-              kind: 'Channel',
-              name: selection.resourceName || selection.channel || '',
-            })).resource || {}) as ResourceEnvelope);
-            break;
-          case 'channel-subscription':
-            document = channelSubscriptionDocumentFromResource(((await getGatewayClient().resources.get({
-              ns: selection.ns,
-              kind: 'ChannelSubscription',
-              name: selection.resourceName || '',
-            })).resource || {}) as ResourceEnvelope);
-            break;
-          case 'schedule':
-            document = scheduleDocumentFromResource(((await getGatewayClient().resources.get({
-              ns: selection.ns,
-              kind: 'Schedule',
-              name: selection.resourceName || '',
-            })).resource || {}) as ResourceEnvelope);
-            break;
-          case 'template':
-          case 'workflow':
-          case 'deployment':
-          case 'deployment-replica':
-          case 'sandbox-class':
-          case 'sandbox-policy':
-          case 'sandbox':
-          case 'mcp-server':
-          case 'knowledge': {
-            const kind = RESOURCE_KIND_BY_SELECTION[selection.type];
-            if (!kind) throw new Error(`Unsupported resource selection '${selection.type}'`);
-            document = (await getGatewayClient().resources.get({
-              ns: selection.ns,
-              kind,
-              name: selection.resourceName || '',
-            })).resource;
-            break;
-          }
-        }
-        if (!document) {
-          throw new Error('Resource not found');
-        }
-
-        if (!cancelled) {
-          const displayDocument = isV2ResourceDocument(document)
-            ? resourceToManifestDocument(document)
-            : yamlSafeValue(document);
-          setResourceDocument(displayDocument);
-          setResourceYaml(dump(displayDocument, { noRefs: true, lineWidth: 100 }));
-        }
-      } catch (err: any) {
-        if (!cancelled) {
-          setResourceError(err?.message || 'Failed to load resource');
-          setResourceYaml('');
-          setResourceDocument(null);
-        }
-      } finally {
-        if (!cancelled) {
-          setResourceLoading(false);
-        }
-      }
-    };
-
-    fetchResource();
-    return () => {
-      cancelled = true;
-    };
-  }, [authToken, gatewayUrl, isConnected, selectedNamespace]);
-
-  const handleConnect = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (gatewayUrl.trim()) {
-      if (isBlockedMixedContentGatewayUrl(gatewayUrl)) {
+    if (submittedGatewayUrl) {
+      if (isBlockedMixedContentGatewayUrl(submittedGatewayUrl)) {
         setConnectionError('Sightline is running over HTTPS, so the gateway URL must also use HTTPS or the same origin.');
         setIsConnected(false);
+        setAuthScreenOpen(true);
         return;
       }
-      const normalizedGatewayUrl = normalizeGatewayUrl(gatewayUrl);
-      localStorage.setItem('talon_gateway_url', normalizedGatewayUrl);
-      localStorage.removeItem('talon_gateway_http_url');
-      if (authToken.trim()) {
-        localStorage.setItem('talon_auth_token', authToken.trim());
-      } else {
-        localStorage.removeItem('talon_auth_token');
+      const normalizedGatewayUrl = normalizeGatewayUrl(submittedGatewayUrl);
+      const nextAuthToken = submittedAuthToken;
+      const previousGatewayUrl = localStorage.getItem('talon_gateway_url');
+      const previousAuthToken = localStorage.getItem('talon_auth_token');
+      const expiredTokenMessage = nextAuthToken ? tokenExpiryError(nextAuthToken) : null;
+      if (expiredTokenMessage) {
+        setConnectionError(expiredTokenMessage);
+        setIsConnected(false);
+        setAuthScreenOpen(true);
+        return;
       }
-      setGatewayUrl(normalizedGatewayUrl);
-      updateGatewayClient(normalizedGatewayUrl);
+
+      setIsConnecting(true);
       setConnectionError(null);
-      setIsConnected(true);
+
+      try {
+        localStorage.setItem('talon_gateway_url', normalizedGatewayUrl);
+        localStorage.removeItem('talon_gateway_http_url');
+        if (nextAuthToken) {
+          localStorage.setItem('talon_auth_token', nextAuthToken);
+        } else {
+          localStorage.removeItem('talon_auth_token');
+        }
+        updateGatewayClient(normalizedGatewayUrl);
+        const probeTimeout = timeoutSignal(CONNECT_TIMEOUT_MS);
+        try {
+          await withConnectionTimeout(
+            getGatewayClient().namespaces.list({ parent: undefined }, { signal: probeTimeout.signal }),
+            CONNECT_TIMEOUT_MS,
+            () => probeTimeout.abort(),
+          );
+        } finally {
+          probeTimeout.clear();
+        }
+
+        setGatewayUrl(normalizedGatewayUrl);
+        setAuthToken(nextAuthToken);
+        setConnectionError(null);
+        explicitConnectRef.current = true;
+        const connectedQuery = buildSearchParams(true, selectedNamespace, searchParams).toString();
+        lastSyncedQueryRef.current = connectedQuery;
+        router.replace(connectedQuery ? `${pathname}?${connectedQuery}` : pathname, { scroll: false });
+        queryClient.removeQueries({ queryKey: ['talon'] });
+        setIsConnected(true);
+        setAuthScreenOpen(false);
+      } catch (error) {
+        if (previousGatewayUrl) {
+          localStorage.setItem('talon_gateway_url', previousGatewayUrl);
+          updateGatewayClient(previousGatewayUrl);
+        } else {
+          localStorage.removeItem('talon_gateway_url');
+          updateGatewayClient(getDefaultGatewayUrl());
+        }
+        if (previousAuthToken) {
+          localStorage.setItem('talon_auth_token', previousAuthToken);
+        } else {
+          localStorage.removeItem('talon_auth_token');
+        }
+        setConnectionError(formatConnectionError(error));
+        setIsConnected(false);
+        setAuthScreenOpen(true);
+      } finally {
+        setIsConnecting(false);
+      }
     }
   };
+
+  if (!storageHydrated) {
+    return <div className="h-screen bg-background" />;
+  }
+
+  if (authScreenOpen || !isConnected) {
+    return (
+      <AuthScreen
+        gatewayUrl={gatewayUrl}
+        authToken={authToken}
+        isConnecting={isConnecting}
+        googleSsoEnabled={googleSsoEnabled}
+        googleSsoError={googleSsoError}
+        connectionError={connectionError}
+        onGatewayUrlChange={(value) => {
+          setGatewayUrl(value);
+          setConnectionError(null);
+        }}
+        onAuthTokenChange={setAuthToken}
+        onGoogleSignIn={handleGoogleSignIn}
+        onConnect={handleConnect}
+      />
+    );
+  }
 
   return (
     <div className="flex h-screen min-w-0 flex-row overflow-x-hidden overflow-y-hidden bg-background text-foreground">
@@ -1336,6 +1286,7 @@ function DebuggerPageContent() {
             isConnected={isConnected} 
             selectedNode={selectedNamespace} 
             onSelect={setSelectedNamespace} 
+            queryScope={queryScope}
           />
         </div>
       </motion.div>
@@ -1372,7 +1323,13 @@ function DebuggerPageContent() {
             {isConnected ? (
               <div 
                 className="flex items-center gap-2 px-3 py-1.5 rounded-xl text-[13px] font-medium transition-all bg-emerald-500/9 text-emerald-300 border border-emerald-500/16 cursor-pointer hover:bg-red-500/10 hover:text-red-300 hover:border-red-500/16"
-                onClick={() => setIsConnected(false)}
+                onClick={() => {
+                  explicitConnectRef.current = false;
+                  queryClient.removeQueries({ queryKey: ['talon'] });
+                  setIsConnected(false);
+                  setAuthScreenOpen(true);
+                  setConnectionError(null);
+                }}
                 onMouseEnter={() => setIsHoveringConnection(true)}
                 onMouseLeave={() => setIsHoveringConnection(false)}
               >
@@ -1392,79 +1349,6 @@ function DebuggerPageContent() {
         <main className="flex min-w-0 flex-1 overflow-x-hidden overflow-y-hidden bg-transparent">
           {/* Center Pane */}
           <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden bg-transparent">
-          {!isConnected ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-background/44 backdrop-blur-md z-20">
-              <motion.div 
-                initial={{ opacity: 0, scale: 0.95 }}
-                animate={{ opacity: 1, scale: 1 }}
-                className="w-full max-w-md p-8 bg-background/84 border border-border/70 shadow-[0_24px_80px_rgba(0,0,0,0.42)] rounded-[1.5rem] backdrop-blur-xl"
-              >
-                <div className="flex flex-col items-center text-center space-y-4 mb-8">
-                  <div className="w-12 h-12 bg-white/[0.045] rounded-xl flex items-center justify-center border border-border/70">
-                    <Activity className="w-6 h-6 text-foreground stroke-[1.5]" />
-                  </div>
-                  <div>
-                    <h2 className="text-lg font-semibold text-foreground">Connect to Talon Engine</h2>
-                    <p className="text-[13px] text-muted-foreground mt-1">Provide the gateway endpoint for this workspace.</p>
-                  </div>
-                </div>
-                
-                <form onSubmit={handleConnect} className="space-y-4">
-                  <div className="space-y-2">
-                    <label className="text-[12px] font-medium text-foreground">Gateway URL</label>
-                    <input
-                      type="url"
-                      required
-                      value={gatewayUrl}
-                      onChange={(e) => {
-                        setGatewayUrl(e.target.value);
-                        setConnectionError(null);
-                      }}
-                      className="w-full bg-white/[0.03] border border-border/70 text-foreground px-3 py-2.5 rounded-xl focus:outline-none focus:ring-1 focus:ring-ring focus:border-ring text-sm transition-shadow font-mono"
-                      placeholder={getDefaultGatewayUrl()}
-                      autoFocus
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className="text-[12px] font-medium text-foreground">Authorization Token (Optional)</label>
-                    <input 
-                      type="password" 
-                      value={authToken}
-                      onChange={(e) => setAuthToken(e.target.value)}
-                      className="w-full bg-white/[0.03] border border-border/70 text-foreground px-3 py-2.5 rounded-xl focus:outline-none focus:ring-1 focus:ring-ring focus:border-ring text-sm transition-shadow font-mono"
-                      placeholder="Enter bearer token"
-                    />
-                  </div>
-                  {googleSsoEnabled ? (
-                    <div className="space-y-2">
-                      <button
-                        type="button"
-                        onClick={handleGoogleSignIn}
-                        className="w-full bg-white/[0.05] text-foreground py-2.5 rounded-xl text-[13px] font-medium hover:bg-white/[0.08] border border-border/70 transition-all flex items-center justify-center gap-2"
-                      >
-                        <ShieldCheck className="w-4 h-4 stroke-[2]" />
-                        Sign in with Google
-                      </button>
-                      {googleSsoError ? (
-                        <p className="text-[12px] text-red-400">{googleSsoError}</p>
-                      ) : null}
-                    </div>
-                  ) : null}
-                  {connectionError ? (
-                    <p className="text-[12px] leading-5 text-red-400">{connectionError}</p>
-                  ) : null}
-                  <button
-                    type="submit"
-                    disabled={!gatewayUrl.trim()}
-                    className="w-full bg-foreground text-background py-2.5 rounded-xl text-[13px] font-medium hover:opacity-90 disabled:opacity-50 transition-all flex items-center justify-center gap-2"
-                  >
-                    <Settings2 className="w-4 h-4 stroke-[2]" />
-                    Initialize Connection
-                  </button>
-                </form>
-              </motion.div>
-            </div>
-          ) : null}
           {selectedNamespace?.type === 'session' ? (
             <div className={cn("min-h-0 min-w-0 flex-1 overflow-hidden transition-opacity duration-300", !isConnected && "opacity-20 pointer-events-none")}>
               <TalonCopilot

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -298,6 +298,7 @@ function tokenExpiryError(token: string) {
   const payload = decodeJwtPayload(token);
   if (!payload?.exp) return null;
   const expiresAt = payload.exp * 1000;
+  if (!Number.isFinite(expiresAt)) return null;
   if (expiresAt > Date.now()) return null;
   return `Authorization token expired at ${new Date(expiresAt).toLocaleString()}.`;
 }

--- a/ui/components/Namespaces/ExplorerTree.tsx
+++ b/ui/components/Namespaces/ExplorerTree.tsx
@@ -1,0 +1,42 @@
+import type { Selection } from '../../lib/selection';
+import type { TreeNode } from '../../hooks/useExplorerTree';
+import { compareTreeNodes } from '../../hooks/useExplorerTree';
+import { TreeNodeRow } from './TreeNodeRow';
+
+export function ExplorerTree({
+  tree,
+  selectedNode,
+  onSelect,
+  onContextMenu,
+  expanded,
+  toggleExpanded,
+}: {
+  tree: TreeNode;
+  selectedNode: Selection | null;
+  onSelect: (selection: Selection) => void;
+  onContextMenu: (event: React.MouseEvent, node: TreeNode) => void;
+  expanded: Set<string>;
+  toggleExpanded: (id: string) => void;
+}) {
+  const childNodes = Object.values(tree.children).sort(compareTreeNodes);
+  if (childNodes.length === 0) {
+    return <div className="py-4 text-center text-[11px] text-muted-foreground">No namespaces discovered.</div>;
+  }
+
+  return (
+    <div className="relative space-y-0.5">
+      {childNodes.map((child) => (
+        <TreeNodeRow
+          key={child.id}
+          node={child}
+          level={0}
+          selectedNodeId={selectedNode?.fullPath || null}
+          onSelect={onSelect}
+          onContextMenu={onContextMenu}
+          expanded={expanded}
+          toggleExpanded={toggleExpanded}
+        />
+      ))}
+    </div>
+  );
+}

--- a/ui/components/Namespaces/NamespaceExplorer.tsx
+++ b/ui/components/Namespaces/NamespaceExplorer.tsx
@@ -201,66 +201,66 @@ export function NamespaceExplorer({
   });
 
   const createAgentMutation = useMutation({
-    mutationFn: async () => {
-      const selectedTemplate = agentCreateTemplates.find((template) => templateOptionId(template) === agentForm.template);
+    mutationFn: async (variables: { ns: string; name: string; template: string }) => {
+      const selectedTemplate = agentCreateTemplates.find((template) => templateOptionId(template) === variables.template);
       const templateSpec = selectedTemplate ? resourceSpec(selectedTemplate, 'template') : null;
       if (templateSpec && templateSpec.kind !== 'Agent') {
-        throw new Error(`Template '${agentForm.template}' renders ${templateSpec.kind}, not Agent`);
+        throw new Error(`Template '${variables.template}' renders ${templateSpec.kind}, not Agent`);
       }
       const agentSpec = templateSpec ? parseJsonObject(templateSpec.specJson) : { systemPrompt: '' };
-      return createResource(agentModalOpen.ns, {
+      return createResource(variables.ns, {
         apiVersion: API_VERSION,
         kind: 'Agent',
-        metadata: resourceMetadata(agentForm.name.trim(), agentModalOpen.ns),
+        metadata: resourceMetadata(variables.name.trim(), variables.ns),
         spec: { kind: { case: 'agent', value: agentSpec } },
       });
     },
-    onSuccess: async () => {
-      await invalidateNamespace(agentModalOpen.ns, ['Agent']);
-      setExpanded((prev) => new Set(prev).add(agentModalOpen.ns));
+    onSuccess: async (_, variables) => {
+      await invalidateNamespace(variables.ns, ['Agent']);
+      setExpanded((prev) => new Set(prev).add(variables.ns));
       setAgentModalOpen({ isOpen: false, ns: '' });
       setAgentForm({ name: '', template: '' });
     },
   });
 
   const createChannelMutation = useMutation({
-    mutationFn: () =>
-      createResource(channelModalOpen.ns, {
+    mutationFn: (variables: { ns: string; name: string; title: string }) =>
+      createResource(variables.ns, {
         apiVersion: API_VERSION,
         kind: 'Channel',
-        metadata: resourceMetadata(channelForm.name.trim(), channelModalOpen.ns),
-        spec: { kind: { case: 'channel', value: { title: channelForm.title.trim(), metadata: {} } } },
+        metadata: resourceMetadata(variables.name.trim(), variables.ns),
+        spec: { kind: { case: 'channel', value: { title: variables.title.trim(), metadata: {} } } },
       }),
-    onSuccess: async () => {
-      await invalidateNamespace(channelModalOpen.ns, ['Channel']);
-      setExpanded((prev) => new Set(prev).add(channelModalOpen.ns));
+    onSuccess: async (_, variables) => {
+      await invalidateNamespace(variables.ns, ['Channel']);
+      setExpanded((prev) => new Set(prev).add(variables.ns));
       setChannelModalOpen({ isOpen: false, ns: '' });
       setChannelForm({ name: '', title: '' });
     },
   });
 
   const createSubscriptionMutation = useMutation({
-    mutationFn: () =>
-      createResource(subscriptionModalOpen.ns, {
+    mutationFn: (variables: { ns: string; channel: string; name: string; agent: string; enabled: boolean; trigger: string; replyMode: string }) =>
+      createResource(variables.ns, {
         apiVersion: API_VERSION,
         kind: 'ChannelSubscription',
-        metadata: resourceMetadata(subscriptionForm.name.trim(), subscriptionModalOpen.ns),
+        metadata: resourceMetadata(variables.name.trim(), variables.ns),
         spec: {
           kind: {
             case: 'channelSubscription',
             value: {
-              channel: subscriptionModalOpen.channel,
-              agent: subscriptionForm.agent.trim(),
-              enabled: subscriptionForm.enabled,
-              trigger: subscriptionForm.trigger,
-              replyMode: subscriptionForm.replyMode,
+              channel: variables.channel,
+              agent: variables.agent.trim(),
+              enabled: variables.enabled,
+              trigger: variables.trigger,
+              replyMode: variables.replyMode,
             },
           },
         },
       }),
-    onSuccess: async () => {
-      await invalidateNamespace(subscriptionModalOpen.ns, ['ChannelSubscription']);
-      setExpanded((prev) => new Set(prev).add(`${subscriptionModalOpen.ns}:channel:${subscriptionModalOpen.channel}`));
+    onSuccess: async (_, variables) => {
+      await invalidateNamespace(variables.ns, ['ChannelSubscription']);
+      setExpanded((prev) => new Set(prev).add(`${variables.ns}:channel:${variables.channel}`));
       setSubscriptionModalOpen({ isOpen: false, ns: '', channel: '' });
       setSubscriptionForm({ name: '', agent: '', trigger: 'mention', replyMode: 'tool', enabled: true });
     },
@@ -332,19 +332,35 @@ export function NamespaceExplorer({
   const submitAgent = (event: React.FormEvent) => {
     event.preventDefault();
     if (!agentForm.name.trim()) return;
-    createAgentMutation.mutate();
+    createAgentMutation.mutate({
+      ns: agentModalOpen.ns,
+      name: agentForm.name,
+      template: agentForm.template,
+    });
   };
 
   const submitChannel = (event: React.FormEvent) => {
     event.preventDefault();
     if (!channelForm.name.trim()) return;
-    createChannelMutation.mutate();
+    createChannelMutation.mutate({
+      ns: channelModalOpen.ns,
+      name: channelForm.name,
+      title: channelForm.title,
+    });
   };
 
   const submitSubscription = (event: React.FormEvent) => {
     event.preventDefault();
     if (!subscriptionForm.name.trim() || !subscriptionForm.agent.trim()) return;
-    createSubscriptionMutation.mutate();
+    createSubscriptionMutation.mutate({
+      ns: subscriptionModalOpen.ns,
+      channel: subscriptionModalOpen.channel,
+      name: subscriptionForm.name,
+      agent: subscriptionForm.agent,
+      enabled: subscriptionForm.enabled,
+      trigger: subscriptionForm.trigger,
+      replyMode: subscriptionForm.replyMode,
+    });
   };
 
   const mutationError =

--- a/ui/components/Namespaces/NamespaceExplorer.tsx
+++ b/ui/components/Namespaces/NamespaceExplorer.tsx
@@ -1,517 +1,51 @@
-import { useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
-import { Box, Activity, ChevronRight, ChevronDown, Folder, Cpu, MessageSquare, Trash2, PlusCircle, Plug, Clock3, FileText, Hash, Radio, Layers3, Package, ShieldCheck, Container } from 'lucide-react';
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-import { getGatewayClient } from '../../lib/grpc';
-import { AnimatePresence, motion } from 'framer-motion';
-import { Button } from "../tailgrids/core/button";
-import { DropdownMenu as Dropdown, DropdownMenuTrigger as DropdownTrigger, DropdownMenuContent as DropdownMenu, DropdownMenuItem as DropdownItem } from "../tailgrids/core/dropdown";
-import { Dialog as Modal, DialogOverlay, DialogContent as ModalContent, DialogHeader as ModalHeader, DialogBody as ModalBody, DialogFooter as ModalFooter, DialogTitle } from "../tailgrids/core/dialog";
-import { Input } from "../tailgrids/core/input";
-import { Select, SelectItem, SelectTrigger, SelectValue, SelectContent } from "../tailgrids/core/select";
-import { Label } from "react-aria-components";
-
-function parseSessionDate(id: string) {
-  // Try UUIDv7
-  if (id && id.length === 36 && id.charAt(8) === '-') {
-    const hex = id.substring(0, 13).replace('-', '');
-    const time = parseInt(hex, 16);
-    return new Date(time).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
-  }
-  
-  // Try ULID
-  if (id && id.length === 26) {
-    const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-    let time = 0;
-    for (let i = 0; i < 10; i++) {
-      const val = ENCODING.indexOf(id.charAt(i).toUpperCase());
-      if (val === -1) return id.substring(0, 8);
-      time = (time * 32) + val;
-    }
-    return new Date(time).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
-  }
-  
-  return id ? id.substring(0, 8) : 'Unknown';
-}
-
-function parseSessionTimestamp(id: string): number | null {
-  // UUIDv7
-  if (id && id.length === 36 && id.charAt(8) === '-') {
-    const hex = id.substring(0, 13).replace('-', '');
-    const time = parseInt(hex, 16);
-    return Number.isNaN(time) ? null : time;
-  }
-
-  // ULID
-  if (id && id.length === 26) {
-    const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-    let time = 0;
-    for (let i = 0; i < 10; i++) {
-      const val = ENCODING.indexOf(id.charAt(i).toUpperCase());
-      if (val === -1) return null;
-      time = (time * 32) + val;
-    }
-    return time;
-  }
-
-  return null;
-}
-
-function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
-
-export type SelectionType =
-  | 'namespace'
-  | 'agent'
-  | 'session'
-  | 'channel'
-  | 'channel-subscription'
-  | 'workflow'
-  | 'schedule'
-  | 'template'
-  | 'deployment'
-  | 'deployment-replica'
-  | 'sandbox-class'
-  | 'sandbox-policy'
-  | 'sandbox'
-  | 'mcp-server'
-  | 'knowledge';
-
-export type Selection = {
-  type: SelectionType;
-  ns: string;
-  agent?: string;
-  channel?: string;
-  sessionId?: string;
-  resourceName?: string;
-  fullPath: string;
-};
-
-export type TreeNode = {
-  id: string;
-  name: string;
-  selection: Selection;
-  badge?: string;
-  children: { [key: string]: TreeNode };
-};
-
-type ExplorerMcpServer = {
-  metadata?: {
-    name?: string;
-    namespace?: string;
-    labels?: Record<string, string>;
-  };
-  spec?: {
-    transport?: string;
-    target?: string;
-    disabled?: boolean;
-    authBroker?: {
-      kind?: string;
-    };
-    policy?: {
-      tools?: {
-        allowlist?: string[];
-      };
-    };
-  };
-};
-
-type EffectiveMcpServer = {
-  server: ExplorerMcpServer;
-  originNamespace: string;
-  badge?: string;
-};
-
-type ExplorerSchedule = {
-  name?: string;
-  ns?: string;
-  labels?: Record<string, string>;
-  spec?: {
-    kind?: string;
-    enabled?: boolean;
-  };
-  status?: {
-    nextRunAt?: bigint | number | string;
-    lastError?: string;
-  };
-};
-
-type ExplorerKnowledge = {
-  metadata?: {
-    name?: string;
-    namespace?: string;
-    labels?: Record<string, string>;
-  };
-  spec?: {
-    path?: string;
-    content?: string;
-  };
-};
-
-type ExplorerControlResource = {
-  kind: string;
-  selectionType: SelectionType;
-  name?: string;
-  ns?: string;
-  badge?: string;
-  sortPrefix: string;
-};
-
-type ExplorerChannel = {
-  name?: string;
-  ns?: string;
-  title?: string;
-  status?: string;
-  updatedAt?: bigint | number | string;
-  updated_at?: bigint | number | string;
-  labels?: Record<string, string>;
-};
-
-type ExplorerChannelSubscription = {
-  name?: string;
-  ns?: string;
-  channel?: string;
-  agent?: string;
-  enabled?: boolean;
-  trigger?: string;
-  replyMode?: string;
-  reply_mode?: string;
-};
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useMutation, useQueries, useQueryClient } from '@tanstack/react-query';
+import { Box, ChevronRight, Cpu, Hash, PlusCircle, Radio, Trash2 } from 'lucide-react';
+import { Label } from 'react-aria-components';
+import { Button } from '../tailgrids/core/button';
+import {
+  DialogBody as ModalBody,
+  DialogContent as ModalContent,
+  DialogFooter as ModalFooter,
+  DialogHeader as ModalHeader,
+  DialogOverlay,
+} from '../tailgrids/core/dialog';
+import {
+  DropdownMenu as Dropdown,
+  DropdownMenuContent as DropdownMenu,
+  DropdownMenuItem as DropdownItem,
+  DropdownMenuTrigger as DropdownTrigger,
+} from '../tailgrids/core/dropdown';
+import { Input } from '../tailgrids/core/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../tailgrids/core/select';
+import { useExplorerQueries } from '../../hooks/useExplorerQueries';
+import { useExplorerTree, type TreeNode } from '../../hooks/useExplorerTree';
+import {
+  RESOURCE_KIND_BY_SELECTION,
+  SYSTEM_NAMESPACE,
+  selectionExpansionIds,
+  type Selection,
+} from '../../lib/selection';
+import {
+  createNamespace,
+  createResource,
+  createSession,
+  deleteNamespace,
+  deleteResource,
+  deleteSession,
+  listResources,
+} from '../../lib/talon/client';
+import { talonQueryKeys, type TalonQueryScope } from '../../lib/talon/queryKeys';
+import {
+  parseJsonObject,
+  resourceMetadata,
+  resourceSpec,
+  type ResourceEnvelope,
+} from '../../lib/talon/resourceMappers';
+import { cn } from '../../utils/cn';
+import { ExplorerTree } from './ExplorerTree';
 
 const API_VERSION = 'talon.impalasys.com/v1';
-const SYSTEM_NAMESPACE = 'Sys';
-
-const RESOURCE_KIND_BY_SELECTION: Partial<Record<SelectionType, string>> = {
-  agent: 'Agent',
-  channel: 'Channel',
-  'channel-subscription': 'ChannelSubscription',
-  workflow: 'Workflow',
-  schedule: 'Schedule',
-  template: 'Template',
-  deployment: 'Deployment',
-  'deployment-replica': 'DeploymentReplica',
-  'sandbox-class': 'SandboxClass',
-  'sandbox-policy': 'SandboxPolicy',
-  sandbox: 'Sandbox',
-  'mcp-server': 'McpServer',
-  knowledge: 'Knowledge',
-};
-
-type ResourceEnvelope = {
-  apiVersion?: string;
-  kind?: string;
-  metadata?: {
-    name?: string;
-    namespace?: string;
-    labels?: Record<string, string>;
-  };
-  spec?: {
-    kind?: {
-      case?: string;
-      value?: any;
-    };
-  };
-  status?: {
-    kind?: {
-      case?: string;
-      value?: any;
-    };
-  };
-};
-
-function resourceSpec(resource: ResourceEnvelope, caseName: string) {
-  return resource.spec?.kind?.case === caseName ? resource.spec.kind.value || {} : {};
-}
-
-function resourceStatus(resource: ResourceEnvelope, caseName: string) {
-  return resource.status?.kind?.case === caseName ? resource.status.kind.value || {} : {};
-}
-
-function resourcePhase(resource: ResourceEnvelope, caseName: string) {
-  return resourceStatus(resource, caseName).phase || '';
-}
-
-function parseJsonObject(value: string | undefined) {
-  if (!value) return {};
-  try {
-    const parsed = JSON.parse(value);
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-
-async function listResourceKind(ns: string, kind: string, options?: { signal?: AbortSignal }) {
-  const response = await getGatewayClient().resources.list({ ns, kind }, options);
-  return (response.resources || []) as ResourceEnvelope[];
-}
-
-function resourceMetadata(name: string, namespace: string) {
-  return {
-    name,
-    namespace,
-    labels: {},
-    annotations: {},
-    ownerReferences: [],
-    finalizers: [],
-    generation: BigInt(0),
-    resourceVersion: '',
-    uid: '',
-  };
-}
-
-function channelFromResource(resource: ResourceEnvelope): ExplorerChannel {
-  const spec = resourceSpec(resource, 'channel');
-  const status = resourceStatus(resource, 'channel');
-  return {
-    name: resource.metadata?.name,
-    ns: resource.metadata?.namespace,
-    title: spec.title,
-    status: status.phase,
-    updatedAt: status.updatedAt,
-    labels: resource.metadata?.labels,
-  };
-}
-
-function channelSubscriptionFromResource(resource: ResourceEnvelope): ExplorerChannelSubscription {
-  const spec = resourceSpec(resource, 'channelSubscription');
-  return {
-    name: resource.metadata?.name,
-    ns: resource.metadata?.namespace,
-    channel: spec.channel,
-    agent: spec.agent,
-    enabled: spec.enabled,
-    trigger: spec.trigger,
-    replyMode: spec.replyMode,
-  };
-}
-
-function scheduleFromResource(resource: ResourceEnvelope): ExplorerSchedule {
-  return {
-    name: resource.metadata?.name,
-    ns: resource.metadata?.namespace,
-    labels: resource.metadata?.labels,
-    spec: resourceSpec(resource, 'schedule'),
-    status: resourceStatus(resource, 'schedule'),
-  };
-}
-
-function knowledgeFromResource(resource: ResourceEnvelope): ExplorerKnowledge {
-  return {
-    metadata: resource.metadata,
-    spec: resourceSpec(resource, 'knowledge'),
-  };
-}
-
-function mcpServerFromResource(resource: ResourceEnvelope): ExplorerMcpServer {
-  return {
-    metadata: resource.metadata,
-    spec: resourceSpec(resource, 'mcpServer'),
-  };
-}
-
-function templateSummary(resource: ResourceEnvelope) {
-  const spec = resourceSpec(resource, 'template');
-  const targetKind = spec.kind || 'Resource';
-  const targetName = spec.metadata?.name || 'unnamed';
-  const targetSpec = parseJsonObject(spec.specJson);
-  const prompt = typeof targetSpec.systemPrompt === 'string' ? targetSpec.systemPrompt.trim() : '';
-  return prompt ? `${targetKind}/${targetName}: ${prompt.slice(0, 120)}` : `${targetKind}/${targetName}`;
-}
-
-function controlResourceFromResource(
-  resource: ResourceEnvelope,
-  kind: string,
-  selectionType: SelectionType,
-  sortPrefix: string,
-): ExplorerControlResource {
-  const name = resource.metadata?.name || `unknown-${kind.toLowerCase()}`;
-  const ns = resource.metadata?.namespace || '';
-  let badge: string | undefined;
-
-  switch (kind) {
-    case 'Template': {
-      const spec = resourceSpec(resource, 'template');
-      badge = spec.kind || 'template';
-      break;
-    }
-    case 'Deployment': {
-      const spec = resourceSpec(resource, 'deployment');
-      badge = resourcePhase(resource, 'deployment') || `${spec.templates?.length || 0} templates`;
-      break;
-    }
-    case 'DeploymentReplica': {
-      const spec = resourceSpec(resource, 'deploymentReplica');
-      const status = resourceStatus(resource, 'deploymentReplica');
-      badge = status.conflicts?.length ? `${status.conflicts.length} conflicts` : (spec.targetNamespace || 'replica');
-      break;
-    }
-    case 'SandboxClass': {
-      const spec = resourceSpec(resource, 'sandboxClass');
-      badge = spec.provider || 'provider';
-      break;
-    }
-    case 'SandboxPolicy': {
-      const spec = resourceSpec(resource, 'sandboxPolicy');
-      badge = spec.classRef?.name || 'policy';
-      break;
-    }
-    case 'Sandbox': {
-      const status = resourceStatus(resource, 'sandbox');
-      badge = status.lease?.ownerSessionId ? 'leased' : (status.phase || 'sandbox');
-      break;
-    }
-    default:
-      badge = kind;
-  }
-
-  return { kind, selectionType, name, ns, badge, sortPrefix };
-}
-
-function namespaceLabel(labels?: Record<string, string>) {
-  return labels?.workspace_name || labels?.workspace || labels?.display_name || labels?.name;
-}
-
-function nodeSortWeight(node: TreeNode) {
-  switch (node.selection.type) {
-    case 'namespace':
-      return 0;
-    case 'agent':
-      return 1;
-    case 'channel':
-      return 2;
-    case 'channel-subscription':
-      return 3;
-    case 'mcp-server':
-      return 4;
-    case 'sandbox':
-      return 5;
-    case 'sandbox-policy':
-      return 6;
-    case 'sandbox-class':
-      return 7;
-    case 'deployment':
-      return 8;
-    case 'deployment-replica':
-      return 9;
-    case 'template':
-      return 10;
-    case 'schedule':
-      return 11;
-    case 'session':
-      return 12;
-    default:
-      return 20;
-  }
-}
-
-function compareTreeNodes(a: TreeNode, b: TreeNode) {
-  const weightDiff = nodeSortWeight(a) - nodeSortWeight(b);
-  if (weightDiff !== 0) return weightDiff;
-
-  if (a.selection.type === 'session' && b.selection.type === 'session') {
-    const aTime = parseSessionTimestamp(a.selection.sessionId || '');
-    const bTime = parseSessionTimestamp(b.selection.sessionId || '');
-    if (aTime !== null && bTime !== null && aTime !== bTime) {
-      return bTime - aTime;
-    }
-  }
-
-  return a.name.localeCompare(b.name);
-}
-
-function namespaceAncestors(ns: string) {
-  if (!ns) return [''];
-  const parts = ns.split(':');
-  const ancestors = [''];
-  for (let i = 0; i < parts.length; i++) {
-    ancestors.push(parts.slice(0, i + 1).join(':'));
-  }
-  return ancestors;
-}
-
-function namespaceResolutionAncestry(ns: string) {
-  if (!ns) return [];
-  const parts = ns.split(':').filter(Boolean);
-  return parts.map((_, index) => parts.slice(0, parts.length - index).join(':'));
-}
-
-function collectMcpLookupNamespaceIds(expanded: Set<string>, selectedNode: Selection | null) {
-  const namespaces = new Set<string>();
-  for (const ns of collectExpandedNamespaceIds(expanded, selectedNode)) {
-    for (const candidate of namespaceResolutionAncestry(ns)) {
-      namespaces.add(candidate);
-    }
-  }
-  return namespaces;
-}
-
-function effectiveMcpServersForNamespace(
-  ns: string,
-  serversByNamespace: Record<string, ExplorerMcpServer[]>,
-): EffectiveMcpServer[] {
-  const ancestry = namespaceResolutionAncestry(ns);
-  const inheritedNames = new Set<string>();
-
-  for (const ancestor of ancestry.slice(1)) {
-    for (const server of serversByNamespace[ancestor] || []) {
-      const name = server.metadata?.name;
-      if (name) inheritedNames.add(name);
-    }
-  }
-
-  const effective = new Map<string, EffectiveMcpServer>();
-  for (const originNamespace of ancestry) {
-    for (const server of serversByNamespace[originNamespace] || []) {
-      const name = server.metadata?.name;
-      if (!name || effective.has(name)) continue;
-      effective.set(name, {
-        server,
-        originNamespace,
-        badge: originNamespace === ns
-          ? (inheritedNames.has(name) ? 'override' : undefined)
-          : `from ${originNamespace}`,
-      });
-    }
-  }
-
-  return Array.from(effective.values()).sort((left, right) =>
-    (left.server.metadata?.name || '').localeCompare(right.server.metadata?.name || ''),
-  );
-}
-
-function selectionExpansionIds(selection: Selection | null) {
-  if (!selection?.ns) return [];
-  const ids = namespaceAncestors(selection.ns);
-  if (selection.agent) {
-    ids.push(`${selection.ns}:${selection.agent}`);
-  }
-  if (selection.channel) {
-    ids.push(`${selection.ns}:channel:${selection.channel}`);
-  }
-  return ids;
-}
-
-function collectExpandedNamespaceIds(expanded: Set<string>, selectedNode: Selection | null) {
-  const namespaces = new Set<string>();
-
-  for (const id of expanded) {
-    if (id) {
-      namespaces.add(id);
-    }
-  }
-
-  if (selectedNode?.ns) {
-    for (const ns of selectionExpansionIds(selectedNode)) {
-      if (ns) {
-        namespaces.add(ns);
-      }
-    }
-  }
-
-  return namespaces;
-}
 
 function SectionShell({
   icon,
@@ -520,7 +54,6 @@ function SectionShell({
   collapsed,
   onToggle,
   grow = false,
-  height,
 }: {
   icon: ReactNode;
   title: string;
@@ -528,567 +61,82 @@ function SectionShell({
   collapsed: boolean;
   onToggle: () => void;
   grow?: boolean;
-  height?: number;
 }) {
   return (
     <section
-      className={cn("flex min-h-0 flex-col overflow-hidden", grow && "flex-1", !grow && "flex-none")}
-      style={!grow && !collapsed && height ? { height: `${height}px` } : undefined}
+      className={cn('flex min-h-0 flex-col overflow-hidden', grow && 'flex-1', !grow && 'flex-none')}
     >
       <button
         type="button"
         onClick={onToggle}
         className="flex items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-white/[0.04]"
       >
-        <ChevronRight className={cn("h-3.5 w-3.5 text-muted-foreground transition-transform", !collapsed && "rotate-90")} />
+        <ChevronRight className={cn('h-3.5 w-3.5 text-muted-foreground transition-transform', !collapsed && 'rotate-90')} />
         {icon}
         <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{title}</h3>
       </button>
-      {!collapsed && (
-        <div className={cn("min-h-0 flex-1 overflow-y-auto px-4 pb-4 custom-scrollbar", !grow && "flex-shrink-0")}>
+      {!collapsed ? (
+        <div className={cn('min-h-0 flex-1 overflow-y-auto px-4 pb-4 custom-scrollbar', !grow && 'flex-shrink-0')}>
           {children}
         </div>
-      )}
+      ) : null}
     </section>
   );
 }
 
-function SplitHandle({ onMouseDown }: { onMouseDown: (event: React.MouseEvent<HTMLButtonElement>) => void }) {
-  return (
-    <button
-      type="button"
-      aria-label="Resize panels"
-      onMouseDown={onMouseDown}
-      className="flex h-3 flex-none cursor-row-resize items-center justify-center border-y border-border/70 hover:bg-white/[0.035]"
-    >
-      <span className="h-px w-10 rounded-full bg-white/10" />
-    </button>
-  );
+function namespaceParent(ns: string) {
+  const parts = ns.split(':').filter(Boolean);
+  parts.pop();
+  return parts.join(':');
 }
 
-function ResourceList({
-  items,
-  emptyState,
-  selectedId,
+function templateOptionId(template: ResourceEnvelope) {
+  return `${template.metadata?.namespace || SYSTEM_NAMESPACE}/${template.metadata?.name || ''}`;
+}
+
+export function NamespaceExplorer({
+  isConnected,
+  selectedNode,
   onSelect,
+  queryScope,
 }: {
-  items: Array<{
-    id: string;
-    name: string;
-    subtitle?: string;
-    tag?: string;
-    tone?: 'default' | 'success' | 'warning';
-    selection: Selection;
-  }>;
-  emptyState: string;
-  selectedId: string | null;
+  isConnected: boolean;
+  selectedNode: Selection | null;
   onSelect: (selection: Selection) => void;
+  queryScope: TalonQueryScope;
 }) {
-  if (items.length === 0) {
-    return <div className="py-3 text-center text-[11px] text-muted-foreground">{emptyState}</div>;
-  }
-
-  return (
-    <div className="space-y-2">
-      {items.map((item) => (
-        <button
-          type="button"
-          key={item.id}
-          onClick={() => onSelect(item.selection)}
-          className={cn(
-            "w-full rounded-2xl border px-3 py-2.5 text-left transition-colors",
-            selectedId === item.id
-              ? "border-border/80 bg-white/[0.05] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
-              : "border-border/70 bg-white/[0.028] hover:bg-white/[0.045]"
-          )}
-        >
-          <div className="flex items-start justify-between gap-2">
-            <div className="min-w-0">
-              <div className="truncate text-[13px] font-medium text-foreground">{item.name}</div>
-              {item.subtitle && (
-                <div className="mt-1 line-clamp-2 text-[11px] text-muted-foreground">{item.subtitle}</div>
-              )}
-            </div>
-            {item.tag && (
-              <span
-                className={cn(
-                  "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
-                  item.tone === 'success' && "border-emerald-500/14 bg-emerald-500/8 text-emerald-300",
-                  item.tone === 'warning' && "border-amber-500/14 bg-amber-500/8 text-amber-300",
-                  item.tone !== 'success' && item.tone !== 'warning' && "border-border/70 bg-white/[0.03] text-muted-foreground",
-                )}
-              >
-                {item.tag}
-              </span>
-            )}
-          </div>
-        </button>
-      ))}
-    </div>
-  );
-}
-
-function NamespaceNode({ 
-  node, 
-  level, 
-  selectedNodeId, 
-  onSelect, 
-  onContextMenu,
-  expanded, 
-  toggleExpanded 
-}: { 
-  node: TreeNode, 
-  level: number,
-  selectedNodeId: string | null,
-  onSelect: (selection: Selection) => void,
-  onContextMenu: (e: React.MouseEvent, node: TreeNode) => void,
-  expanded: Set<string>,
-  toggleExpanded: (id: string) => void
-}) {
-  const childNodes = Object.values(node.children).sort(compareTreeNodes);
-  const hasChildrenOrCanHaveChildren = ![
-    'session',
-    'schedule',
-    'knowledge',
-    'mcp-server',
-    'channel-subscription',
-    'workflow',
-    'template',
-    'deployment-replica',
-    'sandbox-class',
-    'sandbox-policy',
-    'sandbox',
-  ].includes(node.selection.type);
-  const isExpanded = expanded.has(node.id);
-  const isSelected = selectedNodeId === node.id;
-
-  if (level === -1) {
-    return (
-      <div className="space-y-0.5 relative">
-        {childNodes.map(child => (
-          <NamespaceNode 
-            key={child.id} 
-            node={child} 
-            level={0} 
-            selectedNodeId={selectedNodeId} 
-            onSelect={onSelect} 
-            onContextMenu={onContextMenu}
-            expanded={expanded} 
-            toggleExpanded={toggleExpanded} 
-          />
-        ))}
-      </div>
-    );
-  }
-
-  const handleToggle = (e: React.MouseEvent) => {
-    e.stopPropagation(); 
-    if (hasChildrenOrCanHaveChildren) toggleExpanded(node.id);
-  };
-
-  const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onSelect(node.selection);
-  };
-
-  const handleContextMenu = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    onContextMenu(e, node);
-  };
-
-  return (
-    <div>
-      <div 
-        className={cn(
-          "flex items-center gap-1.5 rounded-xl px-2.5 py-2 text-[13px] font-medium select-none group transition-colors hover:bg-white/[0.04]",
-          isSelected ? "border border-border/70 bg-white/[0.055] text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]" : "text-muted-foreground"
-        )}
-        style={{ paddingLeft: `${level * 16 + 8}px` }}
-        onClick={handleClick}
-        onContextMenu={handleContextMenu}
-      >
-         <div 
-           className={cn("p-0.5 rounded-sm flex items-center justify-center transition-colors", 
-            hasChildrenOrCanHaveChildren && "hover:bg-white/[0.05]",
-            !hasChildrenOrCanHaveChildren && "opacity-0 cursor-default"
-           )}
-           onClick={hasChildrenOrCanHaveChildren ? handleToggle : undefined}
-         >
-           {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
-         </div>
-         
-         {node.selection.type === 'namespace' && <Folder className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-muted-foreground")} />}
-         {node.selection.type === 'agent' && <Cpu className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-emerald-500")} />}
-         {node.selection.type === 'session' && <MessageSquare className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-blue-500")} />}
-         {node.selection.type === 'channel' && <Hash className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-cyan-400")} />}
-         {node.selection.type === 'channel-subscription' && <Radio className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-cyan-300")} />}
-         {node.selection.type === 'workflow' && <Activity className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-purple-400")} />}
-         {node.selection.type === 'schedule' && <Clock3 className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-amber-500")} />}
-         {node.selection.type === 'template' && <FileText className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-emerald-400")} />}
-         {node.selection.type === 'deployment' && <Layers3 className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-indigo-400")} />}
-         {node.selection.type === 'deployment-replica' && <Package className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-indigo-300")} />}
-         {node.selection.type === 'sandbox-class' && <ShieldCheck className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-fuchsia-400")} />}
-         {node.selection.type === 'sandbox-policy' && <Box className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-fuchsia-300")} />}
-         {node.selection.type === 'sandbox' && <Container className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-orange-400")} />}
-         {node.selection.type === 'mcp-server' && <Plug className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-blue-500")} />}
-         {node.selection.type === 'knowledge' && <FileText className={cn("w-3.5 h-3.5", isSelected ? "text-foreground" : "text-violet-400")} />}
-
-         <span className="truncate flex-1">{node.name}</span>
-         {node.badge && (
-           <span className="max-w-[8rem] truncate rounded-full border border-border/70 bg-white/[0.03] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-             {node.badge}
-           </span>
-         )}
-         {isSelected && <Activity className="w-3.5 h-3.5 opacity-70 flex-shrink-0" />}
-      </div>
-      
-      <AnimatePresence initial={false}>
-        {isExpanded && hasChildrenOrCanHaveChildren && (
-          <motion.div 
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: "auto", opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.15, ease: "easeInOut" }}
-            className="overflow-hidden"
-          >
-             <div className="mt-0.5 space-y-0.5">
-               {childNodes.length > 0 ? childNodes.map(child => (
-                 <NamespaceNode 
-                   key={child.id} 
-                   node={child} 
-                   level={level + 1} 
-                   selectedNodeId={selectedNodeId} 
-                   onSelect={onSelect} 
-                   onContextMenu={onContextMenu}
-                   expanded={expanded} 
-                   toggleExpanded={toggleExpanded} 
-                 />
-               )) : (
-                 <div 
-                   className="flex items-center gap-1.5 px-2 py-1.5 text-[12px] italic text-muted-foreground/60"
-                   style={{ paddingLeft: `${(level+1) * 16 + 28}px` }}
-                 >
-                   Empty
-                 </div>
-               )}
-             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  );
-}
-
-export function NamespaceExplorer({ 
-  isConnected, 
-  selectedNode, 
-  onSelect 
-}: { 
-  isConnected: boolean, 
-  selectedNode: Selection | null, 
-  onSelect: (selection: Selection) => void 
-}) {
-  const [treeStructure, setTreeStructure] = useState<TreeNode>({
-    id: '', name: 'root', selection: { type: 'namespace', ns: '', fullPath: '' }, children: {}
-  });
-  
+  const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState<Set<string>>(new Set(['']));
   const [namespaceModalOpen, setNamespaceModalOpen] = useState(false);
-  const [isCreatingNamespace, setIsCreatingNamespace] = useState(false);
   const [newNamespace, setNewNamespace] = useState('');
-
-  // Context Menu State
-  const [contextMenu, setContextMenu] = useState<{ x: number, y: number, node: TreeNode } | null>(null);
-
-  // Modals state
-  const [agentModalOpen, setAgentModalOpen] = useState<{ isOpen: boolean, ns: string }>({ isOpen: false, ns: '' });
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; node: TreeNode } | null>(null);
+  const [agentModalOpen, setAgentModalOpen] = useState<{ isOpen: boolean; ns: string }>({ isOpen: false, ns: '' });
   const [agentForm, setAgentForm] = useState({ name: '', template: '' });
-  const [templates, setTemplates] = useState<any[]>([]);
-  const [agentCreateTemplates, setAgentCreateTemplates] = useState<any[]>([]);
-  const [mcpServersByNamespace, setMcpServersByNamespace] = useState<Record<string, ExplorerMcpServer[]>>({});
-  const [schedulesByNamespace, setSchedulesByNamespace] = useState<Record<string, ExplorerSchedule[]>>({});
-  const [knowledgeByNamespace, setKnowledgeByNamespace] = useState<Record<string, ExplorerKnowledge[]>>({});
-  const [channelsByNamespace, setChannelsByNamespace] = useState<Record<string, ExplorerChannel[]>>({});
-  const [channelSubscriptionsByKey, setChannelSubscriptionsByKey] = useState<Record<string, ExplorerChannelSubscription[]>>({});
-  const [controlResourcesByNamespace, setControlResourcesByNamespace] = useState<Record<string, ExplorerControlResource[]>>({});
-  const [isSubmittingAgent, setIsSubmittingAgent] = useState(false);
-  const [channelModalOpen, setChannelModalOpen] = useState<{ isOpen: boolean, ns: string }>({ isOpen: false, ns: '' });
+  const [channelModalOpen, setChannelModalOpen] = useState<{ isOpen: boolean; ns: string }>({ isOpen: false, ns: '' });
   const [channelForm, setChannelForm] = useState({ name: '', title: '' });
-  const [isSubmittingChannel, setIsSubmittingChannel] = useState(false);
-  const [subscriptionModalOpen, setSubscriptionModalOpen] = useState<{ isOpen: boolean, ns: string, channel: string }>({ isOpen: false, ns: '', channel: '' });
-  const [subscriptionForm, setSubscriptionForm] = useState({ name: '', agent: '', trigger: 'mention', replyMode: 'tool', enabled: true });
-  const [isSubmittingSubscription, setIsSubmittingSubscription] = useState(false);
-
-  const [deleteConfirm, setDeleteConfirm] = useState<{ isOpen: boolean, node: TreeNode | null }>({ isOpen: false, node: null });
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [collapsedSections, setCollapsedSections] = useState({
-    explorer: false,
-    templates: false,
-    mcpServers: false,
+  const [subscriptionModalOpen, setSubscriptionModalOpen] = useState<{ isOpen: boolean; ns: string; channel: string }>({
+    isOpen: false,
+    ns: '',
+    channel: '',
   });
-  const [sectionHeights, setSectionHeights] = useState({
-    explorer: 360,
-    templates: 168,
+  const [subscriptionForm, setSubscriptionForm] = useState({
+    name: '',
+    agent: '',
+    trigger: 'mention',
+    replyMode: 'tool',
+    enabled: true,
   });
-  const expandedRef = useRef(expanded);
-  const selectedNodeRef = useRef(selectedNode);
-  const refreshChannelsInFlightRef = useRef(false);
-  const refreshChannelsDebounceRef = useRef<number | null>(null);
-  const refreshChannelsQueuedRef = useRef(false);
-  const refreshChannelsAbortRef = useRef<AbortController | null>(null);
-  const refreshChannelsConfigVersionRef = useRef(0);
-
-  useEffect(() => {
-    expandedRef.current = expanded;
-  }, [expanded]);
-
-  useEffect(() => {
-    selectedNodeRef.current = selectedNode;
-  }, [selectedNode]);
-
-  useEffect(() => {
-    refreshChannelsConfigVersionRef.current += 1;
-    refreshChannelsAbortRef.current?.abort();
-  }, [isConnected]);
-
-  useEffect(() => {
-    return () => {
-      refreshChannelsAbortRef.current?.abort();
-      if (refreshChannelsDebounceRef.current !== null) {
-        window.clearTimeout(refreshChannelsDebounceRef.current);
-        refreshChannelsDebounceRef.current = null;
-      }
-    };
-  }, []);
-
-  const refreshData = useCallback(async () => {
-    if (!isConnected) return;
-    try {
-      const newTree: TreeNode = {
-        id: '', name: 'root', selection: { type: 'namespace', ns: '', fullPath: '' }, children: {}
-      };
-
-      // We discover namespaces starting from the root
-      const discoverQueue: string[] = Array.from(
-        new Set([
-          '',
-          ...Array.from(expanded),
-          ...selectionExpansionIds(selectedNode),
-        ]),
-      );
-      const processedNamespaces = new Set<string>();
-
-      while (discoverQueue.length > 0) {
-        const parentNs = discoverQueue.shift()!;
-        if (processedNamespaces.has(parentNs)) continue;
-        processedNamespaces.add(parentNs);
-
-        try {
-          const res = await getGatewayClient().namespaces.list({ parent: parentNs || undefined });
-          const namespaces = (res.namespaces || []).slice().sort((left, right) => left.name.localeCompare(right.name));
-
-          for (const namespace of namespaces) {
-            const ns = namespace.name;
-            const parts = ns.split(':');
-            let currentLevel = newTree;
-            
-            for (let i = 0; i < parts.length; i++) {
-               const part = parts[i];
-               const currentNsId = parts.slice(0, i + 1).join(':');
-               if (!currentLevel.children[part]) {
-                   currentLevel.children[part] = {
-                       id: currentNsId,
-                       name: part,
-                       badge: i === parts.length - 1 ? namespaceLabel(namespace.labels) : undefined,
-                       selection: { type: 'namespace', ns: currentNsId, fullPath: currentNsId },
-                       children: {}
-                   };
-               } else if (i === parts.length - 1) {
-                   currentLevel.children[part].badge = namespaceLabel(namespace.labels);
-               }
-               currentLevel = currentLevel.children[part];
-            }
-            
-            // If this namespace is expanded, we need to discover its children too
-            if (expanded.has(ns)) {
-              discoverQueue.push(ns);
-            }
-
-            // Fetch agents for this namespace
-            try {
-              const agentResources = await listResourceKind(ns, 'Agent');
-              for (const agentResource of agentResources) {
-                const agent = agentResource.metadata?.name || '';
-                if (!agent) continue;
-                const agentId = `${ns}:${agent}`;
-                currentLevel.children[agent] = {
-                  id: agentId,
-                  name: agent,
-                  selection: { type: 'agent', ns, agent, fullPath: agentId },
-                  children: {}
-                };
-                
-                if (expanded.has(agentId)) {
-                    try {
-                      const sessionRes = await getGatewayClient().sessions.list({ ns, agent });
-                      for (const sessionId of (sessionRes.sessionIds || [])) {
-                        const sessionFullId = `${ns}:${agent}:${sessionId}`;
-                        currentLevel.children[agent].children[sessionId] = {
-                          id: sessionFullId,
-                          name: parseSessionDate(sessionId),
-                          selection: { type: 'session', ns, agent, sessionId, fullPath: sessionFullId },
-                          children: {}
-                        };
-                      }
-                    } catch (e) {
-                      console.warn(`Could not fetch sessions for agent ${agentId}`, e);
-                    }
-                }
-              }
-            } catch (e) {
-              console.warn(`Could not fetch agents for ns ${ns}`, e);
-            }
-
-            const namespaceChannels = channelsByNamespace[ns] || [];
-            for (const channel of namespaceChannels) {
-              const channelName = channel.name || 'unknown-channel';
-              const channelId = `${ns}:channel:${channelName}`;
-              const status = channel.status || 'open';
-              currentLevel.children[`channel:${channelName}`] = {
-                id: channelId,
-                name: channelName,
-                badge: status === 'closed' ? 'closed' : (channel.title || 'channel'),
-                selection: {
-                  type: 'channel',
-                  ns,
-                  channel: channelName,
-                  resourceName: channelName,
-                  fullPath: channelId,
-                },
-                children: {},
-              };
-
-              if (expanded.has(channelId)) {
-                const subscriptions = channelSubscriptionsByKey[`${ns}/${channelName}`] || [];
-                for (const subscription of subscriptions) {
-                  const subscriptionName = subscription.name || 'unknown-subscription';
-                  const subscriptionId = `${channelId}:subscription:${subscriptionName}`;
-                  currentLevel.children[`channel:${channelName}`].children[`subscription:${subscriptionName}`] = {
-                    id: subscriptionId,
-                    name: subscriptionName,
-                    badge: subscription.enabled === false
-                      ? 'disabled'
-                      : `${subscription.trigger || 'mention'}${(subscription.replyMode || subscription.reply_mode) === 'none' ? ' / no reply' : ''}`,
-                    selection: {
-                      type: 'channel-subscription',
-                      ns,
-                      channel: channelName,
-                      resourceName: subscriptionName,
-                      fullPath: subscriptionId,
-                    },
-                    children: {},
-                  };
-                }
-              }
-            }
-
-            const namespaceMcpServers = effectiveMcpServersForNamespace(ns, mcpServersByNamespace);
-            for (const effective of namespaceMcpServers) {
-              const server = effective.server;
-              const serverName = server.metadata?.name || 'unknown-server';
-              const originNamespace = effective.originNamespace;
-              const serverId = originNamespace === ns
-                ? `${ns}:mcp-server:${serverName}`
-                : `${ns}:mcp-server:${originNamespace}:${serverName}`;
-              currentLevel.children[`mcp-server:${originNamespace}:${serverName}`] = {
-                id: serverId,
-                name: serverName,
-                badge: effective.badge,
-                selection: {
-                  type: 'mcp-server',
-                  ns: originNamespace,
-                  resourceName: serverName,
-                  fullPath: serverId,
-                },
-                children: {},
-              };
-            }
-
-            const namespaceSchedules = schedulesByNamespace[ns] || [];
-            for (const schedule of namespaceSchedules) {
-              const scheduleName = schedule.name || 'unknown-schedule';
-              const scheduleId = `${ns}:schedule:${scheduleName}`;
-              const scheduleEnabled = schedule.spec?.enabled !== false;
-              currentLevel.children[`schedule:${scheduleName}`] = {
-                id: scheduleId,
-                name: scheduleName,
-                badge: scheduleEnabled ? (schedule.spec?.kind || 'schedule') : 'disabled',
-                selection: {
-                  type: 'schedule',
-                  ns,
-                  resourceName: scheduleName,
-                  fullPath: scheduleId,
-                },
-                children: {},
-              };
-            }
-
-            const namespaceKnowledge = knowledgeByNamespace[ns] || [];
-            for (const knowledge of namespaceKnowledge) {
-              const knowledgeName = knowledge.metadata?.name || knowledge.spec?.path || 'unknown-knowledge';
-              const knowledgePath = knowledge.spec?.path || '';
-              const knowledgeId = `${ns}:knowledge:${knowledgeName}`;
-              currentLevel.children[`knowledge:${knowledgeName}`] = {
-                id: knowledgeId,
-                name: knowledgePath || knowledgeName,
-                badge: 'knowledge',
-                selection: {
-                  type: 'knowledge',
-                  ns,
-                  resourceName: knowledgeName,
-                  fullPath: knowledgeId,
-                },
-                children: {},
-              };
-            }
-
-            const namespaceControlResources = controlResourcesByNamespace[ns] || [];
-            for (const resource of namespaceControlResources) {
-              const name = resource.name || `unknown-${resource.kind.toLowerCase()}`;
-              const id = `${ns}:${resource.sortPrefix}:${name}`;
-              currentLevel.children[`${resource.sortPrefix}:${name}`] = {
-                id,
-                name,
-                badge: resource.badge,
-                selection: {
-                  type: resource.selectionType,
-                  ns,
-                  resourceName: name,
-                  fullPath: id,
-                },
-                children: {},
-              };
-            }
-          }
-        } catch (e) {
-          console.warn(`Could not list namespaces for parent ${parentNs}`, e);
-        }
-      }
-      setTreeStructure(newTree);
-    } catch (e) {
-      console.error(e);
-    }
-  }, [channelSubscriptionsByKey, channelsByNamespace, controlResourcesByNamespace, isConnected, expanded, knowledgeByNamespace, mcpServersByNamespace, schedulesByNamespace, selectedNode]);
+  const [deleteConfirm, setDeleteConfirm] = useState<{ isOpen: boolean; node: TreeNode | null }>({ isOpen: false, node: null });
+  const [explorerCollapsed, setExplorerCollapsed] = useState(false);
 
   useEffect(() => {
     if (!selectedNode?.ns) return;
     setExpanded((prev) => {
       const next = new Set(prev);
       let changed = false;
-      for (const ns of selectionExpansionIds(selectedNode)) {
-        if (!next.has(ns)) {
-          next.add(ns);
+      for (const id of selectionExpansionIds(selectedNode)) {
+        if (!next.has(id)) {
+          next.add(id);
           changed = true;
         }
       }
@@ -1096,494 +144,175 @@ export function NamespaceExplorer({
     });
   }, [selectedNode]);
 
-  const refreshTemplates = useCallback(async () => {
-    if (!isConnected) {
-      setTemplates([]);
-      return;
-    }
-
-    try {
-      const templates = await listResourceKind(SYSTEM_NAMESPACE, 'Template');
-      setTemplates(templates);
-    } catch (e) {
-      console.warn('Could not fetch templates', e);
-      setTemplates([]);
-    }
-  }, [isConnected]);
-
-  const refreshAgentCreateTemplates = useCallback(async (targetNamespace: string) => {
-    if (!isConnected) {
-      setAgentCreateTemplates([]);
-      return;
-    }
-
-    try {
-      const namespaces = Array.from(new Set([SYSTEM_NAMESPACE, targetNamespace].filter(Boolean)));
-      const loaded = await Promise.all(
-        namespaces.map(async (ns) => {
-          try {
-            return await listResourceKind(ns, 'Template');
-          } catch (e) {
-            console.warn(`Could not fetch templates for ns ${ns}`, e);
-            return [];
-          }
-        }),
-      );
-      setAgentCreateTemplates(loaded.flat());
-    } catch (e) {
-      console.warn('Could not fetch agent create templates', e);
-      setAgentCreateTemplates([]);
-    }
-  }, [isConnected]);
-
-  const templateOptionId = useCallback((template: any) => {
-    return `${template.metadata?.namespace || SYSTEM_NAMESPACE}/${template.metadata?.name || ''}`;
-  }, []);
-
-  const refreshControlResources = useCallback(async () => {
-    if (!isConnected) {
-      setControlResourcesByNamespace({});
-      return;
-    }
-
-    const resourceKinds: Array<{
-      kind: string;
-      selectionType: SelectionType;
-      sortPrefix: string;
-    }> = [
-      { kind: 'Template', selectionType: 'template', sortPrefix: 'template' },
-      { kind: 'Deployment', selectionType: 'deployment', sortPrefix: 'deployment' },
-      { kind: 'DeploymentReplica', selectionType: 'deployment-replica', sortPrefix: 'deployment-replica' },
-      { kind: 'SandboxClass', selectionType: 'sandbox-class', sortPrefix: 'sandbox-class' },
-      { kind: 'SandboxPolicy', selectionType: 'sandbox-policy', sortPrefix: 'sandbox-policy' },
-      { kind: 'Sandbox', selectionType: 'sandbox', sortPrefix: 'sandbox' },
-    ];
-
-    try {
-      const namespaces = collectExpandedNamespaceIds(expanded, selectedNode);
-      const entries = await Promise.all(
-        Array.from(namespaces).map(async (ns) => {
-          const resources: ExplorerControlResource[] = [];
-          for (const config of resourceKinds) {
-            try {
-              const listed = await listResourceKind(ns, config.kind);
-              resources.push(
-                ...listed.map((resource) =>
-                  controlResourceFromResource(resource, config.kind, config.selectionType, config.sortPrefix),
-                ),
-              );
-            } catch (e) {
-              console.warn(`Could not fetch ${config.kind} resources for ns ${ns}`, e);
-            }
-          }
-          return [ns, resources] as const;
-        }),
-      );
-      setControlResourcesByNamespace(Object.fromEntries(entries));
-    } catch (e) {
-      console.warn('Could not list v2 control resources', e);
-      setControlResourcesByNamespace({});
-    }
-  }, [expanded, isConnected, selectedNode]);
-
-  const refreshMcpServers = useCallback(async () => {
-    if (!isConnected) {
-      setMcpServersByNamespace({});
-      return;
-    }
-
-    try {
-      const namespaces = collectMcpLookupNamespaceIds(expanded, selectedNode);
-      const serverEntries = await Promise.all(
-        Array.from(namespaces).map(async (ns) => {
-          try {
-            const resources = await listResourceKind(ns, 'McpServer');
-            return [ns, resources.map(mcpServerFromResource)] as const;
-          } catch (e) {
-            console.warn(`Could not fetch MCP servers for ns ${ns}`, e);
-            return [ns, []] as const;
-          }
-        }),
-      );
-      setMcpServersByNamespace(Object.fromEntries(serverEntries));
-    } catch (e) {
-      console.warn('Could not list namespace MCP servers', e);
-      setMcpServersByNamespace({});
-    }
-  }, [expanded, isConnected, selectedNode]);
-
-  const refreshSchedules = useCallback(async () => {
-    if (!isConnected) {
-      setSchedulesByNamespace({});
-      return;
-    }
-
-    try {
-      const namespaces = collectExpandedNamespaceIds(expanded, selectedNode);
-      const scheduleEntries = await Promise.all(
-        Array.from(namespaces).map(async (ns) => {
-          try {
-            const resources = await listResourceKind(ns, 'Schedule');
-            return [ns, resources.map(scheduleFromResource)] as const;
-          } catch (e) {
-            console.warn(`Could not fetch schedules for ns ${ns}`, e);
-            return [ns, []] as const;
-          }
-        }),
-      );
-      setSchedulesByNamespace(Object.fromEntries(scheduleEntries));
-    } catch (e) {
-      console.warn('Could not list namespaces for schedules', e);
-      setSchedulesByNamespace({});
-    }
-  }, [expanded, isConnected, selectedNode]);
-
-  const refreshKnowledge = useCallback(async () => {
-    if (!isConnected) {
-      setKnowledgeByNamespace({});
-      return;
-    }
-
-    try {
-      const namespaces = collectExpandedNamespaceIds(expanded, selectedNode);
-      const knowledgeEntries = await Promise.all(
-        Array.from(namespaces).map(async (ns) => {
-          try {
-            const resources = await listResourceKind(ns, 'Knowledge');
-            return [ns, resources.map(knowledgeFromResource)] as const;
-          } catch (e) {
-            console.warn(`Could not fetch knowledge for ns ${ns}`, e);
-            return [ns, []] as const;
-          }
-        }),
-      );
-      setKnowledgeByNamespace(Object.fromEntries(knowledgeEntries));
-    } catch (e) {
-      console.warn('Could not list namespaces for knowledge', e);
-      setKnowledgeByNamespace({});
-    }
-  }, [expanded, isConnected, selectedNode]);
-
-  const refreshChannels = useCallback(async () => {
-    if (!isConnected) {
-      refreshChannelsAbortRef.current?.abort();
-      setChannelsByNamespace({});
-      setChannelSubscriptionsByKey({});
-      refreshChannelsQueuedRef.current = false;
-      return;
-    }
-    if (refreshChannelsInFlightRef.current) {
-      refreshChannelsQueuedRef.current = true;
-      return;
-    }
-
-    refreshChannelsInFlightRef.current = true;
-    refreshChannelsQueuedRef.current = false;
-    const requestVersion = refreshChannelsConfigVersionRef.current;
-    const abortController = new AbortController();
-    refreshChannelsAbortRef.current?.abort();
-    refreshChannelsAbortRef.current = abortController;
-    try {
-      const currentExpanded = expandedRef.current;
-      const namespaces = collectExpandedNamespaceIds(currentExpanded, selectedNodeRef.current);
-      const channelEntries = await Promise.all(
-        Array.from(namespaces).map(async (ns) => {
-          try {
-            const resources = await listResourceKind(ns, 'Channel', { signal: abortController.signal });
-            return [ns, resources.map(channelFromResource)] as const;
-          } catch (e) {
-            if (abortController.signal.aborted) throw e;
-            console.warn(`Could not fetch channels for ns ${ns}`, e);
-            return [ns, []] as const;
-          }
-        }),
-      );
-      if (abortController.signal.aborted || requestVersion !== refreshChannelsConfigVersionRef.current) {
-        return;
-      }
-      const channelMap = Object.fromEntries(channelEntries);
-      setChannelsByNamespace(prev => {
-        const next = { ...prev };
-        for (const ns of Object.keys(next)) {
-          if (!namespaces.has(ns)) {
-            delete next[ns];
-          }
-        }
-        return { ...next, ...channelMap };
-      });
-
-      const expandedChannels = Object.entries(channelMap).flatMap(([ns, channels]) =>
-        (channels as ExplorerChannel[])
-          .map((channel) => channel.name || '')
-          .filter((name) => name && currentExpanded.has(`${ns}:channel:${name}`))
-          .map((name) => ({ ns, name })),
-      );
-      const subscriptionEntries = await Promise.all(
-        expandedChannels.map(async ({ ns, name }) => {
-          try {
-            const resources = await listResourceKind(ns, 'ChannelSubscription', { signal: abortController.signal });
-            const subscriptions = resources
-              .map(channelSubscriptionFromResource)
-              .filter((subscription) => subscription.channel === name);
-            return [`${ns}/${name}`, subscriptions] as const;
-          } catch (e) {
-            if (abortController.signal.aborted) throw e;
-            console.warn(`Could not fetch channel subscriptions for ${ns}/${name}`, e);
-            return [`${ns}/${name}`, []] as const;
-          }
-        }),
-      );
-      if (abortController.signal.aborted || requestVersion !== refreshChannelsConfigVersionRef.current) {
-        return;
-      }
-      setChannelSubscriptionsByKey(Object.fromEntries(subscriptionEntries));
-    } catch (e) {
-      if (abortController.signal.aborted || requestVersion !== refreshChannelsConfigVersionRef.current) {
-        return;
-      }
-      console.warn('Could not list namespaces for channels', e);
-      setChannelsByNamespace({});
-      setChannelSubscriptionsByKey({});
-    } finally {
-      if (refreshChannelsAbortRef.current === abortController) {
-        refreshChannelsAbortRef.current = null;
-      }
-      refreshChannelsInFlightRef.current = false;
-      if (refreshChannelsQueuedRef.current) {
-        void refreshChannels();
-      }
-    }
-  }, [isConnected]);
-
   useEffect(() => {
-    refreshData();
-    const interval = setInterval(refreshData, 3000);
-    return () => clearInterval(interval);
-  }, [refreshData]);
-
-  useEffect(() => {
-    refreshTemplates();
-    const interval = setInterval(refreshTemplates, 5000);
-    return () => clearInterval(interval);
-  }, [refreshTemplates]);
-
-  useEffect(() => {
-    refreshMcpServers();
-    const interval = setInterval(refreshMcpServers, 5000);
-    return () => clearInterval(interval);
-  }, [refreshMcpServers]);
-
-  useEffect(() => {
-    refreshSchedules();
-    const interval = setInterval(refreshSchedules, 5000);
-    return () => clearInterval(interval);
-  }, [refreshSchedules]);
-
-  useEffect(() => {
-    refreshKnowledge();
-    const interval = setInterval(refreshKnowledge, 5000);
-    return () => clearInterval(interval);
-  }, [refreshKnowledge]);
-
-  useEffect(() => {
-    refreshControlResources();
-    const interval = setInterval(refreshControlResources, 5000);
-    return () => clearInterval(interval);
-  }, [refreshControlResources]);
-
-  useEffect(() => {
-    refreshChannels();
-    const interval = setInterval(refreshChannels, 5000);
-    return () => clearInterval(interval);
-  }, [refreshChannels]);
-
-  useEffect(() => {
-    if (!isConnected) return;
-    if (refreshChannelsDebounceRef.current !== null) {
-      window.clearTimeout(refreshChannelsDebounceRef.current);
-    }
-    refreshChannelsDebounceRef.current = window.setTimeout(() => {
-      refreshChannelsDebounceRef.current = null;
-      void refreshChannels();
-    }, 150);
-    return () => {
-      if (refreshChannelsDebounceRef.current !== null) {
-        window.clearTimeout(refreshChannelsDebounceRef.current);
-        refreshChannelsDebounceRef.current = null;
-      }
-    };
-  }, [expanded, selectedNode, isConnected, refreshChannels]);
-
-  useEffect(() => {
-    if (selectedNode && selectedNode.type === 'namespace' && !newNamespace) {
-      setNewNamespace(`${selectedNode.ns}:`);
-    } else if (selectedNode && selectedNode.type === 'agent' && !newNamespace) {
+    if (selectedNode && (selectedNode.type === 'namespace' || selectedNode.type === 'agent') && !newNamespace) {
       setNewNamespace(`${selectedNode.ns}:`);
     }
-  }, [selectedNode, newNamespace]);
+  }, [newNamespace, selectedNode]);
 
-  const handleCreateNamespace = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!newNamespace.trim()) return;
-    setIsCreatingNamespace(true);
-    try {
-      await getGatewayClient().namespaces.create({
-        name: newNamespace.trim(),
-        recursive: true
-      });
-      await refreshData();
-      
-      const newExpansions = new Set(expanded);
-      newExpansions.add(newNamespace.trim());
-      setExpanded(newExpansions);
+  const queries = useExplorerQueries({
+    isConnected,
+    scope: queryScope,
+    expanded,
+    selectedNode,
+  });
+  const treeStructure = useExplorerTree({ queries, expanded, selectedNode });
+
+  const agentTemplateQueries = useQueries({
+    queries: Array.from(new Set([SYSTEM_NAMESPACE, agentModalOpen.ns].filter(Boolean))).map((ns) => ({
+      queryKey: talonQueryKeys.resources(queryScope, ns, 'Template'),
+      queryFn: ({ signal }) => listResources(ns, 'Template', { signal }),
+      enabled: isConnected && agentModalOpen.isOpen,
+    })),
+  });
+  const agentCreateTemplates = useMemo(
+    () =>
+      agentTemplateQueries
+        .flatMap((query) => query.data || [])
+        .filter((template) => resourceSpec(template, 'template').kind === 'Agent')
+        .sort((left, right) => {
+          const leftNs = left.metadata?.namespace || SYSTEM_NAMESPACE;
+          const rightNs = right.metadata?.namespace || SYSTEM_NAMESPACE;
+          return leftNs === rightNs
+            ? (left.metadata?.name || '').localeCompare(right.metadata?.name || '')
+            : leftNs.localeCompare(rightNs);
+        }),
+    [agentTemplateQueries],
+  );
+
+  const invalidateNamespace = useCallback(
+    async (ns: string, kinds: string[] = []) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: talonQueryKeys.namespaces(queryScope, namespaceParent(ns)) }),
+        ...kinds.map((kind) => queryClient.invalidateQueries({ queryKey: talonQueryKeys.resources(queryScope, ns, kind) })),
+      ]);
+    },
+    [queryClient, queryScope],
+  );
+
+  const createNamespaceMutation = useMutation({
+    mutationFn: (name: string) => createNamespace(name),
+    onSuccess: async (_, name) => {
+      await invalidateNamespace(name);
+      setExpanded((prev) => new Set(prev).add(name));
       setNewNamespace('');
       setNamespaceModalOpen(false);
-    } catch (e) {
-      console.error(e);
-      alert(e instanceof Error ? e.message : 'Error creating namespace');
-    } finally {
-      setIsCreatingNamespace(false);
-    }
-  };
+    },
+  });
 
-  const handleCreateAgentSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsSubmittingAgent(true);
-    try {
+  const createAgentMutation = useMutation({
+    mutationFn: async () => {
       const selectedTemplate = agentCreateTemplates.find((template) => templateOptionId(template) === agentForm.template);
       const templateSpec = selectedTemplate ? resourceSpec(selectedTemplate, 'template') : null;
       if (templateSpec && templateSpec.kind !== 'Agent') {
         throw new Error(`Template '${agentForm.template}' renders ${templateSpec.kind}, not Agent`);
       }
       const agentSpec = templateSpec ? parseJsonObject(templateSpec.specJson) : { systemPrompt: '' };
-      await getGatewayClient().resources.create({
-        ns: agentModalOpen.ns,
-        manifest: {
-          apiVersion: API_VERSION,
-          kind: 'Agent',
-          metadata: resourceMetadata(agentForm.name.trim(), agentModalOpen.ns),
-          spec: { kind: { case: 'agent', value: agentSpec } },
-        },
+      return createResource(agentModalOpen.ns, {
+        apiVersion: API_VERSION,
+        kind: 'Agent',
+        metadata: resourceMetadata(agentForm.name.trim(), agentModalOpen.ns),
+        spec: { kind: { case: 'agent', value: agentSpec } },
       });
-      setExpanded(prev => new Set(prev).add(agentModalOpen.ns));
-      await refreshData();
+    },
+    onSuccess: async () => {
+      await invalidateNamespace(agentModalOpen.ns, ['Agent']);
+      setExpanded((prev) => new Set(prev).add(agentModalOpen.ns));
       setAgentModalOpen({ isOpen: false, ns: '' });
       setAgentForm({ name: '', template: '' });
-    } catch (e) {
-      console.error(e);
-      alert(e instanceof Error ? e.message : 'Error creating agent');
-    } finally {
-      setIsSubmittingAgent(false);
-    }
-  };
+    },
+  });
 
-  const handleCreateChannelSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!channelForm.name.trim()) return;
-    setIsSubmittingChannel(true);
-    try {
-      await getGatewayClient().resources.create({
-        ns: channelModalOpen.ns,
-        manifest: {
-          apiVersion: API_VERSION,
-          kind: 'Channel',
-          metadata: resourceMetadata(channelForm.name.trim(), channelModalOpen.ns),
-          spec: { kind: { case: 'channel', value: { title: channelForm.title.trim(), metadata: {} } } },
-        },
-      });
-      setExpanded(prev => new Set(prev).add(channelModalOpen.ns));
-      await refreshChannels();
-      await refreshData();
+  const createChannelMutation = useMutation({
+    mutationFn: () =>
+      createResource(channelModalOpen.ns, {
+        apiVersion: API_VERSION,
+        kind: 'Channel',
+        metadata: resourceMetadata(channelForm.name.trim(), channelModalOpen.ns),
+        spec: { kind: { case: 'channel', value: { title: channelForm.title.trim(), metadata: {} } } },
+      }),
+    onSuccess: async () => {
+      await invalidateNamespace(channelModalOpen.ns, ['Channel']);
+      setExpanded((prev) => new Set(prev).add(channelModalOpen.ns));
       setChannelModalOpen({ isOpen: false, ns: '' });
       setChannelForm({ name: '', title: '' });
-    } catch (e) {
-      console.error(e);
-      alert(e instanceof Error ? e.message : 'Error creating channel');
-    } finally {
-      setIsSubmittingChannel(false);
-    }
-  };
+    },
+  });
 
-  const handleCreateSubscriptionSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!subscriptionForm.name.trim() || !subscriptionForm.agent.trim()) return;
-    setIsSubmittingSubscription(true);
-    try {
-      await getGatewayClient().resources.create({
-        ns: subscriptionModalOpen.ns,
-        manifest: {
-          apiVersion: API_VERSION,
-          kind: 'ChannelSubscription',
-          metadata: resourceMetadata(subscriptionForm.name.trim(), subscriptionModalOpen.ns),
-          spec: {
-            kind: {
-              case: 'channelSubscription',
-              value: {
-                channel: subscriptionModalOpen.channel,
-                agent: subscriptionForm.agent.trim(),
-                enabled: subscriptionForm.enabled,
-                trigger: subscriptionForm.trigger,
-                replyMode: subscriptionForm.replyMode,
-              },
+  const createSubscriptionMutation = useMutation({
+    mutationFn: () =>
+      createResource(subscriptionModalOpen.ns, {
+        apiVersion: API_VERSION,
+        kind: 'ChannelSubscription',
+        metadata: resourceMetadata(subscriptionForm.name.trim(), subscriptionModalOpen.ns),
+        spec: {
+          kind: {
+            case: 'channelSubscription',
+            value: {
+              channel: subscriptionModalOpen.channel,
+              agent: subscriptionForm.agent.trim(),
+              enabled: subscriptionForm.enabled,
+              trigger: subscriptionForm.trigger,
+              replyMode: subscriptionForm.replyMode,
             },
           },
         },
-      });
-      setExpanded(prev => new Set(prev).add(`${subscriptionModalOpen.ns}:channel:${subscriptionModalOpen.channel}`));
-      await refreshChannels();
-      await refreshData();
+      }),
+    onSuccess: async () => {
+      await invalidateNamespace(subscriptionModalOpen.ns, ['ChannelSubscription']);
+      setExpanded((prev) => new Set(prev).add(`${subscriptionModalOpen.ns}:channel:${subscriptionModalOpen.channel}`));
       setSubscriptionModalOpen({ isOpen: false, ns: '', channel: '' });
       setSubscriptionForm({ name: '', agent: '', trigger: 'mention', replyMode: 'tool', enabled: true });
-    } catch (e) {
-      console.error(e);
-      alert(e instanceof Error ? e.message : 'Error creating channel subscription');
-    } finally {
-      setIsSubmittingSubscription(false);
-    }
-  };
+    },
+  });
 
-  const handleDeleteConfirmed = async () => {
-    if (!deleteConfirm.node) return;
-    const { selection } = deleteConfirm.node;
-    setIsDeleting(true);
-    try {
+  const createSessionMutation = useMutation({
+    mutationFn: ({ ns, agent }: { ns: string; agent: string }) => createSession(ns, agent),
+    onSuccess: async (_, { ns, agent }) => {
+      await queryClient.invalidateQueries({ queryKey: talonQueryKeys.sessions(queryScope, ns, agent) });
+      setExpanded((prev) => new Set(prev).add(`${ns}:${agent}`));
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (node: TreeNode) => {
+      const { selection } = node;
       if (selection.type === 'namespace') {
-        await getGatewayClient().namespaces.delete({ name: selection.ns });
-      } else if (selection.type === 'agent') {
-        await getGatewayClient().resources.delete({ ns: selection.ns, kind: 'Agent', name: selection.agent || '' });
-      } else if (selection.type === 'session') {
-        await getGatewayClient().sessions.delete({ ns: selection.ns, agent: selection.agent!, sessionId: selection.sessionId! });
-      } else if (selection.type === 'channel') {
-        await getGatewayClient().resources.delete({ ns: selection.ns, kind: 'Channel', name: selection.resourceName || selection.channel || '' });
-      } else if (selection.type === 'channel-subscription') {
-        await getGatewayClient().resources.delete({ ns: selection.ns, kind: 'ChannelSubscription', name: selection.resourceName || '' });
-      } else if (selection.type === 'schedule') {
-        await getGatewayClient().resources.delete({ ns: selection.ns, kind: 'Schedule', name: selection.resourceName || '' });
-      } else {
-        const kind = RESOURCE_KIND_BY_SELECTION[selection.type];
-        if (kind && selection.resourceName) {
-          await getGatewayClient().resources.delete({ ns: selection.ns, kind, name: selection.resourceName });
-        }
+        await deleteNamespace(selection.ns);
+        return { ns: selection.ns, kinds: [] as string[] };
       }
-      await refreshControlResources();
-      await refreshChannels();
-      await refreshData();
+      if (selection.type === 'agent') {
+        await deleteResource(selection.ns, 'Agent', selection.agent || '');
+        return { ns: selection.ns, kinds: ['Agent'] };
+      }
+      if (selection.type === 'session') {
+        await deleteSession(selection.ns, selection.agent!, selection.sessionId!);
+        return { ns: selection.ns, agent: selection.agent || '', kinds: [] as string[] };
+      }
+      const kind = RESOURCE_KIND_BY_SELECTION[selection.type];
+      if (kind && selection.resourceName) {
+        await deleteResource(selection.ns, kind, selection.resourceName);
+        return { ns: selection.ns, kinds: [kind] };
+      }
+      return { ns: selection.ns, kinds: [] as string[] };
+    },
+    onSuccess: async (target) => {
+      if ('agent' in target && target.agent) {
+        await queryClient.invalidateQueries({ queryKey: talonQueryKeys.sessions(queryScope, target.ns, target.agent) });
+      } else {
+        await invalidateNamespace(target.ns, target.kinds);
+      }
       setDeleteConfirm({ isOpen: false, node: null });
-    } catch (e) {
-      console.error(e);
-      alert(e instanceof Error ? e.message : 'Error deleting item');
-    } finally {
-      setIsDeleting(false);
-    }
-  };
+    },
+  });
 
-  const handleContextMenu = (e: React.MouseEvent, node: TreeNode) => {
-    e.preventDefault();
-    setContextMenu({ x: e.clientX, y: e.clientY, node });
+  const handleContextMenu = (event: React.MouseEvent, node: TreeNode) => {
+    event.preventDefault();
+    setContextMenu({ x: event.clientX, y: event.clientY, node });
   };
 
   const toggleExpanded = (id: string) => {
-    setExpanded(prev => {
+    setExpanded((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
@@ -1591,406 +320,283 @@ export function NamespaceExplorer({
     });
   };
 
-  const resizeLowerPanels = useCallback((delta: number) => {
-    setSectionHeights((prev) => {
-      const nextTemplates = Math.max(116, prev.templates + delta);
-      return {
-        ...prev,
-        templates: nextTemplates,
-      };
-    });
-  }, []);
-
-  const resizeUpperPanels = useCallback((delta: number) => {
-    setSectionHeights((prev) => {
-      const nextExplorer = Math.max(180, prev.explorer + delta);
-      const actualDelta = nextExplorer - prev.explorer;
-      const nextTemplates = Math.max(116, prev.templates - actualDelta);
-      const templatesAdjustedDelta = prev.templates - nextTemplates;
-      return {
-        ...prev,
-        explorer: prev.explorer + templatesAdjustedDelta,
-        templates: nextTemplates,
-      };
-    });
-  }, []);
-
   const menuNode = contextMenu?.node;
-  const templateCards = templates
-    .map((template) => ({
-      id: `template:${template.metadata?.namespace || SYSTEM_NAMESPACE}:${template.metadata?.name || 'unknown-template'}`,
-      name: template.metadata?.name || 'Unnamed template',
-      subtitle: templateSummary(template),
-      tag: resourceSpec(template, 'template').kind || 'template',
-      selection: {
-        type: 'template' as const,
-        ns: template.metadata?.namespace || SYSTEM_NAMESPACE,
-        resourceName: template.metadata?.name || '',
-        fullPath: `${template.metadata?.namespace || SYSTEM_NAMESPACE}:template:${template.metadata?.name || 'unknown-template'}`,
-      },
-    }))
-    .sort((left, right) => left.name.localeCompare(right.name));
-  const agentTemplateOptions = agentCreateTemplates
-    .filter((template) => resourceSpec(template, 'template').kind === 'Agent')
-    .sort((left, right) => {
-      const leftNs = left.metadata?.namespace || SYSTEM_NAMESPACE;
-      const rightNs = right.metadata?.namespace || SYSTEM_NAMESPACE;
-      return leftNs === rightNs
-        ? (left.metadata?.name || '').localeCompare(right.metadata?.name || '')
-        : leftNs.localeCompare(rightNs);
-    });
-  const visibleMcpServers: EffectiveMcpServer[] = selectedNode?.ns
-    ? effectiveMcpServersForNamespace(selectedNode.ns, mcpServersByNamespace)
-    : Object.entries(mcpServersByNamespace)
-        .flatMap(([originNamespace, servers]) => servers.map((server) => ({ server, originNamespace })))
-        .sort((left, right) =>
-          `${left.originNamespace}/${left.server.metadata?.name || ''}`.localeCompare(
-            `${right.originNamespace}/${right.server.metadata?.name || ''}`,
-          ),
-        );
-  const mcpCards = visibleMcpServers
-    .map(({ server, originNamespace, badge }) => ({
-      id: `mcp:${originNamespace}:${server.metadata?.name || 'unknown-server'}`,
-      name: server.metadata?.name || 'Unnamed MCP server',
-      subtitle: `${originNamespace} / ${server.spec?.target || 'No target configured'}`,
-      tag: badge || (server.spec?.disabled ? 'disabled' : (server.spec?.transport || 'unknown')),
-      tone: server.spec?.disabled ? 'warning' as const : (badge ? 'default' as const : 'success' as const),
-      selection: {
-        type: 'mcp-server' as const,
-        ns: originNamespace,
-        resourceName: server.metadata?.name || '',
-        fullPath: selectedNode?.ns
-          ? `${selectedNode.ns}:mcp-server:${originNamespace}:${server.metadata?.name || 'unknown-server'}`
-          : `${originNamespace}:mcp-server:${server.metadata?.name || 'unknown-server'}`,
-      },
-    }))
-    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const submitNamespace = (event: React.FormEvent) => {
+    event.preventDefault();
+    const name = newNamespace.trim();
+    if (!name) return;
+    createNamespaceMutation.mutate(name);
+  };
+
+  const submitAgent = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!agentForm.name.trim()) return;
+    createAgentMutation.mutate();
+  };
+
+  const submitChannel = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!channelForm.name.trim()) return;
+    createChannelMutation.mutate();
+  };
+
+  const submitSubscription = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!subscriptionForm.name.trim() || !subscriptionForm.agent.trim()) return;
+    createSubscriptionMutation.mutate();
+  };
+
+  const mutationError =
+    createNamespaceMutation.error ||
+    createAgentMutation.error ||
+    createChannelMutation.error ||
+    createSubscriptionMutation.error ||
+    deleteMutation.error ||
+    createSessionMutation.error;
+
+  useEffect(() => {
+    if (mutationError) {
+      alert(mutationError instanceof Error ? mutationError.message : 'Explorer action failed');
+    }
+  }, [mutationError]);
 
   return (
-    <div className="flex h-full flex-col overflow-hidden relative divide-y divide-border/70 bg-background/68 backdrop-blur-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+    <div className="relative flex h-full flex-col divide-y divide-border/70 overflow-hidden bg-background/68 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] backdrop-blur-xl">
       <SectionShell
-        icon={<Box className="w-3.5 h-3.5 text-muted-foreground stroke-[1.5]" />}
+        icon={<Box className="h-3.5 w-3.5 text-muted-foreground stroke-[1.5]" />}
         title="Explorer"
-        collapsed={collapsedSections.explorer}
-        onToggle={() => setCollapsedSections(prev => ({ ...prev, explorer: !prev.explorer }))}
-        height={sectionHeights.explorer}
-      >
-        <div onContextMenu={(e) => handleContextMenu(e, treeStructure)}>
-          {Object.keys(treeStructure.children).length > 0 ? (
-            <NamespaceNode 
-              node={treeStructure} 
-              level={-1} 
-              selectedNodeId={selectedNode?.fullPath || null} 
-              onSelect={onSelect} 
-              onContextMenu={handleContextMenu}
-              expanded={expanded} 
-              toggleExpanded={toggleExpanded}
-            />
-          ) : (
-            <div className="py-4 text-center text-[11px] text-muted-foreground">No namespaces discovered.</div>
-          )}
-        </div>
-      </SectionShell>
-      {!collapsedSections.explorer && !collapsedSections.templates && (
-        <SplitHandle
-          onMouseDown={(event) => {
-            event.preventDefault();
-            let lastY = event.clientY;
-
-            const handleMouseMove = (moveEvent: MouseEvent) => {
-              const delta = moveEvent.clientY - lastY;
-              lastY = moveEvent.clientY;
-              resizeUpperPanels(delta);
-            };
-
-            const handleMouseUp = () => {
-              window.removeEventListener('mousemove', handleMouseMove);
-              window.removeEventListener('mouseup', handleMouseUp);
-            };
-
-            window.addEventListener('mousemove', handleMouseMove);
-            window.addEventListener('mouseup', handleMouseUp);
-          }}
-        />
-      )}
-
-      <SectionShell
-        icon={<FileText className="w-3.5 h-3.5 text-emerald-500 stroke-[1.5]" />}
-        title="System Templates"
-        collapsed={collapsedSections.templates}
-        onToggle={() => setCollapsedSections(prev => ({ ...prev, templates: !prev.templates }))}
-        height={sectionHeights.templates}
-      >
-        <ResourceList
-          items={templateCards}
-          emptyState="No system templates found."
-          selectedId={selectedNode?.fullPath || null}
-          onSelect={onSelect}
-        />
-      </SectionShell>
-      {!collapsedSections.templates && !collapsedSections.mcpServers && (
-        <SplitHandle
-          onMouseDown={(event) => {
-            event.preventDefault();
-            let lastY = event.clientY;
-
-            const handleMouseMove = (moveEvent: MouseEvent) => {
-              const delta = moveEvent.clientY - lastY;
-              lastY = moveEvent.clientY;
-              resizeLowerPanels(delta);
-            };
-
-            const handleMouseUp = () => {
-              window.removeEventListener('mousemove', handleMouseMove);
-              window.removeEventListener('mouseup', handleMouseUp);
-            };
-
-            window.addEventListener('mousemove', handleMouseMove);
-            window.addEventListener('mouseup', handleMouseUp);
-          }}
-        />
-      )}
-
-      <SectionShell
-        icon={<Plug className="w-3.5 h-3.5 text-blue-500 stroke-[1.5]" />}
-        title="MCP Servers"
-        collapsed={collapsedSections.mcpServers}
-        onToggle={() => setCollapsedSections(prev => ({ ...prev, mcpServers: !prev.mcpServers }))}
+        collapsed={explorerCollapsed}
+        onToggle={() => setExplorerCollapsed((collapsed) => !collapsed)}
         grow
       >
-        <ResourceList
-          items={mcpCards}
-          emptyState="No MCP servers found for this namespace."
-          selectedId={selectedNode?.fullPath || null}
-          onSelect={onSelect}
-        />
+        <div onContextMenu={(event) => handleContextMenu(event, treeStructure)}>
+          <ExplorerTree
+            tree={treeStructure}
+            selectedNode={selectedNode}
+            onSelect={onSelect}
+            onContextMenu={handleContextMenu}
+            expanded={expanded}
+            toggleExpanded={toggleExpanded}
+          />
+          {queries.isInitialLoading ? (
+            <div className="px-2 py-2 text-[11px] text-muted-foreground">Loading namespaces...</div>
+          ) : null}
+        </div>
       </SectionShell>
 
-      {/* Context Menu Dropdown */}
-      <Dropdown 
-        isOpen={!!contextMenu} 
-        onOpenChange={(open) => !open && setContextMenu(null)}
-      >
-        <DropdownTrigger 
-          className="fixed" 
+      <Dropdown isOpen={!!contextMenu} onOpenChange={(open) => !open && setContextMenu(null)}>
+        <DropdownTrigger
+          className="fixed"
           style={{ top: contextMenu?.y || 0, left: contextMenu?.x || 0, width: 1, height: 1, padding: 0 }}
-        >
-          <span />
-        </DropdownTrigger>
+          aria-label="Explorer context menu"
+        />
         <DropdownMenu aria-label="Context Actions" variant="outline">
-          {menuNode?.selection.type === 'namespace' && (
-             <DropdownItem 
-               id="create_namespace" 
-               onAction={() => {
+          {menuNode?.selection.type === 'namespace' ? (
+            <DropdownItem
+              id="create_namespace"
+              onAction={() => {
                 setContextMenu(null);
                 setNewNamespace(menuNode.selection.ns ? `${menuNode.selection.ns}:` : '');
                 setNamespaceModalOpen(true);
-               }}
-             >
-               <div className="flex items-center gap-2">
-                 <PlusCircle className="w-4 h-4 text-muted-foreground"/>
-                 New Namespace
-               </div>
-             </DropdownItem>
-          )}
-          
-          {menuNode?.selection.type === 'namespace' && (
-             <DropdownItem 
-               id="create_agent" 
-               onAction={async () => {
-                setContextMenu(null);
-                await refreshAgentCreateTemplates(menuNode.selection.ns);
-                setAgentModalOpen({ isOpen: true, ns: menuNode.selection.ns });
-               }}
-             >
-               <div className="flex items-center gap-2">
-                 <Cpu className="w-4 h-4 text-muted-foreground"/>
-                 Create Agent
-               </div>
-             </DropdownItem>
-          )}
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <PlusCircle className="h-4 w-4 text-muted-foreground" />
+                New Namespace
+              </div>
+            </DropdownItem>
+          ) : null}
 
-          {menuNode?.selection.type === 'namespace' && (
-             <DropdownItem
-               id="create_channel"
-               onAction={() => {
+          {menuNode?.selection.type === 'namespace' ? (
+            <DropdownItem
+              id="create_agent"
+              onAction={() => {
+                setContextMenu(null);
+                setAgentModalOpen({ isOpen: true, ns: menuNode.selection.ns });
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <Cpu className="h-4 w-4 text-muted-foreground" />
+                Create Agent
+              </div>
+            </DropdownItem>
+          ) : null}
+
+          {menuNode?.selection.type === 'namespace' ? (
+            <DropdownItem
+              id="create_channel"
+              onAction={() => {
                 setContextMenu(null);
                 setChannelModalOpen({ isOpen: true, ns: menuNode.selection.ns });
-               }}
-             >
-               <div className="flex items-center gap-2">
-                 <Hash className="w-4 h-4 text-muted-foreground"/>
-                 Create Channel
-               </div>
-             </DropdownItem>
-          )}
-          
-          {menuNode?.selection.type === 'agent' && (
-             <DropdownItem 
-               id="create_session" 
-               onAction={async () => {
-                setContextMenu(null);
-                try {
-                  await getGatewayClient().sessions.create({ ns: menuNode.selection.ns, agent: menuNode.selection.agent });
-                  setExpanded(prev => new Set(prev).add(menuNode.id));
-                  await refreshData();
-                } catch (e) {
-                  alert('Error creating session');
-                }
-               }}
-             >
-               <div className="flex items-center gap-2">
-                 <PlusCircle className="w-4 h-4 text-muted-foreground"/>
-                 Create Session
-               </div>
-             </DropdownItem>
-          )}
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <Hash className="h-4 w-4 text-muted-foreground" />
+                Create Channel
+              </div>
+            </DropdownItem>
+          ) : null}
 
-          {menuNode?.selection.type === 'channel' && (
-             <DropdownItem
-               id="create_channel_subscription"
-               onAction={() => {
+          {menuNode?.selection.type === 'agent' ? (
+            <DropdownItem
+              id="create_session"
+              onAction={() => {
+                setContextMenu(null);
+                createSessionMutation.mutate({
+                  ns: menuNode.selection.ns,
+                  agent: menuNode.selection.agent || '',
+                });
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <PlusCircle className="h-4 w-4 text-muted-foreground" />
+                Create Session
+              </div>
+            </DropdownItem>
+          ) : null}
+
+          {menuNode?.selection.type === 'channel' ? (
+            <DropdownItem
+              id="create_channel_subscription"
+              onAction={() => {
                 setContextMenu(null);
                 setSubscriptionModalOpen({
                   isOpen: true,
                   ns: menuNode.selection.ns,
                   channel: menuNode.selection.channel || menuNode.selection.resourceName || '',
                 });
-               }}
-             >
-               <div className="flex items-center gap-2">
-                 <Radio className="w-4 h-4 text-muted-foreground"/>
-                 Create Subscription
-               </div>
-             </DropdownItem>
-          )}
+              }}
+            >
+              <div className="flex items-center gap-2">
+                <Radio className="h-4 w-4 text-muted-foreground" />
+                Create Subscription
+              </div>
+            </DropdownItem>
+          ) : null}
 
-           <DropdownItem 
-             id="delete_item" 
-             className="text-danger" 
-             color="danger"
-             onAction={() => {
-                setContextMenu(null);
-                setDeleteConfirm({ isOpen: true, node: menuNode });
-             }}
-           >
-             <div className="flex items-center gap-2">
-               <Trash2 className="w-4 h-4"/>
-               Delete {menuNode?.selection.type}
-             </div>
-           </DropdownItem>
+          <DropdownItem
+            id="delete_item"
+            className="text-danger"
+            color="danger"
+            onAction={() => {
+              setContextMenu(null);
+              setDeleteConfirm({ isOpen: true, node: menuNode || null });
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <Trash2 className="h-4 w-4" />
+              Delete {menuNode?.selection.type}
+            </div>
+          </DropdownItem>
         </DropdownMenu>
       </Dropdown>
 
-      {/* Namespace Creation Modal */}
       <DialogOverlay isOpen={namespaceModalOpen} onOpenChange={(open) => !open && setNamespaceModalOpen(false)}>
         <ModalContent className="sm:max-w-md">
           <ModalHeader className="flex flex-col gap-1">New Namespace</ModalHeader>
           <ModalBody>
-            <form id="create-namespace-form" onSubmit={handleCreateNamespace} className="space-y-4">
+            <form id="create-namespace-form" onSubmit={submitNamespace} className="space-y-4">
               <div>
-                <Label className="block text-sm font-medium mb-1">Namespace Path</Label>
-                <Input 
+                <Label className="mb-1 block text-sm font-medium">Namespace Path</Label>
+                <Input
                   className="w-full"
                   autoFocus
                   placeholder="org:team:child"
                   value={newNamespace}
-                  onChange={(e) => setNewNamespace(e.target.value)}
-                  disabled={isCreatingNamespace}
+                  onChange={(event) => setNewNamespace(event.target.value)}
+                  disabled={createNamespaceMutation.isPending}
                   required
                 />
               </div>
             </form>
           </ModalBody>
-          <ModalFooter className="flex justify-end gap-3 mt-4">
+          <ModalFooter className="mt-4 flex justify-end gap-3">
             <Button variant="ghost" appearance="outline" onClick={() => setNamespaceModalOpen(false)}>
               Cancel
             </Button>
-            <Button variant="primary" type="submit" form="create-namespace-form" disabled={isCreatingNamespace || !newNamespace.trim()}>
+            <Button
+              variant="primary"
+              type="submit"
+              form="create-namespace-form"
+              disabled={createNamespaceMutation.isPending || !newNamespace.trim()}
+            >
               Create Namespace
             </Button>
           </ModalFooter>
         </ModalContent>
       </DialogOverlay>
 
-      {/* Create Agent Modal */}
-      <Modal isOpen={agentModalOpen.isOpen} onOpenChange={(open) => !open && setAgentModalOpen({ isOpen: false, ns: '' })}>
+      <DialogOverlay isOpen={agentModalOpen.isOpen} onOpenChange={(open) => !open && setAgentModalOpen({ isOpen: false, ns: '' })}>
         <ModalContent className="sm:max-w-md">
-            <>
-              <ModalHeader className="flex flex-col gap-1">Create Agent</ModalHeader>
-              <ModalBody>
-                <form id="create-agent-form" onSubmit={handleCreateAgentSubmit} className="space-y-4">
-                  <div>
-                    <Label className="block text-sm font-medium mb-1">Agent Name</Label>
-                    <Input 
-                      className="w-full"
-                      placeholder="my-agent"
-                      value={agentForm.name}
-                      onChange={(e) => setAgentForm(prev => ({ ...prev, name: e.target.value }))}
-                      required
-                    />
-                  </div>
-                  
-                  <div>
-                    <Label className="block text-sm font-medium mb-1">Template</Label>
-                    <Select 
-                      value={agentForm.template || null}
-                      onChange={(key) => {
-                         setAgentForm(prev => ({ ...prev, template: key as string }));
-                      }}
-                      isRequired
-                      placeholder="Select an Agent template"
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {agentTemplateOptions.length > 0 ? agentTemplateOptions.map(t => (
-                          <SelectItem id={templateOptionId(t)} key={templateOptionId(t)}>
-                            {t.metadata?.namespace || SYSTEM_NAMESPACE}/{t.metadata?.name}
-                          </SelectItem>
-                        )) : (
-                          <SelectItem id="default" key="default">Blank Agent</SelectItem>
-                        )}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </form>
-              </ModalBody>
-              <ModalFooter>
-                <Button variant="ghost" appearance="outline" onClick={() => setAgentModalOpen({ isOpen: false, ns: '' })}>
-                  Cancel
-                </Button>
-                <Button color="primary" type="submit" form="create-agent-form" disabled={isSubmittingAgent || !agentForm.name || !agentForm.template}>
-                  Create Agent
-                </Button>
-              </ModalFooter>
-            </>
-        </ModalContent>
-      </Modal>
+          <ModalHeader className="flex flex-col gap-1">Create Agent</ModalHeader>
+          <ModalBody>
+            <form id="create-agent-form" onSubmit={submitAgent} className="space-y-4">
+              <div>
+                <Label className="mb-1 block text-sm font-medium">Agent Name</Label>
+                <Input
+                  className="w-full"
+                  placeholder="my-agent"
+                  value={agentForm.name}
+                  onChange={(event) => setAgentForm((prev) => ({ ...prev, name: event.target.value }))}
+                  required
+                />
+              </div>
 
-      <Modal isOpen={channelModalOpen.isOpen} onOpenChange={(open) => !open && setChannelModalOpen({ isOpen: false, ns: '' })}>
+              <div>
+                <Label className="mb-1 block text-sm font-medium">Template</Label>
+                <Select
+                  value={agentForm.template || null}
+                  onChange={(key) => setAgentForm((prev) => ({ ...prev, template: key as string }))}
+                  placeholder="Blank Agent"
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {agentCreateTemplates.map((template) => (
+                      <SelectItem id={templateOptionId(template)} key={templateOptionId(template)}>
+                        {template.metadata?.namespace || SYSTEM_NAMESPACE}/{template.metadata?.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </form>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="ghost" appearance="outline" onClick={() => setAgentModalOpen({ isOpen: false, ns: '' })}>
+              Cancel
+            </Button>
+            <Button color="primary" type="submit" form="create-agent-form" disabled={createAgentMutation.isPending || !agentForm.name.trim()}>
+              Create Agent
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </DialogOverlay>
+
+      <DialogOverlay isOpen={channelModalOpen.isOpen} onOpenChange={(open) => !open && setChannelModalOpen({ isOpen: false, ns: '' })}>
         <ModalContent className="sm:max-w-md">
           <ModalHeader className="flex flex-col gap-1">Create Channel</ModalHeader>
           <ModalBody>
-            <form id="create-channel-form" onSubmit={handleCreateChannelSubmit} className="space-y-4">
+            <form id="create-channel-form" onSubmit={submitChannel} className="space-y-4">
               <div>
-                <Label className="block text-sm font-medium mb-1">Channel Name</Label>
+                <Label className="mb-1 block text-sm font-medium">Channel Name</Label>
                 <Input
                   className="w-full"
                   placeholder="incident-room"
                   value={channelForm.name}
-                  onChange={(e) => setChannelForm(prev => ({ ...prev, name: e.target.value }))}
+                  onChange={(event) => setChannelForm((prev) => ({ ...prev, name: event.target.value }))}
                   required
                 />
               </div>
               <div>
-                <Label className="block text-sm font-medium mb-1">Title</Label>
+                <Label className="mb-1 block text-sm font-medium">Title</Label>
                 <Input
                   className="w-full"
                   placeholder="Incident Room"
                   value={channelForm.title}
-                  onChange={(e) => setChannelForm(prev => ({ ...prev, title: e.target.value }))}
+                  onChange={(event) => setChannelForm((prev) => ({ ...prev, title: event.target.value }))}
                 />
               </div>
             </form>
@@ -1999,43 +605,46 @@ export function NamespaceExplorer({
             <Button variant="ghost" appearance="outline" onClick={() => setChannelModalOpen({ isOpen: false, ns: '' })}>
               Cancel
             </Button>
-            <Button color="primary" type="submit" form="create-channel-form" disabled={isSubmittingChannel || !channelForm.name.trim()}>
+            <Button color="primary" type="submit" form="create-channel-form" disabled={createChannelMutation.isPending || !channelForm.name.trim()}>
               Create Channel
             </Button>
           </ModalFooter>
         </ModalContent>
-      </Modal>
+      </DialogOverlay>
 
-      <Modal isOpen={subscriptionModalOpen.isOpen} onOpenChange={(open) => !open && setSubscriptionModalOpen({ isOpen: false, ns: '', channel: '' })}>
+      <DialogOverlay
+        isOpen={subscriptionModalOpen.isOpen}
+        onOpenChange={(open) => !open && setSubscriptionModalOpen({ isOpen: false, ns: '', channel: '' })}
+      >
         <ModalContent className="sm:max-w-md">
           <ModalHeader className="flex flex-col gap-1">Create Channel Subscription</ModalHeader>
           <ModalBody>
-            <form id="create-channel-subscription-form" onSubmit={handleCreateSubscriptionSubmit} className="space-y-4">
+            <form id="create-channel-subscription-form" onSubmit={submitSubscription} className="space-y-4">
               <div>
-                <Label className="block text-sm font-medium mb-1">Subscription Name</Label>
+                <Label className="mb-1 block text-sm font-medium">Subscription Name</Label>
                 <Input
                   className="w-full"
                   placeholder="triage"
                   value={subscriptionForm.name}
-                  onChange={(e) => setSubscriptionForm(prev => ({ ...prev, name: e.target.value }))}
+                  onChange={(event) => setSubscriptionForm((prev) => ({ ...prev, name: event.target.value }))}
                   required
                 />
               </div>
               <div>
-                <Label className="block text-sm font-medium mb-1">Agent</Label>
+                <Label className="mb-1 block text-sm font-medium">Agent</Label>
                 <Input
                   className="w-full"
                   placeholder="triage-agent"
                   value={subscriptionForm.agent}
-                  onChange={(e) => setSubscriptionForm(prev => ({ ...prev, agent: e.target.value }))}
+                  onChange={(event) => setSubscriptionForm((prev) => ({ ...prev, agent: event.target.value }))}
                   required
                 />
               </div>
               <div>
-                <Label className="block text-sm font-medium mb-1">Trigger</Label>
+                <Label className="mb-1 block text-sm font-medium">Trigger</Label>
                 <Select
                   value={subscriptionForm.trigger}
-                  onChange={(key) => setSubscriptionForm(prev => ({ ...prev, trigger: key as string }))}
+                  onChange={(key) => setSubscriptionForm((prev) => ({ ...prev, trigger: key as string }))}
                   isRequired
                 >
                   <SelectTrigger className="w-full">
@@ -2050,10 +659,10 @@ export function NamespaceExplorer({
                 </Select>
               </div>
               <div>
-                <Label className="block text-sm font-medium mb-1">Reply Mode</Label>
+                <Label className="mb-1 block text-sm font-medium">Reply Mode</Label>
                 <Select
                   value={subscriptionForm.replyMode}
-                  onChange={(key) => setSubscriptionForm(prev => ({ ...prev, replyMode: key as string }))}
+                  onChange={(key) => setSubscriptionForm((prev) => ({ ...prev, replyMode: key as string }))}
                   isRequired
                 >
                   <SelectTrigger className="w-full">
@@ -2069,7 +678,7 @@ export function NamespaceExplorer({
                 <input
                   type="checkbox"
                   checked={subscriptionForm.enabled}
-                  onChange={(e) => setSubscriptionForm(prev => ({ ...prev, enabled: e.target.checked }))}
+                  onChange={(event) => setSubscriptionForm((prev) => ({ ...prev, enabled: event.target.checked }))}
                 />
                 Enabled
               </label>
@@ -2079,30 +688,40 @@ export function NamespaceExplorer({
             <Button variant="ghost" appearance="outline" onClick={() => setSubscriptionModalOpen({ isOpen: false, ns: '', channel: '' })}>
               Cancel
             </Button>
-            <Button color="primary" type="submit" form="create-channel-subscription-form" disabled={isSubmittingSubscription || !subscriptionForm.name.trim() || !subscriptionForm.agent.trim()}>
+            <Button
+              color="primary"
+              type="submit"
+              form="create-channel-subscription-form"
+              disabled={createSubscriptionMutation.isPending || !subscriptionForm.name.trim() || !subscriptionForm.agent.trim()}
+            >
               Create Subscription
             </Button>
           </ModalFooter>
         </ModalContent>
-      </Modal>
+      </DialogOverlay>
 
-      {/* TailGrids Modal Update */}
       <DialogOverlay isOpen={deleteConfirm.isOpen} onOpenChange={(open) => !open && setDeleteConfirm({ isOpen: false, node: null })}>
         <ModalContent className="sm:max-w-md">
           <ModalHeader className="flex flex-col gap-1 text-red-500">Confirm Deletion</ModalHeader>
           <ModalBody>
-            <div className="text-[13px] text-muted-foreground whitespace-pre-wrap">
+            <div className="whitespace-pre-wrap text-[13px] text-muted-foreground">
               Are you sure you want to delete the {deleteConfirm.node?.selection.type} <b>{deleteConfirm.node?.name}</b>?
-              {deleteConfirm.node?.selection.type === 'namespace' && "\n\nThis will permanently delete all enclosed agents and sessions natively."}
-              {deleteConfirm.node?.selection.type === 'agent' && "\n\nThis action will also sever and erase all associated execution history contexts and sessions."}
+              {deleteConfirm.node?.selection.type === 'namespace' &&
+                '\n\nThis will permanently delete all enclosed agents and sessions natively.'}
+              {deleteConfirm.node?.selection.type === 'agent' &&
+                '\n\nThis action will also sever and erase all associated execution history contexts and sessions.'}
             </div>
           </ModalBody>
-          <ModalFooter className="flex justify-end gap-3 mt-4">
+          <ModalFooter className="mt-4 flex justify-end gap-3">
             <Button variant="ghost" appearance="outline" onClick={() => setDeleteConfirm({ isOpen: false, node: null })}>
               Cancel
             </Button>
-            <Button variant="danger" onClick={handleDeleteConfirmed} disabled={isDeleting}>
-              {isDeleting ? "Deleting..." : "Permanently Delete"}
+            <Button
+              variant="danger"
+              onClick={() => deleteConfirm.node && deleteMutation.mutate(deleteConfirm.node)}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Deleting...' : 'Permanently Delete'}
             </Button>
           </ModalFooter>
         </ModalContent>
@@ -2110,3 +729,5 @@ export function NamespaceExplorer({
     </div>
   );
 }
+
+export type { Selection };

--- a/ui/components/Namespaces/TreeNodeRow.tsx
+++ b/ui/components/Namespaces/TreeNodeRow.tsx
@@ -1,0 +1,152 @@
+import { Activity, Box, ChevronDown, ChevronRight, Clock3, Container, Cpu, FileText, Folder, Hash, Layers3, MessageSquare, Package, Plug, Radio, ShieldCheck } from 'lucide-react';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { SelectionType, Selection } from '../../lib/selection';
+import type { TreeNode } from '../../hooks/useExplorerTree';
+import { compareTreeNodes } from '../../hooks/useExplorerTree';
+import { cn } from '../../utils/cn';
+
+const LEAF_TYPES: SelectionType[] = [
+  'session',
+  'schedule',
+  'knowledge',
+  'mcp-server',
+  'channel-subscription',
+  'workflow',
+  'template',
+  'deployment-replica',
+  'sandbox-class',
+  'sandbox-policy',
+  'sandbox',
+];
+
+function NodeIcon({ type, selected }: { type: SelectionType; selected: boolean }) {
+  const className = (fallback: string) => cn('h-3.5 w-3.5', selected ? 'text-foreground' : fallback);
+  if (type === 'namespace') return <Folder className={className('text-muted-foreground')} />;
+  if (type === 'agent') return <Cpu className={className('text-emerald-500')} />;
+  if (type === 'session') return <MessageSquare className={className('text-blue-500')} />;
+  if (type === 'channel') return <Hash className={className('text-cyan-400')} />;
+  if (type === 'channel-subscription') return <Radio className={className('text-cyan-300')} />;
+  if (type === 'workflow') return <Activity className={className('text-purple-400')} />;
+  if (type === 'schedule') return <Clock3 className={className('text-amber-500')} />;
+  if (type === 'template') return <FileText className={className('text-emerald-400')} />;
+  if (type === 'deployment') return <Layers3 className={className('text-indigo-400')} />;
+  if (type === 'deployment-replica') return <Package className={className('text-indigo-300')} />;
+  if (type === 'sandbox-class') return <ShieldCheck className={className('text-fuchsia-400')} />;
+  if (type === 'sandbox-policy') return <Box className={className('text-fuchsia-300')} />;
+  if (type === 'sandbox') return <Container className={className('text-orange-400')} />;
+  if (type === 'mcp-server') return <Plug className={className('text-blue-500')} />;
+  if (type === 'knowledge') return <FileText className={className('text-violet-400')} />;
+  return <Box className={className('text-muted-foreground')} />;
+}
+
+export function TreeNodeRow({
+  node,
+  level,
+  selectedNodeId,
+  onSelect,
+  onContextMenu,
+  expanded,
+  toggleExpanded,
+}: {
+  node: TreeNode;
+  level: number;
+  selectedNodeId: string | null;
+  onSelect: (selection: Selection) => void;
+  onContextMenu: (e: React.MouseEvent, node: TreeNode) => void;
+  expanded: Set<string>;
+  toggleExpanded: (id: string) => void;
+}) {
+  const childNodes = Object.values(node.children).sort(compareTreeNodes);
+  const hasChildrenOrCanHaveChildren = !LEAF_TYPES.includes(node.selection.type);
+  const isExpanded = expanded.has(node.id);
+  const isSelected = selectedNodeId === node.id;
+
+  const handleToggle = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (hasChildrenOrCanHaveChildren) toggleExpanded(node.id);
+  };
+
+  const handleClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    onSelect(node.selection);
+  };
+
+  const handleContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onContextMenu(event, node);
+  };
+
+  return (
+    <div>
+      <div
+        className={cn(
+          'group flex select-none items-center gap-1.5 rounded-xl px-2.5 py-2 text-[13px] font-medium transition-colors hover:bg-white/[0.04]',
+          isSelected
+            ? 'border border-border/70 bg-white/[0.055] text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]'
+            : 'text-muted-foreground',
+        )}
+        style={{ paddingLeft: `${level * 16 + 8}px` }}
+        onClick={handleClick}
+        onContextMenu={handleContextMenu}
+      >
+        <div
+          className={cn(
+            'flex items-center justify-center rounded-sm p-0.5 transition-colors',
+            hasChildrenOrCanHaveChildren && 'hover:bg-white/[0.05]',
+            !hasChildrenOrCanHaveChildren && 'cursor-default opacity-0',
+          )}
+          onClick={hasChildrenOrCanHaveChildren ? handleToggle : undefined}
+        >
+          {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        </div>
+
+        <NodeIcon type={node.selection.type} selected={isSelected} />
+
+        <span className="min-w-0 flex-1 truncate">{node.name}</span>
+        {node.badge ? (
+          <span className="max-w-[8rem] truncate rounded-full border border-border/70 bg-white/[0.03] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            {node.badge}
+          </span>
+        ) : null}
+        {isSelected ? <Activity className="h-3.5 w-3.5 flex-shrink-0 opacity-70" /> : null}
+      </div>
+
+      <AnimatePresence initial={false}>
+        {isExpanded && hasChildrenOrCanHaveChildren ? (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15, ease: 'easeInOut' }}
+            className="overflow-hidden"
+          >
+            <div className="mt-0.5 space-y-0.5">
+              {childNodes.length > 0 ? (
+                childNodes.map((child) => (
+                  <TreeNodeRow
+                    key={child.id}
+                    node={child}
+                    level={level + 1}
+                    selectedNodeId={selectedNodeId}
+                    onSelect={onSelect}
+                    onContextMenu={onContextMenu}
+                    expanded={expanded}
+                    toggleExpanded={toggleExpanded}
+                  />
+                ))
+              ) : (
+                <div
+                  className="flex items-center gap-1.5 px-2 py-1.5 text-[12px] italic text-muted-foreground/60"
+                  style={{ paddingLeft: `${(level + 1) * 16 + 28}px` }}
+                >
+                  Empty
+                </div>
+              )}
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/ui/components/Search/WorkspaceCommandPalette.tsx
+++ b/ui/components/Search/WorkspaceCommandPalette.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Search } from 'lucide-react';
 import { v1Search } from '@impalasys/talon-client';
 import { getGatewayClient } from '../../lib/grpc';
-import type { Selection } from '../Namespaces/NamespaceExplorer';
+import type { Selection } from '../../lib/selection';
 import {
   Dialog,
   DialogContent,

--- a/ui/components/query-provider.tsx
+++ b/ui/components/query-provider.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState, type ReactNode } from 'react';
+
+export function TalonQueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            gcTime: 10 * 60_000,
+            refetchOnWindowFocus: false,
+            retry: 1,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -1,13 +1,88 @@
 import { test, expect } from '@playwright/test';
+import { createHmac } from 'node:crypto';
+
+function base64Url(value: object) {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function createLocalRootToken() {
+  const header = base64Url({ typ: 'JWT', alg: 'HS256' });
+  const payload = base64Url({
+    sub: 'talon-root-client',
+    aud: 'talon',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+  const body = `${header}.${payload}`;
+  const signature = createHmac('sha256', 'local-dev-talon-jwt').update(body).digest('base64url');
+  return `${body}.${signature}`;
+}
 
 test.describe('Talon UI', () => {
+  test('shows a connection error when the gateway probe fails', async ({ page }) => {
+    await page.goto('/');
+
+    const connectButton = page.locator('button', { hasText: 'Initialize Connection' });
+    const gatewayInput = page.getByLabel('Gateway URL');
+
+    await expect(gatewayInput).toBeVisible();
+    await gatewayInput.fill('http://127.0.0.1:9');
+    await connectButton.click();
+
+    await expect(page.getByText(/Could not connect to gateway/)).toBeVisible({ timeout: 15000 });
+    await expect(gatewayInput).toBeVisible();
+  });
+
+  test('connect reads browser-filled field values that did not fire React change events', async ({ page }) => {
+    await page.goto('/');
+
+    const connectButton = page.locator('button', { hasText: 'Initialize Connection' });
+    const gatewayInput = page.getByLabel('Gateway URL');
+    const tokenInput = page.getByLabel('Authorization Token');
+
+    await expect(gatewayInput).toBeVisible();
+    await gatewayInput.evaluate((node) => {
+      (node as HTMLInputElement).value = 'http://127.0.0.1:9';
+    });
+    await tokenInput.evaluate((node) => {
+      (node as HTMLInputElement).value = 'autofilled-token';
+    });
+
+    await expect(connectButton).toBeEnabled();
+    await connectButton.click();
+
+    await expect(page.getByText(/Could not connect to gateway/)).toBeVisible({ timeout: 15000 });
+    await expect(gatewayInput).toBeVisible();
+  });
+
+  test('connect timeout exits loading state with a visible error', async ({ page }) => {
+    await page.route('**/talon.v1.NamespaceService/List', () => {
+      // Simulate a gateway request that never resolves.
+    });
+    await page.goto('/');
+
+    const connectButton = page.locator('button', { hasText: /Initialize Connection|Connecting/ });
+    const gatewayInput = page.getByLabel('Gateway URL');
+    const tokenInput = page.getByLabel('Authorization Token');
+
+    await expect(gatewayInput).toBeVisible();
+    await gatewayInput.fill(new URL(page.url()).origin);
+    await tokenInput.fill('valid-looking-token');
+    await connectButton.click();
+
+    await expect(connectButton).toContainText('Connecting');
+    await expect(page.getByText(/request timed out/)).toBeVisible({ timeout: 12000 });
+    await expect(connectButton).toContainText('Initialize Connection');
+    await expect(connectButton).toBeEnabled();
+  });
+
   test('should load and connect to the gateway', async ({ page }) => {
     // 1. Visit the page
     await page.goto('/');
 
     // 2. Connect to the Gateway
     const connectButton = page.locator('button', { hasText: 'Initialize Connection' });
-    const gatewayInput = page.locator('input[type="url"]');
+    const gatewayInput = page.getByLabel('Gateway URL');
+    const tokenInput = page.getByLabel('Authorization Token');
     
     // Ensure we are in disconnected state showing the form
     await expect(gatewayInput).toBeVisible();
@@ -15,9 +90,15 @@ test.describe('Talon UI', () => {
     // Use the backend port
     const API_PORT = process.env.API_PORT || '50051';
     await gatewayInput.fill(`http://127.0.0.1:${API_PORT}`);
+    await tokenInput.fill(createLocalRootToken());
     await connectButton.click();
 
-    // 3. Ensure we are connected
+    // 3. Ensure we are connected and stay out of the auth fork after URL sync settles.
     await expect(page.locator('text=Connected')).toBeVisible({ timeout: 45000 });
+    await expect(page).toHaveURL(/connected=true/);
+    await expect(gatewayInput).toBeHidden();
+    await page.waitForTimeout(1000);
+    await expect(page).toHaveURL(/connected=true/);
+    await expect(gatewayInput).toBeHidden();
   });
 });

--- a/ui/hooks/useExplorerQueries.ts
+++ b/ui/hooks/useExplorerQueries.ts
@@ -1,0 +1,228 @@
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import type { Selection } from '../lib/selection';
+import { namespaceAncestors, selectionExpansionIds } from '../lib/selection';
+import { listNamespaces, listResources, listSessions } from '../lib/talon/client';
+import { talonQueryKeys, type TalonQueryScope } from '../lib/talon/queryKeys';
+import { RESOURCE_DESCRIPTORS } from '../lib/talon/resourceDescriptors';
+
+const STATIC_RESOURCE_KINDS = [
+  'Agent',
+  'Channel',
+  'Schedule',
+  'Knowledge',
+  ...RESOURCE_DESCRIPTORS.map((descriptor) => descriptor.kind),
+];
+
+function unique(values: string[]) {
+  return Array.from(new Set(values));
+}
+
+function maybeNamespaceId(id: string) {
+  return id === '' || !id.includes(':channel:');
+}
+
+function namespaceQueryParents(expanded: Set<string>, selectedNode: Selection | null) {
+  const parents = new Set<string>(['']);
+  for (const id of expanded) {
+    if (maybeNamespaceId(id)) parents.add(id);
+  }
+  for (const id of selectionExpansionIds(selectedNode)) {
+    if (maybeNamespaceId(id)) parents.add(id);
+  }
+  return Array.from(parents);
+}
+
+function namespaceScopeFromQueryData(
+  selectedNode: Selection | null,
+  namespaceResults: Array<{ data?: Array<{ name: string }> }>,
+) {
+  const namespaces = new Set<string>();
+
+  if (selectedNode?.ns) {
+    for (const ns of namespaceAncestors(selectedNode.ns)) {
+      if (ns) namespaces.add(ns);
+    }
+  }
+
+  for (const result of namespaceResults) {
+    for (const ns of result.data || []) {
+      if (ns.name) namespaces.add(ns.name);
+    }
+  }
+
+  return Array.from(namespaces).sort();
+}
+
+export function collectExpandedNamespaceIds(expanded: Set<string>, selectedNode: Selection | null) {
+  const namespaces = new Set<string>();
+  for (const id of expanded) {
+    if (id && maybeNamespaceId(id)) namespaces.add(id);
+  }
+  if (selectedNode?.ns) {
+    for (const ns of namespaceAncestors(selectedNode.ns)) {
+      if (ns) namespaces.add(ns);
+    }
+  }
+  return Array.from(namespaces).sort();
+}
+
+export type ExplorerQueries = ReturnType<typeof useExplorerQueries>;
+
+export function useExplorerQueries({
+  isConnected,
+  scope,
+  expanded,
+  selectedNode,
+}: {
+  isConnected: boolean;
+  scope: TalonQueryScope;
+  expanded: Set<string>;
+  selectedNode: Selection | null;
+}) {
+  const namespaceParents = useMemo(
+    () => namespaceQueryParents(expanded, selectedNode),
+    [expanded, selectedNode],
+  );
+
+  const namespaceQueries = useQueries({
+    queries: namespaceParents.map((parent) => ({
+      queryKey: talonQueryKeys.namespaces(scope, parent),
+      queryFn: ({ signal }) => listNamespaces(parent, { signal }),
+      enabled: isConnected,
+    })),
+  });
+
+  const namespaceIds = useMemo(
+    () => namespaceScopeFromQueryData(selectedNode, namespaceQueries),
+    [namespaceQueries, selectedNode],
+  );
+
+  const resourceNamespaceIds = useMemo(() => {
+    const discovered = new Set(namespaceIds);
+    const namespaces = new Set<string>();
+    if (selectedNode?.ns) namespaces.add(selectedNode.ns);
+    for (const id of expanded) {
+      if (id && discovered.has(id)) {
+        namespaces.add(id);
+      }
+    }
+    return Array.from(namespaces).sort();
+  }, [expanded, namespaceIds, selectedNode]);
+
+  const resourceTargets = useMemo(
+    () =>
+      resourceNamespaceIds.flatMap((ns) =>
+        STATIC_RESOURCE_KINDS.map((kind) => ({
+          ns,
+          kind,
+        })),
+      ),
+    [resourceNamespaceIds],
+  );
+
+  const resourceQueries = useQueries({
+    queries: resourceTargets.map(({ ns, kind }) => ({
+      queryKey: talonQueryKeys.resources(scope, ns, kind),
+      queryFn: ({ signal }) => listResources(ns, kind, { signal }),
+      enabled: isConnected && Boolean(ns),
+    })),
+  });
+
+  const resourcesByNamespaceKind = useMemo(() => {
+    const map: Record<string, Record<string, any[]>> = {};
+    resourceTargets.forEach((target, index) => {
+      map[target.ns] ||= {};
+      map[target.ns][target.kind] = resourceQueries[index]?.data || [];
+    });
+    return map;
+  }, [resourceQueries, resourceTargets]);
+
+  const agentSessionTargets = useMemo(() => {
+    const targets: Array<{ ns: string; agent: string }> = [];
+    for (const [ns, byKind] of Object.entries(resourcesByNamespaceKind)) {
+      for (const resource of byKind.Agent || []) {
+        const agent = resource.metadata?.name || '';
+        if (!agent) continue;
+        if (expanded.has(`${ns}:${agent}`) || selectedNode?.agent === agent && selectedNode.ns === ns) {
+          targets.push({ ns, agent });
+        }
+      }
+    }
+    return targets;
+  }, [expanded, resourcesByNamespaceKind, selectedNode]);
+
+  const sessionQueries = useQueries({
+    queries: agentSessionTargets.map(({ ns, agent }) => ({
+      queryKey: talonQueryKeys.sessions(scope, ns, agent),
+      queryFn: ({ signal }) => listSessions(ns, agent, { signal }),
+      enabled: isConnected,
+    })),
+  });
+
+  const sessionsByAgentKey = useMemo(() => {
+    const map: Record<string, string[]> = {};
+    agentSessionTargets.forEach((target, index) => {
+      map[`${target.ns}/${target.agent}`] = sessionQueries[index]?.data || [];
+    });
+    return map;
+  }, [agentSessionTargets, sessionQueries]);
+
+  const channelSubscriptionTargets = useMemo(() => {
+    const targets: Array<{ ns: string; channel: string }> = [];
+    for (const [ns, byKind] of Object.entries(resourcesByNamespaceKind)) {
+      for (const resource of byKind.Channel || []) {
+        const channel = resource.metadata?.name || '';
+        if (!channel) continue;
+        if (expanded.has(`${ns}:channel:${channel}`) || selectedNode?.channel === channel && selectedNode.ns === ns) {
+          targets.push({ ns, channel });
+        }
+      }
+    }
+    return targets;
+  }, [expanded, resourcesByNamespaceKind, selectedNode]);
+
+  const channelSubscriptionNamespaces = useMemo(
+    () => unique(channelSubscriptionTargets.map((target) => target.ns)),
+    [channelSubscriptionTargets],
+  );
+
+  const subscriptionQueries = useQueries({
+    queries: channelSubscriptionNamespaces.map((ns) => ({
+      queryKey: talonQueryKeys.resources(scope, ns, 'ChannelSubscription'),
+      queryFn: ({ signal }) => listResources(ns, 'ChannelSubscription', { signal }),
+      enabled: isConnected,
+    })),
+  });
+
+  const channelSubscriptionsByKey = useMemo(() => {
+    const map: Record<string, any[]> = {};
+    const subscriptionsByNamespace = Object.fromEntries(
+      channelSubscriptionNamespaces.map((ns, index) => [ns, subscriptionQueries[index]?.data || []]),
+    );
+    channelSubscriptionTargets.forEach((target) => {
+      map[`${target.ns}/${target.channel}`] = (subscriptionsByNamespace[target.ns] || []).filter((resource: any) => {
+        const spec = resource.spec?.kind?.case === 'channelSubscription' ? resource.spec.kind.value || {} : {};
+        return spec.channel === target.channel;
+      });
+    });
+    return map;
+  }, [channelSubscriptionNamespaces, channelSubscriptionTargets, subscriptionQueries]);
+
+  return {
+    namespaceParents,
+    namespaceQueries,
+    namespaceIds,
+    resourceNamespaceIds,
+    resourceTargets,
+    resourceQueries,
+    resourcesByNamespaceKind,
+    agentSessionTargets,
+    sessionQueries,
+    sessionsByAgentKey,
+    channelSubscriptionTargets,
+    subscriptionQueries,
+    channelSubscriptionsByKey,
+    isInitialLoading: namespaceQueries.some((query) => query.isLoading),
+  };
+}

--- a/ui/hooks/useExplorerTree.test.ts
+++ b/ui/hooks/useExplorerTree.test.ts
@@ -1,0 +1,70 @@
+// @ts-nocheck
+import { buildExplorerTree, compareTreeNodes } from './useExplorerTree';
+
+function resource(kind: string, ns: string, name: string, caseName: string, value: any = {}) {
+  return {
+    kind,
+    metadata: { name, namespace: ns },
+    spec: { kind: { case: caseName, value } },
+  };
+}
+
+describe('buildExplorerTree', () => {
+  it('derives visible namespace, resource, and expanded session nodes from query data', () => {
+    const tree = buildExplorerTree({
+      expanded: new Set(['', 'demo', 'demo:writer']),
+      queries: {
+        namespaceParents: [''],
+        namespaceQueries: [{ data: [{ name: 'demo', labels: { workspace_name: 'Demo' } }] }],
+        resourcesByNamespaceKind: {
+          demo: {
+            Agent: [resource('Agent', 'demo', 'writer', 'agent')],
+            Channel: [resource('Channel', 'demo', 'incidents', 'channel', { title: 'Incidents' })],
+            Schedule: [resource('Schedule', 'demo', 'nightly', 'schedule', { kind: 'cron', enabled: true })],
+            Knowledge: [],
+            McpServer: [resource('McpServer', 'demo', 'linear', 'mcpServer', { transport: 'stdio' })],
+            Template: [],
+            Deployment: [],
+            DeploymentReplica: [],
+            SandboxClass: [],
+            SandboxPolicy: [],
+            Sandbox: [],
+          },
+        },
+        sessionsByAgentKey: {
+          'demo/writer': ['01HZ0000000000000000000000'],
+        },
+        channelSubscriptionsByKey: {},
+      },
+    } as any);
+
+    expect(tree.children.demo.badge).toBe('Demo');
+    expect(tree.children.demo.children.writer.selection.type).toBe('agent');
+    expect(Object.values(tree.children.demo.children.writer.children)[0].selection.type).toBe('session');
+    expect(tree.children.demo.children['channel:incidents'].badge).toBe('Incidents');
+    expect(tree.children.demo.children['mcp-server:linear'].selection).toMatchObject({
+      type: 'mcp-server',
+      ns: 'demo',
+      resourceName: 'linear',
+    });
+    expect(tree.children.demo.children['mcp-server:linear'].badge).toBe('stdio');
+    expect(tree.children.demo.children['schedule:nightly'].badge).toBe('cron');
+  });
+
+  it('sorts sessions newest first while keeping namespaces above resources', () => {
+    const namespaceNode = {
+      id: 'demo',
+      name: 'demo',
+      selection: { type: 'namespace' as const, ns: 'demo', fullPath: 'demo' },
+      children: {},
+    };
+    const agentNode = {
+      id: 'demo:agent',
+      name: 'agent',
+      selection: { type: 'agent' as const, ns: 'demo', agent: 'agent', fullPath: 'demo/agent' },
+      children: {},
+    };
+
+    expect(compareTreeNodes(namespaceNode, agentNode)).toBeLessThan(0);
+  });
+});

--- a/ui/hooks/useExplorerTree.ts
+++ b/ui/hooks/useExplorerTree.ts
@@ -1,0 +1,310 @@
+import { useMemo } from 'react';
+import type { Selection, SelectionType } from '../lib/selection';
+import { namespaceAncestors } from '../lib/selection';
+import { namespaceLabel } from '../lib/talon/resourceMappers';
+import {
+  channelFromResource,
+  channelSubscriptionFromResource,
+  knowledgeFromResource,
+  scheduleFromResource,
+  type ResourceEnvelope,
+} from '../lib/talon/resourceMappers';
+import { RESOURCE_DESCRIPTORS } from '../lib/talon/resourceDescriptors';
+import type { ExplorerQueries } from './useExplorerQueries';
+
+export type TreeNode = {
+  id: string;
+  name: string;
+  selection: Selection;
+  badge?: string;
+  children: { [key: string]: TreeNode };
+};
+
+function parseSessionTimestamp(id: string): number | null {
+  if (id && id.length === 36 && id.charAt(8) === '-') {
+    const hex = id.substring(0, 13).replace('-', '');
+    const time = parseInt(hex, 16);
+    return Number.isNaN(time) ? null : time;
+  }
+
+  if (id && id.length === 26) {
+    const encoding = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+    let time = 0;
+    for (let i = 0; i < 10; i++) {
+      const val = encoding.indexOf(id.charAt(i).toUpperCase());
+      if (val === -1) return null;
+      time = time * 32 + val;
+    }
+    return time;
+  }
+
+  return null;
+}
+
+export function parseSessionDate(id: string) {
+  const timestamp = parseSessionTimestamp(id);
+  if (timestamp !== null) {
+    return new Date(timestamp).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+  return id ? id.substring(0, 8) : 'Unknown';
+}
+
+export function nodeSortWeight(node: TreeNode) {
+  switch (node.selection.type) {
+    case 'namespace':
+      return 0;
+    case 'agent':
+      return 1;
+    case 'channel':
+      return 2;
+    case 'channel-subscription':
+      return 3;
+    case 'mcp-server':
+      return 4;
+    case 'sandbox':
+      return 5;
+    case 'sandbox-policy':
+      return 6;
+    case 'sandbox-class':
+      return 7;
+    case 'deployment':
+      return 8;
+    case 'deployment-replica':
+      return 9;
+    case 'template':
+      return 10;
+    case 'schedule':
+      return 11;
+    case 'session':
+      return 12;
+    default:
+      return 20;
+  }
+}
+
+export function compareTreeNodes(a: TreeNode, b: TreeNode) {
+  const weightDiff = nodeSortWeight(a) - nodeSortWeight(b);
+  if (weightDiff !== 0) return weightDiff;
+
+  if (a.selection.type === 'session' && b.selection.type === 'session') {
+    const aTime = parseSessionTimestamp(a.selection.sessionId || '');
+    const bTime = parseSessionTimestamp(b.selection.sessionId || '');
+    if (aTime !== null && bTime !== null && aTime !== bTime) {
+      return bTime - aTime;
+    }
+  }
+
+  return a.name.localeCompare(b.name);
+}
+
+function ensureNamespaceNode(root: TreeNode, ns: string, labels?: Record<string, string>) {
+  const parts = ns.split(':').filter(Boolean);
+  let current = root;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    const currentNsId = parts.slice(0, i + 1).join(':');
+    if (!current.children[part]) {
+      current.children[part] = {
+        id: currentNsId,
+        name: part,
+        badge: i === parts.length - 1 ? namespaceLabel(labels) : undefined,
+        selection: { type: 'namespace', ns: currentNsId, fullPath: currentNsId },
+        children: {},
+      };
+    } else if (i === parts.length - 1 && labels) {
+      current.children[part].badge = namespaceLabel(labels);
+    }
+    current = current.children[part];
+  }
+  return current;
+}
+
+function addResourceNode(
+  parent: TreeNode,
+  ns: string,
+  key: string,
+  name: string,
+  selectionType: SelectionType,
+  sortPrefix: string,
+  badge?: string,
+) {
+  const id = `${ns}:${sortPrefix}:${name}`;
+  parent.children[key] = {
+    id,
+    name,
+    badge,
+    selection: {
+      type: selectionType,
+      ns,
+      resourceName: name,
+      fullPath: id,
+    },
+    children: {},
+  };
+}
+
+export function buildExplorerTree({
+  queries,
+  expanded,
+}: {
+  queries: Pick<
+    ExplorerQueries,
+    'namespaceParents' | 'namespaceQueries' | 'resourcesByNamespaceKind' | 'sessionsByAgentKey' | 'channelSubscriptionsByKey'
+  >;
+  expanded: Set<string>;
+}) {
+  const root: TreeNode = {
+    id: '',
+    name: 'root',
+    selection: { type: 'namespace', ns: '', fullPath: '' },
+    children: {},
+  };
+
+  queries.namespaceParents.forEach((_, index) => {
+    for (const namespace of queries.namespaceQueries[index]?.data || []) {
+      ensureNamespaceNode(root, namespace.name, namespace.labels);
+    }
+  });
+
+  for (const ns of Object.keys(queries.resourcesByNamespaceKind)) {
+    if (!ns) continue;
+    const currentLevel = ensureNamespaceNode(root, ns);
+    const resourcesByKind = queries.resourcesByNamespaceKind[ns] || {};
+
+    for (const agentResource of resourcesByKind.Agent || []) {
+      const agent = agentResource.metadata?.name || '';
+      if (!agent) continue;
+      const agentId = `${ns}:${agent}`;
+      currentLevel.children[agent] = {
+        id: agentId,
+        name: agent,
+        selection: { type: 'agent', ns, agent, fullPath: agentId },
+        children: {},
+      };
+
+      if (expanded.has(agentId)) {
+        for (const sessionId of queries.sessionsByAgentKey[`${ns}/${agent}`] || []) {
+          const sessionFullId = `${ns}:${agent}:${sessionId}`;
+          currentLevel.children[agent].children[sessionId] = {
+            id: sessionFullId,
+            name: parseSessionDate(sessionId),
+            selection: { type: 'session', ns, agent, sessionId, fullPath: sessionFullId },
+            children: {},
+          };
+        }
+      }
+    }
+
+    for (const resource of resourcesByKind.Channel || []) {
+      const channel = channelFromResource(resource);
+      const channelName = channel.name || 'unknown-channel';
+      const channelId = `${ns}:channel:${channelName}`;
+      const status = channel.status || 'open';
+      currentLevel.children[`channel:${channelName}`] = {
+        id: channelId,
+        name: channelName,
+        badge: status === 'closed' ? 'closed' : channel.title || 'channel',
+        selection: {
+          type: 'channel',
+          ns,
+          channel: channelName,
+          resourceName: channelName,
+          fullPath: channelId,
+        },
+        children: {},
+      };
+
+      if (expanded.has(channelId)) {
+        for (const subscriptionResource of queries.channelSubscriptionsByKey[`${ns}/${channelName}`] || []) {
+          const subscription = channelSubscriptionFromResource(subscriptionResource);
+          const subscriptionName = subscription.name || 'unknown-subscription';
+          const subscriptionId = `${channelId}:subscription:${subscriptionName}`;
+          currentLevel.children[`channel:${channelName}`].children[`subscription:${subscriptionName}`] = {
+            id: subscriptionId,
+            name: subscriptionName,
+            badge:
+              subscription.enabled === false
+                ? 'disabled'
+                : `${subscription.trigger || 'mention'}${(subscription.replyMode || subscription.reply_mode) === 'none' ? ' / no reply' : ''}`,
+            selection: {
+              type: 'channel-subscription',
+              ns,
+              channel: channelName,
+              resourceName: subscriptionName,
+              fullPath: subscriptionId,
+            },
+            children: {},
+          };
+        }
+      }
+    }
+
+    for (const resource of resourcesByKind.Schedule || []) {
+      const schedule = scheduleFromResource(resource);
+      const scheduleName = schedule.name || 'unknown-schedule';
+      const scheduleId = `${ns}:schedule:${scheduleName}`;
+      currentLevel.children[`schedule:${scheduleName}`] = {
+        id: scheduleId,
+        name: scheduleName,
+        badge: schedule.spec?.enabled !== false ? schedule.spec?.kind || 'schedule' : 'disabled',
+        selection: { type: 'schedule', ns, resourceName: scheduleName, fullPath: scheduleId },
+        children: {},
+      };
+    }
+
+    for (const resource of resourcesByKind.Knowledge || []) {
+      const knowledge = knowledgeFromResource(resource);
+      const knowledgeName = knowledge.metadata?.name || knowledge.spec?.path || 'unknown-knowledge';
+      const knowledgeId = `${ns}:knowledge:${knowledgeName}`;
+      currentLevel.children[`knowledge:${knowledgeName}`] = {
+        id: knowledgeId,
+        name: knowledge.spec?.path || knowledgeName,
+        badge: 'knowledge',
+        selection: { type: 'knowledge', ns, resourceName: knowledgeName, fullPath: knowledgeId },
+        children: {},
+      };
+    }
+
+    for (const descriptor of RESOURCE_DESCRIPTORS) {
+      for (const resource of (resourcesByKind[descriptor.kind] || []) as ResourceEnvelope[]) {
+        const name = resource.metadata?.name || `unknown-${descriptor.kind.toLowerCase()}`;
+        addResourceNode(
+          currentLevel,
+          ns,
+          `${descriptor.sortPrefix}:${name}`,
+          name,
+          descriptor.selectionType,
+          descriptor.sortPrefix,
+          descriptor.badge(resource),
+        );
+      }
+    }
+  }
+
+  return root;
+}
+
+export function useExplorerTree({
+  queries,
+  expanded,
+  selectedNode,
+}: {
+  queries: ExplorerQueries;
+  expanded: Set<string>;
+  selectedNode: Selection | null;
+}) {
+  return useMemo(() => {
+    const tree = buildExplorerTree({ queries, expanded });
+    if (selectedNode?.ns) {
+      for (const ns of namespaceAncestors(selectedNode.ns)) {
+        if (ns) ensureNamespaceNode(tree, ns);
+      }
+    }
+    return tree;
+  }, [expanded, queries, selectedNode]);
+}

--- a/ui/hooks/useResourceDocument.ts
+++ b/ui/hooks/useResourceDocument.ts
@@ -1,0 +1,78 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { dump } from 'js-yaml';
+import type { Selection } from '../lib/selection';
+import { RESOURCE_KIND_BY_SELECTION } from '../lib/selection';
+import { getNamespace, getResource } from '../lib/talon/client';
+import { talonQueryKeys, type TalonQueryScope } from '../lib/talon/queryKeys';
+import {
+  channelDocumentFromResource,
+  channelSubscriptionDocumentFromResource,
+  isV2ResourceDocument,
+  scheduleDocumentFromResource,
+  type ResourceEnvelope,
+} from '../lib/talon/resourceMappers';
+import { resourceToManifestDocument, yamlSafeValue } from '../lib/resourceManifest';
+
+function resourceIdentity(selection: Selection | null) {
+  if (!selection || selection.type === 'session') return null;
+  if (selection.type === 'namespace') {
+    return { kind: 'Namespace', name: selection.ns };
+  }
+  const kind = RESOURCE_KIND_BY_SELECTION[selection.type];
+  const name = selection.agent || selection.resourceName || selection.channel || '';
+  if (!kind || !name) return null;
+  return { kind, name };
+}
+
+function documentFromSelection(selection: Selection, resource: any) {
+  if (selection.type === 'channel') return channelDocumentFromResource((resource || {}) as ResourceEnvelope);
+  if (selection.type === 'channel-subscription') {
+    return channelSubscriptionDocumentFromResource((resource || {}) as ResourceEnvelope);
+  }
+  if (selection.type === 'schedule') return scheduleDocumentFromResource((resource || {}) as ResourceEnvelope);
+  if (isV2ResourceDocument(resource)) return resourceToManifestDocument(resource);
+  return yamlSafeValue(resource);
+}
+
+export function useResourceDocument({
+  isConnected,
+  scope,
+  selection,
+}: {
+  isConnected: boolean;
+  scope: TalonQueryScope;
+  selection: Selection | null;
+}) {
+  const queryClient = useQueryClient();
+  const identity = resourceIdentity(selection);
+
+  const query = useQuery({
+    queryKey:
+      selection && identity
+        ? selection.type === 'namespace'
+          ? talonQueryKeys.resource(scope, selection.ns, 'Namespace', selection.ns)
+          : talonQueryKeys.resource(scope, selection.ns, identity.kind, identity.name)
+        : talonQueryKeys.resource(scope, '', 'none', ''),
+    queryFn: async ({ signal }) => {
+      if (!selection || !identity) return null;
+      if (selection.type === 'namespace') {
+        return getNamespace(selection.ns, { signal });
+      }
+
+      const cachedList = queryClient.getQueryData<ResourceEnvelope[]>(
+        talonQueryKeys.resources(scope, selection.ns, identity.kind),
+      );
+      const cachedResource = cachedList?.find((resource) => resource.metadata?.name === identity.name);
+      if (cachedResource) return cachedResource;
+      return getResource(selection.ns, identity.kind, identity.name, { signal });
+    },
+    enabled: isConnected && Boolean(selection && identity && selection.type !== 'session'),
+  });
+
+  const document = selection && query.data ? documentFromSelection(selection, query.data) : null;
+  return {
+    ...query,
+    document,
+    yaml: document ? dump(document, { noRefs: true, lineWidth: 100 }) : '',
+  };
+}

--- a/ui/lib/selection.test.ts
+++ b/ui/lib/selection.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import {
+  areSelectionsEqual,
+  buildSearchParams,
+  namespaceAncestors,
+  selectionExpansionIds,
+  selectionFromSearchParams,
+} from './selection';
+
+describe('selection helpers', () => {
+  it('parses and serializes deep session URLs without changing the public shape', () => {
+    const params = new URLSearchParams({
+      connected: 'true',
+      ns: 'conic:wks:13',
+      type: 'session',
+      agent: 'cmo',
+      session: 'session-123',
+    });
+
+    const selection = selectionFromSearchParams(params);
+
+    expect(selection).toEqual({
+      type: 'session',
+      ns: 'conic:wks:13',
+      agent: 'cmo',
+      sessionId: 'session-123',
+      fullPath: 'conic:wks:13/cmo/session-123',
+    });
+    expect(buildSearchParams(true, selection, params).toString()).toBe(
+      'connected=true&ns=conic%3Awks%3A13&type=session&agent=cmo&session=session-123',
+    );
+  });
+
+  it('returns namespace and selected child expansion ids for deep links', () => {
+    expect(namespaceAncestors('conic:wks:13')).toEqual(['', 'conic', 'conic:wks', 'conic:wks:13']);
+    expect(
+      selectionExpansionIds({
+        type: 'channel-subscription',
+        ns: 'conic:wks',
+        channel: 'incidents',
+        resourceName: 'triage',
+        fullPath: 'conic:wks:channel:incidents:subscription:triage',
+      }),
+    ).toEqual(['', 'conic', 'conic:wks', 'conic:wks:channel:incidents']);
+  });
+
+  it('compares selection identity fields only', () => {
+    expect(
+      areSelectionsEqual(
+        { type: 'agent', ns: 'demo', agent: 'writer', fullPath: 'demo/writer' },
+        { type: 'agent', ns: 'demo', agent: 'writer', fullPath: 'different' },
+      ),
+    ).toBe(true);
+  });
+});

--- a/ui/lib/selection.ts
+++ b/ui/lib/selection.ts
@@ -1,0 +1,249 @@
+export const SYSTEM_NAMESPACE = 'Sys';
+
+export type SelectionType =
+  | 'namespace'
+  | 'agent'
+  | 'session'
+  | 'channel'
+  | 'channel-subscription'
+  | 'workflow'
+  | 'schedule'
+  | 'template'
+  | 'deployment'
+  | 'deployment-replica'
+  | 'sandbox-class'
+  | 'sandbox-policy'
+  | 'sandbox'
+  | 'mcp-server'
+  | 'knowledge';
+
+export type Selection = {
+  type: SelectionType;
+  ns: string;
+  agent?: string;
+  channel?: string;
+  sessionId?: string;
+  resourceName?: string;
+  fullPath: string;
+};
+
+export const RESOURCE_KIND_BY_SELECTION: Partial<Record<SelectionType, string>> = {
+  agent: 'Agent',
+  channel: 'Channel',
+  'channel-subscription': 'ChannelSubscription',
+  workflow: 'Workflow',
+  schedule: 'Schedule',
+  template: 'Template',
+  deployment: 'Deployment',
+  'deployment-replica': 'DeploymentReplica',
+  'sandbox-class': 'SandboxClass',
+  'sandbox-policy': 'SandboxPolicy',
+  sandbox: 'Sandbox',
+  'mcp-server': 'McpServer',
+  knowledge: 'Knowledge',
+};
+
+export function areSelectionsEqual(left: Selection | null, right: Selection | null) {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.type === right.type &&
+    left.ns === right.ns &&
+    left.agent === right.agent &&
+    left.channel === right.channel &&
+    left.sessionId === right.sessionId &&
+    left.resourceName === right.resourceName
+  );
+}
+
+export function namespaceAncestors(ns: string) {
+  if (!ns) return [''];
+  const parts = ns.split(':');
+  const ancestors = [''];
+  for (let i = 0; i < parts.length; i++) {
+    ancestors.push(parts.slice(0, i + 1).join(':'));
+  }
+  return ancestors;
+}
+
+export function namespaceResolutionAncestry(ns: string) {
+  if (!ns) return [];
+  const parts = ns.split(':').filter(Boolean);
+  return parts.map((_, index) => parts.slice(0, parts.length - index).join(':'));
+}
+
+export function selectionExpansionIds(selection: Selection | null) {
+  if (!selection?.ns) return [];
+  const ids = namespaceAncestors(selection.ns);
+  if (selection.agent) {
+    ids.push(`${selection.ns}:${selection.agent}`);
+  }
+  if (selection.channel) {
+    ids.push(`${selection.ns}:channel:${selection.channel}`);
+  }
+  return ids;
+}
+
+export function selectionFromSearchParams(searchParams: URLSearchParams): Selection | null {
+  const type = searchParams.get('type');
+  const ns = searchParams.get('ns');
+  const agent = searchParams.get('agent');
+  const channel = searchParams.get('channel');
+  const sessionId = searchParams.get('session');
+  const resourceName = searchParams.get('name');
+
+  if (type === 'template' && resourceName) {
+    const namespace = ns || SYSTEM_NAMESPACE;
+    return {
+      type: 'template',
+      ns: namespace,
+      resourceName,
+      fullPath: `${namespace}:template:${resourceName}`,
+    };
+  }
+
+  if (!ns) return null;
+
+  if (sessionId && agent) {
+    return {
+      type: 'session',
+      ns,
+      agent,
+      sessionId,
+      fullPath: `${ns}/${agent}/${sessionId}`,
+    };
+  }
+
+  if (agent) {
+    return {
+      type: 'agent',
+      ns,
+      agent,
+      fullPath: `${ns}/${agent}`,
+    };
+  }
+
+  if (type === 'channel-subscription' && channel && resourceName) {
+    return {
+      type: 'channel-subscription',
+      ns,
+      channel,
+      resourceName,
+      fullPath: `${ns}:channel:${channel}:subscription:${resourceName}`,
+    };
+  }
+
+  if (type === 'channel' && (resourceName || channel)) {
+    const channelName = resourceName || channel || '';
+    return {
+      type: 'channel',
+      ns,
+      channel: channelName,
+      resourceName: channelName,
+      fullPath: `${ns}:channel:${channelName}`,
+    };
+  }
+
+  if (type === 'schedule' && resourceName) {
+    return {
+      type: 'schedule',
+      ns,
+      resourceName,
+      fullPath: `${ns}:schedule:${resourceName}`,
+    };
+  }
+
+  if (type === 'mcp-server' && resourceName) {
+    return {
+      type: 'mcp-server',
+      ns,
+      resourceName,
+      fullPath: `${ns}:mcp-server:${resourceName}`,
+    };
+  }
+
+  if (type === 'knowledge' && resourceName) {
+    return {
+      type: 'knowledge',
+      ns,
+      resourceName,
+      fullPath: `${ns}:knowledge:${resourceName}`,
+    };
+  }
+
+  if (
+    (
+      type === 'deployment' ||
+      type === 'workflow' ||
+      type === 'deployment-replica' ||
+      type === 'sandbox-class' ||
+      type === 'sandbox-policy' ||
+      type === 'sandbox'
+    ) &&
+    resourceName
+  ) {
+    return {
+      type,
+      ns,
+      resourceName,
+      fullPath: `${ns}:${type}:${resourceName}`,
+    };
+  }
+
+  return {
+    type: 'namespace',
+    ns,
+    fullPath: ns,
+  };
+}
+
+export function buildSearchParams(isConnected: boolean, selection: Selection | null, currentSearchParams?: URLSearchParams) {
+  const params = new URLSearchParams();
+  const historyPageSize = currentSearchParams?.get('historyPageSize');
+
+  if (isConnected) {
+    params.set('connected', 'true');
+  }
+
+  if (historyPageSize && /^\d+$/.test(historyPageSize) && Number(historyPageSize) > 0) {
+    params.set('historyPageSize', historyPageSize);
+  }
+
+  if (selection?.ns) params.set('ns', selection.ns);
+  if (selection?.type) params.set('type', selection.type);
+  if (selection?.agent) params.set('agent', selection.agent);
+  if (selection?.channel) params.set('channel', selection.channel);
+  if (selection?.sessionId) params.set('session', selection.sessionId);
+  if (selection?.resourceName) params.set('name', selection.resourceName);
+
+  return params;
+}
+
+export function getSelectionTitle(selection: Selection | null) {
+  if (!selection) return 'No Resource Selected';
+  if (selection.type === 'namespace') return selection.ns;
+  if (selection.type === 'agent') return selection.agent || 'Agent';
+  if (selection.type === 'session') return selection.sessionId || 'Session';
+  if (selection.type === 'channel') return selection.channel || selection.resourceName || 'Channel';
+  return selection.resourceName || selection.type;
+}
+
+export function getSelectionSubtitle(selection: Selection | null) {
+  if (!selection) return 'Select a namespace, agent, deployment, sandbox, template, MCP server, or session.';
+  if (selection.type === 'namespace') return 'Namespace';
+  if (selection.type === 'agent') return `${selection.ns} / Agent`;
+  if (selection.type === 'session') return `${selection.ns} / ${selection.agent}`;
+  if (selection.type === 'channel') return `${selection.ns} / Channel`;
+  if (selection.type === 'channel-subscription') return `${selection.ns} / ${selection.channel} / ChannelSubscription`;
+  if (selection.type === 'workflow') return `${selection.ns} / Workflow`;
+  if (selection.type === 'schedule') return `${selection.ns} / Schedule`;
+  if (selection.type === 'mcp-server') return `${selection.ns} / MCPServer`;
+  if (selection.type === 'knowledge') return `${selection.ns} / Knowledge`;
+  if (selection.type === 'template') return `${selection.ns} / Template`;
+  if (selection.type === 'deployment') return `${selection.ns} / Deployment`;
+  if (selection.type === 'deployment-replica') return `${selection.ns} / DeploymentReplica`;
+  if (selection.type === 'sandbox-class') return `${selection.ns} / SandboxClass`;
+  if (selection.type === 'sandbox-policy') return `${selection.ns} / SandboxPolicy`;
+  if (selection.type === 'sandbox') return `${selection.ns} / Sandbox`;
+  return 'Sys / MCPServer';
+}

--- a/ui/lib/talon/client.ts
+++ b/ui/lib/talon/client.ts
@@ -1,0 +1,50 @@
+import { getGatewayClient } from '../grpc';
+import type { ResourceEnvelope } from './resourceMappers';
+
+export async function listNamespaces(parent: string, options?: { signal?: AbortSignal }) {
+  const response = await getGatewayClient().namespaces.list({ parent: parent || undefined }, options);
+  return response.namespaces || [];
+}
+
+export async function getNamespace(name: string, options?: { signal?: AbortSignal }) {
+  return getGatewayClient().namespaces.get({ name }, options);
+}
+
+export async function createNamespace(name: string) {
+  return getGatewayClient().namespaces.create({ name, recursive: true });
+}
+
+export async function deleteNamespace(name: string) {
+  return getGatewayClient().namespaces.delete({ name });
+}
+
+export async function listResources(ns: string, kind: string, options?: { signal?: AbortSignal }) {
+  const response = await getGatewayClient().resources.list({ ns, kind }, options);
+  return (response.resources || []) as ResourceEnvelope[];
+}
+
+export async function getResource(ns: string, kind: string, name: string, options?: { signal?: AbortSignal }) {
+  const response = await getGatewayClient().resources.get({ ns, kind, name }, options);
+  return response.resource as ResourceEnvelope | undefined;
+}
+
+export async function createResource(ns: string, manifest: any) {
+  return getGatewayClient().resources.create({ ns, manifest });
+}
+
+export async function deleteResource(ns: string, kind: string, name: string) {
+  return getGatewayClient().resources.delete({ ns, kind, name });
+}
+
+export async function listSessions(ns: string, agent: string, options?: { signal?: AbortSignal }) {
+  const response = await getGatewayClient().sessions.list({ ns, agent }, options);
+  return response.sessionIds || [];
+}
+
+export async function createSession(ns: string, agent: string) {
+  return getGatewayClient().sessions.create({ ns, agent });
+}
+
+export async function deleteSession(ns: string, agent: string, sessionId: string) {
+  return getGatewayClient().sessions.delete({ ns, agent, sessionId });
+}

--- a/ui/lib/talon/queryKeys.test.ts
+++ b/ui/lib/talon/queryKeys.test.ts
@@ -17,4 +17,13 @@ describe('talonQueryKeys', () => {
     expect(firstTokenKey[1].auth).not.toEqual(secondTokenKey[1].auth);
     expect(JSON.stringify(firstTokenKey)).not.toContain('secret');
   });
+
+  it('nests resource detail keys under namespace resource list keys', () => {
+    const scope = { gatewayUrl: 'http://a', authToken: null };
+    expect(talonQueryKeys.resource(scope, 'demo', 'Agent', 'cmo')).toEqual([
+      ...talonQueryKeys.resources(scope, 'demo', 'Agent'),
+      'detail',
+      'cmo',
+    ]);
+  });
 });

--- a/ui/lib/talon/queryKeys.test.ts
+++ b/ui/lib/talon/queryKeys.test.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import { talonQueryKeys } from './queryKeys';
+
+describe('talonQueryKeys', () => {
+  it('scopes keys by gateway and auth token fingerprint', () => {
+    expect(talonQueryKeys.resources({ gatewayUrl: 'http://a', authToken: null }, 'demo', 'Agent')).toEqual([
+      'talon',
+      { gatewayUrl: 'http://a', auth: 'anon' },
+      'resources',
+      'demo',
+      'Agent',
+    ]);
+    const firstTokenKey = talonQueryKeys.resources({ gatewayUrl: 'http://a', authToken: 'secret' }, 'demo', 'Agent');
+    const secondTokenKey = talonQueryKeys.resources({ gatewayUrl: 'http://a', authToken: 'different' }, 'demo', 'Agent');
+    expect(firstTokenKey[1].auth).toMatch(/^auth:6:/);
+    expect(secondTokenKey[1].auth).toMatch(/^auth:9:/);
+    expect(firstTokenKey[1].auth).not.toEqual(secondTokenKey[1].auth);
+    expect(JSON.stringify(firstTokenKey)).not.toContain('secret');
+  });
+});

--- a/ui/lib/talon/queryKeys.ts
+++ b/ui/lib/talon/queryKeys.ts
@@ -1,0 +1,33 @@
+export type TalonQueryScope = {
+  gatewayUrl: string;
+  authToken?: string | null;
+};
+
+function authFingerprint(token?: string | null) {
+  if (!token) return 'anon';
+  let hash = 0;
+  for (let index = 0; index < token.length; index += 1) {
+    hash = (hash * 31 + token.charCodeAt(index)) >>> 0;
+  }
+  return `auth:${token.length}:${hash.toString(36)}`;
+}
+
+function scopeKey(scope: TalonQueryScope) {
+  return {
+    gatewayUrl: scope.gatewayUrl || '',
+    auth: authFingerprint(scope.authToken),
+  };
+}
+
+export const talonQueryKeys = {
+  all: (scope: TalonQueryScope) => ['talon', scopeKey(scope)] as const,
+  namespaces: (scope: TalonQueryScope, parent: string) => [...talonQueryKeys.all(scope), 'namespaces', parent] as const,
+  resources: (scope: TalonQueryScope, ns: string, kind: string) =>
+    [...talonQueryKeys.all(scope), 'resources', ns, kind] as const,
+  resource: (scope: TalonQueryScope, ns: string, kind: string, name: string) =>
+    [...talonQueryKeys.all(scope), 'resource', ns, kind, name] as const,
+  sessions: (scope: TalonQueryScope, ns: string, agent: string) =>
+    [...talonQueryKeys.all(scope), 'sessions', ns, agent] as const,
+  knowledge: (scope: TalonQueryScope, ns: string, agent: string) =>
+    [...talonQueryKeys.all(scope), 'knowledge', ns, agent] as const,
+};

--- a/ui/lib/talon/queryKeys.ts
+++ b/ui/lib/talon/queryKeys.ts
@@ -25,7 +25,7 @@ export const talonQueryKeys = {
   resources: (scope: TalonQueryScope, ns: string, kind: string) =>
     [...talonQueryKeys.all(scope), 'resources', ns, kind] as const,
   resource: (scope: TalonQueryScope, ns: string, kind: string, name: string) =>
-    [...talonQueryKeys.all(scope), 'resource', ns, kind, name] as const,
+    [...talonQueryKeys.resources(scope, ns, kind), 'detail', name] as const,
   sessions: (scope: TalonQueryScope, ns: string, agent: string) =>
     [...talonQueryKeys.all(scope), 'sessions', ns, agent] as const,
   knowledge: (scope: TalonQueryScope, ns: string, agent: string) =>

--- a/ui/lib/talon/resourceDescriptors.test.ts
+++ b/ui/lib/talon/resourceDescriptors.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import { RESOURCE_DESCRIPTOR_BY_SELECTION, RESOURCE_DESCRIPTORS } from './resourceDescriptors';
+
+describe('resource descriptors', () => {
+  it('keeps supported resource kinds in a registry keyed by selection type', () => {
+    expect(RESOURCE_DESCRIPTORS.map((descriptor) => descriptor.kind)).toEqual(
+      expect.arrayContaining(['McpServer', 'Template', 'Deployment', 'Sandbox']),
+    );
+    expect(RESOURCE_DESCRIPTOR_BY_SELECTION['mcp-server']?.kind).toBe('McpServer');
+    expect(RESOURCE_DESCRIPTOR_BY_SELECTION.template?.kind).toBe('Template');
+    expect(RESOURCE_DESCRIPTOR_BY_SELECTION.sandbox?.sortPrefix).toBe('sandbox');
+  });
+
+  it('maps resource badges without rendering the explorer', () => {
+    const descriptor = RESOURCE_DESCRIPTOR_BY_SELECTION.deployment!;
+    expect(
+      descriptor.badge({
+        kind: 'Deployment',
+        metadata: { name: 'prod', namespace: 'demo' },
+        spec: { kind: { case: 'deployment', value: { templates: [{ name: 'agent' }] } } },
+        status: { kind: { case: 'deployment', value: { phase: '' } } },
+      }),
+    ).toBe('1 templates');
+  });
+});

--- a/ui/lib/talon/resourceDescriptors.ts
+++ b/ui/lib/talon/resourceDescriptors.ts
@@ -1,0 +1,112 @@
+import type { SelectionType } from '../selection';
+import { resourcePhase, resourceSpec, resourceStatus, type ResourceEnvelope } from './resourceMappers';
+
+export type ExplorerIconKey =
+  | 'activity'
+  | 'box'
+  | 'clock'
+  | 'container'
+  | 'cpu'
+  | 'file'
+  | 'folder'
+  | 'hash'
+  | 'layers'
+  | 'message'
+  | 'package'
+  | 'plug'
+  | 'radio'
+  | 'shield';
+
+export type ResourceDescriptor = {
+  kind: string;
+  selectionType: SelectionType;
+  sortPrefix: string;
+  sortWeight: number;
+  icon: ExplorerIconKey;
+  appearsInTree: boolean;
+  hasChildren?: boolean;
+  badge(resource: ResourceEnvelope): string | undefined;
+};
+
+export const RESOURCE_DESCRIPTORS: ResourceDescriptor[] = [
+  {
+    kind: 'McpServer',
+    selectionType: 'mcp-server',
+    sortPrefix: 'mcp-server',
+    sortWeight: 4,
+    icon: 'plug',
+    appearsInTree: true,
+    badge: (resource) => {
+      const spec = resourceSpec(resource, 'mcpServer') as { disabled?: boolean; transport?: string };
+      return spec.disabled ? 'disabled' : spec.transport || 'mcp';
+    },
+  },
+  {
+    kind: 'Template',
+    selectionType: 'template',
+    sortPrefix: 'template',
+    sortWeight: 10,
+    icon: 'file',
+    appearsInTree: true,
+    badge: (resource) => resourceSpec(resource, 'template').kind || 'template',
+  },
+  {
+    kind: 'Deployment',
+    selectionType: 'deployment',
+    sortPrefix: 'deployment',
+    sortWeight: 8,
+    icon: 'layers',
+    appearsInTree: true,
+    badge: (resource) => {
+      const spec = resourceSpec(resource, 'deployment');
+      return resourcePhase(resource, 'deployment') || `${spec.templates?.length || 0} templates`;
+    },
+  },
+  {
+    kind: 'DeploymentReplica',
+    selectionType: 'deployment-replica',
+    sortPrefix: 'deployment-replica',
+    sortWeight: 9,
+    icon: 'package',
+    appearsInTree: true,
+    badge: (resource) => {
+      const spec = resourceSpec(resource, 'deploymentReplica');
+      const status = resourceStatus(resource, 'deploymentReplica');
+      return status.conflicts?.length ? `${status.conflicts.length} conflicts` : spec.targetNamespace || 'replica';
+    },
+  },
+  {
+    kind: 'SandboxClass',
+    selectionType: 'sandbox-class',
+    sortPrefix: 'sandbox-class',
+    sortWeight: 7,
+    icon: 'shield',
+    appearsInTree: true,
+    badge: (resource) => resourceSpec(resource, 'sandboxClass').provider || 'provider',
+  },
+  {
+    kind: 'SandboxPolicy',
+    selectionType: 'sandbox-policy',
+    sortPrefix: 'sandbox-policy',
+    sortWeight: 6,
+    icon: 'box',
+    appearsInTree: true,
+    badge: (resource) => resourceSpec(resource, 'sandboxPolicy').classRef?.name || 'policy',
+  },
+  {
+    kind: 'Sandbox',
+    selectionType: 'sandbox',
+    sortPrefix: 'sandbox',
+    sortWeight: 5,
+    icon: 'container',
+    appearsInTree: true,
+    badge: (resource) => {
+      const status = resourceStatus(resource, 'sandbox');
+      return status.lease?.ownerSessionId ? 'leased' : status.phase || 'sandbox';
+    },
+  },
+];
+
+export const RESOURCE_DESCRIPTOR_BY_SELECTION = Object.fromEntries(
+  RESOURCE_DESCRIPTORS.map((descriptor) => [descriptor.selectionType, descriptor]),
+) as Partial<Record<SelectionType, ResourceDescriptor>>;

--- a/ui/lib/talon/resourceMappers.ts
+++ b/ui/lib/talon/resourceMappers.ts
@@ -1,0 +1,232 @@
+export type ResourceEnvelope = {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    labels?: Record<string, string>;
+  };
+  spec?: {
+    kind?: {
+      case?: string;
+      value?: any;
+    };
+  };
+  status?: {
+    kind?: {
+      case?: string;
+      value?: any;
+    };
+  };
+};
+
+export type ExplorerChannel = {
+  name?: string;
+  ns?: string;
+  title?: string;
+  status?: string;
+  updatedAt?: bigint | number | string;
+  updated_at?: bigint | number | string;
+  labels?: Record<string, string>;
+};
+
+export type ExplorerChannelSubscription = {
+  name?: string;
+  ns?: string;
+  channel?: string;
+  agent?: string;
+  enabled?: boolean;
+  trigger?: string;
+  replyMode?: string;
+  reply_mode?: string;
+};
+
+export type ExplorerSchedule = {
+  name?: string;
+  ns?: string;
+  labels?: Record<string, string>;
+  spec?: {
+    kind?: string;
+    enabled?: boolean;
+  };
+  status?: {
+    nextRunAt?: bigint | number | string;
+    lastError?: string;
+  };
+};
+
+export type ExplorerKnowledge = {
+  metadata?: ResourceEnvelope['metadata'];
+  spec?: {
+    path?: string;
+    content?: string;
+  };
+};
+
+export type ChannelDocument = {
+  name?: string;
+  ns?: string;
+  title?: string;
+  status?: string;
+  metadata?: Record<string, string>;
+  labels?: Record<string, string>;
+};
+
+export type ChannelSubscriptionDocument = {
+  name?: string;
+  ns?: string;
+  channel?: string;
+  agent?: string;
+  enabled?: boolean;
+  trigger?: string;
+  replyMode?: string;
+  contextPolicy?: any;
+};
+
+export type ScheduleDocument = {
+  name?: string;
+  ns?: string;
+  labels?: Record<string, string>;
+  spec?: any;
+  status?: any;
+};
+
+export function resourceSpec(resource: ResourceEnvelope | undefined, caseName: string) {
+  return resource?.spec?.kind?.case === caseName ? resource.spec.kind.value || {} : {};
+}
+
+export function resourceStatus(resource: ResourceEnvelope | undefined, caseName: string) {
+  return resource?.status?.kind?.case === caseName ? resource.status.kind.value || {} : {};
+}
+
+export function resourcePhase(resource: ResourceEnvelope, caseName: string) {
+  return resourceStatus(resource, caseName).phase || '';
+}
+
+export function parseJsonObject(value: string | undefined) {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function resourceMetadata(name: string, namespace: string) {
+  return {
+    name,
+    namespace,
+    labels: {},
+    annotations: {},
+    ownerReferences: [],
+    finalizers: [],
+    generation: BigInt(0),
+    resourceVersion: '',
+    uid: '',
+  };
+}
+
+export function namespaceLabel(labels?: Record<string, string>) {
+  return labels?.workspace_name || labels?.workspace || labels?.display_name || labels?.name;
+}
+
+export function channelFromResource(resource: ResourceEnvelope): ExplorerChannel {
+  const spec = resourceSpec(resource, 'channel');
+  const status = resourceStatus(resource, 'channel');
+  return {
+    name: resource.metadata?.name,
+    ns: resource.metadata?.namespace,
+    title: spec.title,
+    status: status.phase,
+    updatedAt: status.updatedAt,
+    labels: resource.metadata?.labels,
+  };
+}
+
+export function channelDocumentFromResource(resource: ResourceEnvelope): ChannelDocument {
+  const spec = resourceSpec(resource, 'channel');
+  const status = resourceStatus(resource, 'channel');
+  return {
+    name: resource.metadata?.name,
+    ns: resource.metadata?.namespace,
+    title: spec.title,
+    status: status.phase,
+    metadata: spec.metadata,
+    labels: resource.metadata?.labels,
+  };
+}
+
+export function channelSubscriptionFromResource(resource: ResourceEnvelope): ExplorerChannelSubscription {
+  const spec = resourceSpec(resource, 'channelSubscription');
+  return {
+    name: resource.metadata?.name,
+    ns: resource.metadata?.namespace,
+    channel: spec.channel,
+    agent: spec.agent,
+    enabled: spec.enabled,
+    trigger: spec.trigger,
+    replyMode: spec.replyMode,
+  };
+}
+
+export function channelSubscriptionDocumentFromResource(resource: ResourceEnvelope): ChannelSubscriptionDocument {
+  const spec = resourceSpec(resource, 'channelSubscription');
+  return {
+    name: resource.metadata?.name,
+    ns: resource.metadata?.namespace,
+    channel: spec.channel,
+    agent: spec.agent,
+    enabled: spec.enabled,
+    trigger: spec.trigger,
+    replyMode: spec.replyMode,
+    contextPolicy: spec.contextPolicy,
+  };
+}
+
+export function scheduleFromResource(resource: ResourceEnvelope): ExplorerSchedule {
+  return {
+    name: resource.metadata?.name,
+    ns: resource.metadata?.namespace,
+    labels: resource.metadata?.labels,
+    spec: resourceSpec(resource, 'schedule'),
+    status: resourceStatus(resource, 'schedule'),
+  };
+}
+
+export function scheduleDocumentFromResource(resource: ResourceEnvelope): ScheduleDocument {
+  return {
+    name: resource.metadata?.name,
+    ns: resource.metadata?.namespace,
+    labels: resource.metadata?.labels,
+    spec: resourceSpec(resource, 'schedule'),
+    status: resourceStatus(resource, 'schedule'),
+  };
+}
+
+export function knowledgeFromResource(resource: ResourceEnvelope): ExplorerKnowledge {
+  return {
+    metadata: resource.metadata,
+    spec: resourceSpec(resource, 'knowledge'),
+  };
+}
+
+export function templateSummary(resource: ResourceEnvelope) {
+  const spec = resourceSpec(resource, 'template');
+  const targetKind = spec.kind || 'Resource';
+  const targetName = spec.metadata?.name || 'unnamed';
+  const targetSpec = parseJsonObject(spec.specJson);
+  const prompt = typeof targetSpec.systemPrompt === 'string' ? targetSpec.systemPrompt.trim() : '';
+  return prompt ? `${targetKind}/${targetName}: ${prompt.slice(0, 120)}` : `${targetKind}/${targetName}`;
+}
+
+export function isV2ResourceDocument(document: any): document is ResourceEnvelope {
+  return Boolean(
+    document &&
+      typeof document === 'object' &&
+      typeof document.apiVersion === 'string' &&
+      typeof document.kind === 'string' &&
+      document.metadata &&
+      document.spec?.kind?.case,
+  );
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,7 @@
     "@impalasys/talon-client": "workspace:0.1.17",
     "@tailgrids/icons": "^2.0.0",
     "@tailwindcss/postcss": "^4.1.13",
+    "@tanstack/react-query": "^5.101.2",
     "ai": "^5.0.52",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary

Refactors Sightline's explorer around TanStack Query and a modular explorer domain layer, replacing the previous eager/refetch-heavy namespace tree with scoped query keys, typed resource descriptors, pure mappers, and derived tree hooks.

Also hardens the auth/connect flow:

- Auth now renders as a full-screen state fork and unmounts the explorer while open.
- Gateway/token fields submit actual form values, including browser-filled values that do not emit React change events.
- Successful connect updates `connected=true` before closing auth, preventing the URL-sync race that reopened the auth page.
- Connection attempts now probe the gateway, time out, surface gateway/auth errors, and detect expired JWTs.
- Talon query cache is cleared across auth boundary changes and query keys avoid raw token material.
- System Templates and MCP side panels are removed; MCP resources now flow through standard namespace resource descriptors.
- Controlled dialog usage no longer renders React Aria `PressResponder` warnings.

## Root Cause

The explorer mixed server state, UI state, resource mapping, tree derivation, and rendering in one large component. That made it easy to refetch broad scopes, hard to invalidate exact resources, and difficult to add resource kinds without threading conditionals everywhere.

The auth failure was a separate state race: after connect succeeded, the UI closed auth before URL state had `connected=true`, so the URL-read effect could reopen auth immediately. Controlled inputs also made browser/autofill values fragile.

## Validation

- Live in-app browser: fresh local root token + `https://gateway.talon.orb.local` connected, auth page disappeared, URL became `?connected=true...`, and the explorer remained stable after settling.
- `pnpm --dir ui exec jest lib/selection.test.ts lib/talon/queryKeys.test.ts lib/talon/resourceDescriptors.test.ts hooks/useExplorerTree.test.ts --coverage=false`
- `BACKEND_COMMAND='python3 -m http.server 8090' REUSE_EXISTING_SERVER=true WEB_PORT=3002 API_PORT=50051 pnpm --dir ui exec playwright test e2e/app.spec.ts --project=chromium`
- Focused touched-file TypeScript filter was clean.

Full `pnpm --dir ui exec tsc --noEmit` still reports pre-existing repo-wide issues from Jest globals in app TS checking and an unrelated `packages/talon-chat` type error.