### PR TITLE
[codex] Refactor Sightline auth options

### DIFF
--- a/docs/wiki/local-single-host-development.md
+++ b/docs/wiki/local-single-host-development.md
@@ -124,7 +124,7 @@ Once the gateway is listening, mint a short-lived root bootstrap JWT from the
 private PEM and use it immediately to create a local API key:
 
 ```bash
-export TALON_API_KEY="$(./target/debug/talon-cli --gateway http://127.0.0.1:50051 --token "$(./target/debug/talon-cli auth local-token --private-key-pem-file ./src/control/security/test_rsa_private_key.pem)" auth api-key create --name local-dev --grant readwrite | awk -F= '/^secret=/{print $2}')"
+export TALON_API_KEY="$(./target/debug/talon-cli --gateway http://127.0.0.1:50051 --token "$(TALON_JWT_ISSUER=https://talon.localhost ./target/debug/talon-cli auth local-token --private-key-pem-file ./src/control/security/test_rsa_private_key.pem)" auth api-key create --name local-dev --grant readwrite | awk -F= '/^secret=/{print $2}')"
 ```
 
 Use the exported `TALON_API_KEY` for later CLI calls instead of reusing the

--- a/docs/wiki/local-single-host-development.md
+++ b/docs/wiki/local-single-host-development.md
@@ -103,6 +103,7 @@ From the repository root:
 ```bash
 env \
   TALON_CONFIG_PATH="$ROOT/config.yaml" \
+  TALON_JWT_PRIVATE_KEY_PEM="$(cat ./src/control/security/test_rsa_private_key.pem)" \
   GRPC_ADDR=127.0.0.1:50051 \
   RUST_LOG=info \
   ./target/debug/talon-server
@@ -116,7 +117,19 @@ Initializing LocalSocketMessagePublisher at $ROOT/data/talon-broker.sock...
 gRPC Gateway listening on: 127.0.0.1:50051
 ```
 
-## 5. Start the worker
+## 5. Bootstrap a local API key
+
+Once the gateway is listening, mint a short-lived root bootstrap JWT from the
+private PEM and use it immediately to create a local API key:
+
+```bash
+export TALON_API_KEY="$(./target/debug/talon-cli --gateway http://127.0.0.1:50051 --token "$(./target/debug/talon-cli auth local-token --private-key-pem-file ./src/control/security/test_rsa_private_key.pem)" auth api-key create --name local-dev --grant readwrite | awk -F= '/^secret=/{print $2}')"
+```
+
+Use the exported `TALON_API_KEY` for later CLI calls instead of reusing the
+bootstrap JWT.
+
+## 6. Start the worker
 
 In a second terminal:
 
@@ -146,7 +159,7 @@ TALON_LOCAL_SCHEDULER_RUNNER=1
 
 Only add those when you want the scheduler tables and runner behavior.
 
-## 6. Verify listeners
+## 7. Verify listeners
 
 ```bash
 lsof -iTCP:50051 -iTCP:18081 -sTCP:LISTEN
@@ -157,7 +170,7 @@ You should see:
 - gateway gRPC and gRPC-Web on `50051`
 - worker on `18081`
 
-## 7. Connect the UI
+## 8. Connect the UI
 
 In Sightline, connect to:
 
@@ -165,13 +178,17 @@ In Sightline, connect to:
 http://127.0.0.1:50051
 ```
 
-## 8. Apply resources
+Use the API key from the bootstrap step when the auth modal asks for
+credentials.
+
+## 9. Apply resources
 
 Create the namespace:
 
 ```bash
 ./target/debug/talon-cli \
   --gateway http://127.0.0.1:50051 \
+  --api-key "$TALON_API_KEY" \
   apply --file "$ROOT/manifests/pretzel.namespace.yaml"
 ```
 
@@ -180,6 +197,7 @@ Create the agent:
 ```bash
 ./target/debug/talon-cli \
   --gateway http://127.0.0.1:50051 \
+  --api-key "$TALON_API_KEY" \
   apply --file "$ROOT/manifests/dj.agent.yaml"
 ```
 
@@ -188,6 +206,7 @@ Verify through the edge:
 ```bash
 ./target/debug/talon-cli \
   --gateway http://127.0.0.1:50051 \
+  --api-key "$TALON_API_KEY" \
   get agents --namespace pretzel
 ```
 

