### PR TITLE
[codex] Support custom MCP HTTP headers

### DIFF
--- a/src/harness/mcp/mod.rs
+++ b/src/harness/mcp/mod.rs
@@ -97,18 +97,19 @@ impl McpClient {
         })
     }
 
-    pub async fn connect_http(target: &str, headers: &HashMap<String, String>) -> Result<Self> {
-        validate_http_headers(headers)?;
-        let mut transport_config =
-            StreamableHttpClientTransportConfig::with_uri(target.to_string());
-
-        let auth_header = authorization_bearer_token(headers)?;
-        if let Some(auth_header) = auth_header.clone() {
-            transport_config = transport_config.auth_header(auth_header);
-        }
+    pub async fn connect_http(
+        target: &str,
+        default_headers: reqwest::header::HeaderMap,
+    ) -> Result<Self> {
+        let transport_config = StreamableHttpClientTransportConfig::with_uri(target.to_string());
 
         let transport = StreamableHttpClientTransport::with_client(
-            AuthenticatedReqwestClient::new(reqwest::Client::default(), auth_header),
+            AuthenticatedReqwestClient::new(
+                reqwest::Client::builder()
+                    .default_headers(default_headers)
+                    .build()?,
+                None,
+            ),
             transport_config,
         );
         let service = ().serve(transport).await?;
@@ -268,6 +269,13 @@ impl AuthenticatedReqwestClient {
         }
         request_builder
     }
+
+    fn has_authorization_header(custom_headers: &HashMap<HeaderName, HeaderValue>) -> bool {
+        // Used before applying rmcp bearer-token fallback so explicit request auth wins.
+        custom_headers
+            .keys()
+            .any(|name| name.as_str().eq_ignore_ascii_case("authorization"))
+    }
 }
 
 pub(crate) fn content_type_matches(value: &reqwest::header::HeaderValue, expected: &str) -> bool {
@@ -295,12 +303,14 @@ impl StreamableHttpClient for AuthenticatedReqwestClient {
             .get(uri.as_ref())
             .header(ACCEPT, MCP_EVENT_STREAM_MIME_TYPE)
             .header(MCP_HEADER_SESSION_ID, session_id.as_ref());
+        if !Self::has_authorization_header(&custom_headers) {
+            if let Some(auth_header) = self.bearer_token(auth_token) {
+                request_builder = request_builder.bearer_auth(auth_header);
+            }
+        }
         request_builder = Self::apply_custom_headers(request_builder, custom_headers);
         if let Some(last_event_id) = last_event_id {
             request_builder = request_builder.header(MCP_HEADER_LAST_EVENT_ID, last_event_id);
-        }
-        if let Some(auth_header) = self.bearer_token(auth_token) {
-            request_builder = request_builder.bearer_auth(auth_header);
         }
 
         let response = request_builder
@@ -334,10 +344,12 @@ impl StreamableHttpClient for AuthenticatedReqwestClient {
         custom_headers: HashMap<HeaderName, HeaderValue>,
     ) -> Result<(), StreamableHttpError<Self::Error>> {
         let mut request_builder = self.inner.delete(uri.as_ref());
-        request_builder = Self::apply_custom_headers(request_builder, custom_headers);
-        if let Some(auth_header) = self.bearer_token(auth_token) {
-            request_builder = request_builder.bearer_auth(auth_header);
+        if !Self::has_authorization_header(&custom_headers) {
+            if let Some(auth_header) = self.bearer_token(auth_token) {
+                request_builder = request_builder.bearer_auth(auth_header);
+            }
         }
+        request_builder = Self::apply_custom_headers(request_builder, custom_headers);
 
         let response = request_builder
             .header(MCP_HEADER_SESSION_ID, session.as_ref())
@@ -368,10 +380,12 @@ impl StreamableHttpClient for AuthenticatedReqwestClient {
             .inner
             .post(uri.as_ref())
             .header(ACCEPT, MCP_POST_ACCEPT_HEADER);
-        request = Self::apply_custom_headers(request, custom_headers);
-        if let Some(auth_header) = self.bearer_token(auth_token) {
-            request = request.bearer_auth(auth_header);
+        if !Self::has_authorization_header(&custom_headers) {
+            if let Some(auth_header) = self.bearer_token(auth_token) {
+                request = request.bearer_auth(auth_header);
+            }
         }
+        request = Self::apply_custom_headers(request, custom_headers);
         if let Some(session_id) = session_id {
             request = request.header(MCP_HEADER_SESSION_ID, session_id.as_ref());
         }
@@ -463,7 +477,7 @@ async fn connect_configured(config: &McpConnectionConfig) -> Result<McpClient> {
         }
         "http" => {
             let headers = resolve_http_headers(config).await?;
-            McpClient::connect_http(&config.target, &headers).await
+            McpClient::connect_http(&config.target, headers).await
         }
         other => Err(anyhow!(
             "Unsupported MCP transport '{}' for server '{}'",
@@ -573,6 +587,7 @@ pub(crate) fn authorization_header(headers: &HashMap<String, String>) -> Option<
         .map(|(_, value)| value.clone())
 }
 
+#[cfg(test)]
 pub(crate) fn authorization_bearer_token(
     headers: &HashMap<String, String>,
 ) -> Result<Option<String>> {
@@ -603,25 +618,11 @@ pub(crate) fn authorization_bearer_token(
     Ok(Some(trimmed.to_string()))
 }
 
-pub(crate) fn validate_http_headers(headers: &HashMap<String, String>) -> Result<()> {
-    let unsupported = headers
-        .keys()
-        .find(|name| !name.eq_ignore_ascii_case("authorization"));
-    if let Some(name) = unsupported {
-        return Err(anyhow!(
-            "Unsupported HTTP header '{}' for MCP transport; only Authorization is currently supported",
-            name
-        ));
-    }
-
-    Ok(())
-}
-
 pub(crate) async fn resolve_http_headers(
     config: &McpConnectionConfig,
-) -> Result<HashMap<String, String>> {
-    validate_http_headers(&config.headers)?;
-
+) -> Result<reqwest::header::HeaderMap> {
+    // Preserve configured headers exactly, including Authorization; callers may use non-Bearer
+    // schemes or preformatted values that should not be normalized by the transport wrapper.
     let mut headers = config.headers.clone();
     if let Some(auth_broker) = &config.auth_broker {
         if authorization_header(&headers).is_some() {
@@ -635,7 +636,27 @@ pub(crate) async fn resolve_http_headers(
         headers.insert("Authorization".to_string(), format!("Bearer {}", token));
     }
 
-    Ok(headers)
+    let mut parsed = reqwest::header::HeaderMap::new();
+    for (name, value) in headers {
+        let header_name =
+            reqwest::header::HeaderName::from_bytes(name.as_bytes()).map_err(|err| {
+                anyhow!(
+                    "Invalid HTTP header name '{}' for MCP transport: {}",
+                    name,
+                    err
+                )
+            })?;
+        let header_value =
+            reqwest::header::HeaderValue::from_bytes(value.as_bytes()).map_err(|err| {
+                anyhow!(
+                    "Invalid HTTP header value for '{}' in MCP transport: {}",
+                    name,
+                    err
+                )
+            })?;
+        parsed.insert(header_name, header_value);
+    }
+    Ok(parsed)
 }
 
 async fn resolve_broker_bearer_token(

--- a/src/harness/mcp/tests.rs
+++ b/src/harness/mcp/tests.rs
@@ -9,8 +9,8 @@ mod tests {
         authorization_bearer_token, authorization_header, call_tool_for_config,
         clear_broker_auth_cache_for_test, content_type_matches, format_tool_result,
         invalidate_all_broker_auth_cache, invalidate_broker_auth_cache, list_tools_for_config,
-        resolve_http_headers, validate_http_headers, AuthenticatedReqwestClient,
-        McpAuthBrokerConfig, McpClient, McpConnectionConfig,
+        resolve_http_headers, AuthenticatedReqwestClient, McpAuthBrokerConfig, McpClient,
+        McpConnectionConfig,
     };
     use crate::test_support::{EnvVarGuard, PlatformJwtEnvGuard, TEST_PLATFORM_JWT_ISSUER};
     use axum::{
@@ -36,6 +36,29 @@ mod tests {
     use std::time::Duration;
     use tokio::net::TcpListener;
     use tokio::sync::Barrier;
+
+    fn parsed_authorization_header(headers: &reqwest::header::HeaderMap) -> Option<&str> {
+        headers
+            .get(reqwest::header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+    }
+
+    fn http_config_with_headers(headers: HashMap<String, String>) -> McpConnectionConfig {
+        McpConnectionConfig {
+            server_name: "github".to_string(),
+            server_ref: "github".to_string(),
+            transport: "http".to_string(),
+            target: "https://api.githubcopilot.com/mcp/".to_string(),
+            args: Vec::new(),
+            headers,
+            disabled: false,
+            namespace: None,
+            mcp_server_name: Some("github".to_string()),
+            agent_name: None,
+            jwt_issuer: None,
+            auth_broker: None,
+        }
+    }
 
     fn assert_broker_assertion(
         headers: &HeaderMap,
@@ -343,21 +366,50 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_validate_http_headers_allows_authorization_only() {
-        let mut headers = HashMap::new();
-        headers.insert("Authorization".to_string(), "Bearer token".to_string());
+    #[tokio::test]
+    async fn test_resolve_http_headers_allows_static_headers() {
+        let config = http_config_with_headers(HashMap::from([
+            ("Authorization".to_string(), "Bearer token".to_string()),
+            ("x-consumer-api-key".to_string(), "secret".to_string()),
+            ("x-conic-workspace".to_string(), "demo".to_string()),
+        ]));
 
-        assert!(validate_http_headers(&headers).is_ok());
+        let headers = resolve_http_headers(&config).await.unwrap();
+        assert_eq!(parsed_authorization_header(&headers), Some("Bearer token"));
+        assert_eq!(
+            headers
+                .get("x-consumer-api-key")
+                .and_then(|value| value.to_str().ok()),
+            Some("secret")
+        );
+        assert_eq!(
+            headers
+                .get("x-conic-workspace")
+                .and_then(|value| value.to_str().ok()),
+            Some("demo")
+        );
     }
 
-    #[test]
-    fn test_validate_http_headers_rejects_non_authorization_headers() {
-        let mut headers = HashMap::new();
-        headers.insert("x-conic-workspace".to_string(), "demo".to_string());
+    #[tokio::test]
+    async fn test_resolve_http_headers_rejects_invalid_header_names() {
+        let config = http_config_with_headers(HashMap::from([(
+            "bad header".to_string(),
+            "demo".to_string(),
+        )]));
 
-        let err = validate_http_headers(&headers).unwrap_err().to_string();
-        assert!(err.contains("Unsupported HTTP header"));
+        let err = resolve_http_headers(&config).await.unwrap_err().to_string();
+        assert!(err.contains("Invalid HTTP header name"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_http_headers_rejects_invalid_header_values() {
+        let config = http_config_with_headers(HashMap::from([(
+            "x-consumer-api-key".to_string(),
+            "bad\r\nvalue".to_string(),
+        )]));
+
+        let err = resolve_http_headers(&config).await.unwrap_err().to_string();
+        assert!(err.contains("Invalid HTTP header value"));
     }
 
     #[test]
@@ -571,12 +623,12 @@ mod tests {
 
         let headers = resolve_http_headers(&config).await.unwrap();
         assert_eq!(
-            authorization_header(&headers).as_deref(),
+            parsed_authorization_header(&headers),
             Some("Bearer ghs_brokered_token")
         );
         let headers = resolve_http_headers(&config).await.unwrap();
         assert_eq!(
-            authorization_header(&headers).as_deref(),
+            parsed_authorization_header(&headers),
             Some("Bearer ghs_brokered_token")
         );
         assert_eq!(hits.load(Ordering::SeqCst), 1);
@@ -745,7 +797,7 @@ mod tests {
                 start_barrier.wait().await;
                 let headers = resolve_http_headers(&config).await.unwrap();
                 assert_eq!(
-                    authorization_header(&headers).as_deref(),
+                    parsed_authorization_header(&headers),
                     Some("Bearer ghs_brokered_token")
                 );
             }));
@@ -912,7 +964,7 @@ mod tests {
         };
         let headers = resolve_http_headers(&no_expiry_config).await.unwrap();
         assert_eq!(
-            authorization_header(&headers).as_deref(),
+            parsed_authorization_header(&headers),
             Some("Bearer ttl-token")
         );
     }
@@ -1094,6 +1146,116 @@ mod tests {
                 Some("evt-42".to_string()),
                 Some("override-token".to_string()),
                 custom_headers,
+            )
+            .await
+            .unwrap();
+        let _ = stream.next().await;
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_authenticated_reqwest_client_get_stream_does_not_override_custom_authorization() {
+        let app = Router::new().route(
+            "/mcp",
+            get(|headers: HeaderMap| async move {
+                assert_eq!(
+                    headers
+                        .get("authorization")
+                        .and_then(|value| value.to_str().ok()),
+                    Some("Bearer custom-token")
+                );
+                (
+                    [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                    "data: {}\n\n",
+                )
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let client = AuthenticatedReqwestClient::new(
+            reqwest::Client::default(),
+            Some("default-token".to_string()),
+        );
+        let custom_headers = HashMap::from([(
+            axum::http::HeaderName::from_static("authorization"),
+            axum::http::HeaderValue::from_static("Bearer custom-token"),
+        )]);
+
+        let mut stream = client
+            .get_stream(
+                format!("http://{addr}/mcp").into(),
+                "session-1".into(),
+                None,
+                Some("override-token".to_string()),
+                custom_headers,
+            )
+            .await
+            .unwrap();
+        let _ = stream.next().await;
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_authenticated_reqwest_client_get_stream_uses_default_static_headers() {
+        let app = Router::new().route(
+            "/mcp",
+            get(|headers: HeaderMap| async move {
+                assert_eq!(
+                    headers
+                        .get("x-consumer-api-key")
+                        .and_then(|value| value.to_str().ok()),
+                    Some("consumer-secret")
+                );
+                assert_eq!(
+                    headers
+                        .get("x-conic-workspace")
+                        .and_then(|value| value.to_str().ok()),
+                    Some("demo")
+                );
+                (
+                    [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                    "data: {}\n\n",
+                )
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let mut default_headers = reqwest::header::HeaderMap::new();
+        default_headers.insert(
+            "x-consumer-api-key",
+            reqwest::header::HeaderValue::from_static("consumer-secret"),
+        );
+        default_headers.insert(
+            "x-conic-workspace",
+            reqwest::header::HeaderValue::from_static("demo"),
+        );
+        let client = AuthenticatedReqwestClient::new(
+            reqwest::Client::builder()
+                .default_headers(default_headers)
+                .build()
+                .unwrap(),
+            None,
+        );
+
+        let mut stream = client
+            .get_stream(
+                format!("http://{addr}/mcp").into(),
+                "session-1".into(),
+                None,
+                None,
+                HashMap::new(),
             )
             .await
             .unwrap();
@@ -1448,11 +1610,11 @@ mod tests {
         };
 
         assert_eq!(
-            authorization_header(&resolve_http_headers(&base).await.unwrap()).as_deref(),
+            parsed_authorization_header(&resolve_http_headers(&base).await.unwrap()),
             Some("Bearer token-github")
         );
         assert_eq!(
-            authorization_header(&resolve_http_headers(&other_server).await.unwrap()).as_deref(),
+            parsed_authorization_header(&resolve_http_headers(&other_server).await.unwrap()),
             Some("Bearer token-jira")
         );
         assert_eq!(hits.load(Ordering::SeqCst), 2);


### PR DESCRIPTION
## Summary
- Allow arbitrary valid static HTTP headers for MCP HTTP transports instead of limiting config to Authorization
- Forward those static headers through the reqwest client so values like x-consumer-api-key are actually sent
- Keep early validation for malformed header names and values

## Root Cause
The MCP HTTP connection path explicitly rejected every configured header except Authorization, then extracted Authorization into the bearer-token path and dropped the rest. That made valid API-key style headers unusable.

## Validation
- cargo fmt
- cargo test harness::mcp::tests