### PR TITLE
[codex] Support multi-document apply manifests

### DIFF
--- a/src/cli/cli_render_tests.rs
+++ b/src/cli/cli_render_tests.rs
@@ -57,4 +57,69 @@ metadata:
 
         assert!(rendered.trim().is_empty());
     }
+
+    #[test]
+    fn render_manifest_file_resolves_content_from_file_in_multi_document_yaml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let knowledge_path = dir.path().join("guide.md");
+        std::fs::write(&knowledge_path, "hello from file").expect("write knowledge");
+        let manifest_path = dir.path().join("stack.yaml");
+        std::fs::write(
+            &manifest_path,
+            r#"
+apiVersion: talon.impalasys.com/v1
+kind: Namespace
+metadata:
+  name: demo
+---
+apiVersion: talon.impalasys.com/v1
+kind: Knowledge
+metadata:
+  namespace: demo
+  name: guide
+spec:
+  path: guide.md
+  contentFromFile: guide.md
+"#,
+        )
+        .expect("write manifest");
+
+        let rendered =
+            render_manifest_file(manifest_path.to_str().unwrap(), &[]).expect("render manifest");
+
+        assert!(rendered.contains("content: hello from file"));
+        assert!(!rendered.contains("contentFromFile"));
+        assert!(!rendered.contains("---\n---"));
+    }
+
+    #[test]
+    fn resolve_manifest_sources_allows_non_mapping_documents() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let knowledge_path = dir.path().join("guide.md");
+        std::fs::write(&knowledge_path, "hello from file").expect("write knowledge");
+        let manifest_path = dir.path().join("stack.yaml");
+        std::fs::write(&manifest_path, "").expect("write manifest");
+
+        let rendered = resolve_manifest_sources(
+            manifest_path.to_str().unwrap(),
+            r#"
+- just
+- a
+- list
+---
+apiVersion: talon.impalasys.com/v1
+kind: Knowledge
+metadata:
+  namespace: demo
+  name: guide
+spec:
+  path: guide.md
+  contentFromFile: guide.md
+"#,
+        )
+        .expect("resolve sources");
+
+        assert!(rendered.contains("- just"));
+        assert!(rendered.contains("content: hello from file"));
+    }
 }

--- a/src/cli/commands/apply.rs
+++ b/src/cli/commands/apply.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use anyhow::{Context, Result};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -12,7 +13,9 @@ use crate::gateway::rpc::resources_proto;
 use talon_client::v1::{CreateNamespaceRequest, CreateResourceRequest};
 
 use super::Cli;
