### PR TITLE
[codex] Fix CLI gateway URL normalization

### DIFF
--- a/sdk/rust/talon-client/src/client.rs
+++ b/sdk/rust/talon-client/src/client.rs
@@ -215,7 +215,7 @@ fn unix_timestamp() -> u64 {
 }
 
 async fn connect_native(options: GatewayClientOptions) -> Result<NativeTalonClient, BoxError> {
-    let endpoint_url = native_endpoint_url(&options.endpoint);
+    let endpoint_url = endpoint_url(&options.endpoint);
     if options
         .api_key
         .as_deref()
@@ -244,7 +244,7 @@ async fn connect_native(options: GatewayClientOptions) -> Result<NativeTalonClie
     Ok(TalonClientset::from_service(service))
 }
 
-fn native_endpoint_url(endpoint: &str) -> String {
+fn endpoint_url(endpoint: &str) -> String {
     let endpoint = endpoint.trim();
     if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
         return endpoint.to_string();
@@ -261,31 +261,31 @@ fn native_endpoint_url(endpoint: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{native_endpoint_url, GatewayClientOptions, NativeTalonClient};
+    use super::{endpoint_url, GatewayClientOptions, NativeTalonClient};
 
     #[test]
-    fn native_endpoint_url_defaults_hosted_gateways_to_https() {
+    fn endpoint_url_defaults_hosted_gateways_to_https() {
         assert_eq!(
-            native_endpoint_url("talon.impala.systems"),
+            endpoint_url("talon.impala.systems"),
             "https://talon.impala.systems"
         );
         assert_eq!(
-            native_endpoint_url(" https://talon.impala.systems:443 "),
+            endpoint_url(" https://talon.impala.systems:443 "),
             "https://talon.impala.systems:443"
         );
     }
 
     #[test]
-    fn native_endpoint_url_keeps_local_gateways_on_http() {
+    fn endpoint_url_keeps_local_gateways_on_http() {
         assert_eq!(
-            native_endpoint_url("localhost:50051"),
+            endpoint_url("localhost:50051"),
             "http://localhost:50051"
         );
         assert_eq!(
-            native_endpoint_url("127.0.0.1:50051"),
+            endpoint_url("127.0.0.1:50051"),
             "http://127.0.0.1:50051"
         );
-        assert_eq!(native_endpoint_url("[::1]:50051"), "http://[::1]:50051");
+        assert_eq!(endpoint_url("[::1]:50051"), "http://[::1]:50051");
     }
 
     #[tokio::test]
@@ -329,7 +329,9 @@ impl GrpcWebHttpService {
         }
         Ok(Self {
             client: builder.build()?,
-            endpoint: options.endpoint.trim_end_matches('/').to_string(),
+            endpoint: endpoint_url(&options.endpoint)
+                .trim_end_matches('/')
+                .to_string(),
             authorization: options.authorization,
         })
     }

--- a/sdk/rust/talon-client/tests/generated.rs
+++ b/sdk/rust/talon-client/tests/generated.rs
@@ -103,7 +103,7 @@ async fn grpc_web_talon_client_uses_http1_grpc_web_requests() {
             .expect("write response body");
     });
 
-    let gateway = format!("http://{addr}");
+    let gateway = addr.to_string();
     let mut client = talon_client::GrpcWebTalonClient::connect_grpc_web(gateway)
         .expect("connect gRPC-Web client");
     let response = client

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -160,10 +160,19 @@ pub(crate) fn gateway_http_base(cli: &Cli) -> String {
             return trimmed.trim_end_matches('/').to_string();
         }
     }
-    let gateway = cli.gateway_url();
-    let trimmed = gateway.trim_end_matches('/');
+    gateway_http_base_from_endpoint(&cli.gateway_url())
+}
+
+fn gateway_http_base_from_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim().trim_end_matches('/');
     if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
         trimmed.to_string()
+    } else if trimmed.starts_with("localhost:")
+        || trimmed.starts_with("127.")
+        || trimmed.starts_with("0.0.0.0:")
+        || trimmed.starts_with("[::1]:")
+    {
+        format!("http://{trimmed}")
     } else {
         format!("https://{trimmed}")
     }