--- a/docs/wiki/local-single-host-development.md
+++ b/docs/wiki/local-single-host-development.md
@@ -104,6 +104,7 @@ From the repository root:
 env \
   TALON_CONFIG_PATH="$ROOT/config.yaml" \
   TALON_JWT_PRIVATE_KEY_PEM="$(cat ./src/control/security/test_rsa_private_key.pem)" \
+  TALON_JWT_ISSUER=https://talon.localhost \
   GRPC_ADDR=127.0.0.1:50051 \
   RUST_LOG=info \
   ./target/debug/talon-server

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -29,6 +29,8 @@ import {
   Package,
   ShieldCheck,
   Container,
+  ChevronDown,
+  KeyRound,
 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';
@@ -40,7 +42,9 @@ import {
   getDefaultGatewayUrl,
   getGatewayClient,
   isBlockedMixedContentGatewayUrl,
+  isExpiredSignatureAuthError,
   normalizeGatewayUrl,
+  TALON_AUTH_EXPIRED_EVENT,
   updateGatewayClient,
 } from '../lib/grpc';
 import {
@@ -60,6 +64,8 @@ import { useResourceDocument } from '../hooks/useResourceDocument';
 
 const isStaticExport = process.env.NEXT_PUBLIC_TALON_STATIC_EXPORT === '1';
 const CONNECT_TIMEOUT_MS = 8000;
+const RUNTIME_AUTH_TOKEN_STORAGE_KEY = 'talon_auth_token';
+const MANUAL_JWT_STORAGE_KEY = 'talon_manual_jwt';
 declare global {
   interface Window {
     google?: {
@@ -305,35 +311,41 @@ function tokenExpiryError(token: string) {
 
 function AuthScreen({
   gatewayUrl,
-  authToken,
+  jwtToken,
+  apiKey,
   isConnecting,
   googleSsoEnabled,
   googleSsoError,
   connectionError,
   onGatewayUrlChange,
-  onAuthTokenChange,
+  onJwtTokenChange,
+  onApiKeyChange,
   onGoogleSignIn,
   onConnect,
 }: {
   gatewayUrl: string;
-  authToken: string;
+  jwtToken: string;
+  apiKey: string;
   isConnecting: boolean;
   googleSsoEnabled: boolean;
   googleSsoError: string | null;
   connectionError: string | null;
   onGatewayUrlChange: (value: string) => void;
-  onAuthTokenChange: (value: string) => void;
+  onJwtTokenChange: (value: string) => void;
+  onApiKeyChange: (value: string) => void;
   onGoogleSignIn: () => void;
-  onConnect: (values: { gatewayUrl: string; authToken: string }) => void;
+  onConnect: (values: { gatewayUrl: string; apiKey: string; jwtToken: string }) => void;
 }) {
   const formRef = useRef<HTMLFormElement>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const submitConnection = () => {
     const form = formRef.current;
     if (!form) return;
     const formData = new FormData(form);
     onConnect({
       gatewayUrl: String(formData.get('gatewayUrl') || ''),
-      authToken: String(formData.get('authToken') || ''),
+      apiKey: String(formData.get('apiKey') || ''),
+      jwtToken: String(formData.get('jwtToken') || ''),
     });
   };
 
@@ -391,17 +403,44 @@ function AuthScreen({
               />
             </div>
             <div className="space-y-2">
-              <label htmlFor="auth-token-input" className="text-[12px] font-medium text-foreground">Authorization Token (Optional)</label>
+              <label htmlFor="api-key-input" className="text-[12px] font-medium text-foreground">API Key (Optional)</label>
               <input
-                id="auth-token-input"
-                name="authToken"
+                id="api-key-input"
+                name="apiKey"
                 type="password"
-                defaultValue={authToken}
-                onChange={(event) => onAuthTokenChange(event.target.value)}
+                value={apiKey}
+                onChange={(event) => onApiKeyChange(event.target.value)}
                 className="w-full rounded-lg border border-border/70 bg-background px-3 py-2.5 font-mono text-sm text-foreground transition-shadow focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
-                placeholder="Enter bearer token"
+                placeholder="talon_sk_..."
                 disabled={isConnecting}
               />
+            </div>
+            <div className="rounded-lg border border-border/70 bg-muted/15">
+              <button
+                type="button"
+                onClick={() => setAdvancedOpen((open) => !open)}
+                className="flex w-full items-center justify-between px-3 py-2.5 text-[12px] font-medium text-foreground"
+                aria-expanded={advancedOpen}
+                aria-controls="advanced-auth-options"
+              >
+                Advanced options
+                <ChevronDown className={cn("h-4 w-4 text-muted-foreground transition-transform", advancedOpen && "rotate-180")} />
+              </button>
+              {advancedOpen ? (
+                <div id="advanced-auth-options" className="space-y-2 border-t border-border/70 px-3 py-3">
+                  <label htmlFor="jwt-token-input" className="text-[12px] font-medium text-foreground">JWT Token (Optional)</label>
+                  <input
+                    id="jwt-token-input"
+                    name="jwtToken"
+                    type="password"
+                    value={jwtToken}
+                    onChange={(event) => onJwtTokenChange(event.target.value)}
+                    className="w-full rounded-lg border border-border/70 bg-background px-3 py-2.5 font-mono text-sm text-foreground transition-shadow focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+                    placeholder="Enter bearer token"
+                    disabled={isConnecting}
+                  />
+                </div>
+              ) : null}
             </div>
             {googleSsoEnabled ? (
               <div className="space-y-2">
@@ -424,7 +463,7 @@ function AuthScreen({
               disabled={isConnecting}
               className="flex w-full items-center justify-center gap-2 rounded-lg bg-foreground py-2.5 text-[13px] font-medium text-background transition-all hover:opacity-90 disabled:opacity-50"
             >
-              <Settings2 className="h-4 w-4 stroke-[2]" />
+              {apiKey.trim() ? <KeyRound className="h-4 w-4 stroke-[2]" /> : <Settings2 className="h-4 w-4 stroke-[2]" />}
               {isConnecting ? 'Connecting...' : 'Initialize Connection'}
             </button>
           </motion.form>
@@ -873,6 +912,8 @@ function DebuggerPageContent() {
   const explicitConnectRef = useRef(false);
   const [gatewayUrl, setGatewayUrl] = useState('');
   const [authToken, setAuthToken] = useState('');
+  const [manualJwtToken, setManualJwtToken] = useState('');
+  const [apiKey, setApiKey] = useState('');
   const [googleSsoEnabled, setGoogleSsoEnabled] = useState(false);
   const [googleWebClientId, setGoogleWebClientId] = useState<string | null>(null);
   const [googleSsoError, setGoogleSsoError] = useState<string | null>(null);
@@ -929,9 +970,13 @@ function DebuggerPageContent() {
       }
     }
     localStorage.removeItem('talon_gateway_http_url');
-    const savedToken = localStorage.getItem('talon_auth_token');
+    const savedToken = localStorage.getItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY);
     if (savedToken) {
       setAuthToken(savedToken);
+    }
+    const savedManualJwt = localStorage.getItem(MANUAL_JWT_STORAGE_KEY);
+    if (savedManualJwt) {
+      setManualJwtToken(savedManualJwt);
     }
     setStorageHydrated(true);
   }, []);
@@ -946,7 +991,9 @@ function DebuggerPageContent() {
     const hasTalonHandoff = Boolean(talonAuthToken || talonGatewayUrl || talonGatewayHttpUrl);
     if (talonAuthToken) {
       setAuthToken(talonAuthToken);
-      localStorage.setItem('talon_auth_token', talonAuthToken);
+      setManualJwtToken(talonAuthToken);
+      localStorage.setItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY, talonAuthToken);
+      localStorage.setItem(MANUAL_JWT_STORAGE_KEY, talonAuthToken);
       currentParams.delete('talon_auth_token');
     }
     if (talonGatewayUrl) {
@@ -1044,6 +1091,22 @@ function DebuggerPageContent() {
     };
   }, [effectiveGatewayHttpUrl, storageHydrated]);
 
+  useEffect(() => {
+    const handleExpiredAuth = () => {
+      explicitConnectRef.current = false;
+      queryClient.removeQueries({ queryKey: ['talon'] });
+      localStorage.removeItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY);
+      setAuthToken('');
+      setApiKey('');
+      setIsConnected(false);
+      setAuthScreenOpen(true);
+      setConnectionError('Your authorization token expired. Sign in again to continue.');
+    };
+
+    window.addEventListener(TALON_AUTH_EXPIRED_EVENT, handleExpiredAuth);
+    return () => window.removeEventListener(TALON_AUTH_EXPIRED_EVENT, handleExpiredAuth);
+  }, [queryClient]);
+
   const handleGoogleSignIn = useCallback(async () => {
     if (!googleWebClientId) return;
     setGoogleSsoError(null);
@@ -1085,7 +1148,10 @@ function DebuggerPageContent() {
               clientType: 'sightline',
             });
             setAuthToken(payload.accessToken);
-            localStorage.setItem('talon_auth_token', payload.accessToken);
+            setManualJwtToken('');
+            setApiKey('');
+            localStorage.setItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY, payload.accessToken);
+            localStorage.removeItem(MANUAL_JWT_STORAGE_KEY);
             if (gatewayUrl.trim()) {
               if (isBlockedMixedContentGatewayUrl(gatewayUrl)) {
                 setConnectionError('Sightline is running over HTTPS, so the gateway URL must also use HTTPS or the same origin.');
@@ -1137,11 +1203,21 @@ function DebuggerPageContent() {
     }
   }, [authScreenOpen, storageHydrated, isConnected, selectedNamespace, pathname, router, searchParams]);
 
-  const handleConnect = async ({ gatewayUrl: submittedGatewayUrlValue, authToken: submittedAuthTokenValue }: { gatewayUrl: string; authToken: string }) => {
+  const handleConnect = async ({
+    gatewayUrl: submittedGatewayUrlValue,
+    apiKey: submittedApiKeyValue,
+    jwtToken: submittedJwtTokenValue,
+  }: {
+    gatewayUrl: string;
+    apiKey: string;
+    jwtToken: string;
+  }) => {
     const submittedGatewayUrl = (submittedGatewayUrlValue || gatewayUrl).trim();
-    const submittedAuthToken = (submittedAuthTokenValue || authToken).trim();
+    const submittedApiKey = submittedApiKeyValue.trim();
+    const submittedJwtToken = (submittedJwtTokenValue || manualJwtToken).trim();
     setGatewayUrl(submittedGatewayUrl);
-    setAuthToken(submittedAuthToken);
+    setApiKey(submittedApiKey);
+    setManualJwtToken(submittedJwtToken);
 
     if (submittedGatewayUrl) {
       if (isBlockedMixedContentGatewayUrl(submittedGatewayUrl)) {
@@ -1151,10 +1227,10 @@ function DebuggerPageContent() {
         return;
       }
       const normalizedGatewayUrl = normalizeGatewayUrl(submittedGatewayUrl);
-      const nextAuthToken = submittedAuthToken;
       const previousGatewayUrl = localStorage.getItem('talon_gateway_url');
-      const previousAuthToken = localStorage.getItem('talon_auth_token');
-      const expiredTokenMessage = nextAuthToken ? tokenExpiryError(nextAuthToken) : null;
+      const previousAuthToken = localStorage.getItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY);
+      const previousManualJwt = localStorage.getItem(MANUAL_JWT_STORAGE_KEY);
+      const expiredTokenMessage = !submittedApiKey && submittedJwtToken ? tokenExpiryError(submittedJwtToken) : null;
       if (expiredTokenMessage) {
         setConnectionError(expiredTokenMessage);
         setIsConnected(false);
@@ -1168,12 +1244,28 @@ function DebuggerPageContent() {
       try {
         localStorage.setItem('talon_gateway_url', normalizedGatewayUrl);
         localStorage.removeItem('talon_gateway_http_url');
-        if (nextAuthToken) {
-          localStorage.setItem('talon_auth_token', nextAuthToken);
-        } else {
-          localStorage.removeItem('talon_auth_token');
-        }
         updateGatewayClient(normalizedGatewayUrl);
+        let nextAuthToken = submittedJwtToken;
+        if (submittedApiKey) {
+          localStorage.removeItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY);
+        }
+        if (submittedApiKey) {
+          const exchanged = await getGatewayClient().auth.exchangeApiKey({
+            apiKey: submittedApiKey,
+          });
+          nextAuthToken = exchanged.accessToken;
+          setManualJwtToken('');
+          localStorage.removeItem(MANUAL_JWT_STORAGE_KEY);
+        } else if (submittedJwtToken) {
+          localStorage.setItem(MANUAL_JWT_STORAGE_KEY, submittedJwtToken);
+        } else {
+          localStorage.removeItem(MANUAL_JWT_STORAGE_KEY);
+        }
+        if (nextAuthToken) {
+          localStorage.setItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY, nextAuthToken);
+        } else {
+          localStorage.removeItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY);
+        }
         const probeTimeout = timeoutSignal(CONNECT_TIMEOUT_MS);
         try {
           await withConnectionTimeout(
@@ -1187,6 +1279,7 @@ function DebuggerPageContent() {
 
         setGatewayUrl(normalizedGatewayUrl);
         setAuthToken(nextAuthToken);
+        setApiKey('');
         setConnectionError(null);
         explicitConnectRef.current = true;
         const connectedQuery = buildSearchParams(true, selectedNamespace, searchParams).toString();
@@ -1204,11 +1297,22 @@ function DebuggerPageContent() {
           updateGatewayClient(getDefaultGatewayUrl());
         }
         if (previousAuthToken) {
-          localStorage.setItem('talon_auth_token', previousAuthToken);
+          localStorage.setItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY, previousAuthToken);
         } else {
-          localStorage.removeItem('talon_auth_token');
+          localStorage.removeItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY);
         }
-        setConnectionError(formatConnectionError(error));
+        if (previousManualJwt) {
+          localStorage.setItem(MANUAL_JWT_STORAGE_KEY, previousManualJwt);
+        } else {
+          localStorage.removeItem(MANUAL_JWT_STORAGE_KEY);
+        }
+        if (isExpiredSignatureAuthError(error)) {
+          setAuthToken('');
+          localStorage.removeItem(RUNTIME_AUTH_TOKEN_STORAGE_KEY);
+          setConnectionError('Your authorization token expired. Sign in again to continue.');
+        } else {
+          setConnectionError(formatConnectionError(error));
+        }
         setIsConnected(false);
         setAuthScreenOpen(true);
       } finally {
@@ -1225,7 +1329,8 @@ function DebuggerPageContent() {
     return (
       <AuthScreen
         gatewayUrl={gatewayUrl}
-        authToken={authToken}
+        jwtToken={manualJwtToken}
+        apiKey={apiKey}
         isConnecting={isConnecting}
         googleSsoEnabled={googleSsoEnabled}
         googleSsoError={googleSsoError}
@@ -1234,7 +1339,8 @@ function DebuggerPageContent() {
           setGatewayUrl(value);
           setConnectionError(null);
         }}
-        onAuthTokenChange={setAuthToken}
+        onJwtTokenChange={setManualJwtToken}
+        onApiKeyChange={setApiKey}
         onGoogleSignIn={handleGoogleSignIn}
         onConnect={handleConnect}
       />

--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -21,13 +21,13 @@ test.describe('Talon UI', () => {
 
     const connectButton = page.locator('button', { hasText: 'Initialize Connection' });
     const gatewayInput = page.getByLabel('Gateway URL');
-    const tokenInput = page.getByLabel('Authorization Token');
+    const apiKeyInput = page.getByLabel('API Key');
 
     await expect(gatewayInput).toBeVisible();
     await gatewayInput.evaluate((node) => {
       (node as HTMLInputElement).value = 'http://127.0.0.1:9';
     });
-    await tokenInput.evaluate((node) => {
+    await apiKeyInput.evaluate((node) => {
       (node as HTMLInputElement).value = 'autofilled-token';
     });
 
@@ -46,11 +46,11 @@ test.describe('Talon UI', () => {
 
     const connectButton = page.locator('button', { hasText: /Initialize Connection|Connecting/ });
     const gatewayInput = page.getByLabel('Gateway URL');
-    const tokenInput = page.getByLabel('Authorization Token');
 
     await expect(gatewayInput).toBeVisible();
     await gatewayInput.fill(new URL(page.url()).origin);
-    await tokenInput.fill('valid-looking-token');
+    await page.getByRole('button', { name: 'Advanced options' }).click();
+    await page.getByLabel('JWT Token').fill('valid-looking-token');
     await connectButton.click();
 
     await expect(connectButton).toContainText('Connecting');
@@ -69,15 +69,18 @@ test.describe('Talon UI', () => {
     // 2. Connect to the Gateway
     const connectButton = page.locator('button', { hasText: 'Initialize Connection' });
     const gatewayInput = page.getByLabel('Gateway URL');
-    const tokenInput = page.getByLabel('Authorization Token');
+    const apiKeyInput = page.getByLabel('API Key');
     
     // Ensure we are in disconnected state showing the form
     await expect(gatewayInput).toBeVisible();
     
     await gatewayInput.fill(gatewayUrl);
     const auth = readE2EAuth();
-    if (auth?.accessToken) {
-      await tokenInput.fill(auth.accessToken);
+    if (auth?.apiKey) {
+      await apiKeyInput.fill(auth.apiKey);
+    } else if (auth?.accessToken) {
+      await page.getByRole('button', { name: 'Advanced options' }).click();
+      await page.getByLabel('JWT Token').fill(auth.accessToken);
     }
     await connectButton.click();
 

--- a/ui/lib/grpc.test.ts
+++ b/ui/lib/grpc.test.ts
@@ -3,6 +3,7 @@ import {
   buildGatewayHeaders,
   getDefaultGatewayUrl,
   getGatewayClient,
+  isExpiredSignatureAuthError,
   normalizeGatewayUrl,
   updateGatewayClient,
 } from "./grpc";
@@ -92,6 +93,21 @@ describe("applyGatewayAuthorizationHeader", () => {
     );
 
     expect(calls).toEqual([]);
+  });
+});
+
+describe("isExpiredSignatureAuthError", () => {
+  it("detects expired signature messages", () => {
+    expect(isExpiredSignatureAuthError({ rawMessage: "JWT expired signature" })).toBe(true);
+    expect(isExpiredSignatureAuthError({ message: "signature has expired" })).toBe(true);
+  });
+
+  it("detects unauthenticated expired errors", () => {
+    expect(isExpiredSignatureAuthError({ codeName: "Unauthenticated", message: "token expired" })).toBe(true);
+  });
+
+  it("ignores unrelated auth errors", () => {
+    expect(isExpiredSignatureAuthError({ codeName: "Unauthenticated", message: "invalid audience" })).toBe(false);
   });
 });
 

--- a/ui/lib/grpc.ts
+++ b/ui/lib/grpc.ts
@@ -61,11 +61,37 @@ export function applyGatewayAuthorizationHeader(
   }
 }
 
+export const TALON_AUTH_EXPIRED_EVENT = "talon-auth-expired";
+
+export function isExpiredSignatureAuthError(error: unknown) {
+  const candidate = error as {
+    message?: string;
+    rawMessage?: string;
+    code?: string | number;
+    codeName?: string;
+    cause?: { message?: string };
+  };
+  const message = `${candidate?.rawMessage || candidate?.message || candidate?.cause?.message || ""}`.toLowerCase();
+  const code = `${candidate?.codeName || candidate?.code || ""}`.toLowerCase();
+  return (
+    message.includes("expired signature") ||
+    message.includes("signature has expired") ||
+    (code.includes("unauthenticated") && message.includes("expired"))
+  );
+}
+
 const authInterceptor: Interceptor = (next) => async (req) => {
   if (typeof window !== 'undefined') {
     applyGatewayAuthorizationHeader(req.header, localStorage.getItem('talon_auth_token'));
   }
-  return await next(req);
+  try {
+    return await next(req);
+  } catch (error) {
+    if (typeof window !== 'undefined' && isExpiredSignatureAuthError(error)) {
+      window.dispatchEvent(new CustomEvent(TALON_AUTH_EXPIRED_EVENT));
+    }
+    throw error;
+  }
 };
 
 const createClientset = (url: string): TalonClient => createTalonClient({


### PR DESCRIPTION
## Summary

Refactors Sightline authentication so API keys are a first-class connection option while manual JWT entry moves into an advanced section.

## Changes

- Adds API key input to the Sightline auth screen and exchanges API keys for runtime access tokens.
- Keeps manual JWT input hidden under Advanced options and persists only explicitly entered JWTs in that field.
- Clears remembered manual JWT input after Google or API-key auth so exchanged access tokens are not shown as reusable JWTs.
- Reopens the auth modal when an RPC fails with an expired-signature auth error.
- Updates auth-related e2e expectations and adds unit coverage for expired-signature detection.

## Validation

- `pnpm --filter @impalasys/talon-client build`
- `pnpm --dir ui exec jest lib/grpc.test.ts --runInBand --coverage=false`
- `pnpm --dir ui build`

Note: `pnpm --dir ui build` completed successfully and emitted the existing Turbopack NFT trace warning around `ui/app/api/talon/objects/route.ts`.