### PR TITLE
[codex] Fix ordered assistant tool replay

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -335,21 +335,68 @@ function messageImageParts(
   });
 }
 
+function coalesceAssistantTimelineForDisplay(timeline: AssistantTimelineItem[]) {
+  const nextTimeline: AssistantTimelineItem[] = [];
+  let latestUsage: Extract<AssistantTimelineItem, { type: "usage" }> | null = null;
+
+  for (const item of timeline) {
+    if (item.type === "usage") {
+      latestUsage = item;
+      continue;
+    }
+
+    if (item.type === "text") {
+      const lastItem = nextTimeline.at(-1);
+      if (lastItem?.type === "text") {
+        nextTimeline[nextTimeline.length - 1] = {
+          type: "text",
+          text: `${lastItem.text}${item.text}`,
+        };
+      } else {
+        nextTimeline.push(item);
+      }
+      continue;
+    }
+
+    if (item.type === "reasoning") {
+      const lastItem = nextTimeline.at(-1);
+      if (lastItem?.type === "reasoning") {
+        nextTimeline[nextTimeline.length - 1] = {
+          type: "reasoning",
+          text: `${lastItem.text}${item.text}`,
+        };
+      } else {
+        nextTimeline.push(item);
+      }
+      continue;
+    }
+
+    nextTimeline.push(item);
+  }
+
+  if (latestUsage) {
+    nextTimeline.push(latestUsage);
+  }
+
+  return nextTimeline;
+}
+
 function splitFinalAssistantTimeline(timeline: AssistantTimelineItem[]) {
+  const displayTimeline = coalesceAssistantTimelineForDisplay(timeline);
   let finalTextIndex = -1;
-  for (let index = timeline.length - 1; index >= 0; index -= 1) {
-    const item = timeline[index];
+  for (let index = displayTimeline.length - 1; index >= 0; index -= 1) {
+    const item = displayTimeline[index];
     if (item?.type === "text" && item.text.trim().length > 0) {
       finalTextIndex = index;
       break;
     }
   }
   if (finalTextIndex < 0) {
-    return { workTimeline: timeline, finalTimeline: [] };
+    return { workTimeline: displayTimeline, finalTimeline: [] };
   }
   return {
-    workTimeline: timeline.filter((_, index) => index !== finalTextIndex),
-    finalTimeline: [timeline[finalTextIndex]],
+    workTimeline: displayTimeline.filter((_, index) => index !== finalTextIndex),
+    finalTimeline: [displayTimeline[finalTextIndex]],
   };
 }
 
@@ -673,7 +720,7 @@ export function TalonSession({
     return messages.map((message, messageIndex) => {
       const content = getMessageContent(message);
       const images = messageImageParts(message, objectUrlForRef);
-      const timeline = getMessageAssistantTimeline(message);
+      const timeline = coalesceAssistantTimelineForDisplay(getMessageAssistantTimeline(message));
       const reasoningContent = getMessageReasoningContent(message);
       const usage = getMessageUsage(message);
       const usageSummary = formatUsageSummary(usage);
@@ -773,11 +820,11 @@ export function TalonSession({
                 <div style={{ borderTop: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }} />
 
                 {isWorkExpanded ? (
-                  <div style={{ display: "flex", flexDirection: "column", gap: 6, paddingTop: 12, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 8, paddingTop: 12 }}>
                     {workTimeline.map((item, index) => {
                       if (item.type === "text") {
                         return (
-                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55 }}>
+                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-assistant-fg, inherit)" }}>
                             <MarkdownMessage>{item.text}</MarkdownMessage>
                           </div>
                         );
@@ -785,7 +832,7 @@ export function TalonSession({
 
                       if (item.type === "reasoning") {
                         return (
-                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55 }}>
+                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
                             {item.text}
                           </div>
                         );
@@ -817,7 +864,7 @@ export function TalonSession({
                               border: "none",
                               background: "transparent",
                               padding: "0.25rem 0",
-                              color: "inherit",
+                              color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))",
                               cursor: "pointer",
                               textAlign: "left",
                             }}
@@ -863,7 +910,7 @@ export function TalonSession({
                     })}
 
                     {!workHasReasoning && reasoningContent ? (
-                      <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55 }}>
+                      <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
                         {reasoningContent}
                       </div>
                     ) : null}

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -122,6 +122,7 @@ const DEFAULT_HISTORY_PAGE_SIZE = 50;
 const DEFAULT_HISTORY_MESSAGE_LIMIT = 100;
 const DEFAULT_HISTORY_STEP_LIMIT = 1000;
 const HISTORY_SCROLL_LOAD_THRESHOLD_PX = 120;
+const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 48;
 
 function border(color: string) {
   return `1px solid ${color}`;
@@ -352,6 +353,10 @@ function splitFinalAssistantTimeline(timeline: AssistantTimelineItem[]) {
   };
 }
 
+function isNearScrollBottom(container: HTMLElement) {
+  return container.scrollHeight - container.scrollTop - container.clientHeight <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
+}
+
 function historyMessageTimestamp(message: Pick<CopilotMessage, "createdAt">) {
   return normalizeEpochToMilliseconds(message.createdAt);
 }
@@ -527,6 +532,7 @@ export function TalonSession({
   const imageAttachmentsRef = useRef<PendingImageAttachment[]>([]);
   const submittedPreviewUrlsRef = useRef<string[]>([]);
   const skipNextAutoScrollRef = useRef(false);
+  const autoScrollPinnedRef = useRef(true);
   const prependScrollRestoreRef = useRef<{ previousScrollTop: number; previousScrollHeight: number } | null>(null);
   const isLoadingOlderHistoryRef = useRef(false);
 
@@ -570,6 +576,7 @@ export function TalonSession({
   }, [currentSession]);
 
   const scrollTranscriptToBottom = useCallback((behavior: ScrollBehavior) => {
+    autoScrollPinnedRef.current = true;
     const container = scrollContainerRef.current;
     if (container) {
       if (typeof container.scrollTo === "function") {
@@ -598,7 +605,9 @@ export function TalonSession({
       return;
     }
     const rafId = window.requestAnimationFrame(() => {
-      scrollTranscriptToBottom("auto");
+      if (autoScrollPinnedRef.current) {
+        scrollTranscriptToBottom("auto");
+      }
       updateTranscriptScrollThumb();
     });
     return () => window.cancelAnimationFrame(rafId);
@@ -766,9 +775,17 @@ export function TalonSession({
                 {isWorkExpanded ? (
                   <div style={{ display: "flex", flexDirection: "column", gap: 6, paddingTop: 12, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
                     {workTimeline.map((item, index) => {
-                      if (item.type === "text" || item.type === "reasoning") {
+                      if (item.type === "text") {
                         return (
-                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 13, lineHeight: 1.55 }}>
+                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55 }}>
+                            <MarkdownMessage>{item.text}</MarkdownMessage>
+                          </div>
+                        );
+                      }
+
+                      if (item.type === "reasoning") {
+                        return (
+                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55 }}>
                             {item.text}
                           </div>
                         );
@@ -846,7 +863,7 @@ export function TalonSession({
                     })}
 
                     {!workHasReasoning && reasoningContent ? (
-                      <div style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 13, lineHeight: 1.55 }}>
+                      <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55 }}>
                         {reasoningContent}
                       </div>
                     ) : null}
@@ -887,7 +904,7 @@ export function TalonSession({
 
                     if (item.type === "reasoning") {
                       return (
-                        <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
+                        <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
                           {item.text}
                         </div>
                       );
@@ -1048,6 +1065,7 @@ export function TalonSession({
   const loadInitialSessionPage = useCallback(
     async (target: { ns: string; agent: string; sessionId: string }) => {
       const res = normalizeHistoryPage(await getSessionMessagesPage(target));
+      autoScrollPinnedRef.current = true;
       setMessages(res.messages);
       setHasMoreHistory(res.hasMore);
       setNextBeforeMessageId(res.nextBeforeMessageId);
@@ -1228,6 +1246,7 @@ export function TalonSession({
     setLoadingStartedAt(null);
     setExpandedThinkingMessages({});
     setExpandedToolItems({});
+    autoScrollPinnedRef.current = true;
   }, []);
 
   const clearSession = useCallback(async () => {
@@ -1472,6 +1491,7 @@ export function TalonSession({
       setMessages((prev) => [...prev, userMessage]);
       setLoadingStartedAt(normalizeEpochToMilliseconds(userMessage.createdAt) ?? Date.now());
       setLoadingNow(Date.now());
+      autoScrollPinnedRef.current = true;
       setIsLoading(true);
 
       const sessions = gatewayClient?.sessions;
@@ -1548,6 +1568,9 @@ export function TalonSession({
     updateTranscriptScrollThumb();
     const container = scrollContainerRef.current;
     const session = currentSessionRef.current;
+    if (container && !prependScrollRestoreRef.current) {
+      autoScrollPinnedRef.current = isNearScrollBottom(container);
+    }
     if (!container || !session || isLoadingOlderHistoryRef.current || !hasMoreHistory || !nextBeforeMessageId) {
       return;
     }

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -334,6 +334,24 @@ function messageImageParts(
   });
 }
 
+function splitFinalAssistantTimeline(timeline: AssistantTimelineItem[]) {
+  let finalTextIndex = -1;
+  for (let index = timeline.length - 1; index >= 0; index -= 1) {
+    const item = timeline[index];
+    if (item?.type === "text" && item.text.trim().length > 0) {
+      finalTextIndex = index;
+      break;
+    }
+  }
+  if (finalTextIndex < 0) {
+    return { workTimeline: timeline, finalTimeline: [] };
+  }
+  return {
+    workTimeline: timeline.filter((_, index) => index !== finalTextIndex),
+    finalTimeline: [timeline[finalTextIndex]],
+  };
+}
+
 function historyMessageTimestamp(message: Pick<CopilotMessage, "createdAt">) {
   return normalizeEpochToMilliseconds(message.createdAt);
 }
@@ -652,9 +670,23 @@ export function TalonSession({
       const usageSummary = formatUsageSummary(usage);
       const isUserMessage = message.role === "user";
       const isLatestMessage = messageIndex === messages.length - 1;
-      const isStreamingAssistantMessage = isLoading && isLatestMessage && message.role === "assistant";
-      const hasExpandedWorkDetails = Boolean(reasoningContent) || Boolean(usageSummary);
-      const hasWorkDetails = message.role === "assistant" && (hasExpandedWorkDetails || isStreamingAssistantMessage);
+      const isLiveAssistantMessage = isLoading && isLatestMessage && message.role === "assistant";
+      const finalizedTimeline = isLiveAssistantMessage
+        ? { workTimeline: [], finalTimeline: timeline }
+        : splitFinalAssistantTimeline(timeline);
+      const visibleTimeline = isLiveAssistantMessage
+        ? timeline
+        : finalizedTimeline.finalTimeline;
+      const workTimeline = isLiveAssistantMessage
+        ? []
+        : finalizedTimeline.workTimeline;
+      const workHasReasoning = workTimeline.some((item) => item.type === "reasoning");
+      const workHasUsage = workTimeline.some((item) => item.type === "usage");
+      const hasExpandedWorkDetails =
+        workTimeline.length > 0 ||
+        (!workHasReasoning && Boolean(reasoningContent)) ||
+        (!workHasUsage && Boolean(usageSummary));
+      const hasWorkDetails = message.role === "assistant" && (hasExpandedWorkDetails || isLiveAssistantMessage);
       let previousUserMessage: CopilotMessage | undefined;
       if (message.role === "assistant") {
         for (let index = messageIndex - 1; index >= 0; index -= 1) {
@@ -664,7 +696,7 @@ export function TalonSession({
           }
         }
       }
-      const workLabel = isStreamingAssistantMessage
+      const workLabel = isLiveAssistantMessage
         ? formatWorkingDuration(loadingStartedAt, loadingNow)
         : formatWorkDuration(previousUserMessage?.createdAt, message.createdAt);
       const isWorkExpanded = expandedThinkingMessages[message.id] ?? false;
@@ -733,13 +765,93 @@ export function TalonSession({
 
                 {isWorkExpanded ? (
                   <div style={{ display: "flex", flexDirection: "column", gap: 6, paddingTop: 12, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
-                    {reasoningContent ? (
+                    {workTimeline.map((item, index) => {
+                      if (item.type === "text" || item.type === "reasoning") {
+                        return (
+                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 13, lineHeight: 1.55 }}>
+                            {item.text}
+                          </div>
+                        );
+                      }
+
+                      if (item.type === "usage") {
+                        const itemUsageSummary = formatUsageSummary(item.usage);
+                        return itemUsageSummary ? (
+                          <div key={`${message.id}-work-${index}`} style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                            {itemUsageSummary}
+                          </div>
+                        ) : null;
+                      }
+
+                      const toolKey = `${message.id}-work-tool-${item.toolCallId || index}`;
+                      const isToolExpanded = expandedToolItems[toolKey] ?? false;
+                      return (
+                        <div key={toolKey}>
+                          <button
+                            className="talon-session-tool-row"
+                            type="button"
+                            onClick={() => toggleToolItem(toolKey)}
+                            style={{
+                              width: "auto",
+                              maxWidth: "100%",
+                              display: "flex",
+                              alignItems: "center",
+                              gap: 8,
+                              border: "none",
+                              background: "transparent",
+                              padding: "0.25rem 0",
+                              color: "inherit",
+                              cursor: "pointer",
+                              textAlign: "left",
+                            }}
+                          >
+                            <Wrench size="14" strokeWidth={1.9} style={{ flexShrink: 0, color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))" }} />
+                            <span style={{ minWidth: 0, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                              Called <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{item.toolName}</span>
+                            </span>
+                            <ChevronRight
+                              className="talon-session-tool-chevron"
+                              size="14"
+                              style={{
+                                flexShrink: 0,
+                                transform: isToolExpanded ? "rotate(90deg)" : "rotate(0deg)",
+                                color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))",
+                              }}
+                            />
+                          </button>
+                          {isToolExpanded ? (
+                            <div style={{ display: "flex", flexDirection: "column", gap: 10, paddingBottom: 12, paddingLeft: 22 }}>
+                              <div>
+                                <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                                  Input
+                                </div>
+                                <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
+                                  <code>{JSON.stringify(item.args ?? {}, null, 2)}</code>
+                                </pre>
+                              </div>
+                              {item.result !== undefined ? (
+                                <div>
+                                  <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                                    Output
+                                  </div>
+                                  <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
+                                    <code>{typeof item.result === "string" ? item.result : JSON.stringify(item.result, null, 2)}</code>
+                                  </pre>
+                                </div>
+                              ) : null}
+                            </div>
+                          ) : null}
+                        </div>
+                      );
+                    })}
+
+                    {!workHasReasoning && reasoningContent ? (
                       <div style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", fontSize: 13, lineHeight: 1.55 }}>
                         {reasoningContent}
                       </div>
                     ) : null}
 
-                    {usageSummary ? (
+                    {!workHasUsage && usageSummary ? (
                       <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
                         {usageSummary}
                       </div>
@@ -762,15 +874,32 @@ export function TalonSession({
                 fontFamily: message.role === "system" ? "ui-monospace, SFMono-Regular, monospace" : undefined,
               }}
             >
-              {message.role === "assistant" && timeline.length > 0 ? (
+              {message.role === "assistant" && visibleTimeline.length > 0 ? (
                 <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                  {timeline.map((item, index) => {
+                  {visibleTimeline.map((item, index) => {
                     if (item.type === "text") {
                       return (
                         <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "normal", overflowWrap: "anywhere" }}>
                           <MarkdownMessage>{item.text}</MarkdownMessage>
                         </div>
                       );
+                    }
+
+                    if (item.type === "reasoning") {
+                      return (
+                        <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
+                          {item.text}
+                        </div>
+                      );
+                    }
+
+                    if (item.type === "usage") {
+                      const itemUsageSummary = formatUsageSummary(item.usage);
+                      return itemUsageSummary ? (
+                        <div key={`${message.id}-timeline-${index}`} style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                          {itemUsageSummary}
+                        </div>
+                      ) : null;
                     }
 
                     const toolKey = `${message.id}-timeline-tool-${item.toolCallId || index}`;

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -647,15 +647,13 @@ export function TalonSession({
       const content = getMessageContent(message);
       const images = messageImageParts(message, objectUrlForRef);
       const timeline = getMessageAssistantTimeline(message);
-      const textTimelineItems = timeline.filter((item): item is Extract<AssistantTimelineItem, { type: "text" }> => item.type === "text");
-      const toolTimelineItems = timeline.filter((item): item is Extract<AssistantTimelineItem, { type: "tool" }> => item.type === "tool");
       const reasoningContent = getMessageReasoningContent(message);
       const usage = getMessageUsage(message);
       const usageSummary = formatUsageSummary(usage);
       const isUserMessage = message.role === "user";
       const isLatestMessage = messageIndex === messages.length - 1;
-      const isStreamingAssistantMessage = isLoading && isLatestMessage && message.role === "assistant" && !content;
-      const hasExpandedWorkDetails = Boolean(reasoningContent) || toolTimelineItems.length > 0 || Boolean(usageSummary);
+      const isStreamingAssistantMessage = isLoading && isLatestMessage && message.role === "assistant";
+      const hasExpandedWorkDetails = Boolean(reasoningContent) || Boolean(usageSummary);
       const hasWorkDetails = message.role === "assistant" && (hasExpandedWorkDetails || isStreamingAssistantMessage);
       let previousUserMessage: CopilotMessage | undefined;
       if (message.role === "assistant") {
@@ -741,69 +739,6 @@ export function TalonSession({
                       </div>
                     ) : null}
 
-                    {toolTimelineItems.map((item, index) => {
-                      const toolKey = `${message.id}-${item.toolCallId || index}`;
-                      const isToolExpanded = expandedToolItems[toolKey] ?? false;
-                      return (
-                        <div key={toolKey}>
-                          <button
-                            className="talon-session-tool-row"
-                            type="button"
-                            onClick={() => toggleToolItem(toolKey)}
-                            style={{
-                              width: "auto",
-                              maxWidth: "100%",
-                              display: "flex",
-                              alignItems: "center",
-                              gap: 8,
-                              border: "none",
-                              background: "transparent",
-                              padding: "0.25rem 0",
-                              color: "inherit",
-                              cursor: "pointer",
-                              textAlign: "left",
-                            }}
-                          >
-                            <Wrench size="14" strokeWidth={1.9} style={{ flexShrink: 0, color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))" }} />
-                            <span style={{ minWidth: 0, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                              Called <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{item.toolName}</span>
-                            </span>
-                            <ChevronRight
-                              className="talon-session-tool-chevron"
-                              size="14"
-                              style={{
-                                flexShrink: 0,
-                                transform: isToolExpanded ? "rotate(90deg)" : "rotate(0deg)",
-                                color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))",
-                              }}
-                            />
-                          </button>
-                          {isToolExpanded ? (
-                            <div style={{ display: "flex", flexDirection: "column", gap: 10, paddingBottom: 12, paddingLeft: 22 }}>
-                              <div>
-                                <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                  Input
-                                </div>
-                                <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
-                                  <code>{JSON.stringify(item.args ?? {}, null, 2)}</code>
-                                </pre>
-                              </div>
-                              {item.result !== undefined ? (
-                                <div>
-                                  <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                    Output
-                                  </div>
-                                  <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
-                                    <code>{typeof item.result === "string" ? item.result : JSON.stringify(item.result, null, 2)}</code>
-                                  </pre>
-                                </div>
-                              ) : null}
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    })}
-
                     {usageSummary ? (
                       <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
                         {usageSummary}
@@ -827,13 +762,78 @@ export function TalonSession({
                 fontFamily: message.role === "system" ? "ui-monospace, SFMono-Regular, monospace" : undefined,
               }}
             >
-              {message.role === "assistant" && textTimelineItems.length > 0 ? (
+              {message.role === "assistant" && timeline.length > 0 ? (
                 <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                  {textTimelineItems.map((item, index) => (
-                    <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "normal", overflowWrap: "anywhere" }}>
-                      <MarkdownMessage>{item.text}</MarkdownMessage>
-                    </div>
-                  ))}
+                  {timeline.map((item, index) => {
+                    if (item.type === "text") {
+                      return (
+                        <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "normal", overflowWrap: "anywhere" }}>
+                          <MarkdownMessage>{item.text}</MarkdownMessage>
+                        </div>
+                      );
+                    }
+
+                    const toolKey = `${message.id}-timeline-tool-${item.toolCallId || index}`;
+                    const isToolExpanded = expandedToolItems[toolKey] ?? false;
+                    return (
+                      <div key={toolKey}>
+                        <button
+                          className="talon-session-tool-row"
+                          type="button"
+                          onClick={() => toggleToolItem(toolKey)}
+                          style={{
+                            width: "auto",
+                            maxWidth: "100%",
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            border: "none",
+                            background: "transparent",
+                            padding: "0.25rem 0",
+                            color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))",
+                            cursor: "pointer",
+                            textAlign: "left",
+                          }}
+                        >
+                          <Wrench size="14" strokeWidth={1.9} style={{ flexShrink: 0, color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))" }} />
+                          <span style={{ minWidth: 0, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                            Called <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{item.toolName}</span>
+                          </span>
+                          <ChevronRight
+                            className="talon-session-tool-chevron"
+                            size="14"
+                            style={{
+                              flexShrink: 0,
+                              transform: isToolExpanded ? "rotate(90deg)" : "rotate(0deg)",
+                              color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))",
+                            }}
+                          />
+                        </button>
+                        {isToolExpanded ? (
+                          <div style={{ display: "flex", flexDirection: "column", gap: 10, paddingBottom: 12, paddingLeft: 22 }}>
+                            <div>
+                              <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                                Input
+                              </div>
+                              <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
+                                <code>{JSON.stringify(item.args ?? {}, null, 2)}</code>
+                              </pre>
+                            </div>
+                            {item.result !== undefined ? (
+                              <div>
+                                <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                                  Output
+                                </div>
+                                <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
+                                  <code>{typeof item.result === "string" ? item.result : JSON.stringify(item.result, null, 2)}</code>
+                                </pre>
+                              </div>
+                            ) : null}
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
                 </div>
               ) : (
                 message.role === "assistant" ? <MarkdownMessage>{content}</MarkdownMessage> : content

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -17,6 +17,8 @@ export type ToolInvocationItem = {
 
 export type AssistantTimelineItem =
   | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
+  | { type: "usage"; usage: UsageSummary }
   | {
       type: "tool";
       toolCallId: string;

--- a/packages/talon-chat/src/lib/chatTimeline.ts
+++ b/packages/talon-chat/src/lib/chatTimeline.ts
@@ -7,6 +7,8 @@ export type ToolInvocationItem = {
 
 export type AssistantTimelineItem =
   | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
+  | { type: "usage"; usage: UsageSummary }
   | {
       type: "tool";
       toolCallId: string;
@@ -183,6 +185,31 @@ function appendTextToTimeline(
   return nextTimeline;
 }
 
+function appendReasoningToTimeline(
+  timeline: AssistantTimelineItem[],
+  chunk: string,
+): AssistantTimelineItem[] {
+  if (!chunk) return timeline;
+  const nextTimeline = [...timeline];
+  const lastItem = nextTimeline.at(-1);
+  if (lastItem?.type === "reasoning") {
+    nextTimeline[nextTimeline.length - 1] = {
+      type: "reasoning",
+      text: `${lastItem.text}${chunk}`,
+    };
+  } else {
+    nextTimeline.push({ type: "reasoning", text: chunk });
+  }
+  return nextTimeline;
+}
+
+function appendUsageToTimeline(
+  timeline: AssistantTimelineItem[],
+  usage: UsageSummary,
+): AssistantTimelineItem[] {
+  return [...timeline, { type: "usage", usage }];
+}
+
 function upsertToolInTimeline(
   timeline: AssistantTimelineItem[],
   toolCallId: string,
@@ -272,7 +299,18 @@ function timelineFromParts(message: Partial<CopilotMessage>): AssistantTimelineI
       continue;
     }
 
+    if (isReasoningPart(part)) {
+      timeline = appendReasoningToTimeline(timeline, partContent(part));
+      continue;
+    }
+
     const payload = parsePartPayload(part);
+
+    if (partType(part) === 5 || partType(part) === "SESSION_MESSAGE_PART_TYPE_USAGE") {
+      timeline = appendUsageToTimeline(timeline, usageFromPayload(payload));
+      continue;
+    }
+
     const toolCallId = toolCallIdFromPart(part, payload);
     const toolName =
       typeof part.toolName === "string"
@@ -434,6 +472,17 @@ function buildAssistantTimelineFromSteps(steps: any[] | undefined): Map<string, 
       continue;
     }
 
+    if (typeof step?.content === "string" && step.content && isReasoningStep(step.stepType)) {
+      byMessage.set(messageId, appendReasoningToTimeline(timeline, step.content));
+      continue;
+    }
+
+    if (isUsageStep(step?.stepType)) {
+      const payload = parseJsonObject(step.payloadJson);
+      byMessage.set(messageId, appendUsageToTimeline(timeline, usageFromPayload(payload)));
+      continue;
+    }
+
     if (isActionStep(step?.stepType)) {
       const payload = parseJsonObject(step.payloadJson);
       const toolCallId = payloadString(payload, "tool_call_id", "toolCallId") ?? "";
@@ -580,6 +629,7 @@ export function appendAssistantReasoning(messages: CopilotMessage[], messageId: 
   nextMessages[assistantIndex] = {
     ...current,
     reasoningContent: `${getMessageReasoningContent(current)}${chunk}`,
+    timeline: appendReasoningToTimeline(getMessageAssistantTimeline(current), chunk),
   };
   return nextMessages;
 }
@@ -626,6 +676,7 @@ export function applyUsageToMessages(messages: CopilotMessage[], messageId: stri
   nextMessages[assistantIndex] = {
     ...current,
     usage,
+    timeline: appendUsageToTimeline(getMessageAssistantTimeline(current), usage),
   };
   return nextMessages;
 }

--- a/packages/talon-chat/src/lib/chatTimeline.ts
+++ b/packages/talon-chat/src/lib/chatTimeline.ts
@@ -207,7 +207,14 @@ function appendUsageToTimeline(
   timeline: AssistantTimelineItem[],
   usage: UsageSummary,
 ): AssistantTimelineItem[] {
-  return [...timeline, { type: "usage", usage }];
+  const nextTimeline = [...timeline];
+  const existingIndex = nextTimeline.findIndex((item) => item.type === "usage");
+  const nextItem: AssistantTimelineItem = { type: "usage", usage };
+  if (existingIndex >= 0) {
+    nextTimeline[existingIndex] = nextItem;
+    return nextTimeline;
+  }
+  return [...nextTimeline, nextItem];
 }
 
 function upsertToolInTimeline(

--- a/src/harness/executor/context_budget.rs
+++ b/src/harness/executor/context_budget.rs
@@ -3,9 +3,10 @@
 
 use super::runtime::LoopMessage;
 use crate::harness::llm::{chat_content_part, text_part, ChatContentPart};
-use serde_json::{json, Map, Value};
+use serde_json::Value;
 
 const INLINE_IMAGE_CONTEXT_WEIGHT: usize = 4_000;
+const TOOL_RESULT_STORAGE_PREVIEW_CHARS: usize = 12_000;
 
 #[derive(Debug, Clone)]
 enum HistorySegment {
@@ -22,10 +23,6 @@ pub struct ContextBudget {
     pub max_message_chars: usize,
     pub max_tool_result_chars: usize,
     pub max_tool_argument_chars: usize,
-    pub max_json_string_chars: usize,
-    pub max_json_object_entries: usize,
-    pub max_json_array_items: usize,
-    pub max_json_depth: usize,
 }
 
 impl Default for ContextBudget {
@@ -35,30 +32,18 @@ impl Default for ContextBudget {
             max_message_chars: env_usize("TALON_LLM_MESSAGE_MAX_CHARS", 12_000),
             max_tool_result_chars: env_usize("TALON_LLM_TOOL_RESULT_MAX_CHARS", 128_000),
             max_tool_argument_chars: env_usize("TALON_LLM_TOOL_ARGUMENT_MAX_CHARS", 4_000),
-            max_json_string_chars: env_usize("TALON_LLM_JSON_STRING_MAX_CHARS", 512),
-            max_json_object_entries: env_usize("TALON_LLM_JSON_OBJECT_MAX_ENTRIES", 24),
-            max_json_array_items: env_usize("TALON_LLM_JSON_ARRAY_MAX_ITEMS", 8),
-            max_json_depth: env_usize("TALON_LLM_JSON_MAX_DEPTH", 6),
         }
     }
 }
 
 pub fn tool_result_preview(result: &str) -> String {
-    tool_result_preview_with_budget(result, ContextBudget::default())
-}
-
-pub fn tool_result_preview_with_budget(result: &str, budget: ContextBudget) -> String {
-    let compacted = serde_json::from_str::<Value>(result)
-        .ok()
-        .map(|value| compact_json_value(&value, budget, 0))
-        .and_then(|value| serde_json::to_string_pretty(&value).ok())
-        .unwrap_or_else(|| truncate_middle(result, budget.max_tool_result_chars));
-
-    if compacted.len() <= budget.max_tool_result_chars {
-        compacted
-    } else {
-        truncate_middle(&compacted, budget.max_tool_result_chars)
-    }
+    truncate_middle(
+        result,
+        env_usize(
+            "TALON_SESSION_TOOL_RESULT_PREVIEW_CHARS",
+            TOOL_RESULT_STORAGE_PREVIEW_CHARS,
+        ),
+    )
 }
 
 pub fn compact_history_for_llm(history: &[LoopMessage]) -> Vec<LoopMessage> {
@@ -69,80 +54,87 @@ pub fn compact_history_for_llm_with_budget(
     history: &[LoopMessage],
     budget: ContextBudget,
 ) -> Vec<LoopMessage> {
-    let normalized = history
-        .iter()
-        .map(|message| normalize_loop_message(message, budget))
-        .collect::<Vec<_>>();
-    let segments = segment_history(&normalized, budget);
-    let flattened = flatten_segments(&segments);
+    let raw_total_chars = history.iter().map(serialized_message_weight).sum::<usize>();
 
-    let total_chars = flattened
-        .iter()
-        .map(serialized_message_weight)
-        .sum::<usize>();
-    debug_assert!(
-        tool_history_is_consistent(&flattened),
-        "normalized replay history must preserve valid tool-call structure"
-    );
-    if total_chars <= budget.total_chars {
-        return flattened;
+    // The common path should be lossless. Do not normalize tool output, tool
+    // args, or assistant text until the conversation actually exceeds budget.
+    if raw_total_chars <= budget.total_chars && tool_history_is_consistent(history) {
+        return history.to_vec();
     }
 
-    let system_messages = flattened
-        .iter()
-        .filter(|message| message.role == "system")
-        .cloned()
-        .collect::<Vec<_>>();
-    let system_weight = system_messages
-        .iter()
-        .map(serialized_message_weight)
-        .sum::<usize>();
-    let remaining_budget = budget.total_chars.saturating_sub(system_weight);
+    let mut segments = segment_history(history, budget);
+    debug_assert!(
+        tool_history_is_consistent(&flatten_segments(&segments)),
+        "segmented replay history must preserve valid tool-call structure"
+    );
 
-    let mut kept_tail: Vec<HistorySegment> = Vec::new();
-    let mut kept_weight = 0usize;
-    let mut omitted = 0usize;
-
-    for (index, segment) in segments.iter().enumerate().rev() {
-        if segment.is_system_only() {
+    // First compact older segments in place. Only after every older segment has
+    // been squeezed do we omit whole segments from the front of the transcript.
+    for index in 0..segments.len() {
+        if total_segment_weight(&segments) <= budget.total_chars {
+            break;
+        }
+        if segments[index].is_system_only() {
             continue;
         }
-        let weight = segment.weight();
-        if kept_weight + weight > remaining_budget && !kept_tail.is_empty() {
-            omitted += segments[..=index]
-                .iter()
-                .filter(|remaining| !remaining.is_system_only())
-                .map(HistorySegment::message_count)
-                .sum::<usize>();
-            break;
+        let compacted = segments[index].compact(budget);
+        if compacted.weight() < segments[index].weight() {
+            segments[index] = compacted;
         }
-        if kept_weight + weight > remaining_budget && kept_tail.is_empty() {
-            let fitted = segment.force_fit(budget);
-            kept_tail.push(fitted);
-            omitted += segments[..index]
-                .iter()
-                .filter(|remaining| !remaining.is_system_only())
-                .map(HistorySegment::message_count)
-                .sum::<usize>();
-            break;
-        }
-        kept_weight += weight;
-        kept_tail.push(segment.clone());
     }
 
-    kept_tail.reverse();
+    let mut system_messages = segments
+        .iter()
+        .filter_map(|segment| match segment {
+            HistorySegment::Message(message) if message.role == "system" => Some(message.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut non_system_segments = segments
+        .into_iter()
+        .filter(|segment| !segment.is_system_only())
+        .collect::<Vec<_>>();
+    let mut omitted = 0usize;
+
+    loop {
+        let marker = omitted_marker(omitted);
+        let total_chars = system_messages
+            .iter()
+            .map(serialized_message_weight)
+            .sum::<usize>()
+            + marker.as_ref().map(serialized_message_weight).unwrap_or(0)
+            + total_segment_weight(&non_system_segments);
+        if total_chars <= budget.total_chars {
+            if let Some(marker) = marker {
+                system_messages.push(marker);
+            }
+            break;
+        }
+
+        if non_system_segments.len() <= 1 {
+            if let Some(segment) = non_system_segments.first_mut() {
+                let fitted = segment.force_fit(budget);
+                if fitted.weight() < segment.weight() {
+                    *segment = fitted;
+                    continue;
+                }
+            }
+            if let Some(marker) = marker {
+                system_messages.push(marker);
+            }
+            break;
+        }
+
+        let removed = non_system_segments.remove(0);
+        if matches!(removed, HistorySegment::ToolInteraction { .. }) {
+            non_system_segments.insert(0, removed.force_fit(budget));
+        } else {
+            omitted += removed.message_count();
+        }
+    }
 
     let mut compacted = system_messages;
-    if omitted > 0 {
-        compacted.push(LoopMessage::text(
-            "system",
-            format!(
-                "[{} earlier messages omitted to stay within Talon context budget.]",
-                omitted
-            ),
-        ));
-    }
-    compacted.extend(flatten_segments(&kept_tail));
+    compacted.extend(flatten_segments(&non_system_segments));
     debug_assert!(
         tool_history_is_consistent(&compacted),
         "compacted replay history must preserve valid tool-call structure"
@@ -150,17 +142,14 @@ pub fn compact_history_for_llm_with_budget(
     compacted
 }
 
-fn normalize_loop_message(message: &LoopMessage, budget: ContextBudget) -> LoopMessage {
+fn compact_loop_message(message: &LoopMessage, budget: ContextBudget) -> LoopMessage {
     let max_chars = if message.role == "tool" {
         budget.max_tool_result_chars
     } else {
         budget.max_message_chars
     };
     let content_parts = if message.role == "tool" {
-        text_parts(tool_result_preview_with_budget(
-            &message.text_content(),
-            budget,
-        ))
+        text_parts(compact_tool_result_for_llm(&message.text_content(), budget))
     } else if message.role == "system" {
         message.content_parts.clone()
     } else {
@@ -187,7 +176,7 @@ fn normalize_loop_message(message: &LoopMessage, budget: ContextBudget) -> LoopM
 }
 
 fn force_fit_message(message: &LoopMessage, budget: ContextBudget) -> LoopMessage {
-    let mut compacted = normalize_loop_message(message, budget);
+    let mut compacted = compact_loop_message(message, budget);
     let metadata_weight = message.role.len()
         + message
             .tool_calls
@@ -318,6 +307,23 @@ fn flatten_segments(segments: &[HistorySegment]) -> Vec<LoopMessage> {
         }
     }
     flattened
+}
+
+fn total_segment_weight(segments: &[HistorySegment]) -> usize {
+    segments.iter().map(HistorySegment::weight).sum()
+}
+
+fn omitted_marker(omitted: usize) -> Option<LoopMessage> {
+    if omitted == 0 {
+        return None;
+    }
+    Some(LoopMessage::text(
+        "system",
+        format!(
+            "[{} earlier messages omitted to stay within Talon context budget.]",
+            omitted
+        ),
+    ))
 }
 
 fn tool_segment_summary(
@@ -526,6 +532,24 @@ impl HistorySegment {
             )),
         }
     }
+
+    fn compact(&self, budget: ContextBudget) -> HistorySegment {
+        match self {
+            HistorySegment::Message(message) => {
+                HistorySegment::Message(compact_loop_message(message, budget))
+            }
+            HistorySegment::ToolInteraction {
+                assistant,
+                tool_results,
+            } => HistorySegment::ToolInteraction {
+                assistant: compact_loop_message(assistant, budget),
+                tool_results: tool_results
+                    .iter()
+                    .map(|message| compact_loop_message(message, budget))
+                    .collect(),
+            },
+        }
+    }
 }
 
 fn tool_history_is_consistent(history: &[LoopMessage]) -> bool {
@@ -552,56 +576,116 @@ fn tool_history_is_consistent(history: &[LoopMessage]) -> bool {
     pending_call_ids.is_empty()
 }
 
-fn compact_json_value(value: &Value, budget: ContextBudget, depth: usize) -> Value {
-    if depth >= budget.max_json_depth {
-        return summarize_deep_json_value(value);
+fn compact_tool_result_for_llm(result: &str, budget: ContextBudget) -> String {
+    if result.len() <= budget.max_tool_result_chars {
+        return result.to_string();
     }
 
-    match value {
-        Value::Object(object) => {
-            let mut compacted = Map::new();
-            for (index, (key, child)) in object.iter().enumerate() {
-                if index >= budget.max_json_object_entries {
-                    compacted.insert(
-                        "_truncated_keys".to_string(),
-                        json!(object.len() - budget.max_json_object_entries),
-                    );
-                    break;
-                }
-                compacted.insert(key.clone(), compact_json_value(child, budget, depth + 1));
-            }
-            Value::Object(compacted)
-        }
-        Value::Array(array) => {
-            let mut compacted = array
-                .iter()
-                .take(budget.max_json_array_items)
-                .map(|child| compact_json_value(child, budget, depth + 1))
-                .collect::<Vec<_>>();
-            if array.len() > budget.max_json_array_items {
-                compacted.push(json!({
-                    "_truncated_items": array.len() - budget.max_json_array_items
-                }));
-            }
-            Value::Array(compacted)
-        }
-        Value::String(text) => Value::String(truncate_middle(text, budget.max_json_string_chars)),
-        other => other.clone(),
+    let Ok(mut value) = serde_json::from_str::<Value>(result) else {
+        return truncate_middle(result, budget.max_tool_result_chars);
+    };
+    let Ok(rendered) = serde_json::to_string_pretty(&value) else {
+        return truncate_middle(result, budget.max_tool_result_chars);
+    };
+    if rendered.len() <= budget.max_tool_result_chars {
+        return rendered;
     }
+
+    // Keep JSON shape intact: trim only string leaves, largest first, and
+    // rerender after each trim because JSON escaping changes the final size.
+    for _ in 0..128 {
+        let rendered = serde_json::to_string_pretty(&value).unwrap_or_else(|_| result.to_string());
+        if rendered.len() <= budget.max_tool_result_chars {
+            return rendered;
+        }
+
+        let Some(largest) = largest_string_leaf_path(&value) else {
+            return truncate_middle(&rendered, budget.max_tool_result_chars);
+        };
+        let excess = rendered.len().saturating_sub(budget.max_tool_result_chars);
+        let Some(text) = string_leaf_mut(&mut value, &largest) else {
+            return truncate_middle(&rendered, budget.max_tool_result_chars);
+        };
+        let next_len = text
+            .chars()
+            .count()
+            .saturating_sub(excess.saturating_add(64));
+        let truncated = truncate_middle(text, next_len);
+        if truncated == *text {
+            return truncate_middle(&rendered, budget.max_tool_result_chars);
+        }
+        *text = truncated;
+    }
+
+    serde_json::to_string_pretty(&value)
+        .ok()
+        .map(|rendered| truncate_middle(&rendered, budget.max_tool_result_chars))
+        .unwrap_or_else(|| truncate_middle(result, budget.max_tool_result_chars))
 }
 
-fn summarize_deep_json_value(value: &Value) -> Value {
+#[derive(Clone)]
+enum JsonPathElement {
+    Key(String),
+    Index(usize),
+}
+
+fn largest_string_leaf_path(value: &Value) -> Option<Vec<JsonPathElement>> {
+    fn visit(
+        value: &Value,
+        path: &mut Vec<JsonPathElement>,
+        largest: &mut Option<(usize, Vec<JsonPathElement>)>,
+    ) {
+        match value {
+            Value::String(text) => {
+                let len = text.chars().count();
+                if largest
+                    .as_ref()
+                    .is_none_or(|(current_len, _)| len > *current_len)
+                {
+                    *largest = Some((len, path.clone()));
+                }
+            }
+            Value::Array(array) => {
+                for (index, child) in array.iter().enumerate() {
+                    path.push(JsonPathElement::Index(index));
+                    visit(child, path, largest);
+                    path.pop();
+                }
+            }
+            Value::Object(object) => {
+                for (key, child) in object {
+                    path.push(JsonPathElement::Key(key.clone()));
+                    visit(child, path, largest);
+                    path.pop();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut largest = None;
+    visit(value, &mut Vec::new(), &mut largest);
+    largest.map(|(_, path)| path)
+}
+
+fn string_leaf_mut<'a>(
+    mut value: &'a mut Value,
+    path: &[JsonPathElement],
+) -> Option<&'a mut String> {
+    for element in path {
+        match element {
+            JsonPathElement::Key(key) => {
+                value = value.as_object_mut()?.get_mut(key)?;
+            }
+            JsonPathElement::Index(index) => {
+                value = value.as_array_mut()?.get_mut(*index)?;
+            }
+        }
+    }
+    value.as_str()?;
     match value {
-        Value::Object(object) => json!({
-            "_type": "object",
-            "_keys": object.len(),
-        }),
-        Value::Array(array) => json!({
-            "_type": "array",
-            "_items": array.len(),
-        }),
-        Value::String(text) => Value::String(truncate_middle(text, 128)),
-        other => other.clone(),
+        Value::String(text) => Some(text),
+        _ => None,
     }
 }
 
@@ -649,7 +733,7 @@ fn env_usize(key: &str, default: usize) -> usize {
 mod tests {
     use super::{
         compact_history_for_llm_with_budget, serialized_message_weight, tool_history_is_consistent,
-        tool_result_preview_with_budget, ContextBudget,
+        ContextBudget,
     };
     use crate::harness::executor::LoopMessage;
     use crate::harness::llm::{chat_content_part, image_data_part, text_part, ToolCall};
@@ -661,10 +745,6 @@ mod tests {
             max_message_chars: 200,
             max_tool_result_chars: 180,
             max_tool_argument_chars: 120,
-            max_json_string_chars: 40,
-            max_json_object_entries: 4,
-            max_json_array_items: 3,
-            max_json_depth: 3,
         }
     }
 
@@ -674,10 +754,6 @@ mod tests {
             max_message_chars: 8_000,
             max_tool_result_chars: 4_000,
             max_tool_argument_chars: 2_000,
-            max_json_string_chars: 256,
-            max_json_object_entries: 16,
-            max_json_array_items: 6,
-            max_json_depth: 5,
         }
     }
 
@@ -702,18 +778,75 @@ mod tests {
     }
 
     #[test]
-    fn tool_result_preview_compacts_large_json() {
-        let preview = tool_result_preview_with_budget(
-            r#"{"items":[{"path":"a","content":"0123456789012345678901234567890123456789XYZ"},{"path":"b","content":"more"},{"path":"c","content":"more"},{"path":"d","content":"more"}],"meta":{"page":1,"perPage":30,"owner":"pablonyx","repo":"proliferate","unused":"x"}}"#,
-            budget(),
+    fn compact_history_is_lossless_when_total_history_fits() {
+        let stdout = "inspection report text ".repeat(120);
+        let tool_output = format!(
+            r#"{{"data":{{"stdout":{},"status":"ok"}}}}"#,
+            serde_json::to_string(&stdout).unwrap()
         );
+        let mut assistant = message("assistant", "");
+        assistant.tool_calls = Some(vec![ToolCall {
+            id: "tool-1".to_string(),
+            name: "extract".to_string(),
+            arguments: "{}".to_string(),
+        }]);
+        let mut tool = message("tool", tool_output.clone());
+        tool.tool_call_id = Some("tool-1".to_string());
+        let history = vec![
+            message("system", "sys"),
+            assistant,
+            tool,
+            message("user", "continue"),
+        ];
+        let relaxed_budget = ContextBudget {
+            total_chars: 20_000,
+            max_tool_result_chars: 500,
+            ..budget()
+        };
 
-        assert!(preview.len() <= budget().max_tool_result_chars);
-        assert!(
-            preview.contains("_truncated_items")
-                || preview.contains("_truncated_keys")
-                || preview.contains("chars omitted")
+        let compacted = compact_history_for_llm_with_budget(&history, relaxed_budget);
+
+        assert_eq!(compacted, history);
+        assert!(compacted[2].text_content().contains(&stdout));
+    }
+
+    #[test]
+    fn over_budget_tool_json_trims_large_string_leaves_without_changing_shape() {
+        let tool_output = format!(
+            r#"{{"data":{{"stdout":{},"stderr":"small","status":"ok"}},"items":[{{"path":"report.txt","content":"tiny"}}]}}"#,
+            serde_json::to_string(&"A".repeat(2_000)).unwrap()
         );
+        let mut assistant = message("assistant", "");
+        assistant.tool_calls = Some(vec![ToolCall {
+            id: "tool-1".to_string(),
+            name: "extract".to_string(),
+            arguments: "{}".to_string(),
+        }]);
+        let mut tool = message("tool", tool_output);
+        tool.tool_call_id = Some("tool-1".to_string());
+        let compact_budget = ContextBudget {
+            total_chars: 900,
+            max_tool_result_chars: 360,
+            max_tool_argument_chars: 120,
+            ..budget()
+        };
+
+        let compacted = compact_history_for_llm_with_budget(&[assistant, tool], compact_budget);
+        let tool_message = compacted
+            .iter()
+            .find(|message| message.role == "tool")
+            .expect("tool result should remain when compacted interaction fits");
+        let parsed: serde_json::Value = serde_json::from_str(&tool_message.text_content())
+            .expect("compacted tool result should remain JSON");
+
+        assert!(tool_message.text_content().len() <= compact_budget.max_tool_result_chars);
+        assert_eq!(parsed["data"]["stderr"], "small");
+        assert_eq!(parsed["data"]["status"], "ok");
+        assert_eq!(parsed["items"][0]["path"], "report.txt");
+        assert!(parsed["data"]["stdout"]
+            .as_str()
+            .unwrap()
+            .contains("chars omitted"));
     }
 
     #[test]
@@ -840,7 +973,7 @@ mod tests {
     }
 
     #[test]
-    fn compact_history_degrades_oversized_tool_interaction_instead_of_splitting_it() {
+    fn compact_history_compacts_oversized_tool_interaction_without_splitting_it() {
         let history = vec![
             {
                 let mut message = message("assistant", "");
@@ -866,24 +999,20 @@ mod tests {
             max_message_chars: 120,
             max_tool_result_chars: 80,
             max_tool_argument_chars: 60,
-            max_json_string_chars: 32,
-            max_json_object_entries: 4,
-            max_json_array_items: 3,
-            max_json_depth: 3,
         };
 
         let compacted = compact_history_for_llm_with_budget(&history, tiny_budget);
 
         assert!(tool_history_is_consistent(&compacted));
-        assert!(!compacted.iter().any(|message| message.role == "tool"));
-        assert!(!compacted.iter().any(|message| message
+        assert!(compacted.iter().any(|message| message.role == "tool"));
+        assert!(compacted.iter().any(|message| message
             .tool_calls
             .as_ref()
-            .is_some_and(|calls| !calls.is_empty())));
-        assert!(compacted.iter().any(|message| {
-            message.text_content().contains("valid tool transcript")
-                || message.text_content().contains("earlier messages omitted")
-        }));
+            .is_some_and(|calls| calls.iter().any(|call| call.id == "tool-1"))));
+        assert!(compacted
+            .iter()
+            .filter(|message| message.role == "tool")
+            .all(|message| message.text_content().len() <= tiny_budget.max_tool_result_chars));
     }
 
     #[test]

--- a/src/harness/executor/history.rs
+++ b/src/harness/executor/history.rs
@@ -208,18 +208,29 @@ fn flush_tool_batch(
         return;
     }
 
-    let mut matched_calls = Vec::new();
-    let mut matched_results = Vec::new();
-    let results_by_id = tool_results
+    let result_ids = tool_results
+        .iter()
+        .filter_map(|result| result.tool_call_id.as_deref())
+        .map(str::to_string)
+        .collect::<std::collections::HashSet<_>>();
+    let matched_calls = tool_calls
+        .iter()
+        .filter(|call| result_ids.contains(&call.id))
+        .cloned()
+        .collect::<Vec<_>>();
+    let matched_call_ids = matched_calls
+        .iter()
+        .map(|call| call.id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    let matched_results = tool_results
         .drain(..)
-        .filter_map(|result| result.tool_call_id.clone().map(|id| (id, result)))
-        .collect::<std::collections::HashMap<_, _>>();
-    for call in tool_calls.iter() {
-        if let Some(result) = results_by_id.get(&call.id) {
-            matched_calls.push(call.clone());
-            matched_results.push(result.clone());
-        }
-    }
+        .filter(|result| {
+            result
+                .tool_call_id
+                .as_deref()
+                .is_some_and(|id| matched_call_ids.contains(id))
+        })
+        .collect::<Vec<_>>();
 
     if matched_calls.is_empty() {
         tool_calls.clear();
@@ -545,6 +556,39 @@ mod tests {
         assert_eq!(history[1].text_content(), "result-a");
         assert_eq!(history[2].tool_call_id.as_deref(), Some("call-b"));
         assert_eq!(history[2].text_content(), "result-b");
+        assert_eq!(history[3].role, "assistant");
+        assert_eq!(history[3].text_content(), "done.");
+    }
+
+    #[tokio::test]
+    async fn assistant_session_message_preserves_tool_result_order_within_batch() {
+        let store = InMemoryObjectStore::default();
+        let message = assistant_message(vec![
+            session_text_part("000001", "checking. "),
+            tool_call_part("call-a", "search", serde_json::json!({ "q": "a" })),
+            tool_call_part("call-b", "fetch", serde_json::json!({ "id": "b" })),
+            tool_result_part_for_call("call-b", "fetch", "result-b"),
+            tool_result_part_for_call("call-a", "search", "result-a"),
+            session_text_part("000006", "done."),
+        ]);
+
+        let history = session_message_to_loop_messages(&message, &store)
+            .await
+            .unwrap();
+
+        assert_eq!(history.len(), 4);
+        let calls = history[0].tool_calls.as_ref().unwrap();
+        assert_eq!(
+            calls
+                .iter()
+                .map(|call| call.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["call-a", "call-b"]
+        );
+        assert_eq!(history[1].tool_call_id.as_deref(), Some("call-b"));
+        assert_eq!(history[1].text_content(), "result-b");
+        assert_eq!(history[2].tool_call_id.as_deref(), Some("call-a"));
+        assert_eq!(history[2].text_content(), "result-a");
         assert_eq!(history[3].role, "assistant");
         assert_eq!(history[3].text_content(), "done.");
     }

--- a/src/harness/executor/history.rs
+++ b/src/harness/executor/history.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::{context_budget::tool_result_preview, runtime::LoopMessage};
+use super::runtime::LoopMessage;
 use crate::control::object_store::ObjectStore;
 use crate::gateway::rpc::data_proto;
 use crate::harness::llm::{image_data_part, image_url_part, text_part, ChatContentPart, ToolCall};
@@ -272,11 +272,11 @@ fn tool_result_message_from_part(part: &data_proto::SessionMessagePart) -> Optio
         serde_json::from_str(&part.payload_json).unwrap_or(serde_json::Value::Null);
     let tool_call_id = payload.get("tool_call_id").and_then(|v| v.as_str())?;
     let output = payload
-        .get("output_preview")
+        .get("output")
         .and_then(|v| v.as_str())
-        .or_else(|| payload.get("output").and_then(|v| v.as_str()))
-        .map(tool_result_preview)
-        .unwrap_or_else(|| tool_result_preview(&part.content));
+        .or_else(|| payload.get("output_preview").and_then(|v| v.as_str()))
+        .map(str::to_string)
+        .unwrap_or_else(|| part.content.clone());
     let mut message = LoopMessage::text("tool", output);
     message.tool_call_id = Some(tool_call_id.to_string());
     Some(message)
@@ -368,13 +368,14 @@ mod tests {
     }
 
     #[test]
-    fn tool_result_message_prefers_output_preview_when_present() {
+    fn tool_result_message_prefers_raw_output_when_present() {
+        let raw_output = format!("{{\"payload\":\"{}\"}}", "x".repeat(10_000));
         let part = tool_result_part(
             "preview".to_string(),
             serde_json::json!({
                 "tool_call_id": "tool-1",
                 "output_preview": "small preview",
-                "output": format!("{{\"payload\":\"{}\"}}", "x".repeat(10_000)),
+                "output": raw_output,
             })
             .to_string(),
         );
@@ -382,11 +383,11 @@ mod tests {
         let message = tool_result_message_from_part(&part).unwrap();
 
         assert_eq!(message.tool_call_id.as_deref(), Some("tool-1"));
-        assert_eq!(message.text_content(), "small preview");
+        assert_eq!(message.text_content(), raw_output);
     }
 
     #[test]
-    fn tool_result_message_compacts_legacy_raw_output() {
+    fn tool_result_message_keeps_legacy_raw_output() {
         let raw_output = format!(
             "{{\"payload\":\"{}\",\"items\":[\"{}\",\"{}\"]}}",
             "x".repeat(20_000),
@@ -404,11 +405,7 @@ mod tests {
 
         let message = tool_result_message_from_part(&part).unwrap();
 
-        assert!(message.text_content().len() < 10_000);
-        assert!(
-            message.text_content().contains("chars omitted")
-                || message.text_content().contains("_truncated")
-        );
+        assert_eq!(message.text_content(), raw_output);
     }
 
     #[test]

--- a/src/harness/executor/history.rs
+++ b/src/harness/executor/history.rs
@@ -1,0 +1,705 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::{context_budget::tool_result_preview, runtime::LoopMessage};
+use crate::control::object_store::ObjectStore;
+use crate::gateway::rpc::data_proto;
+use crate::harness::llm::{image_data_part, image_url_part, text_part, ChatContentPart, ToolCall};
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose, Engine as _};
+use std::path::Path;
+
+pub async fn session_message_to_loop_messages(
+    message: &data_proto::SessionMessage,
+    objects: &(dyn ObjectStore + Send + Sync),
+) -> Result<Vec<LoopMessage>> {
+    if message.role == data_proto::MessageRole::RoleAssistant as i32 {
+        return assistant_session_message_to_loop_messages(message, objects).await;
+    }
+
+    Ok(vec![LoopMessage {
+        role: match data_proto::MessageRole::try_from(message.role) {
+            Ok(data_proto::MessageRole::RoleUser) => "user",
+            Ok(data_proto::MessageRole::RoleSystem) => "system",
+            _ => "user",
+        }
+        .to_string(),
+        content_parts: message_content_parts(message, objects).await?,
+        tool_calls: None,
+        tool_call_id: None,
+    }])
+}
+
+fn inferred_image_media_type(key: &str) -> Option<&'static str> {
+    match Path::new(key)
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+pub(crate) async fn message_content_parts(
+    message: &data_proto::SessionMessage,
+    objects: &(dyn ObjectStore + Send + Sync),
+) -> Result<Vec<ChatContentPart>> {
+    let mut content_parts = Vec::new();
+    for part in &message.parts {
+        content_parts.extend(message_part_content_parts(part, objects).await?);
+    }
+    Ok(content_parts)
+}
+
+async fn message_part_content_parts(
+    part: &data_proto::SessionMessagePart,
+    objects: &(dyn ObjectStore + Send + Sync),
+) -> Result<Vec<ChatContentPart>> {
+    if part.part_type == data_proto::SessionMessagePartType::Text as i32 {
+        return Ok(if part.content.is_empty() {
+            Vec::new()
+        } else {
+            vec![text_part(part.content.clone())]
+        });
+    }
+
+    if part.part_type != data_proto::SessionMessagePartType::Image as i32 {
+        return Ok(Vec::new());
+    }
+
+    let mut content_parts = Vec::new();
+    if !part.content.is_empty() {
+        content_parts.push(text_part(part.content.clone()));
+    }
+
+    let payload = serde_json::from_str::<serde_json::Value>(&part.payload_json)
+        .unwrap_or(serde_json::Value::Null);
+    let detail = payload
+        .get("detail")
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string);
+    if let Some(url) = payload.get("url").and_then(|value| value.as_str()) {
+        content_parts.push(image_url_part(url.to_string(), detail));
+        return Ok(content_parts);
+    }
+
+    let Some(object) = part.object.as_ref() else {
+        return Ok(content_parts);
+    };
+    let stored = objects.get(&object.key).await?.ok_or_else(|| {
+        anyhow!(
+            "object '{}' referenced by message part is missing",
+            object.key
+        )
+    })?;
+    let mut media_type = if object.media_type.trim().is_empty() {
+        stored.metadata.media_type.trim().to_string()
+    } else {
+        object.media_type.trim().to_string()
+    };
+    if media_type.is_empty() {
+        media_type = inferred_image_media_type(&object.key)
+            .ok_or_else(|| anyhow!("missing media type for image object '{}'", object.key))?
+            .to_string();
+    }
+    if !media_type.to_ascii_lowercase().starts_with("image/") {
+        return Err(anyhow!(
+            "unsupported media type '{}' for image object '{}'",
+            media_type,
+            object.key
+        ));
+    }
+    content_parts.push(image_data_part(
+        media_type,
+        general_purpose::STANDARD.encode(stored.bytes),
+        detail,
+    ));
+    Ok(content_parts)
+}
+
+async fn assistant_session_message_to_loop_messages(
+    message: &data_proto::SessionMessage,
+    objects: &(dyn ObjectStore + Send + Sync),
+) -> Result<Vec<LoopMessage>> {
+    let mut history = Vec::new();
+    let mut content_parts = Vec::new();
+    let mut tool_calls = Vec::new();
+    let mut tool_results = Vec::new();
+    let mut seen_result_ids = std::collections::HashSet::new();
+
+    for part in &message.parts {
+        if part.part_type == data_proto::SessionMessagePartType::Text as i32
+            || part.part_type == data_proto::SessionMessagePartType::Image as i32
+        {
+            flush_tool_batch(
+                &mut history,
+                &mut content_parts,
+                &mut tool_calls,
+                &mut tool_results,
+                &mut seen_result_ids,
+            );
+            content_parts.extend(message_part_content_parts(part, objects).await?);
+            continue;
+        }
+
+        if part.part_type == data_proto::SessionMessagePartType::ToolCall as i32 {
+            if let Some(tool_call) = tool_call_from_part(part) {
+                tool_calls.push(tool_call);
+            }
+            continue;
+        }
+
+        if part.part_type == data_proto::SessionMessagePartType::ToolResult as i32 {
+            if tool_calls.is_empty() {
+                continue;
+            }
+            if let Some(message) = tool_result_message_from_part(part) {
+                let Some(tool_call_id) = message.tool_call_id.as_deref() else {
+                    continue;
+                };
+                let expected = tool_calls.iter().any(|call| call.id == tool_call_id);
+                if expected && seen_result_ids.insert(tool_call_id.to_string()) {
+                    tool_results.push(message);
+                }
+            }
+        }
+    }
+
+    flush_tool_batch(
+        &mut history,
+        &mut content_parts,
+        &mut tool_calls,
+        &mut tool_results,
+        &mut seen_result_ids,
+    );
+    flush_assistant_content(&mut history, &mut content_parts);
+    Ok(history)
+}
+
+fn flush_assistant_content(
+    history: &mut Vec<LoopMessage>,
+    content_parts: &mut Vec<ChatContentPart>,
+) {
+    if content_parts.is_empty() {
+        return;
+    }
+    history.push(LoopMessage {
+        role: "assistant".to_string(),
+        content_parts: std::mem::take(content_parts),
+        tool_calls: None,
+        tool_call_id: None,
+    });
+}
+
+fn flush_tool_batch(
+    history: &mut Vec<LoopMessage>,
+    content_parts: &mut Vec<ChatContentPart>,
+    tool_calls: &mut Vec<ToolCall>,
+    tool_results: &mut Vec<LoopMessage>,
+    seen_result_ids: &mut std::collections::HashSet<String>,
+) {
+    if tool_calls.is_empty() {
+        return;
+    }
+
+    let mut matched_calls = Vec::new();
+    let mut matched_results = Vec::new();
+    let results_by_id = tool_results
+        .drain(..)
+        .filter_map(|result| result.tool_call_id.clone().map(|id| (id, result)))
+        .collect::<std::collections::HashMap<_, _>>();
+    for call in tool_calls.iter() {
+        if let Some(result) = results_by_id.get(&call.id) {
+            matched_calls.push(call.clone());
+            matched_results.push(result.clone());
+        }
+    }
+
+    if matched_calls.is_empty() {
+        tool_calls.clear();
+        seen_result_ids.clear();
+        return;
+    }
+
+    history.push(LoopMessage {
+        role: "assistant".to_string(),
+        content_parts: std::mem::take(content_parts),
+        tool_calls: Some(matched_calls),
+        tool_call_id: None,
+    });
+    history.extend(matched_results);
+    tool_calls.clear();
+    seen_result_ids.clear();
+}
+
+fn tool_call_from_part(part: &data_proto::SessionMessagePart) -> Option<ToolCall> {
+    let payload: serde_json::Value =
+        serde_json::from_str(&part.payload_json).unwrap_or(serde_json::Value::Null);
+    let tool_call_id = payload.get("tool_call_id").and_then(|v| v.as_str())?;
+    if tool_call_id.is_empty() {
+        return None;
+    }
+    let input = payload
+        .get("input")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    Some(ToolCall {
+        id: tool_call_id.to_string(),
+        name: part.name.clone(),
+        arguments: serde_json::to_string(&input).unwrap_or_else(|_| "null".to_string()),
+    })
+}
+
+fn tool_result_message_from_part(part: &data_proto::SessionMessagePart) -> Option<LoopMessage> {
+    let payload: serde_json::Value =
+        serde_json::from_str(&part.payload_json).unwrap_or(serde_json::Value::Null);
+    let tool_call_id = payload.get("tool_call_id").and_then(|v| v.as_str())?;
+    let output = payload
+        .get("output_preview")
+        .and_then(|v| v.as_str())
+        .or_else(|| payload.get("output").and_then(|v| v.as_str()))
+        .map(tool_result_preview)
+        .unwrap_or_else(|| tool_result_preview(&part.content));
+    let mut message = LoopMessage::text("tool", output);
+    message.tool_call_id = Some(tool_call_id.to_string());
+    Some(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        message_content_parts, session_message_to_loop_messages, tool_result_message_from_part,
+    };
+    use crate::control::object_store::{InMemoryObjectStore, ObjectMetadata, ObjectStore};
+    use crate::gateway::rpc::data_proto;
+    use crate::harness::llm::image_data_part;
+    use std::collections::HashMap;
+
+    fn tool_result_part(content: String, payload_json: String) -> data_proto::SessionMessagePart {
+        data_proto::SessionMessagePart {
+            id: "part-1".to_string(),
+            part_type: data_proto::SessionMessagePartType::ToolResult as i32,
+            content,
+            name: "tool".to_string(),
+            payload_json,
+            created_at: 0,
+            object: None,
+        }
+    }
+
+    fn session_text_part(id: &str, content: &str) -> data_proto::SessionMessagePart {
+        data_proto::SessionMessagePart {
+            id: id.to_string(),
+            part_type: data_proto::SessionMessagePartType::Text as i32,
+            content: content.to_string(),
+            name: String::new(),
+            payload_json: String::new(),
+            created_at: 0,
+            object: None,
+        }
+    }
+
+    fn tool_call_part(
+        id: &str,
+        name: &str,
+        input: serde_json::Value,
+    ) -> data_proto::SessionMessagePart {
+        data_proto::SessionMessagePart {
+            id: format!("call-{id}"),
+            part_type: data_proto::SessionMessagePartType::ToolCall as i32,
+            content: "Tool call".to_string(),
+            name: name.to_string(),
+            payload_json: serde_json::json!({
+                "tool_call_id": id,
+                "input": input,
+            })
+            .to_string(),
+            created_at: 0,
+            object: None,
+        }
+    }
+
+    fn tool_result_part_for_call(
+        id: &str,
+        name: &str,
+        output: &str,
+    ) -> data_proto::SessionMessagePart {
+        data_proto::SessionMessagePart {
+            id: format!("result-{id}"),
+            part_type: data_proto::SessionMessagePartType::ToolResult as i32,
+            content: output.to_string(),
+            name: name.to_string(),
+            payload_json: serde_json::json!({
+                "tool_call_id": id,
+                "output_preview": output,
+                "output": output,
+            })
+            .to_string(),
+            created_at: 0,
+            object: None,
+        }
+    }
+
+    fn assistant_message(parts: Vec<data_proto::SessionMessagePart>) -> data_proto::SessionMessage {
+        data_proto::SessionMessage {
+            id: "assistant-1".to_string(),
+            role: data_proto::MessageRole::RoleAssistant as i32,
+            created_at: 0,
+            labels: HashMap::new(),
+            parts,
+        }
+    }
+
+    #[test]
+    fn tool_result_message_prefers_output_preview_when_present() {
+        let part = tool_result_part(
+            "preview".to_string(),
+            serde_json::json!({
+                "tool_call_id": "tool-1",
+                "output_preview": "small preview",
+                "output": format!("{{\"payload\":\"{}\"}}", "x".repeat(10_000)),
+            })
+            .to_string(),
+        );
+
+        let message = tool_result_message_from_part(&part).unwrap();
+
+        assert_eq!(message.tool_call_id.as_deref(), Some("tool-1"));
+        assert_eq!(message.text_content(), "small preview");
+    }
+
+    #[test]
+    fn tool_result_message_compacts_legacy_raw_output() {
+        let raw_output = format!(
+            "{{\"payload\":\"{}\",\"items\":[\"{}\",\"{}\"]}}",
+            "x".repeat(20_000),
+            "y".repeat(8_000),
+            "z".repeat(8_000)
+        );
+        let part = tool_result_part(
+            raw_output.clone(),
+            serde_json::json!({
+                "tool_call_id": "tool-1",
+                "output": raw_output,
+            })
+            .to_string(),
+        );
+
+        let message = tool_result_message_from_part(&part).unwrap();
+
+        assert!(message.text_content().len() < 10_000);
+        assert!(
+            message.text_content().contains("chars omitted")
+                || message.text_content().contains("_truncated")
+        );
+    }
+
+    #[test]
+    fn tool_result_message_requires_tool_call_id() {
+        let part = tool_result_part(
+            "preview".to_string(),
+            serde_json::json!({
+                "output_preview": "small preview",
+            })
+            .to_string(),
+        );
+
+        assert!(tool_result_message_from_part(&part).is_none());
+    }
+
+    #[test]
+    fn tool_result_message_falls_back_to_step_content_when_payload_has_no_output() {
+        let part = tool_result_part(
+            "fallback output".to_string(),
+            serde_json::json!({
+                "tool_call_id": "tool-1"
+            })
+            .to_string(),
+        );
+
+        let message = tool_result_message_from_part(&part).unwrap();
+        assert_eq!(message.text_content(), "fallback output");
+    }
+
+    #[tokio::test]
+    async fn assistant_session_message_replays_interleaved_tool_cycles_in_order() {
+        let store = InMemoryObjectStore::default();
+        let message = assistant_message(vec![
+            session_text_part("000001", "before A. "),
+            tool_call_part("call-a", "search", serde_json::json!({ "q": "a" })),
+            tool_result_part_for_call("call-a", "search", "result-a"),
+            session_text_part("000004", "before B. "),
+            tool_call_part("call-b", "fetch", serde_json::json!({ "id": "b" })),
+            tool_result_part_for_call("call-b", "fetch", "result-b"),
+            session_text_part("000007", "final."),
+        ]);
+
+        let history = session_message_to_loop_messages(&message, &store)
+            .await
+            .unwrap();
+
+        assert_eq!(history.len(), 5);
+        assert_eq!(history[0].role, "assistant");
+        assert_eq!(history[0].text_content(), "before A. ");
+        assert_eq!(history[0].tool_calls.as_ref().unwrap()[0].id, "call-a");
+        assert_eq!(history[1].role, "tool");
+        assert_eq!(history[1].tool_call_id.as_deref(), Some("call-a"));
+        assert_eq!(history[1].text_content(), "result-a");
+        assert_eq!(history[2].role, "assistant");
+        assert_eq!(history[2].text_content(), "before B. ");
+        assert_eq!(history[2].tool_calls.as_ref().unwrap()[0].id, "call-b");
+        assert_eq!(history[3].role, "tool");
+        assert_eq!(history[3].tool_call_id.as_deref(), Some("call-b"));
+        assert_eq!(history[3].text_content(), "result-b");
+        assert_eq!(history[4].role, "assistant");
+        assert_eq!(history[4].text_content(), "final.");
+        assert!(history[4].tool_calls.is_none());
+    }
+
+    #[tokio::test]
+    async fn assistant_session_message_drops_tool_call_without_result() {
+        let store = InMemoryObjectStore::default();
+        let message = assistant_message(vec![
+            session_text_part("000001", "before. "),
+            tool_call_part(
+                "call-missing",
+                "search",
+                serde_json::json!({ "q": "missing" }),
+            ),
+            session_text_part("000003", "after."),
+        ]);
+
+        let history = session_message_to_loop_messages(&message, &store)
+            .await
+            .unwrap();
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].role, "assistant");
+        assert_eq!(history[0].text_content(), "before. after.");
+        assert!(history[0].tool_calls.is_none());
+    }
+
+    #[tokio::test]
+    async fn assistant_session_message_keeps_only_matched_calls_in_partial_batch() {
+        let store = InMemoryObjectStore::default();
+        let message = assistant_message(vec![
+            session_text_part("000001", "checking. "),
+            tool_call_part(
+                "call-missing",
+                "search",
+                serde_json::json!({ "q": "missing" }),
+            ),
+            tool_call_part("call-ok", "fetch", serde_json::json!({ "id": "ok" })),
+            tool_result_part_for_call("call-ok", "fetch", "result-ok"),
+        ]);
+
+        let history = session_message_to_loop_messages(&message, &store)
+            .await
+            .unwrap();
+
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].role, "assistant");
+        assert_eq!(history[0].text_content(), "checking. ");
+        let calls = history[0].tool_calls.as_ref().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call-ok");
+        assert_eq!(history[1].role, "tool");
+        assert_eq!(history[1].tool_call_id.as_deref(), Some("call-ok"));
+        assert_eq!(history[1].text_content(), "result-ok");
+    }
+
+    #[tokio::test]
+    async fn assistant_session_message_keeps_interleaved_results_in_one_batch_until_text() {
+        let store = InMemoryObjectStore::default();
+        let message = assistant_message(vec![
+            session_text_part("000001", "checking. "),
+            tool_call_part("call-a", "search", serde_json::json!({ "q": "a" })),
+            tool_result_part_for_call("call-a", "search", "result-a"),
+            tool_call_part("call-b", "fetch", serde_json::json!({ "id": "b" })),
+            tool_result_part_for_call("call-b", "fetch", "result-b"),
+            session_text_part("000006", "done."),
+        ]);
+
+        let history = session_message_to_loop_messages(&message, &store)
+            .await
+            .unwrap();
+
+        assert_eq!(history.len(), 4);
+        assert_eq!(history[0].role, "assistant");
+        assert_eq!(history[0].text_content(), "checking. ");
+        let calls = history[0].tool_calls.as_ref().unwrap();
+        assert_eq!(
+            calls
+                .iter()
+                .map(|call| call.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["call-a", "call-b"]
+        );
+        assert_eq!(history[1].tool_call_id.as_deref(), Some("call-a"));
+        assert_eq!(history[1].text_content(), "result-a");
+        assert_eq!(history[2].tool_call_id.as_deref(), Some("call-b"));
+        assert_eq!(history[2].text_content(), "result-b");
+        assert_eq!(history[3].role, "assistant");
+        assert_eq!(history[3].text_content(), "done.");
+    }
+
+    #[tokio::test]
+    async fn assistant_session_message_ignores_orphan_tool_results() {
+        let store = InMemoryObjectStore::default();
+        let message = assistant_message(vec![
+            session_text_part("000001", "before. "),
+            tool_result_part_for_call("orphan", "search", "orphan-result"),
+            session_text_part("000003", "after."),
+        ]);
+
+        let history = session_message_to_loop_messages(&message, &store)
+            .await
+            .unwrap();
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].role, "assistant");
+        assert_eq!(history[0].text_content(), "before. after.");
+        assert!(history[0].tool_calls.is_none());
+    }
+
+    #[tokio::test]
+    async fn assistant_session_message_drops_invalid_calls_and_duplicate_results() {
+        let store = InMemoryObjectStore::default();
+        let mut invalid_call = tool_call_part("", "search", serde_json::json!({ "q": "bad" }));
+        invalid_call.id = "invalid-call".to_string();
+        let message = assistant_message(vec![
+            session_text_part("000001", "checking. "),
+            invalid_call,
+            tool_call_part("call-ok", "fetch", serde_json::json!({ "id": "ok" })),
+            tool_result_part_for_call("call-ok", "fetch", "first-result"),
+            tool_result_part_for_call("call-ok", "fetch", "duplicate-result"),
+        ]);
+
+        let history = session_message_to_loop_messages(&message, &store)
+            .await
+            .unwrap();
+
+        assert_eq!(history.len(), 2);
+        let calls = history[0].tool_calls.as_ref().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call-ok");
+        assert_eq!(history[1].tool_call_id.as_deref(), Some("call-ok"));
+        assert_eq!(history[1].text_content(), "first-result");
+    }
+
+    #[tokio::test]
+    async fn message_content_parts_infers_missing_image_media_type_from_extension() {
+        let store = InMemoryObjectStore::default();
+        let object = store
+            .put(
+                "sessions/session-1/screenshot.jpeg",
+                b"jpeg-bytes",
+                ObjectMetadata::default(),
+            )
+            .await
+            .unwrap();
+        let message = data_proto::SessionMessage {
+            id: "msg-1".to_string(),
+            role: data_proto::MessageRole::RoleUser as i32,
+            created_at: 2,
+            labels: HashMap::new(),
+            parts: vec![data_proto::SessionMessagePart {
+                id: "000001".to_string(),
+                part_type: data_proto::SessionMessagePartType::Image as i32,
+                content: String::new(),
+                name: String::new(),
+                payload_json: String::new(),
+                created_at: 2,
+                object: Some(object),
+            }],
+        };
+
+        let parts = message_content_parts(&message, &store).await.unwrap();
+
+        assert_eq!(
+            parts,
+            vec![image_data_part(
+                "image/jpeg",
+                "anBlZy1ieXRlcw==",
+                None::<String>
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn message_content_parts_rejects_non_image_object_media_type() {
+        let store = InMemoryObjectStore::default();
+        let object = store
+            .put(
+                "sessions/session-1/file.txt",
+                b"text",
+                ObjectMetadata {
+                    media_type: "text/plain".to_string(),
+                    ..ObjectMetadata::default()
+                },
+            )
+            .await
+            .unwrap();
+        let message = data_proto::SessionMessage {
+            id: "msg-1".to_string(),
+            role: data_proto::MessageRole::RoleUser as i32,
+            created_at: 2,
+            labels: HashMap::new(),
+            parts: vec![data_proto::SessionMessagePart {
+                id: "000001".to_string(),
+                part_type: data_proto::SessionMessagePartType::Image as i32,
+                content: String::new(),
+                name: String::new(),
+                payload_json: String::new(),
+                created_at: 2,
+                object: Some(object),
+            }],
+        };
+
+        let err = message_content_parts(&message, &store).await.unwrap_err();
+
+        assert!(err.to_string().contains(
+            "unsupported media type 'text/plain' for image object 'sessions/session-1/file.txt'"
+        ));
+    }
+
+    #[tokio::test]
+    async fn message_content_parts_rejects_unknown_image_media_type() {
+        let store = InMemoryObjectStore::default();
+        let object = store
+            .put(
+                "sessions/session-1/upload",
+                b"unknown-bytes",
+                ObjectMetadata::default(),
+            )
+            .await
+            .unwrap();
+        let message = data_proto::SessionMessage {
+            id: "msg-1".to_string(),
+            role: data_proto::MessageRole::RoleUser as i32,
+            created_at: 2,
+            labels: HashMap::new(),
+            parts: vec![data_proto::SessionMessagePart {
+                id: "000001".to_string(),
+                part_type: data_proto::SessionMessagePartType::Image as i32,
+                content: String::new(),
+                name: String::new(),
+                payload_json: String::new(),
+                created_at: 2,
+                object: Some(object),
+            }],
+        };
+
+        let err = message_content_parts(&message, &store).await.unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("missing media type for image object 'sessions/session-1/upload'"));
+    }
+}

--- a/src/harness/executor/mod.rs
+++ b/src/harness/executor/mod.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 pub mod context_budget;
+pub mod history;
 pub mod rpc;
 pub mod runtime;
 pub mod task;
 
 pub use context_budget::{compact_history_for_llm, tool_result_preview, ContextBudget};
+pub use history::session_message_to_loop_messages;
 pub use rpc::{RpcMessage, RpcRequest, RpcResponse};
 pub use runtime::{
     tool_result_loop_message, AgentEvent, AgentExecutor, CaptureSink, ContextAssembler,

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -484,7 +484,6 @@ impl AgentExecutor {
         loop {
             if turn_limit == 0 {
                 let msg = "Turn limit reached".to_string();
-                sink.on_error(&msg).await;
                 return Err(anyhow::anyhow!(msg));
             }
             turn_limit -= 1;

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -3,7 +3,7 @@
 
 use crate::control::config::Config;
 use crate::control::ControlPlane;
-use crate::harness::executor::context_budget::{compact_history_for_llm, tool_result_preview};
+use crate::harness::executor::context_budget::compact_history_for_llm;
 use crate::harness::knowledge::KnowledgeBook;
 use crate::harness::llm::resolver::resolve_model_profile;
 use crate::harness::llm::{
@@ -703,7 +703,7 @@ impl AgentExecutor {
 }
 
 pub fn tool_result_loop_message(tool_call_id: &str, result: &str) -> LoopMessage {
-    let mut tool_message = LoopMessage::text("tool", tool_result_preview(result));
+    let mut tool_message = LoopMessage::text("tool", result.to_string());
     tool_message.tool_call_id = Some(tool_call_id.to_string());
     tool_message
 }
@@ -720,7 +720,6 @@ mod tests {
         manifests,
         protobuf_value::{value::Kind as ProtoValueKind, ListValue, Value as ProtoValue},
     };
-    use crate::harness::executor::ContextBudget;
     use crate::harness::knowledge::{
         KnowledgeBook, KnowledgeEntry, KnowledgeListEntry, KnowledgeResult,
     };
@@ -989,22 +988,16 @@ mod tests {
                 && message.text_content()
                     == "I'm talking about the blogs link in the footer and the blogs pages"
         }));
-        let tool_message = messages
+        assert!(!messages.iter().any(|message| message.role == "tool"));
+        assert!(!messages
             .iter()
-            .find(|message| message.role == "tool")
-            .unwrap();
-        assert!(
-            tool_message.text_content().len() <= ContextBudget::default().max_tool_result_chars
-        );
-        assert!(
-            tool_message.text_content().contains("chars omitted")
-                || tool_message.text_content().contains("_truncated")
-        );
-        let assistant_tool_call = messages
-            .iter()
-            .find(|message| message.tool_calls.iter().any(|call| call.id == "tool-1"))
-            .unwrap();
-        assert_eq!(assistant_tool_call.role, "assistant");
+            .any(|message| message.tool_calls.iter().any(|call| call.id == "tool-1")));
+        assert!(messages.iter().any(|message| {
+            message.role == "assistant"
+                && message
+                    .text_content()
+                    .contains("Prior tool interaction omitted")
+        }));
         assert!(messages.iter().any(|message| {
             message.role == "system" && message.text_content().contains("earlier messages omitted")
         }));

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -90,10 +90,7 @@ impl AgentRuntime {
         for (_, value) in msg_entries {
             if let Ok(msg) = data_proto::SessionMessage::decode(value.as_slice()) {
                 if msg.role == data_proto::MessageRole::RoleAssistant as i32
-                    && msg
-                        .labels
-                        .get(SESSION_LABEL_PROJECTION_STATE)
-                        .is_some_and(|state| state != SESSION_PROJECTION_STATE_COMMITTED)
+                    && !assistant_projection_is_replayable(&msg)
                 {
                     continue;
                 }
@@ -300,6 +297,18 @@ fn builtin_tool_names() -> &'static [&'static str] {
         crate::harness::native_tools::CHANNEL_PUBLISH_TOOL,
         crate::harness::native_tools::CHANNEL_SKIP_REPLY_TOOL,
     ]
+}
+
+fn assistant_projection_is_replayable(message: &data_proto::SessionMessage) -> bool {
+    match message
+        .labels
+        .get(SESSION_LABEL_PROJECTION_STATE)
+        .map(String::as_str)
+    {
+        None | Some(SESSION_PROJECTION_STATE_COMMITTED) => true,
+        Some(crate::harness::sessions::SESSION_PROJECTION_STATE_FAILED) => true,
+        Some(_) => false,
+    }
 }
 
 fn qualify_mcp_tool_name(
@@ -893,6 +902,107 @@ mod tests {
         );
         assert_eq!(runtime.context.history[2].role, "tool");
         assert_eq!(runtime.context.history[2].text_content(), "tool preview");
+    }
+
+    #[tokio::test]
+    async fn agent_runtime_build_replays_failed_terminal_assistant_projection() {
+        let kv = Arc::new(MockKvStore::default());
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
+        let config = runtime_config();
+        let registry = crate::worker::mcp_registry::McpRegistry::new();
+        let spec = manifests::AgentSpec {
+            features: Vec::new(),
+            model_policy: None,
+            system_prompt: "assist".to_string(),
+            mcp_server_refs: vec!["missing-server".to_string()],
+            capabilities: HashMap::new(),
+            a2a: None,
+            runtime: None,
+        };
+
+        put_agent_resource(kv.clone(), "conic", "writer", Some(spec)).await;
+        let mut failed_labels = HashMap::new();
+        failed_labels.insert(
+            crate::harness::sessions::SESSION_LABEL_PROJECTION_STATE.to_string(),
+            crate::harness::sessions::SESSION_PROJECTION_STATE_FAILED.to_string(),
+        );
+        kv.set_msg(
+            &crate::control::keys::session_message("conic", "writer", "session-1", "msg-1"),
+            &data_proto::SessionMessage {
+                id: "msg-1".to_string(),
+                role: data_proto::MessageRole::RoleAssistant as i32,
+                created_at: 20,
+                labels: failed_labels,
+                parts: vec![
+                    data_proto::SessionMessagePart {
+                        id: "000001".to_string(),
+                        part_type: data_proto::SessionMessagePartType::Text as i32,
+                        content: "I found Gmail is connected. ".to_string(),
+                        name: String::new(),
+                        payload_json: String::new(),
+                        created_at: 20,
+                        object: None,
+                    },
+                    data_proto::SessionMessagePart {
+                        id: "000002".to_string(),
+                        part_type: data_proto::SessionMessagePartType::ToolCall as i32,
+                        content: "Tool call".to_string(),
+                        name: "search_tools".to_string(),
+                        payload_json: serde_json::json!({
+                            "tool_call_id": "call-1",
+                            "input": { "query": "gmail" }
+                        })
+                        .to_string(),
+                        created_at: 21,
+                        object: None,
+                    },
+                    data_proto::SessionMessagePart {
+                        id: "000003".to_string(),
+                        part_type: data_proto::SessionMessagePartType::ToolResult as i32,
+                        content: "gmail_search available".to_string(),
+                        name: "search_tools".to_string(),
+                        payload_json: serde_json::json!({
+                            "tool_call_id": "call-1",
+                            "output_preview": "gmail_search available"
+                        })
+                        .to_string(),
+                        created_at: 22,
+                        object: None,
+                    },
+                    data_proto::SessionMessagePart {
+                        id: "000004".to_string(),
+                        part_type: data_proto::SessionMessagePartType::Error as i32,
+                        content: "Turn limit reached".to_string(),
+                        name: String::new(),
+                        payload_json: String::new(),
+                        created_at: 23,
+                        object: None,
+                    },
+                ],
+            },
+        )
+        .await
+        .unwrap();
+
+        let runtime = AgentRuntime::build("conic", "writer", "session-1", &cp, &config, &registry)
+            .await
+            .unwrap();
+
+        assert_eq!(runtime.context.history.len(), 2);
+        assert_eq!(runtime.context.history[0].role, "assistant");
+        assert_eq!(
+            runtime.context.history[0].text_content(),
+            "I found Gmail is connected. "
+        );
+        assert_eq!(
+            runtime.context.history[0].tool_calls.as_ref().unwrap()[0].name,
+            "search_tools"
+        );
+        assert_eq!(runtime.context.history[1].role, "tool");
+        assert_eq!(
+            runtime.context.history[1].text_content(),
+            "gmail_search available"
+        );
     }
 
     #[tokio::test]

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use anyhow::{anyhow, Result};
-use std::path::Path;
 use std::sync::Arc;
 
 use super::mcp_registry::McpRegistry;
@@ -12,17 +11,15 @@ use crate::control::ProtoKeyValueStoreExt;
 use crate::gateway::rpc::data_proto;
 use crate::gateway::rpc::resources_proto;
 use crate::gateway::rpc::{manifests, protobuf_value::value::Kind as ProtoValueKind};
-use crate::harness::executor::context_budget::tool_result_preview;
 use crate::harness::executor::{
-    AgentExecutor, ContextAssembler, ExecutionContext, LoopMessage, RegisteredMcpTool,
+    session_message_to_loop_messages, AgentExecutor, ContextAssembler, ExecutionContext,
+    RegisteredMcpTool,
 };
 use crate::harness::knowledge::KvKnowledgeBook;
-use crate::harness::llm::{image_data_part, image_url_part, text_part, ChatContentPart, ToolCall};
 use crate::harness::sessions::{
     SESSION_LABEL_PROJECTION_STATE, SESSION_PROJECTION_STATE_COMMITTED,
 };
 use crate::harness::skills::registry::ToolRegistry;
-use base64::{engine::general_purpose, Engine as _};
 use prost::Message;
 
 /// Fully-assembled, ready-to-run environment for one agent session.
@@ -100,61 +97,7 @@ impl AgentRuntime {
                 {
                     continue;
                 }
-                let role = match data_proto::MessageRole::try_from(msg.role) {
-                    Ok(data_proto::MessageRole::RoleUser) => "user",
-                    Ok(data_proto::MessageRole::RoleAssistant) => "assistant",
-                    Ok(data_proto::MessageRole::RoleSystem) => "system",
-                    _ => "user",
-                };
-
-                let mut tool_calls = None;
-                let mut tool_results: Vec<LoopMessage> = Vec::new();
-
-                if msg.role == data_proto::MessageRole::RoleAssistant as i32 {
-                    let mut collected_tool_calls = Vec::new();
-                    for part in &msg.parts {
-                        if part.part_type == data_proto::SessionMessagePartType::ToolCall as i32 {
-                            let payload: serde_json::Value =
-                                serde_json::from_str(&part.payload_json)
-                                    .unwrap_or(serde_json::Value::Null);
-                            let tool_call_id = payload
-                                .get("tool_call_id")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string();
-                            let input = payload
-                                .get("input")
-                                .cloned()
-                                .unwrap_or(serde_json::Value::Null);
-                            collected_tool_calls.push(ToolCall {
-                                id: tool_call_id,
-                                name: part.name.clone(),
-                                arguments: serde_json::to_string(&input)
-                                    .unwrap_or_else(|_| "null".to_string()),
-                            });
-                        } else if part.part_type
-                            == data_proto::SessionMessagePartType::ToolResult as i32
-                        {
-                            if let Some(message) = tool_result_message_from_part(part) {
-                                tool_results.push(message);
-                            }
-                        }
-                    }
-
-                    if !collected_tool_calls.is_empty() {
-                        tool_calls = Some(collected_tool_calls);
-                    }
-                }
-
-                history.push(LoopMessage {
-                    role: role.to_string(),
-                    content_parts: message_content_parts(&msg, cp.objects.as_ref()).await?,
-                    tool_calls,
-                    tool_call_id: None,
-                });
-                if !tool_results.is_empty() {
-                    history.extend(tool_results);
-                }
+                history.extend(session_message_to_loop_messages(&msg, cp.objects.as_ref()).await?);
             }
         }
 
@@ -391,115 +334,15 @@ fn sanitize_tool_name_component(value: &str) -> String {
     sanitized.trim_matches('_').to_string()
 }
 
-fn inferred_image_media_type(key: &str) -> Option<&'static str> {
-    match Path::new(key)
-        .extension()
-        .and_then(|value| value.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "png" => Some("image/png"),
-        "jpg" | "jpeg" => Some("image/jpeg"),
-        "gif" => Some("image/gif"),
-        "webp" => Some("image/webp"),
-        _ => None,
-    }
-}
-
-async fn message_content_parts(
-    message: &data_proto::SessionMessage,
-    objects: &(dyn crate::control::object_store::ObjectStore + Send + Sync),
-) -> Result<Vec<ChatContentPart>> {
-    let mut content_parts = Vec::new();
-    for part in &message.parts {
-        if part.part_type == data_proto::SessionMessagePartType::Text as i32 {
-            if !part.content.is_empty() {
-                content_parts.push(text_part(part.content.clone()));
-            }
-            continue;
-        }
-
-        if part.part_type != data_proto::SessionMessagePartType::Image as i32 {
-            continue;
-        }
-
-        if !part.content.is_empty() {
-            content_parts.push(text_part(part.content.clone()));
-        }
-
-        let payload = serde_json::from_str::<serde_json::Value>(&part.payload_json)
-            .unwrap_or(serde_json::Value::Null);
-        let detail = payload
-            .get("detail")
-            .and_then(|value| value.as_str())
-            .map(ToString::to_string);
-        if let Some(url) = payload.get("url").and_then(|value| value.as_str()) {
-            content_parts.push(image_url_part(url.to_string(), detail));
-            continue;
-        }
-
-        let Some(object) = part.object.as_ref() else {
-            continue;
-        };
-        let stored = objects.get(&object.key).await?.ok_or_else(|| {
-            anyhow!(
-                "object '{}' referenced by message part is missing",
-                object.key
-            )
-        })?;
-        let mut media_type = if object.media_type.trim().is_empty() {
-            stored.metadata.media_type.trim().to_string()
-        } else {
-            object.media_type.trim().to_string()
-        };
-        if media_type.is_empty() {
-            media_type = inferred_image_media_type(&object.key)
-                .ok_or_else(|| anyhow!("missing media type for image object '{}'", object.key))?
-                .to_string();
-        }
-        if !media_type.to_ascii_lowercase().starts_with("image/") {
-            return Err(anyhow!(
-                "unsupported media type '{}' for image object '{}'",
-                media_type,
-                object.key
-            ));
-        }
-        content_parts.push(image_data_part(
-            media_type,
-            general_purpose::STANDARD.encode(stored.bytes),
-            detail,
-        ));
-    }
-    Ok(content_parts)
-}
-
-fn tool_result_message_from_part(part: &data_proto::SessionMessagePart) -> Option<LoopMessage> {
-    let payload: serde_json::Value =
-        serde_json::from_str(&part.payload_json).unwrap_or(serde_json::Value::Null);
-    let tool_call_id = payload.get("tool_call_id").and_then(|v| v.as_str())?;
-    let output = payload
-        .get("output_preview")
-        .and_then(|v| v.as_str())
-        .or_else(|| payload.get("output").and_then(|v| v.as_str()))
-        .map(tool_result_preview)
-        .unwrap_or_else(|| tool_result_preview(&part.content));
-    let mut message = LoopMessage::text("tool", output);
-    message.tool_call_id = Some(tool_call_id.to_string());
-    Some(message)
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
         builtin_tool_names, config_for_agent_namespace, has_capability_action,
-        message_content_parts, qualify_mcp_tool_name, tool_result_message_from_part,
-        visible_tools_for_agent, AgentRuntime,
+        qualify_mcp_tool_name, visible_tools_for_agent, AgentRuntime,
     };
     use crate::control::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::{
         keys::{ResourceKey, ResourceList},
-        object_store::{InMemoryObjectStore, ObjectMetadata, ObjectStore},
         ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{data_proto, manifests, protobuf_value, resources_proto};
@@ -511,18 +354,6 @@ mod tests {
     use std::pin::Pin;
     use std::sync::Arc;
     use tokio::sync::Mutex;
-
-    fn tool_result_part(content: String, payload_json: String) -> data_proto::SessionMessagePart {
-        data_proto::SessionMessagePart {
-            id: "part-1".to_string(),
-            part_type: data_proto::SessionMessagePartType::ToolResult as i32,
-            content,
-            name: "tool".to_string(),
-            payload_json,
-            created_at: 0,
-            object: None,
-        }
-    }
 
     #[derive(Default)]
     struct MockKvStore {
@@ -733,50 +564,6 @@ mod tests {
         assert_eq!(scoped.mcp_server_name.as_deref(), Some("conic"));
     }
 
-    #[test]
-    fn tool_result_message_prefers_output_preview_when_present() {
-        let part = tool_result_part(
-            "preview".to_string(),
-            serde_json::json!({
-                "tool_call_id": "tool-1",
-                "output_preview": "small preview",
-                "output": format!("{{\"payload\":\"{}\"}}", "x".repeat(10_000)),
-            })
-            .to_string(),
-        );
-
-        let message = tool_result_message_from_part(&part).unwrap();
-
-        assert_eq!(message.tool_call_id.as_deref(), Some("tool-1"));
-        assert_eq!(message.text_content(), "small preview");
-    }
-
-    #[test]
-    fn tool_result_message_compacts_legacy_raw_output() {
-        let raw_output = format!(
-            "{{\"payload\":\"{}\",\"items\":[\"{}\",\"{}\"]}}",
-            "x".repeat(20_000),
-            "y".repeat(8_000),
-            "z".repeat(8_000)
-        );
-        let part = tool_result_part(
-            raw_output.clone(),
-            serde_json::json!({
-                "tool_call_id": "tool-1",
-                "output": raw_output,
-            })
-            .to_string(),
-        );
-
-        let message = tool_result_message_from_part(&part).unwrap();
-
-        assert!(message.text_content().len() < 10_000);
-        assert!(
-            message.text_content().contains("chars omitted")
-                || message.text_content().contains("_truncated")
-        );
-    }
-
     fn spec_with_capabilities(capabilities: &[(&str, &[&str])]) -> manifests::AgentSpec {
         manifests::AgentSpec {
             features: Vec::new(),
@@ -861,33 +648,6 @@ mod tests {
         assert!(has_capability_action(&spec, "schedules", "inspect"));
         assert!(!has_capability_action(&spec, "schedules", "delete"));
         assert!(!has_capability_action(&spec, "sessions", "inspect"));
-    }
-
-    #[test]
-    fn tool_result_message_requires_tool_call_id() {
-        let part = tool_result_part(
-            "preview".to_string(),
-            serde_json::json!({
-                "output_preview": "small preview",
-            })
-            .to_string(),
-        );
-
-        assert!(tool_result_message_from_part(&part).is_none());
-    }
-
-    #[test]
-    fn tool_result_message_falls_back_to_step_content_when_payload_has_no_output() {
-        let part = tool_result_part(
-            "fallback output".to_string(),
-            serde_json::json!({
-                "tool_call_id": "tool-1"
-            })
-            .to_string(),
-        );
-
-        let message = tool_result_message_from_part(&part).unwrap();
-        assert_eq!(message.text_content(), "fallback output");
     }
 
     #[test]
@@ -1211,115 +971,5 @@ mod tests {
                 image_data_part("image/png", "cG5nLWJ5dGVz", None::<String>),
             ]
         );
-    }
-
-    #[tokio::test]
-    async fn message_content_parts_infers_missing_image_media_type_from_extension() {
-        let store = InMemoryObjectStore::default();
-        let object = store
-            .put(
-                "sessions/session-1/screenshot.jpeg",
-                b"jpeg-bytes",
-                ObjectMetadata::default(),
-            )
-            .await
-            .unwrap();
-        let message = data_proto::SessionMessage {
-            id: "msg-1".to_string(),
-            role: data_proto::MessageRole::RoleUser as i32,
-            created_at: 2,
-            labels: HashMap::new(),
-            parts: vec![data_proto::SessionMessagePart {
-                id: "000001".to_string(),
-                part_type: data_proto::SessionMessagePartType::Image as i32,
-                content: String::new(),
-                name: String::new(),
-                payload_json: String::new(),
-                created_at: 2,
-                object: Some(object),
-            }],
-        };
-
-        let parts = message_content_parts(&message, &store).await.unwrap();
-
-        assert_eq!(
-            parts,
-            vec![image_data_part(
-                "image/jpeg",
-                "anBlZy1ieXRlcw==",
-                None::<String>
-            )]
-        );
-    }
-
-    #[tokio::test]
-    async fn message_content_parts_rejects_non_image_object_media_type() {
-        let store = InMemoryObjectStore::default();
-        let object = store
-            .put(
-                "sessions/session-1/file.txt",
-                b"text",
-                ObjectMetadata {
-                    media_type: "text/plain".to_string(),
-                    ..ObjectMetadata::default()
-                },
-            )
-            .await
-            .unwrap();
-        let message = data_proto::SessionMessage {
-            id: "msg-1".to_string(),
-            role: data_proto::MessageRole::RoleUser as i32,
-            created_at: 2,
-            labels: HashMap::new(),
-            parts: vec![data_proto::SessionMessagePart {
-                id: "000001".to_string(),
-                part_type: data_proto::SessionMessagePartType::Image as i32,
-                content: String::new(),
-                name: String::new(),
-                payload_json: String::new(),
-                created_at: 2,
-                object: Some(object),
-            }],
-        };
-
-        let err = message_content_parts(&message, &store).await.unwrap_err();
-
-        assert!(err.to_string().contains(
-            "unsupported media type 'text/plain' for image object 'sessions/session-1/file.txt'"
-        ));
-    }
-
-    #[tokio::test]
-    async fn message_content_parts_rejects_unknown_image_media_type() {
-        let store = InMemoryObjectStore::default();
-        let object = store
-            .put(
-                "sessions/session-1/upload",
-                b"unknown-bytes",
-                ObjectMetadata::default(),
-            )
-            .await
-            .unwrap();
-        let message = data_proto::SessionMessage {
-            id: "msg-1".to_string(),
-            role: data_proto::MessageRole::RoleUser as i32,
-            created_at: 2,
-            labels: HashMap::new(),
-            parts: vec![data_proto::SessionMessagePart {
-                id: "000001".to_string(),
-                part_type: data_proto::SessionMessagePartType::Image as i32,
-                content: String::new(),
-                name: String::new(),
-                payload_json: String::new(),
-                created_at: 2,
-                object: Some(object),
-            }],
-        };
-
-        let err = message_content_parts(&message, &store).await.unwrap_err();
-
-        assert!(err
-            .to_string()
-            .contains("missing media type for image object 'sessions/session-1/upload'"));
     }
 }

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -335,9 +335,6 @@ test.describe('Chat Streaming', () => {
     await expect(page.getByText('Let me check that.', { exact: false })).toBeVisible({ timeout: 30000 });
     await expect(page.getByText('I checked knowledge_search for docs.example.com.', { exact: true })).toBeVisible({ timeout: 30000 });
 
-    const workToggle = page.getByRole('button', { name: /Worked for \d+s/ }).last();
-    await expect(workToggle).toBeVisible({ timeout: 10000 });
-    await workToggle.click();
     await expect(page.getByText(/Called\s+knowledge_search/)).toBeVisible({ timeout: 10000 });
 
     const transcript = (await page.locator('body').textContent()) || '';

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -335,6 +335,9 @@ test.describe('Chat Streaming', () => {
     await expect(page.getByText('Let me check that.', { exact: false })).toBeVisible({ timeout: 30000 });
     await expect(page.getByText('I checked knowledge_search for docs.example.com.', { exact: true })).toBeVisible({ timeout: 30000 });
 
+    const workToggle = page.getByRole('button', { name: /Worked for \d+s/ }).last();
+    await expect(workToggle).toBeVisible({ timeout: 10000 });
+    await workToggle.click();
     await expect(page.getByText(/Called\s+knowledge_search/)).toBeVisible({ timeout: 10000 });
 
     const transcript = (await page.locator('body').textContent()) || '';

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -936,6 +936,73 @@ describe('TalonCopilot', () => {
     });
   });
 
+  it('does not scroll the transcript down for new tokens after the user scrolls up', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockReset();
+
+    const scrollTo = jest.fn();
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    const stream = makeControllableStreamResponse();
+    fetchMock
+      .mockResolvedValueOnce(makeJsonResponse({ sessionId: 'sess-scroll-lock' }))
+      .mockResolvedValueOnce(stream.response)
+      .mockResolvedValueOnce(makeJsonResponse({
+        sessionId: 'sess-scroll-lock',
+        state: 'IDLE',
+        messages: [
+          {
+            id: 'assistant-scroll-lock',
+            role: 'ROLE_ASSISTANT',
+            content: 'New token.',
+            createdAt: String(Date.now() * 1000),
+          },
+        ],
+        steps: [],
+      }));
+
+    const { container } = render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayUrl="http://localhost:18789"
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Ask Talon to perform a task...'), {
+      target: { value: 'please stream' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    stream.release('f:{"messageId":"assistant-scroll-lock"}\n');
+    await waitFor(() => expect(scrollTo).toHaveBeenCalled());
+    scrollTo.mockClear();
+
+    const scrollContainer = container.querySelector('div[style*="overflow-y: auto"]') as HTMLDivElement;
+    Object.defineProperty(scrollContainer, 'scrollTop', { configurable: true, value: 100, writable: true });
+    Object.defineProperty(scrollContainer, 'scrollHeight', { configurable: true, value: 1000 });
+    Object.defineProperty(scrollContainer, 'clientHeight', { configurable: true, value: 200 });
+    fireEvent.scroll(scrollContainer);
+
+    stream.release('0:"New token."\n');
+    expect(await screen.findByText('New token.')).toBeInTheDocument();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    stream.release(null);
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: originalScrollTo,
+    });
+  });
+
   it('loads older history pages when scrolled near the top', async () => {
     const gatewayClient = {
       createSession: jest.fn(),

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -320,6 +320,93 @@ describe('TalonCopilot', () => {
     expect(await screen.findByText('Hello from history')).toBeInTheDocument();
   });
 
+  it('renders finalized work as typed timeline events instead of muting assistant text', async () => {
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-work',
+        state: 'IDLE',
+        items: [
+          {
+            message: {
+              id: 'assistant-work',
+              role: 'ROLE_ASSISTANT',
+              parts: [
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_REASONING',
+                  content: 'I should inspect the available tools first. ',
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                  content: "I'll work on",
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_USAGE',
+                  payloadJson: JSON.stringify({
+                    reasoning_tokens: 141,
+                    output_tokens: 333,
+                    input_tokens: 726,
+                    total_tokens: 1059,
+                  }),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                  content: ' retrieving that email.',
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                  toolCallId: 'call-1',
+                  toolName: 'knowledge_search',
+                  payloadJson: JSON.stringify({
+                    tool_call_id: 'call-1',
+                    input: { query: 'inspection report' },
+                  }),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                  toolCallId: 'call-1',
+                  toolName: 'knowledge_search',
+                  payloadJson: JSON.stringify({
+                    tool_call_id: 'call-1',
+                    output: { matches: 0 },
+                  }),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                  content: 'Final answer.',
+                },
+              ],
+              createdAt: String(Date.now() * 1000),
+            },
+            steps: [],
+          },
+        ],
+        hasMore: false,
+      }),
+      getSession: jest.fn(),
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayUrl="http://localhost:18789"
+        gatewayClient={gatewayClient}
+        sessionId="sess-work"
+      />,
+    );
+
+    expect(await screen.findByText('Final answer.')).toBeInTheDocument();
+    expect(screen.queryByText("I'll work on")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+
+    expect(await screen.findByText("I'll work on retrieving that email.")).toBeInTheDocument();
+    expect(screen.getByText('I should inspect the available tools first.')).toBeInTheDocument();
+    expect(screen.getByText(/Called/)).toHaveTextContent('knowledge_search');
+    expect(screen.getAllByText('141 reasoning • 333 output • 726 input • 1059 total')).toHaveLength(1);
+  });
+
   it('renders reloaded image object refs from session history', async () => {
     const gatewayClient = {
       createSession: jest.fn(),


### PR DESCRIPTION
## Summary
- Reconstruct committed assistant session messages as ordered replay fragments instead of one bucketed LoopMessage.
- Preserve text/image chronology around tool calls while ignoring reasoning/usage parts for LLM replay.
- Drop broken tool calls without matching results, orphan tool results, invalid call ids, and duplicate results after the first.

## Root Cause
Assistant SessionMessage parts were flattened by type during history hydration: all text became one assistant message, all tool calls became one batch, and all tool results followed afterward. Multi-step tool runs then replayed to the LLM with corrupted chronology.

## Validation
- cargo test -p talon worker::runtime --lib
- cargo test -p talon harness::executor::context_budget --lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session history is now replayed into executor-ready messages, including text, images, tool calls, and tool results.
  * Assistant **reasoning** and **usage** are surfaced in the chat timeline, with updated “work” vs “final” rendering and “Worked” reveal.
* **Bug Fixes**
  * Improved tool-call replay: correct batching/order, tool-result deduping, and ignoring unmatched/invalid results.
  * Stronger image handling with validation of media types and missing/unsupported references.
  * Reworked transcript compaction to truncate tool outputs more reliably and use a clearer “earlier messages omitted” marker.
  * Max turn limit no longer triggers an error event; auto-scroll respects a pinned state.
* **Tests**
  * Added/updated coverage for tool batching/replay, image validation, reasoning “Worked” visibility, pinned auto-scroll during streaming, and new compaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->