@@ -846,11 +855,14 @@ pub(crate) async fn connect_gateway(cli: &Cli) -> Result<TalonClient> {
 #[cfg(test)]
 mod tests {
     use super::{
-        api_key_cache_hash, google_token_request_form, mint_namespace_jwt, parse_ttl_seconds,
+        api_key_cache_hash, gateway_http_base, gateway_http_base_from_endpoint,
+        google_token_request_form, mint_namespace_jwt, parse_ttl_seconds,
         resolve_token_ttl_seconds, StoredGatewayAuth, DEFAULT_GOOGLE_CLI_CLIENT_SECRET,
         DEFAULT_TOKEN_TTL,
     };
+    use crate::cli::commands::Cli;
     use crate::gateway::auth::verify_jwt;
+    use clap::Parser;
 
     #[test]
     fn google_token_request_form_includes_client_secret_when_present() {
@@ -883,6 +895,47 @@ mod tests {
             DEFAULT_GOOGLE_CLI_CLIENT_SECRET,
             option_env!("TALON_GOOGLE_CLIENT_SECRET")
         );
+    }
+
+    #[test]
+    fn gateway_http_base_defaults_hosted_gateways_to_https() {
+        assert_eq!(
+            gateway_http_base_from_endpoint("talon.impala.systems"),
+            "https://talon.impala.systems"
+        );
+    }
+
+    #[test]
+    fn gateway_http_base_keeps_local_gateways_on_http() {
+        assert_eq!(
+            gateway_http_base_from_endpoint("localhost:50051"),
+            "http://localhost:50051"
+        );
+        assert_eq!(
+            gateway_http_base_from_endpoint("127.0.0.1:50051"),
+            "http://127.0.0.1:50051"
+        );
+        assert_eq!(
+            gateway_http_base_from_endpoint("[::1]:50051"),
+            "http://[::1]:50051"
+        );
+    }
+
+    #[test]
+    fn gateway_http_base_uses_cli_gateway_inference() {
+        let _guard = crate::test_support::env_lock();
+        std::env::remove_var("TALON_GATEWAY");
+        std::env::remove_var("TALON_GATEWAY_URL");
+        std::env::remove_var("TALON_GRPC_WEB");
+        let cli = Cli::parse_from([
+            "talon-cli",
+            "--gateway",
+            "localhost:50051",
+            "auth",
+            "whoami",
+        ]);
+
+        assert_eq!(gateway_http_base(&cli), "http://localhost:50051");
     }
 
     #[test]

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -70,7 +70,10 @@ impl Cli {
             return gateway.clone();
         }
         if let Ok(env_gateway) = std::env::var("TALON_GATEWAY") {
-            return env_gateway;
+            let env_gateway = env_gateway.trim();
+            if !env_gateway.is_empty() {
+                return env_gateway.to_string();
+            }
         }
         if self.grpc_web_enabled() {
             DEFAULT_GRPC_WEB_GATEWAY.to_string()
@@ -199,6 +202,18 @@ mod tests {
         let cli = parse_cli(&["--grpc-web", "auth", "whoami"]);
 
         assert_eq!(cli.gateway_url(), "http://env-gateway:50051");
+        clear_gateway_env();
+    }
+
+    #[test]
+    fn blank_talon_gateway_env_falls_back_to_default_gateway() {
+        let _guard = crate::test_support::env_lock();
+        clear_gateway_env();
+        std::env::set_var("TALON_GATEWAY", " ");
+
+        let cli = parse_cli(&["auth", "whoami"]);
+
+        assert_eq!(cli.gateway_url(), DEFAULT_GRPC_GATEWAY);
         clear_gateway_env();
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #86 addressing the AI reviewer concerns after the default gateway change merged.

- Normalize bare gRPC-Web endpoints in the Rust SDK before requests are built, matching the native gRPC inference rules.
- Keep bare local gateway hosts on `http://` for CLI HTTP auth flows instead of forcing HTTPS.
- Ignore blank `TALON_GATEWAY` values so defaults still apply.
- Add regression coverage for the reviewed cases, including a gRPC-Web request using a bare local address.

## Validation

- `cargo test cli::commands::tests --lib`
- `cargo test gateway_http_base --lib`
- `cargo test --manifest-path sdk/rust/talon-client/Cargo.toml endpoint_url`
- `cargo test --manifest-path sdk/rust/talon-client/Cargo.toml grpc_web_talon_client_uses_http1_grpc_web_requests`
- `cargo check --bin talon-cli`
- `cargo check --manifest-path sdk/rust/talon-client/Cargo.toml`