### PR TITLE
[codex] Add GenAI OpenTelemetry spans

### DIFF
--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -12,6 +12,7 @@ use crate::harness::llm::{
 };
 use crate::harness::mcp::{call_tool_for_config, McpConnectionConfig};
 use crate::harness::skills::registry::ToolRegistry;
+use crate::harness::telemetry;
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -20,7 +21,9 @@ use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
 const DEFAULT_EXECUTION_TURN_LIMIT: usize = 25;
 const LLM_PREFLIGHT_METRICS: &[&str] = &[
@@ -469,12 +472,25 @@ impl AgentExecutor {
     /// Run the prepared execution context to completion, emitting events to
     /// `sink` along the way.
     /// Returns the final reply text.
-    #[tracing::instrument(
-        name = "AgentExecutor.execute",
-        skip_all,
-        fields(agent_id = %context.agent_id, history_len = context.history.len())
-    )]
     pub async fn execute(
+        &self,
+        context: &mut ExecutionContext,
+        sink: &dyn ExecutionSink,
+        cancellation_token: Option<&CancellationToken>,
+    ) -> Result<String> {
+        let span = telemetry::agent_span(&self.namespace, &self.agent_id, &self.session_id);
+        let instrument_span = span.clone();
+        let result = self
+            .execute_inner(context, sink, cancellation_token)
+            .instrument(instrument_span)
+            .await;
+        if let Err(err) = &result {
+            telemetry::record_error(&span, err);
+        }
+        result
+    }
+
+    async fn execute_inner(
         &self,
         context: &mut ExecutionContext,
         sink: &dyn ExecutionSink,
@@ -509,20 +525,45 @@ impl AgentExecutor {
                 chrono::Utc::now().timestamp(),
             )
             .await?;
-            let mut stream = self
+            let request = ChatRequest {
+                messages,
+                tools,
+                thinking,
+            };
+            let reasoning_level = request
+                .thinking
+                .as_ref()
+                .map(|thinking| thinking.effort.as_str());
+            let llm_span = telemetry::chat_span(
+                &self.namespace,
+                &self.agent_id,
+                &self.session_id,
+                &self.llm_provider_key,
+                &self.llm_model,
+                &request,
+                reasoning_level,
+            );
+            let llm_started_at = Instant::now();
+            let mut saw_first_chunk = false;
+            let mut stream = match self
                 .llm
-                .stream_chat_completion(ChatRequest {
-                    messages,
-                    tools,
-                    thinking,
-                })
-                .await?;
+                .stream_chat_completion(request)
+                .instrument(llm_span.clone())
+                .await
+            {
+                Ok(stream) => stream,
+                Err(err) => {
+                    telemetry::record_error(&llm_span, &err);
+                    return Err(err);
+                }
+            };
 
             loop {
                 let next_chunk = if let Some(token) = cancellation_token {
                     tokio::select! {
                         _ = token.cancelled() => {
                             tracing::info!(agent_id = %context.agent_id, "Generation interrupted by user");
+                            telemetry::record_chat_output(&llm_span, &final_reply, &[]);
                             context.push(LoopMessage::text("assistant", final_reply.clone()));
                             sink.on_done(&final_reply).await;
                             return Ok(final_reply);
@@ -537,7 +578,23 @@ impl AgentExecutor {
                     break;
                 };
 
-                match chunk? {
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(err) => {
+                        telemetry::record_error(&llm_span, &err);
+                        return Err(err);
+                    }
+                };
+
+                if !saw_first_chunk {
+                    saw_first_chunk = true;
+                    telemetry::record_time_to_first_chunk(
+                        &llm_span,
+                        llm_started_at.elapsed().as_secs_f64(),
+                    );
+                }
+
+                match chunk {
                     ChatStreamEvent {
                         event: Some(chat_stream_event::Event::TextDelta(token)),
                     } => {
@@ -590,6 +647,14 @@ impl AgentExecutor {
                 tool_calls: tool_calls.clone(),
                 usage: final_usage,
             };
+            telemetry::record_chat_output(
+                &llm_span,
+                &llm_response.content,
+                &llm_response.tool_calls,
+            );
+            if let Some(usage) = llm_response.usage.as_ref() {
+                telemetry::record_usage(&llm_span, usage);
+            }
             sink.on_llm_response(&llm_response).await?;
             crate::control::usage::charge_namespace_usage(
                 self.control_plane.kv.as_ref(),
@@ -611,6 +676,14 @@ impl AgentExecutor {
             if !tool_calls.is_empty() {
                 for tool in &tool_calls {
                     let input = Self::tool_call_input(tool);
+                    let tool_type = self.tool_type(&tool.name).await;
+                    let tool_span = telemetry::tool_span(
+                        &self.namespace,
+                        &self.agent_id,
+                        &self.session_id,
+                        tool,
+                        tool_type,
+                    );
                     crate::control::usage::check_namespace_usage(
                         self.control_plane.kv.as_ref(),
                         &self.usage_subject(),
@@ -619,7 +692,11 @@ impl AgentExecutor {
                     )
                     .await?;
                     sink.on_tool_call(&tool.id, &tool.name, &input).await;
-                    let result = self.execute_tool_call_result(tool).await;
+                    let result = self
+                        .execute_tool_call_result(tool)
+                        .instrument(tool_span.clone())
+                        .await;
+                    telemetry::record_tool_result(&tool_span, &result);
                     sink.on_tool_result_recorded(&tool.id, &tool.name, &result)
                         .await?;
                     crate::control::usage::charge_namespace_usage(
@@ -651,6 +728,24 @@ impl AgentExecutor {
 
     pub fn tool_call_input(tool: &ToolCall) -> Value {
         serde_json::from_str(&tool.arguments).unwrap_or(Value::Null)
+    }
+
+    async fn tool_type(&self, name: &str) -> &'static str {
+        if self.mcp_tools.contains_key(name) {
+            "mcp"
+        } else if matches!(
+            name,
+            crate::harness::knowledge::KNOWLEDGE_WRITE_TOOL
+                | crate::harness::knowledge::KNOWLEDGE_SEARCH_TOOL
+                | crate::harness::knowledge::KNOWLEDGE_GET_TOOL
+                | crate::harness::knowledge::KNOWLEDGE_LIST_TOOL
+        ) {
+            "retrieval"
+        } else if self.registry.read().await.get_tool(name).is_some() {
+            "native"
+        } else {
+            "unknown"
+        }
     }
 
     fn usage_subject(&self) -> crate::control::usage::UsageSubject {

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -13,3 +13,4 @@ pub mod native_tools;
 pub mod sandbox;
 pub mod sessions;
 pub mod skills;
+pub mod telemetry;

--- a/src/harness/telemetry.rs
+++ b/src/harness/telemetry.rs
@@ -198,17 +198,34 @@ fn serialize_json_array(values: impl IntoIterator<Item = Value>) -> String {
 }
 
 fn message_value(message: &ChatMessage) -> Value {
-    let mut parts = content_parts_value(&message.content_parts);
-    for call in &message.tool_calls {
-        parts.push(tool_call_part_value(call));
-    }
-    if let Some(tool_call_id) = &message.tool_call_id {
-        for part in &mut parts {
-            if let Some(object) = part.as_object_mut() {
-                object.insert("id".to_string(), Value::String(tool_call_id.clone()));
+    let parts = if message.role == "tool" {
+        let tool_call_id = message.tool_call_id.as_deref().unwrap_or_default();
+        message
+            .content_parts
+            .iter()
+            .filter_map(|part| match part.content.as_ref()? {
+                chat_content_part::Content::Text(text) => Some(json!({
+                    "type": "tool_call_response",
+                    "id": tool_call_id,
+                    "result": text,
+                })),
+                _ => None,
+            })
+            .collect()
+    } else {
+        let mut parts = content_parts_value(&message.content_parts);
+        for call in &message.tool_calls {
+            parts.push(tool_call_part_value(call));
+        }
+        if let Some(tool_call_id) = &message.tool_call_id {
+            for part in &mut parts {
+                if let Some(object) = part.as_object_mut() {
+                    object.insert("id".to_string(), Value::String(tool_call_id.clone()));
+                }
             }
         }
-    }
+        parts
+    };
     json!({
         "role": message.role,
         "parts": parts,
@@ -250,9 +267,10 @@ fn tool_call_part_value(call: &ToolCall) -> Value {
 }
 
 fn low_cardinality_error_text(error: &str) -> &'static str {
-    if error.contains("cancel") || error.contains("interrupt") {
+    let error_lc = error.to_ascii_lowercase();
+    if error_lc.contains("cancel") || error_lc.contains("interrupt") {
         "cancelled"
-    } else if error.contains("timeout") {
+    } else if error_lc.contains("timeout") {
         "timeout"
     } else {
         "_OTHER"
@@ -350,6 +368,15 @@ mod tests {
         message.tool_call_id = Some("call-1".to_string());
         let json = serialize_messages_json(&[message]);
         let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value[0]["parts"][0]["type"], "tool_call_response");
         assert_eq!(value[0]["parts"][0]["id"], "call-1");
+        assert_eq!(value[0]["parts"][0]["result"], "result");
+    }
+
+    #[test]
+    fn error_classification_is_case_insensitive() {
+        assert_eq!(low_cardinality_error_text("Cancelled by user"), "cancelled");
+        assert_eq!(low_cardinality_error_text("Timeout occurred"), "timeout");
+        assert_eq!(low_cardinality_error_text("unknown failure"), "_OTHER");
     }
 }

--- a/src/harness/telemetry.rs
+++ b/src/harness/telemetry.rs
@@ -176,8 +176,14 @@ pub fn serialize_output_messages_json(content: &str, tool_calls: &[ToolCall]) ->
 
 pub fn serialize_tool_definitions_json(tools: &[Tool]) -> String {
     serialize_json_array(tools.iter().map(|tool| {
-        let parameters = serde_json::from_str::<Value>(&tool.input_schema_json)
-            .unwrap_or_else(|_| Value::String(tool.input_schema_json.clone()));
+        let parameters =
+            serde_json::from_str::<Value>(&tool.input_schema_json).unwrap_or_else(|_| {
+                if tool.input_schema_json.trim().is_empty() {
+                    json!({})
+                } else {
+                    Value::String(tool.input_schema_json.clone())
+                }
+            });
         json!({
             "type": "function",
             "name": tool.name,
@@ -338,6 +344,25 @@ mod tests {
         let value: Value = serde_json::from_str(&json).unwrap();
         assert_eq!(value[0]["name"], "lookup");
         assert_eq!(value[0]["parameters"]["type"], "object");
+    }
+
+    #[test]
+    fn tool_definitions_use_empty_object_for_blank_schema() {
+        let json = serialize_tool_definitions_json(&[
+            Tool {
+                name: "blank".to_string(),
+                description: "Blank".to_string(),
+                input_schema_json: String::new(),
+            },
+            Tool {
+                name: "whitespace".to_string(),
+                description: "Whitespace".to_string(),
+                input_schema_json: "  \n\t".to_string(),
+            },
+        ]);
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value[0]["parameters"], json!({}));
+        assert_eq!(value[1]["parameters"], json!({}));
     }
 
     #[test]

--- a/src/harness/telemetry.rs
+++ b/src/harness/telemetry.rs
@@ -1,0 +1,355 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use crate::harness::llm::{
+    chat_content_part, ChatContentPart, ChatMessage, ChatRequest, ChatUsage, Tool, ToolCall,
+};
+use serde_json::{json, Value};
+use tracing::{field, Span};
+
+pub fn tenant_slug(namespace: &str) -> Option<&str> {
+    namespace
+        .strip_prefix("Tenant:")
+        .and_then(|rest| rest.split(':').next())
+        .filter(|slug| !slug.is_empty())
+}
+
+pub fn genai_provider_name(provider_key: &str) -> String {
+    let normalized = provider_key.trim().to_ascii_lowercase();
+    if normalized.contains("anthropic") {
+        "anthropic".to_string()
+    } else if normalized.contains("openai") {
+        "openai".to_string()
+    } else {
+        normalized
+    }
+}
+
+pub fn agent_span(namespace: &str, agent_id: &str, session_id: &str) -> Span {
+    let otel_name = format!("invoke_agent {agent_id}");
+    let span = tracing::info_span!(
+        "invoke_agent",
+        "otel.name" = otel_name.as_str(),
+        "gen_ai.operation.name" = "invoke_agent",
+        "gen_ai.agent.name" = agent_id,
+        "gen_ai.conversation.id" = session_id,
+        "talon.namespace" = namespace,
+        "talon.tenant.slug" = field::Empty,
+        "talon.session.id" = session_id,
+        "talon.agent.name" = agent_id,
+        "error.type" = field::Empty,
+    );
+    if let Some(slug) = tenant_slug(namespace) {
+        span.record("talon.tenant.slug", slug);
+    }
+    span
+}
+
+pub fn chat_span(
+    namespace: &str,
+    agent_id: &str,
+    session_id: &str,
+    provider_key: &str,
+    model: &str,
+    request: &ChatRequest,
+    reasoning_level: Option<&str>,
+) -> Span {
+    let provider = genai_provider_name(provider_key);
+    let input_messages = serialize_messages_json(&request.messages);
+    let tool_definitions = serialize_tool_definitions_json(&request.tools);
+    let otel_name = format!("chat {model}");
+    let span = tracing::info_span!(
+        "chat",
+        "otel.name" = otel_name.as_str(),
+        "gen_ai.operation.name" = "chat",
+        "gen_ai.provider.name" = provider.as_str(),
+        "gen_ai.request.model" = model,
+        "gen_ai.request.stream" = true,
+        "gen_ai.request.reasoning.level" = field::Empty,
+        "gen_ai.conversation.id" = session_id,
+        "gen_ai.input.messages" = input_messages.as_str(),
+        "gen_ai.tool.definitions" = tool_definitions.as_str(),
+        "gen_ai.output.messages" = field::Empty,
+        "gen_ai.usage.input_tokens" = field::Empty,
+        "gen_ai.usage.output_tokens" = field::Empty,
+        "gen_ai.usage.reasoning.output_tokens" = field::Empty,
+        "gen_ai.usage.total_tokens" = field::Empty,
+        "gen_ai.response.time_to_first_chunk" = field::Empty,
+        "talon.namespace" = namespace,
+        "talon.tenant.slug" = field::Empty,
+        "talon.session.id" = session_id,
+        "talon.agent.name" = agent_id,
+        "talon.llm.provider_key" = provider_key,
+        "error.type" = field::Empty,
+    );
+    if let Some(slug) = tenant_slug(namespace) {
+        span.record("talon.tenant.slug", slug);
+    }
+    if let Some(level) = reasoning_level.filter(|level| !level.trim().is_empty()) {
+        span.record("gen_ai.request.reasoning.level", level);
+    }
+    span
+}
+
+pub fn tool_span(
+    namespace: &str,
+    agent_id: &str,
+    session_id: &str,
+    tool_call: &ToolCall,
+    tool_type: &str,
+) -> Span {
+    let arguments = serialize_json_or_string(&tool_call.arguments);
+    let otel_name = format!("execute_tool {}", tool_call.name);
+    let span = tracing::info_span!(
+        "execute_tool",
+        "otel.name" = otel_name.as_str(),
+        "gen_ai.operation.name" = "execute_tool",
+        "gen_ai.tool.name" = tool_call.name.as_str(),
+        "gen_ai.tool.call.id" = tool_call.id.as_str(),
+        "gen_ai.tool.type" = tool_type,
+        "gen_ai.tool.call.arguments" = arguments.as_str(),
+        "gen_ai.tool.call.result" = field::Empty,
+        "talon.namespace" = namespace,
+        "talon.tenant.slug" = field::Empty,
+        "talon.session.id" = session_id,
+        "talon.agent.name" = agent_id,
+        "error.type" = field::Empty,
+    );
+    if let Some(slug) = tenant_slug(namespace) {
+        span.record("talon.tenant.slug", slug);
+    }
+    span
+}
+
+pub fn record_usage(span: &Span, usage: &ChatUsage) {
+    span.record("gen_ai.usage.input_tokens", usage.input_tokens);
+    span.record("gen_ai.usage.output_tokens", usage.output_tokens);
+    span.record(
+        "gen_ai.usage.reasoning.output_tokens",
+        usage.reasoning_tokens,
+    );
+    span.record("gen_ai.usage.total_tokens", usage.total_tokens);
+}
+
+pub fn record_time_to_first_chunk(span: &Span, seconds: f64) {
+    span.record("gen_ai.response.time_to_first_chunk", seconds);
+}
+
+pub fn record_chat_output(span: &Span, content: &str, tool_calls: &[ToolCall]) {
+    let output = serialize_output_messages_json(content, tool_calls);
+    span.record("gen_ai.output.messages", output.as_str());
+}
+
+pub fn record_tool_result(span: &Span, result: &str) {
+    let output = serialize_json_or_string(result);
+    span.record("gen_ai.tool.call.result", output.as_str());
+}
+
+pub fn record_error(span: &Span, error: &anyhow::Error) {
+    span.record("error.type", low_cardinality_error_text(&error.to_string()));
+}
+
+pub fn record_error_text(span: &Span, error: &str) {
+    span.record("error.type", low_cardinality_error_text(error));
+}
+
+pub fn serialize_messages_json(messages: &[ChatMessage]) -> String {
+    serialize_json_array(messages.iter().map(message_value))
+}
+
+pub fn serialize_output_messages_json(content: &str, tool_calls: &[ToolCall]) -> String {
+    let mut parts = Vec::new();
+    if !content.is_empty() {
+        parts.push(json!({
+            "type": "text",
+            "content": content,
+        }));
+    }
+    for call in tool_calls {
+        parts.push(tool_call_part_value(call));
+    }
+    serialize_json_array([json!({
+        "role": "assistant",
+        "parts": parts,
+    })])
+}
+
+pub fn serialize_tool_definitions_json(tools: &[Tool]) -> String {
+    serialize_json_array(tools.iter().map(|tool| {
+        let parameters = serde_json::from_str::<Value>(&tool.input_schema_json)
+            .unwrap_or_else(|_| Value::String(tool.input_schema_json.clone()));
+        json!({
+            "type": "function",
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": parameters,
+        })
+    }))
+}
+
+pub fn serialize_json_or_string(value: &str) -> String {
+    serde_json::from_str::<Value>(value)
+        .unwrap_or_else(|_| Value::String(value.to_string()))
+        .to_string()
+}
+
+fn serialize_json_array(values: impl IntoIterator<Item = Value>) -> String {
+    Value::Array(values.into_iter().collect()).to_string()
+}
+
+fn message_value(message: &ChatMessage) -> Value {
+    let mut parts = content_parts_value(&message.content_parts);
+    for call in &message.tool_calls {
+        parts.push(tool_call_part_value(call));
+    }
+    if let Some(tool_call_id) = &message.tool_call_id {
+        for part in &mut parts {
+            if let Some(object) = part.as_object_mut() {
+                object.insert("id".to_string(), Value::String(tool_call_id.clone()));
+            }
+        }
+    }
+    json!({
+        "role": message.role,
+        "parts": parts,
+    })
+}
+
+fn content_parts_value(parts: &[ChatContentPart]) -> Vec<Value> {
+    parts
+        .iter()
+        .filter_map(|part| match part.content.as_ref()? {
+            chat_content_part::Content::Text(text) => Some(json!({
+                "type": "text",
+                "content": text,
+            })),
+            chat_content_part::Content::ImageUrl(image) => Some(json!({
+                "type": "image",
+                "url": image.url,
+                "detail": image.detail,
+            })),
+            chat_content_part::Content::ImageData(image) => Some(json!({
+                "type": "image",
+                "media_type": image.media_type,
+                "data": image.data_base64,
+                "detail": image.detail,
+            })),
+        })
+        .collect()
+}
+
+fn tool_call_part_value(call: &ToolCall) -> Value {
+    let arguments = serde_json::from_str::<Value>(&call.arguments)
+        .unwrap_or_else(|_| Value::String(call.arguments.clone()));
+    json!({
+        "type": "tool_call",
+        "id": call.id,
+        "name": call.name,
+        "arguments": arguments,
+    })
+}
+
+fn low_cardinality_error_text(error: &str) -> &'static str {
+    if error.contains("cancel") || error.contains("interrupt") {
+        "cancelled"
+    } else if error.contains("timeout") {
+        "timeout"
+    } else {
+        "_OTHER"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness::llm::{
+        chat_message_text, image_data_part, image_url_part, text_part, ChatMessage, Tool, ToolCall,
+    };
+
+    #[test]
+    fn tenant_slug_uses_first_segment_after_tenant_prefix() {
+        assert_eq!(tenant_slug("Tenant:acme"), Some("acme"));
+        assert_eq!(tenant_slug("Tenant:acme:prod"), Some("acme"));
+        assert_eq!(tenant_slug("conic:wks:13"), None);
+        assert_eq!(tenant_slug("Tenant:"), None);
+    }
+
+    #[test]
+    fn provider_name_maps_known_provider_families() {
+        assert_eq!(genai_provider_name("prod-openai"), "openai");
+        assert_eq!(genai_provider_name("Anthropic"), "anthropic");
+        assert_eq!(genai_provider_name("novita"), "novita");
+    }
+
+    #[test]
+    fn messages_serialize_content_and_tool_shapes() {
+        let message = ChatMessage {
+            role: "assistant".to_string(),
+            content_parts: vec![
+                text_part("hello"),
+                image_url_part("https://example.test/image.png", Some("high")),
+                image_data_part("image/png", "base64-data", Some("low")),
+            ],
+            tool_calls: vec![ToolCall {
+                id: "call-1".to_string(),
+                name: "lookup".to_string(),
+                arguments: r#"{"query":"plan"}"#.to_string(),
+            }],
+            tool_call_id: None,
+        };
+
+        let json = serialize_messages_json(&[message]);
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value[0]["role"], "assistant");
+        assert_eq!(value[0]["parts"][0]["content"], "hello");
+        assert_eq!(
+            value[0]["parts"][1]["url"],
+            "https://example.test/image.png"
+        );
+        assert_eq!(value[0]["parts"][2]["data"], "base64-data");
+        assert_eq!(value[0]["parts"][3]["arguments"]["query"], "plan");
+    }
+
+    #[test]
+    fn tool_definitions_parse_json_schema_when_possible() {
+        let json = serialize_tool_definitions_json(&[Tool {
+            name: "lookup".to_string(),
+            description: "Search".to_string(),
+            input_schema_json: r#"{"type":"object"}"#.to_string(),
+        }]);
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value[0]["name"], "lookup");
+        assert_eq!(value[0]["parameters"]["type"], "object");
+    }
+
+    #[test]
+    fn json_or_string_preserves_structured_json_and_plain_strings() {
+        assert_eq!(serialize_json_or_string(r#"{"ok":true}"#), r#"{"ok":true}"#);
+        assert_eq!(serialize_json_or_string("plain"), r#""plain""#);
+    }
+
+    #[test]
+    fn output_messages_include_text_and_tool_calls() {
+        let json = serialize_output_messages_json(
+            "done",
+            &[ToolCall {
+                id: "call-1".to_string(),
+                name: "lookup".to_string(),
+                arguments: r#"{"x":1}"#.to_string(),
+            }],
+        );
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value[0]["role"], "assistant");
+        assert_eq!(value[0]["parts"][0]["content"], "done");
+        assert_eq!(value[0]["parts"][1]["name"], "lookup");
+    }
+
+    #[test]
+    fn tool_response_message_records_tool_call_id() {
+        let mut message = chat_message_text("tool", "result");
+        message.tool_call_id = Some("call-1".to_string());
+        let json = serialize_messages_json(&[message]);
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value[0]["parts"][0]["id"], "call-1");
+    }
+}

--- a/src/harness/telemetry.rs
+++ b/src/harness/telemetry.rs
@@ -55,8 +55,6 @@ pub fn chat_span(
     reasoning_level: Option<&str>,
 ) -> Span {
     let provider = genai_provider_name(provider_key);
-    let input_messages = serialize_messages_json(&request.messages);
-    let tool_definitions = serialize_tool_definitions_json(&request.tools);
     let otel_name = format!("chat {model}");
     let span = tracing::info_span!(
         "chat",
@@ -67,8 +65,8 @@ pub fn chat_span(
         "gen_ai.request.stream" = true,
         "gen_ai.request.reasoning.level" = field::Empty,
         "gen_ai.conversation.id" = session_id,
-        "gen_ai.input.messages" = input_messages.as_str(),
-        "gen_ai.tool.definitions" = tool_definitions.as_str(),
+        "gen_ai.input.messages" = field::Empty,
+        "gen_ai.tool.definitions" = field::Empty,
         "gen_ai.output.messages" = field::Empty,
         "gen_ai.usage.input_tokens" = field::Empty,
         "gen_ai.usage.output_tokens" = field::Empty,
@@ -87,6 +85,12 @@ pub fn chat_span(
     }
     if let Some(level) = reasoning_level.filter(|level| !level.trim().is_empty()) {
         span.record("gen_ai.request.reasoning.level", level);
+    }
+    if !span.is_disabled() {
+        let input_messages = serialize_messages_json(&request.messages);
+        let tool_definitions = serialize_tool_definitions_json(&request.tools);
+        span.record("gen_ai.input.messages", input_messages.as_str());
+        span.record("gen_ai.tool.definitions", tool_definitions.as_str());
     }
     span
 }


### PR DESCRIPTION
## Summary

Adds OpenTelemetry GenAI semantic-convention spans for Talon-native agent execution.

- Adds a centralized GenAI telemetry helper for tenant attribution, provider mapping, and full LLM/tool content serialization.
- Wraps Talon-native agent execution in `invoke_agent` spans.
- Adds streamed LLM `chat {model}` spans with input messages, tool definitions, output messages, usage tokens, time to first chunk, and error classification.
- Adds `execute_tool {tool}` spans with full tool arguments/results and tool type classification.

## Impact

Existing OTEL enablement remains unchanged. No new environment variables, proto changes, or SDK changes are introduced. Talon emits full GenAI content to the internal OTLP path; downstream collector/routing infrastructure remains responsible for tenant isolation, redaction, omission, and customer export policy.

## Validation

- `cargo fmt --check`
- `cargo test harness::telemetry --lib`
- `cargo test harness::executor::runtime --lib`
- `cargo test --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced telemetry for agent runs, including streaming, tool execution, timing, usage, and error reporting.
  * Improved visibility into chat and tool activity with richer event tracking and structured output data.
  * Added support for better classification of tools and request metadata during execution.

* **Tests**
  * Added coverage for telemetry helpers, serialization behavior, schema handling, and error categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->