-use crate::cli::{connect_gateway, parse_raw_manifest, render_manifest_file, to_sdk_resource_manifest};
+use crate::cli::{
+    connect_gateway, parse_raw_manifest, render_manifest_file, to_sdk_resource_manifest,
+};
 
 #[derive(clap::Args)]
 pub(crate) struct ApplyCommand {
@@ -213,6 +216,10 @@ fn resource_manifest_from_manifest(
 fn reject_status_field(content: &str) -> Result<()> {
     let value: serde_yaml::Value =
         serde_yaml::from_str(content).context("Failed to parse resource manifest YAML")?;
+    reject_status_field_in_value(&value)
+}
+
+fn reject_status_field_in_value(value: &serde_yaml::Value) -> Result<()> {
     let has_status = value
         .as_mapping()
         .map(|mapping| mapping.contains_key(serde_yaml::Value::String("status".to_string())))
@@ -258,6 +265,22 @@ fn build_apply_plan(content: &str) -> Result<ApplyPlan> {
     }
 }
 
+fn build_apply_plans(content: &str) -> Result<Vec<ApplyPlan>> {
+    let mut plans = Vec::new();
+    for document in serde_yaml::Deserializer::from_str(content) {
+        let value = serde_yaml::Value::deserialize(document)
+            .context("Failed to parse resource manifest YAML")?;
+        if matches!(value, serde_yaml::Value::Null) {
+            continue;
+        }
+        reject_status_field_in_value(&value)?;
+        let document =
+            serde_yaml::to_string(&value).context("Failed to serialize YAML document")?;
+        plans.push(build_apply_plan(&document)?);
+    }
+    Ok(plans)
+}
+
 fn plan_namespace_to_ensure(plan: &ApplyPlan) -> Option<&str> {
     match plan {
         ApplyPlan::Resource { ns, .. } => Some(ns.as_str())
@@ -268,50 +291,54 @@ fn plan_namespace_to_ensure(plan: &ApplyPlan) -> Option<&str> {
 }
 
 pub(super) async fn apply_manifest(cli: &Cli, content: &str) -> Result<String> {
-    let plan = build_apply_plan(content)?;
+    let plans = build_apply_plans(content)?;
     let mut client = connect_gateway(cli).await?;
-    if let Some(namespace) = plan_namespace_to_ensure(&plan) {
-        client
-            .create_namespace(CreateNamespaceRequest {
-                name: namespace.to_string(),
-                recursive: true,
-                labels: HashMap::new(),
-            })
-            .await
-            .with_context(|| format!("Gateway rejected implicit Namespace '{}'", namespace))?;
-    }
-
-    match plan {
-        ApplyPlan::Namespace { name, labels } => {
+    let mut messages = Vec::new();
+    for plan in plans {
+        if let Some(namespace) = plan_namespace_to_ensure(&plan) {
             client
                 .create_namespace(CreateNamespaceRequest {
-                    name: name.clone(),
+                    name: namespace.to_string(),
                     recursive: true,
-                    labels,
+                    labels: HashMap::new(),
                 })
                 .await
-                .with_context(|| format!("Gateway rejected Namespace '{}'", name))?;
-            Ok(format!("✓ Namespace '{}' applied successfully.", name))
+                .with_context(|| format!("Gateway rejected implicit Namespace '{}'", namespace))?;
         }
-        ApplyPlan::Resource {
-            ns,
-            kind,
-            name,
-            manifest,
-        } => {
-            client
-                .create_resource(CreateResourceRequest {
-                    ns: ns.clone(),
-                    manifest: Some(to_sdk_resource_manifest(&manifest)?),
-                })
-                .await
-                .with_context(|| format!("Gateway rejected {} '{}/{}'", kind, ns, name))?;
-            Ok(format!(
-                "✓ {} '{}/{}' applied successfully.",
-                kind, ns, name
-            ))
+
+        match plan {
+            ApplyPlan::Namespace { name, labels } => {
+                client
+                    .create_namespace(CreateNamespaceRequest {
+                        name: name.clone(),
+                        recursive: true,
+                        labels,
+                    })
+                    .await
+                    .with_context(|| format!("Gateway rejected Namespace '{}'", name))?;
+                messages.push(format!("✓ Namespace '{}' applied successfully.", name));
+            }
+            ApplyPlan::Resource {
+                ns,
+                kind,
+                name,
+                manifest,
+            } => {
+                client
+                    .create_resource(CreateResourceRequest {
+                        ns: ns.clone(),
+                        manifest: Some(to_sdk_resource_manifest(&manifest)?),
+                    })
+                    .await
+                    .with_context(|| format!("Gateway rejected {} '{}/{}'", kind, ns, name))?;
+                messages.push(format!(
+                    "✓ {} '{}/{}' applied successfully.",
+                    kind, ns, name
+                ));
+            }
         }
     }
+    Ok(messages.join("\n"))
 }
 
 #[cfg(test)]
@@ -360,11 +387,64 @@ mod tests {
 
     #[test]
     fn worker_manifest_is_not_user_authorable() {
-        let err = build_apply_plan(
+        let err = build_apply_plans(
             "apiVersion: talon.impalasys.com/v1\nkind: Worker\nmetadata:\n  name: worker-a\n",
         )
         .expect_err("Worker manifests should not be accepted by apply");
 
         assert!(err.to_string().contains("Unsupported manifest kind"));
+    }
+
+    #[test]
+    fn build_apply_plans_accepts_multi_document_yaml() {
+        let plans = build_apply_plans(
+            r#"
+apiVersion: talon.impalasys.com/v1
+kind: Namespace
+metadata:
+  name: demo
+---
+apiVersion: talon.impalasys.com/v1
+kind: Knowledge
+metadata:
+  namespace: demo
+  name: guide
+spec:
+  path: guide.md
+  content: hello
+---
+"#,
+        )
+        .expect("multi-document YAML should plan");
+
+        assert_eq!(plans.len(), 2);
+        assert!(matches!(plans[0], ApplyPlan::Namespace { .. }));
+        assert!(matches!(plans[1], ApplyPlan::Resource { .. }));
+    }
+
+    #[test]
+    fn build_apply_plans_rejects_status_in_any_document() {
+        let err = build_apply_plans(
+            r#"
+apiVersion: talon.impalasys.com/v1
+kind: Namespace
+metadata:
+  name: demo
+---
+apiVersion: talon.impalasys.com/v1
+kind: Knowledge
+metadata:
+  namespace: demo
+  name: guide
+spec:
+  path: guide.md
+  content: hello
+status:
+  phase: ready
+"#,
+        )
+        .expect_err("status should be rejected in a YAML stream");
+
+        assert!(err.to_string().contains("status is controller-owned"));
     }
 }

--- a/src/cli/commands/apply.rs
+++ b/src/cli/commands/apply.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -13,9 +13,7 @@ use crate::gateway::rpc::resources_proto;
 use talon_client::v1::{CreateNamespaceRequest, CreateResourceRequest};
 
 use super::Cli;
-use crate::cli::{
-    connect_gateway, parse_raw_manifest, render_manifest_file, to_sdk_resource_manifest,
-};
+use crate::cli::{connect_gateway, render_manifest_file, to_sdk_resource_manifest};
 
 #[derive(clap::Args)]
 pub(crate) struct ApplyCommand {
@@ -36,7 +34,7 @@ pub(super) async fn run(cli: &Cli, command: &ApplyCommand) -> Result<()> {
             continue;
         }
 
-        println!("{}", apply_manifest(cli, &content).await?);
+        apply_manifest(cli, &content).await?;
     }
     Ok(())
 }
@@ -105,12 +103,11 @@ fn is_generic_resource_kind(kind: &str) -> bool {
 }
 
 fn resource_manifest_from_manifest(
+    raw: &crate::control::manifest::RawManifest,
     content: &str,
 ) -> Result<(String, String, String, resources_proto::ResourceManifest)> {
     use resources_proto::resource_spec::Kind as SpecKind;
 
-    let raw = parse_raw_manifest(content)?;
-    reject_status_field(content)?;
     let mut manifest = match raw.kind.as_str() {
         "MCPServer" | "McpServer" => {
             let server = crate::control::manifest::parse_mcp_server(content)?;
@@ -213,12 +210,6 @@ fn resource_manifest_from_manifest(
     ))
 }
 
-fn reject_status_field(content: &str) -> Result<()> {
-    let value: serde_yaml::Value =
-        serde_yaml::from_str(content).context("Failed to parse resource manifest YAML")?;
-    reject_status_field_in_value(&value)
-}
-
 fn reject_status_field_in_value(value: &serde_yaml::Value) -> Result<()> {
     let has_status = value
         .as_mapping()
@@ -244,17 +235,21 @@ enum ApplyPlan {
     },
 }
 
-fn build_apply_plan(content: &str) -> Result<ApplyPlan> {
-    match parse_raw_manifest(content)?.kind.as_str() {
+fn build_apply_plan_from_value(value: serde_yaml::Value) -> Result<ApplyPlan> {
+    reject_status_field_in_value(&value)?;
+    let raw: crate::control::manifest::RawManifest =
+        serde_yaml::from_value(value.clone()).context("Failed to parse manifest YAML")?;
+    let document = serde_yaml::to_string(&value).context("Failed to serialize YAML document")?;
+    match raw.kind.as_str() {
         "Namespace" => {
-            let namespace = crate::control::manifest::parse_namespace(content)?;
+            let namespace = crate::control::manifest::parse_namespace(&document)?;
             Ok(ApplyPlan::Namespace {
                 name: namespace.name().to_string(),
                 labels: namespace.labels().clone(),
             })
         }
         _ => {
-            let (ns, kind, name, manifest) = resource_manifest_from_manifest(content)?;
+            let (ns, kind, name, manifest) = resource_manifest_from_manifest(&raw, &document)?;
             Ok(ApplyPlan::Resource {
                 ns,
                 kind,
@@ -273,10 +268,7 @@ fn build_apply_plans(content: &str) -> Result<Vec<ApplyPlan>> {
         if matches!(value, serde_yaml::Value::Null) {
             continue;
         }
-        reject_status_field_in_value(&value)?;
-        let document =
-            serde_yaml::to_string(&value).context("Failed to serialize YAML document")?;
-        plans.push(build_apply_plan(&document)?);
+        plans.push(build_apply_plan_from_value(value)?);
     }
     Ok(plans)
 }
@@ -290,20 +282,24 @@ fn plan_namespace_to_ensure(plan: &ApplyPlan) -> Option<&str> {
     }
 }
 
-pub(super) async fn apply_manifest(cli: &Cli, content: &str) -> Result<String> {
+pub(super) async fn apply_manifest(cli: &Cli, content: &str) -> Result<()> {
     let plans = build_apply_plans(content)?;
     let mut client = connect_gateway(cli).await?;
-    let mut messages = Vec::new();
+    let mut ensured_namespaces = HashSet::new();
     for plan in plans {
         if let Some(namespace) = plan_namespace_to_ensure(&plan) {
-            client
-                .create_namespace(CreateNamespaceRequest {
-                    name: namespace.to_string(),
-                    recursive: true,
-                    labels: HashMap::new(),
-                })
-                .await
-                .with_context(|| format!("Gateway rejected implicit Namespace '{}'", namespace))?;
+            if ensured_namespaces.insert(namespace.to_string()) {
+                client
+                    .create_namespace(CreateNamespaceRequest {
+                        name: namespace.to_string(),
+                        recursive: true,
+                        labels: HashMap::new(),
+                    })
+                    .await
+                    .with_context(|| {
+                        format!("Gateway rejected implicit Namespace '{}'", namespace)
+                    })?;
+            }
         }
 
         match plan {
@@ -316,7 +312,7 @@ pub(super) async fn apply_manifest(cli: &Cli, content: &str) -> Result<String> {
                     })
                     .await
                     .with_context(|| format!("Gateway rejected Namespace '{}'", name))?;
-                messages.push(format!("✓ Namespace '{}' applied successfully.", name));
+                println!("✓ Namespace '{}' applied successfully.", name);
             }
             ApplyPlan::Resource {
                 ns,
@@ -331,14 +327,11 @@ pub(super) async fn apply_manifest(cli: &Cli, content: &str) -> Result<String> {
                     })
                     .await
                     .with_context(|| format!("Gateway rejected {} '{}/{}'", kind, ns, name))?;
-                messages.push(format!(
-                    "✓ {} '{}/{}' applied successfully.",
-                    kind, ns, name
-                ));
+                println!("✓ {} '{}/{}' applied successfully.", kind, ns, name);
             }
         }
     }
-    Ok(messages.join("\n"))
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/cli/manifest_render.rs
+++ b/src/cli/manifest_render.rs
@@ -31,14 +31,36 @@ pub(super) fn render_manifest_file(file: &str, vars: &[String]) -> Result<String
 }
 
 fn resolve_manifest_sources(file: &str, rendered: &str) -> Result<String> {
-    let raw = parse_raw_manifest(rendered)?;
-    if raw.kind != "Knowledge" {
-        return Ok(rendered.to_string());
+    let mut documents = Vec::new();
+    let mut changed = false;
+    for document in serde_yaml::Deserializer::from_str(rendered) {
+        let mut manifest: serde_yaml::Value = serde_yaml::Value::deserialize(document)
+            .context("Failed to parse rendered manifest")?;
+        if matches!(manifest, serde_yaml::Value::Null) {
+            continue;
+        }
+
+        let raw: crate::control::manifest::RawManifest =
+            serde_yaml::from_value(manifest.clone()).context("Failed to parse manifest YAML")?;
+        if raw.kind == "Knowledge" {
+            resolve_knowledge_manifest_sources(file, &mut manifest)?;
+            changed = true;
+        }
+
+        documents.push(
+            serde_yaml::to_string(&manifest).context("Failed to serialize rendered manifest")?,
+        );
     }
 
-    let mut manifest: serde_yaml::Value =
-        serde_yaml::from_str(rendered).context("Failed to parse rendered Knowledge manifest")?;
-    let file_manifest: KnowledgeManifestFile = serde_yaml::from_str(rendered)
+    if changed {
+        Ok(documents.join("---\n"))
+    } else {
+        Ok(rendered.to_string())
+    }
+}
+
+fn resolve_knowledge_manifest_sources(file: &str, manifest: &mut serde_yaml::Value) -> Result<()> {
+    let file_manifest: KnowledgeManifestFile = serde_yaml::from_value(manifest.clone())
         .context("Failed to parse Knowledge manifest source directives")?;
 
     let content = match (
@@ -75,7 +97,7 @@ fn resolve_manifest_sources(file: &str, rendered: &str) -> Result<String> {
         );
     }
 
-    serde_yaml::to_string(&manifest).context("Failed to serialize resolved Knowledge manifest")
+    Ok(())
 }
 
 fn canonicalize_manifest_path(base_dir: &Path, raw_path: &str) -> PathBuf {

--- a/src/cli/manifest_render.rs
+++ b/src/cli/manifest_render.rs
@@ -40,11 +40,14 @@ fn resolve_manifest_sources(file: &str, rendered: &str) -> Result<String> {
             continue;
         }
 
-        let raw: crate::control::manifest::RawManifest =
-            serde_yaml::from_value(manifest.clone()).context("Failed to parse manifest YAML")?;
-        if raw.kind == "Knowledge" {
-            resolve_knowledge_manifest_sources(file, &mut manifest)?;
-            changed = true;
+        if manifest.is_mapping() {
+            let raw: crate::control::manifest::RawManifest =
+                serde_yaml::from_value(manifest.clone())
+                    .context("Failed to parse manifest YAML")?;
+            if raw.kind == "Knowledge" {
+                resolve_knowledge_manifest_sources(file, &mut manifest)?;
+                changed = true;
+            }
         }
 
         documents.push(
@@ -53,7 +56,7 @@ fn resolve_manifest_sources(file: &str, rendered: &str) -> Result<String> {
     }
 
     if changed {
-        Ok(documents.join("---\n"))
+        Ok(documents.concat())
     } else {
         Ok(rendered.to_string())
     }


### PR DESCRIPTION
## Summary

Adds support for Kubernetes-style multi-document YAML streams in `talon apply`, so a single `-f` file can contain multiple resources separated by `---`.

## Details

- Parses rendered apply input with `serde_yaml::Deserializer` and builds one apply plan per non-empty document.
- Applies documents in file order while reusing one gateway client connection.
- Preserves status-field rejection for every document in the stream.
- Updates render-time manifest source resolution so `Knowledge.spec.contentFromFile` still works inside multi-document YAML files.

## Validation

- `cargo test -q cli::commands::apply::tests`
- `cargo test -q cli::cli_render_tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI now supports YAML streams with multiple documents when rendering and applying manifests.
  * File-based content in knowledge manifests is now inlined into the rendered output.

* **Bug Fixes**
  * Improved handling of non-mapping YAML documents in manifest rendering.
  * Removed extra empty document separators in rendered multi-document output.
  * Apply operations now reject `status` fields consistently across all documents in a YAML stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->