### PR TITLE
[codex] Update CLI gateway defaults

### DIFF
--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -160,7 +160,13 @@ pub(crate) fn gateway_http_base(cli: &Cli) -> String {
             return trimmed.trim_end_matches('/').to_string();
         }
     }
-    cli.gateway.trim_end_matches('/').to_string()
+    let gateway = cli.gateway_url();
+    let trimmed = gateway.trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{trimmed}")
+    }
 }
 
 pub(crate) fn stored_auth_path() -> Result<PathBuf> {
@@ -822,16 +828,10 @@ fn api_key_cache_hash(api_key: &str, grant: Option<&str>) -> String {
     general_purpose::URL_SAFE_NO_PAD.encode(hasher.finalize())
 }
 
-fn grpc_web_enabled(cli: &Cli) -> bool {
-    cli.grpc_web
-        || std::env::var("TALON_GRPC_WEB")
-            .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-            .unwrap_or(false)
-}
-
 pub(crate) async fn connect_gateway(cli: &Cli) -> Result<TalonClient> {
-    let mut options = GatewayClientOptions::new(cli.gateway.clone());
-    options.transport = if grpc_web_enabled(cli) {
+    let gateway = cli.gateway_url();
+    let mut options = GatewayClientOptions::new(gateway.clone());
+    options.transport = if cli.grpc_web_enabled() {
         GatewayTransport::GrpcWeb
     } else {
         GatewayTransport::Grpc
@@ -840,7 +840,7 @@ pub(crate) async fn connect_gateway(cli: &Cli) -> Result<TalonClient> {
     TalonClient::connect_with_options(options)
         .await
         .map_err(|err| anyhow::anyhow!("{err}"))
-        .with_context(|| format!("Could not connect to gateway at {}", cli.gateway))
+        .with_context(|| format!("Could not connect to gateway at {gateway}"))
 }
 
 #[cfg(test)]

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -25,13 +25,16 @@ pub(crate) use workflow::WorkflowCommand;
 
 use clap::{Parser, Subcommand};
 
+pub(crate) const DEFAULT_GRPC_GATEWAY: &str = "grpc.talon.impala.systems";
+pub(crate) const DEFAULT_GRPC_WEB_GATEWAY: &str = "talon.impala.systems";
+
 #[derive(Parser)]
 #[command(name = "talon-cli")]
 #[command(about = "Administration CLI for the Talon system", long_about = None)]
 pub(crate) struct Cli {
-    /// gRPC gateway address (e.g. http://localhost:50051)
-    #[arg(long, default_value = "http://localhost:50051")]
-    pub(crate) gateway: String,
+    /// gRPC gateway address (defaults to grpc.talon.impala.systems, or talon.impala.systems with --grpc-web)
+    #[arg(long)]
+    pub(crate) gateway: Option<String>,
 
     /// Gateway password for Basic auth. Uses username "" and password value.
     #[arg(long)]
@@ -59,6 +62,29 @@ pub(crate) struct Cli {
 
     #[command(subcommand)]
     pub(crate) command: Commands,
+}
+
+impl Cli {
+    pub(crate) fn gateway_url(&self) -> String {
+        if let Some(gateway) = self.gateway.as_ref() {
+            return gateway.clone();
+        }
+        if let Ok(env_gateway) = std::env::var("TALON_GATEWAY") {
+            return env_gateway;
+        }
+        if self.grpc_web_enabled() {
+            DEFAULT_GRPC_WEB_GATEWAY.to_string()
+        } else {
+            DEFAULT_GRPC_GATEWAY.to_string()
+        }
+    }
+
+    pub(crate) fn grpc_web_enabled(&self) -> bool {
+        self.grpc_web
+            || std::env::var("TALON_GRPC_WEB")
+                .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+                .unwrap_or(false)
+    }
 }
 
 #[derive(Subcommand)]
@@ -112,4 +138,67 @@ pub(super) async fn run_cli(cli: &Cli) -> Result<RunOutcome> {
     }
 
     Ok(RunOutcome { exit_code: None })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, DEFAULT_GRPC_GATEWAY, DEFAULT_GRPC_WEB_GATEWAY};
+    use clap::Parser;
+
+    fn parse_cli(args: &[&str]) -> Cli {
+        Cli::parse_from(std::iter::once("talon-cli").chain(args.iter().copied()))
+    }
+
+    fn clear_gateway_env() {
+        std::env::remove_var("TALON_GATEWAY");
+        std::env::remove_var("TALON_GRPC_WEB");
+    }
+
+    #[test]
+    fn default_gateway_uses_native_grpc_host() {
+        let _guard = crate::test_support::env_lock();
+        clear_gateway_env();
+
+        let cli = parse_cli(&["auth", "whoami"]);
+
+        assert_eq!(cli.gateway_url(), DEFAULT_GRPC_GATEWAY);
+    }
+
+    #[test]
+    fn grpc_web_default_gateway_uses_web_host() {
+        let _guard = crate::test_support::env_lock();
+        clear_gateway_env();
+
+        let cli = parse_cli(&["--grpc-web", "auth", "whoami"]);
+
+        assert_eq!(cli.gateway_url(), DEFAULT_GRPC_WEB_GATEWAY);
+    }
+
+    #[test]
+    fn explicit_gateway_overrides_grpc_web_default() {
+        let _guard = crate::test_support::env_lock();
+        clear_gateway_env();
+
+        let cli = parse_cli(&[
+            "--grpc-web",
+            "--gateway",
+            "http://localhost:50051",
+            "auth",
+            "whoami",
+        ]);
+
+        assert_eq!(cli.gateway_url(), "http://localhost:50051");
+    }
+
+    #[test]
+    fn talon_gateway_env_overrides_default_gateway() {
+        let _guard = crate::test_support::env_lock();
+        clear_gateway_env();
+        std::env::set_var("TALON_GATEWAY", "http://env-gateway:50051");
+
+        let cli = parse_cli(&["--grpc-web", "auth", "whoami"]);
+
+        assert_eq!(cli.gateway_url(), "http://env-gateway:50051");
+        clear_gateway_env();
+    }
 }

--- a/src/cli/entry.rs
+++ b/src/cli/entry.rs
@@ -6,9 +6,6 @@ pub async fn main() -> Result<()> {
     crate::control::security::install_rustls_crypto_provider();
     let mut cli = Cli::parse();
 
-    if let Ok(env_gateway) = std::env::var("TALON_GATEWAY") {
-        cli.gateway = env_gateway;
-    }
     if cli.password.is_none() {
         cli.password = resolve_gateway_password(&cli);
     }


### PR DESCRIPTION
## Summary

Updates the Talon CLI gateway resolution so the default native gRPC endpoint is `grpc.talon.impala.systems`, while `--grpc-web` defaults to `talon.impala.systems`.

The CLI now resolves the effective gateway after parsing, preserving explicit `--gateway` and `TALON_GATEWAY` overrides. HTTP auth helpers normalize bare hostnames to HTTPS for the hosted defaults.

## Validation

- `cargo test cli::commands::tests --lib`
- `cargo check --bin talon-cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved gateway selection for the CLI, with support for explicit gateway input, environment-based overrides, and automatic defaults for standard and web-based connections.
  * Gateway URLs are now normalized automatically, including adding a secure scheme when needed.

* **Bug Fixes**
  * Fixed gateway connection handling to use the resolved gateway consistently during login and connection errors.
  * Reduced unexpected overrides from environment settings during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->