### PR TITLE
[codex] Enforce rustfmt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -47,6 +49,9 @@ jobs:
 
       - name: Cargo metadata
         run: cargo metadata --locked
+
+      - name: Cargo fmt
+        run: cargo fmt --all --check
 
       - name: Cargo build
         run: cargo build --locked --bins
@@ -175,6 +180,8 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -229,7 +236,10 @@ jobs:
           (cd sdk/go/talon-server && go test ./...)
 
       - name: Test Rust SDKs
-        run: cargo test --manifest-path sdk/rust/Cargo.toml
+        run: |
+          cargo fmt --manifest-path sdk/rust/Cargo.toml --all --check
+          cargo fmt --manifest-path sdk/examples/rust/Cargo.toml --all --check
+          cargo test --manifest-path sdk/rust/Cargo.toml
 
       - name: Test Java SDKs
         working-directory: sdk/java

--- a/sdk/examples/rust/src/main.rs
+++ b/sdk/examples/rust/src/main.rs
@@ -10,7 +10,8 @@ use talon_server::{Options, Server};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let server = Server::start(Options::default())?;
-    let mut client = NativeTalonClient::connect(format!("http://{}", server.grpc_endpoint())).await?;
+    let mut client =
+        NativeTalonClient::connect(format!("http://{}", server.grpc_endpoint())).await?;
 
     client
         .namespaces

--- a/sdk/rust/talon-client/src/client.rs
+++ b/sdk/rust/talon-client/src/client.rs
@@ -277,14 +277,8 @@ mod tests {
 
     #[test]
     fn endpoint_url_keeps_local_gateways_on_http() {
-        assert_eq!(
-            endpoint_url("localhost:50051"),
-            "http://localhost:50051"
-        );
-        assert_eq!(
-            endpoint_url("127.0.0.1:50051"),
-            "http://127.0.0.1:50051"
-        );
+        assert_eq!(endpoint_url("localhost:50051"), "http://localhost:50051");
+        assert_eq!(endpoint_url("127.0.0.1:50051"), "http://127.0.0.1:50051");
         assert_eq!(endpoint_url("[::1]:50051"), "http://[::1]:50051");
     }
 


### PR DESCRIPTION
## Summary

- Install the `rustfmt` component in Rust CI jobs that need formatting checks.
- Add `cargo fmt --all --check` to the main Cargo job.
- Add Rust SDK and Rust example formatting checks to the SDK job.
- Apply rustfmt output to the existing Rust SDK/client example sources.

## Impact

Rust formatting is now enforced in CI, including checked-in generated SDK Rust files that are included by the SDK crate. Future formatting drift should fail early in pull requests.

## Validation

- `cargo fmt --all --check`
- `cargo fmt --manifest-path sdk/rust/Cargo.toml --all --check`
- `cargo fmt --manifest-path sdk/examples/rust/Cargo.toml --all --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Rust formatting checks to continuous integration, helping catch style issues earlier in builds and tests.
* **Tests**
  * Expanded Rust validation to verify formatting for SDK projects before running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->