### PR TITLE
Fix chronological session message IDs

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -20,6 +20,7 @@ pub mod security;
 pub mod telemetry;
 pub mod topics;
 pub mod usage;
+pub mod uuid;
 
 use std::path::PathBuf;
 

--- a/src/control/pubsub.rs
+++ b/src/control/pubsub.rs
@@ -271,7 +271,7 @@ impl MessagePublisher for GcpPubSubPublisher {
         // Create a temporary subscription for this stream
         let project = configured_project_id();
         let base_name = topic_name.rsplit('/').next().unwrap_or(topic_name);
-        let sub_id = format!("{}-sub-{}", base_name, uuid::Uuid::now_v7());
+        let sub_id = format!("{}-sub-{}", base_name, crate::control::uuid::v7());
         let fq_sub = fully_qualified_subscription_name(&project, &sub_id);
         self.backend.ensure_subscription(&fq_topic, &fq_sub).await?;
         let _guard = SubscriptionGuard {

--- a/src/control/pubsub/local_socket.rs
+++ b/src/control/pubsub/local_socket.rs
@@ -191,7 +191,7 @@ impl MessagePublisher for LocalSocketMessagePublisher {
         topic: &str,
     ) -> Result<Pin<Box<dyn futures::Stream<Item = Vec<u8>> + Send>>> {
         self.ensure_server().await?;
-        let subscription = format!("local-sub-{}", uuid::Uuid::now_v7());
+        let subscription = format!("local-sub-{}", crate::control::uuid::v7());
         self.subscriber()
             .subscribe_named(topic, &subscription)
             .await

--- a/src/control/resources.rs
+++ b/src/control/resources.rs
@@ -227,8 +227,8 @@ impl ResourceStore {
             .and_then(|existing| existing.metadata.as_ref())
             .map(|meta| meta.uid.clone())
             .filter(|uid| !uid.is_empty())
-            .unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
-        let resource_version = uuid::Uuid::now_v7().to_string();
+            .unwrap_or_else(crate::control::uuid::v7);
+        let resource_version = crate::control::uuid::resource_version();
 
         if preserve_existing_status {
             resource.status = existing
@@ -337,7 +337,7 @@ impl ResourceStore {
                 .metadata
                 .as_mut()
                 .ok_or_else(|| anyhow!("resource metadata missing"))?;
-            meta.resource_version = uuid::Uuid::now_v7().to_string();
+            meta.resource_version = crate::control::uuid::resource_version();
             validate_resource_kind(&resource)?;
             let next = encode_stored_resource(&resource)?;
             if self
@@ -413,7 +413,7 @@ impl ResourceStore {
                 .as_mut()
                 .ok_or_else(|| anyhow!("resource metadata missing"))?;
             meta.deletion_timestamp = Some(now);
-            meta.resource_version = uuid::Uuid::now_v7().to_string();
+            meta.resource_version = crate::control::uuid::resource_version();
             self.kv
                 .set(&key, &encode_stored_resource(&resource)?)
                 .await?;

--- a/src/control/scheduler/local_postgres.rs
+++ b/src/control/scheduler/local_postgres.rs
@@ -354,7 +354,7 @@ fn compute_retry_delay_seconds(attempts: i32) -> i64 {
 #[async_trait::async_trait]
 impl SchedulerBackend for LocalPostgresSchedulerBackend {
     async fn schedule(&self, req: ScheduleWakeupRequest) -> Result<ScheduledWakeup> {
-        let handle = uuid::Uuid::now_v7().to_string();
+        let handle = crate::control::uuid::scheduler_handle();
         let query = format!(
             "INSERT INTO {} (handle, namespace, schedule_id, revision, fire_at_micros, payload, created_at_micros)
              VALUES ($1, $2, $3, $4, $5, $6, $7)",

--- a/src/control/scheduler/local_sqlite.rs
+++ b/src/control/scheduler/local_sqlite.rs
@@ -421,7 +421,7 @@ impl LocalSqliteSchedulerStore {
     }
 
     async fn schedule(&self, req: ScheduleWakeupRequest) -> Result<ScheduledWakeup> {
-        let handle = uuid::Uuid::now_v7().to_string();
+        let handle = crate::control::uuid::scheduler_handle();
         let query = format!(
             "INSERT INTO {} (handle, namespace, schedule_id, revision, fire_at_micros, payload, created_at_micros)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",

--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -555,7 +555,7 @@ pub async fn create_session_with_labels(
         chrono::Utc::now().timestamp(),
     )
     .await?;
-    let session_id = uuid::Uuid::now_v7().to_string();
+    let session_id = crate::control::uuid::session_id();
     let session = data_proto::Session {
         id: session_id.clone(),
         agent: agent.to_string(),
@@ -610,13 +610,13 @@ pub async fn send_message(
     message: &str,
     labels: HashMap<String, String>,
     now: DateTime<Utc>,
-) -> Result<()> {
+) -> Result<String> {
     if message.trim().is_empty() {
         return Err(EmptyMessageError.into());
     }
     let now_micros = now.timestamp_micros();
     let user_msg = data_proto::SessionMessage {
-        id: uuid::Uuid::now_v7().to_string(),
+        id: crate::control::uuid::session_message_id(),
         role: data_proto::MessageRole::RoleUser as i32,
         created_at: now_micros,
         labels,
@@ -631,9 +631,7 @@ pub async fn send_message(
         }],
     };
 
-    send_session_message(kv, pubsub, ns, agent, session_id, user_msg, now)
-        .await
-        .map(|_| ())
+    send_session_message(kv, pubsub, ns, agent, session_id, user_msg, now).await
 }
 
 pub async fn send_session_message(
@@ -684,7 +682,7 @@ pub async fn send_session_message(
     }
 
     if user_msg.id.is_empty() {
-        user_msg.id = uuid::Uuid::now_v7().to_string();
+        user_msg.id = crate::control::uuid::session_message_id();
     }
     if user_msg.role == data_proto::MessageRole::RoleUnspecified as i32 {
         user_msg.role = data_proto::MessageRole::RoleUser as i32;
@@ -732,7 +730,7 @@ pub async fn send_session_message(
         );
     }
 
-    let submission_id = message_id.clone();
+    let submission_id = crate::control::uuid::session_submission_id();
     let submission = crate::harness::sessions::pending_submission(
         submission_id.clone(),
         session_id.to_string(),
@@ -765,7 +763,7 @@ pub async fn send_session_message(
         agent: agent.to_string(),
         message: message_text,
         ns: ns.to_string(),
-        submission_id,
+        submission_id: submission_id.clone(),
     };
     if let Err(err) = pubsub
         .publish(
@@ -788,7 +786,7 @@ pub async fn send_session_message(
         message_id = %message_id,
         "Queued scheduled message for session dispatch"
     );
-    Ok(message_id)
+    Ok(submission_id)
 }
 
 pub(crate) fn session_message_text_projection(message: &data_proto::SessionMessage) -> String {
@@ -1335,7 +1333,7 @@ mod tests {
         let now = DateTime::parse_from_rfc3339("2026-05-02T12:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        send_message(
+        let returned_submission_id = send_message(
             cp.kv.as_ref(),
             cp.pubsub.as_ref(),
             "conic:test",
@@ -1370,7 +1368,14 @@ mod tests {
                     .flatten()
             })
             .expect("session dispatch event should be published");
-        assert_eq!(dispatch.submission_id, dispatch.message_id);
+        assert_ne!(dispatch.submission_id, dispatch.message_id);
+        assert_eq!(returned_submission_id, dispatch.submission_id);
+        assert_eq!(
+            uuid::Uuid::parse_str(&dispatch.submission_id)
+                .expect("submission id should be UUIDv7")
+                .get_version_num(),
+            7
+        );
         assert_eq!(
             index_event.key,
             keys::session_message("conic:test", "assistant", "session-1", &dispatch.message_id)
@@ -1387,7 +1392,7 @@ mod tests {
             .await
             .unwrap()
             .expect("session submission should be created");
-        assert_eq!(submission.submission_id, dispatch.message_id);
+        assert_eq!(submission.submission_id, dispatch.submission_id);
         assert_eq!(submission.user_message_id, dispatch.message_id);
         assert_eq!(
             submission.status,

--- a/src/control/search/events.rs
+++ b/src/control/search/events.rs
@@ -12,7 +12,7 @@ pub(crate) async fn publish_index_event(
 ) -> Result<()> {
     let now = chrono::Utc::now().timestamp_micros();
     if event.id.is_empty() {
-        event.id = uuid::Uuid::now_v7().to_string();
+        event.id = crate::control::uuid::event_id();
     }
     if event.operation == IndexOperation::Unspecified as i32 {
         event.operation = IndexOperation::Upsert as i32;

--- a/src/control/uuid.rs
+++ b/src/control/uuid.rs
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// Generate a canonical UUIDv7 string.
+///
+/// Talon uses UUIDv7 for IDs that are also storage keys and therefore must
+/// preserve chronological ordering under lexicographic key scans. Do not add
+/// semantic prefixes, suffixes, hashes, or role names to these IDs.
+pub fn v7() -> String {
+    uuid::Uuid::now_v7().to_string()
+}
+
+pub fn session_id() -> String {
+    v7()
+}
+
+pub fn session_message_id() -> String {
+    v7()
+}
+
+pub fn channel_message_id() -> String {
+    v7()
+}
+
+pub fn session_submission_id() -> String {
+    v7()
+}
+
+pub fn session_attempt_id() -> String {
+    v7()
+}
+
+pub fn resource_version() -> String {
+    v7()
+}
+
+pub fn event_id() -> String {
+    v7()
+}
+
+pub fn scheduler_handle() -> String {
+    v7()
+}
+
+pub fn worker_id() -> String {
+    v7()
+}
+
+pub fn process_id() -> String {
+    v7()
+}
+
+pub fn request_id() -> String {
+    v7()
+}
+
+pub fn auth_record_id() -> String {
+    v7()
+}
+
+pub fn unique_name(prefix: &str) -> String {
+    format!("{}-{}", prefix, v7())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn session_message_ids_are_canonical_uuid_v7() {
+        let id = super::session_message_id();
+        let parsed = uuid::Uuid::parse_str(&id).expect("id should parse as UUID");
+
+        assert_eq!(parsed.get_version_num(), 7);
+        assert_eq!(id, parsed.to_string());
+    }
+
+    #[test]
+    fn generated_v7_ids_sort_in_creation_order_within_process() {
+        let first = super::v7();
+        let second = super::v7();
+
+        assert!(first < second);
+    }
+}

--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -14,7 +14,6 @@ use axum::{
 use futures::StreamExt;
 use serde_json::{json, Value};
 use tonic::Code;
-use uuid::Uuid;
 
 use crate::control::scheduling;
 use crate::control::{
@@ -685,7 +684,7 @@ fn a2a_stream_status_update_value(
                 "status": {
                     "state": state,
                     "message": {
-                        "messageId": Uuid::now_v7().to_string(),
+                        "messageId": crate::control::uuid::session_message_id(),
                         "contextId": context_id,
                         "taskId": task_id,
                         "role": "ROLE_AGENT",

--- a/src/gateway/rest/a2a/tasks.rs
+++ b/src/gateway/rest/a2a/tasks.rs
@@ -57,7 +57,7 @@ fn a2a_context_id(message: &A2aMessageJson) -> String {
         .context_id
         .clone()
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| Uuid::now_v7().to_string())
+        .unwrap_or_else(crate::control::uuid::session_id)
 }
 
 pub(super) fn a2a_session_hint(message: &A2aMessageJson) -> Result<Option<String>, Response> {
@@ -784,7 +784,7 @@ fn a2a_message_to_session_message(
     }
 
     Ok(crate::gateway::rpc::data_proto::SessionMessage {
-        id: Uuid::now_v7().to_string(),
+        id: crate::control::uuid::session_message_id(),
         role: crate::gateway::rpc::data_proto::MessageRole::RoleUser as i32,
         created_at: timestamp,
         labels,

--- a/src/gateway/rpc/auth.rs
+++ b/src/gateway/rpc/auth.rs
@@ -184,7 +184,7 @@ impl GrpcGatewayHandler {
             }
         }
 
-        let id = uuid::Uuid::now_v7().to_string();
+        let id = crate::control::uuid::auth_record_id();
         let secret = random_url_token(API_KEY_SECRET_BYTES);
         let raw_key = format!("{API_KEY_PREFIX}{id}_{secret}");
         let prefix = raw_key

--- a/src/gateway/rpc/channels.rs
+++ b/src/gateway/rpc/channels.rs
@@ -179,7 +179,7 @@ pub(crate) async fn persist_channel_message(
     mut message: data_proto::ChannelMessage,
 ) -> anyhow::Result<data_proto::ChannelMessage> {
     if message.id.is_empty() {
-        message.id = uuid::Uuid::now_v7().to_string();
+        message.id = crate::control::uuid::channel_message_id();
     }
     let now = chrono::Utc::now().timestamp_micros();
     if message.created_at == 0 {
@@ -497,7 +497,7 @@ impl GrpcGatewayHandler {
         let message = persist_channel_message(
             &cp,
             data_proto::ChannelMessage {
-                id: uuid::Uuid::now_v7().to_string(),
+                id: crate::control::uuid::channel_message_id(),
                 ns: req.ns.clone(),
                 channel: req.channel.clone(),
                 author_kind: if req.author_kind.is_empty() {

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -792,7 +792,7 @@ async fn dispatch_to_channel(
     let message = super::channels::persist_channel_message(
         cp,
         data_proto::ChannelMessage {
-            id: connector_message_id(event),
+            id: crate::control::uuid::channel_message_id(),
             ns: channel_namespace.clone(),
             channel: channel_name.to_string(),
             author_kind: connector_author_kind(event),
@@ -931,7 +931,7 @@ async fn connector_session_id(
         }
         let reservation = format!(
             "{CONNECTOR_SESSION_RESERVATION_PREFIX}{}",
-            uuid::Uuid::now_v7()
+            crate::control::uuid::session_id()
         );
         if !cp
             .kv
@@ -1256,7 +1256,7 @@ fn connector_session_message(
         ));
     }
     Ok(data_proto::SessionMessage {
-        id: connector_message_id(event),
+        id: crate::control::uuid::session_message_id(),
         role: data_proto::MessageRole::RoleUser as i32,
         created_at: now,
         labels,
@@ -1332,17 +1332,6 @@ fn insert_label(labels: &mut HashMap<String, String>, key: &str, value: &str) {
     if !value.trim().is_empty() {
         labels.insert(key.to_string(), value.to_string());
     }
-}
-
-fn connector_message_id(event: &external_proto::ConnectorMessageEvent) -> String {
-    let source = if !event.event_id.trim().is_empty() {
-        format!("{}\x1f{}", event.registration_id, event.event_id)
-    } else if !event.external_message_id.trim().is_empty() {
-        format!("{}\x1f{}", event.registration_id, event.external_message_id)
-    } else {
-        return uuid::Uuid::now_v7().to_string();
-    };
-    format!("connector-{}", hex_sha256(source.as_bytes()))
 }
 
 fn connector_author_kind(event: &external_proto::ConnectorMessageEvent) -> String {
@@ -1473,5 +1462,37 @@ fn map_dispatch_error(err: anyhow::Error) -> tonic::Status {
         tonic::Status::not_found("Session not found")
     } else {
         tonic::Status::internal(format!("failed to dispatch connector message: {err}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connector_session_message_uses_chronological_uuid_message_id() {
+        let message = connector_session_message(
+            &external_proto::ConnectorMessageEvent {
+                event_id: "provider-event-1".to_string(),
+                event_kind: external_proto::ConnectorMessageEventKind::Created as i32,
+                registration_id: "Namespace/conic/ConnectorClass/slack".to_string(),
+                connector_class: "slack".to_string(),
+                external_message_id: "provider-message-1".to_string(),
+                text: "hello from connector".to_string(),
+                event_time_ms: 1_700_000_000_000,
+                ..Default::default()
+            },
+            HashMap::new(),
+        )
+        .expect("connector message should be valid");
+
+        assert!(!message.id.starts_with("connector-"));
+        assert!(!message.id.ends_with("-assistant"));
+        assert_eq!(
+            uuid::Uuid::parse_str(&message.id)
+                .expect("message id should be UUID")
+                .get_version_num(),
+            7
+        );
     }
 }

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -74,7 +74,7 @@ fn normalize_appended_session_message(
 ) -> data_proto::SessionMessage {
     let now_micros = chrono::Utc::now().timestamp_micros();
     if message.id.is_empty() {
-        message.id = uuid::Uuid::now_v7().to_string();
+        message.id = crate::control::uuid::session_message_id();
     }
     if message.role == data_proto::MessageRole::RoleUnspecified as i32 {
         message.role = data_proto::MessageRole::RoleUser as i32;
@@ -319,7 +319,7 @@ impl GrpcGatewayHandler {
         })?;
 
         // Use ULID (UUID v7 gives time-sorted guarantees like ULID)
-        let session_id = uuid::Uuid::now_v7().to_string();
+        let session_id = crate::control::uuid::session_id();
 
         let session = data_proto::Session {
             id: session_id.clone(),

--- a/src/harness/acp.rs
+++ b/src/harness/acp.rs
@@ -580,7 +580,7 @@ impl AcpAgentRuntime {
         params: &Value,
         sink: &dyn ExecutionSink,
     ) -> Result<Value> {
-        let request_id = uuid::Uuid::now_v7().to_string();
+        let request_id = crate::control::uuid::request_id();
         let payload = json!({
             "requestId": request_id,
             "protocol": "acp",

--- a/src/harness/sandbox/daytona.rs
+++ b/src/harness/sandbox/daytona.rs
@@ -65,7 +65,7 @@ impl SandboxBackend for DaytonaSandboxBackend {
         let command = shell_command(&spec);
         let _ = daytona_execute(backend_id, &command).await?;
         Ok(ProcessHandle {
-            id: uuid::Uuid::now_v7().to_string(),
+            id: crate::control::uuid::process_id(),
         })
     }
 

--- a/src/harness/sandbox/docker.rs
+++ b/src/harness/sandbox/docker.rs
@@ -33,7 +33,7 @@ impl SandboxBackend for DockerSandboxBackend {
         policy: &SandboxPolicySpecJson,
     ) -> Result<SandboxHandle> {
         let image = docker_image(class, policy);
-        let container_name = format!("talon-sandbox-{}", uuid::Uuid::now_v7());
+        let container_name = crate::control::uuid::unique_name("talon-sandbox");
         let mut args = vec![
             "run".to_string(),
             "-d".to_string(),
@@ -113,7 +113,7 @@ impl SandboxBackend for DockerSandboxBackend {
         args.extend(spec.args.clone());
 
         let output = Command::new("docker").args(&args).output().await?;
-        let process_id = uuid::Uuid::now_v7().to_string();
+        let process_id = crate::control::uuid::process_id();
         self.processes.lock().await.insert(
             process_id.clone(),
             ProcessOutput {

--- a/src/harness/sandbox/e2b.rs
+++ b/src/harness/sandbox/e2b.rs
@@ -101,7 +101,7 @@ impl SandboxBackend for E2bSandboxBackend {
 
     async fn exec(&self, backend_id: &str, spec: ExecSpec) -> Result<ProcessHandle> {
         let output = e2b_run_command(backend_id, spec).await?;
-        let process_id = uuid::Uuid::now_v7().to_string();
+        let process_id = crate::control::uuid::process_id();
         e2b_process_outputs()
             .lock()
             .await

--- a/src/harness/sandbox/mock.rs
+++ b/src/harness/sandbox/mock.rs
@@ -35,7 +35,7 @@ impl SandboxBackend for MockSandboxBackend {
         _policy: &SandboxPolicySpecJson,
     ) -> Result<SandboxHandle> {
         Ok(SandboxHandle {
-            backend_id: format!("mock-{}-{}", class.provider, uuid::Uuid::now_v7()),
+            backend_id: crate::control::uuid::unique_name(&format!("mock-{}", class.provider)),
         })
     }
 
@@ -44,7 +44,7 @@ impl SandboxBackend for MockSandboxBackend {
     }
 
     async fn exec(&self, _backend_id: &str, spec: ExecSpec) -> Result<ProcessHandle> {
-        let process_id = uuid::Uuid::now_v7().to_string();
+        let process_id = crate::control::uuid::process_id();
         mock_sandbox_state()
             .lock()
             .await

--- a/src/harness/sessions/submission.rs
+++ b/src/harness/sessions/submission.rs
@@ -106,7 +106,7 @@ pub async fn claim_submission(
         }
 
         submission.status = SessionSubmissionStatus::Claimed as i32;
-        submission.attempt_id = uuid::Uuid::now_v7().to_string();
+        submission.attempt_id = crate::control::uuid::session_attempt_id();
         submission.claim_worker_id = worker_id.to_string();
         submission.attempt_count = submission.attempt_count.saturating_add(1);
         submission.claim_expires_at = Some(now_micros.saturating_add(claim_ttl_micros));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ pub mod test_support {
 
     impl PostgresContainer {
         pub fn start(prefix: &str) -> Self {
-            let name = format!("{}-{}", prefix, uuid::Uuid::now_v7());
+            let name = crate::control::uuid::unique_name(prefix);
             let run = Command::new("docker")
                 .args([
                     "run",

--- a/src/worker/controllers/sandbox.rs
+++ b/src/worker/controllers/sandbox.rs
@@ -187,7 +187,7 @@ impl<B: SandboxBackend> SandboxLeaseService<B> {
         agent: &str,
         session_id: &str,
     ) -> Result<LeasedSandbox> {
-        let token = uuid::Uuid::now_v7().to_string();
+        let token = crate::control::uuid::v7();
         let leased = self
             .update_sandbox_status(&sandbox, |status| {
                 let now = chrono::Utc::now().timestamp_micros();
@@ -350,7 +350,7 @@ impl<B: SandboxBackend> SandboxController<B> {
             .metadata
             .as_ref()
             .ok_or_else(|| anyhow!("SandboxPolicy metadata is required"))?;
-        let name = format!("{}-{}", policy_meta.name, uuid::Uuid::now_v7());
+        let name = crate::control::uuid::unique_name(&policy_meta.name);
         let sandbox = resources_proto::Resource {
             api_version: policy.api_version.clone(),
             kind: "Sandbox".to_string(),

--- a/src/worker/registration.rs
+++ b/src/worker/registration.rs
@@ -40,7 +40,7 @@ impl WorkerRegistration {
 
 pub fn worker_id() -> String {
     GENERATED_WORKER_ID
-        .get_or_init(|| uuid::Uuid::now_v7().to_string())
+        .get_or_init(crate::control::uuid::worker_id)
         .clone()
 }
 

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -417,7 +417,7 @@ impl WorkerEventHandler {
             .lock()
             .await
             .insert(event.session_id.clone(), cancellation_token.clone());
-        let reply_msg_id = format!("{}-assistant", submission.submission_id);
+        let reply_msg_id = crate::control::uuid::session_message_id();
         let reply_msg_key = crate::control::keys::session_message(
             ns,
             &event.agent,
@@ -1910,7 +1910,12 @@ mod tests {
         let deliveries = deliveries.lock().unwrap().clone();
         assert_eq!(deliveries.len(), 1);
         let delivery = &deliveries[0];
-        assert_eq!(delivery["deliveryId"], "user-1-assistant");
+        assert_eq!(
+            uuid::Uuid::parse_str(delivery["deliveryId"].as_str().unwrap_or_default())
+                .expect("delivery id should be UUIDv7")
+                .get_version_num(),
+            7
+        );
         assert_eq!(delivery["connectorClass"], "slack");
         assert_eq!(delivery["connectorName"], "slack-main");
         assert_eq!(delivery["externalConversationId"], "C123");
@@ -2028,12 +2033,31 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(session.status, "ERROR");
+        let message_keys = kv
+            .list_keys(&crate::control::keys::session_message_prefix(
+                "conic:test",
+                "assistant",
+                "session-1",
+            ))
+            .await
+            .unwrap();
+        let error_message_id = message_keys
+            .iter()
+            .map(|key| key.name.as_str())
+            .find(|id| *id != "user-1")
+            .expect("assistant error message should be persisted");
+        assert_eq!(
+            uuid::Uuid::parse_str(error_message_id)
+                .expect("assistant error message id should be UUIDv7")
+                .get_version_num(),
+            7
+        );
         let error_message = kv
             .get_msg::<data_proto::SessionMessage>(&crate::control::keys::session_message(
                 "conic:test",
                 "assistant",
                 "session-1",
-                "user-1-assistant",
+                error_message_id,
             ))
             .await
             .unwrap()

--- a/src/worker/workflows.rs
+++ b/src/worker/workflows.rs
@@ -255,7 +255,7 @@ pub async fn create_run(
     let now = Utc::now().timestamp_micros();
     let spec_json = serde_json::to_string(spec)?;
     let run = data_proto::WorkflowRun {
-        id: uuid::Uuid::now_v7().to_string(),
+        id: crate::control::uuid::v7(),
         workflow: workflow.name().to_string(),
         ns: workflow.namespace().to_string(),
         status: STATUS_QUEUED.to_string(),
@@ -1658,7 +1658,7 @@ pub async fn append_run_event(
     payload: Value,
 ) -> Result<data_proto::WorkflowRunEvent> {
     let event = data_proto::WorkflowRunEvent {
-        id: uuid::Uuid::now_v7().to_string(),
+        id: crate::control::uuid::v7(),
         ns: run.ns.clone(),
         workflow: run.workflow.clone(),
         run_id: run.id.clone(),


### PR DESCRIPTION
## Summary
- add explicit UUIDv7 ID helpers for resource-specific identifiers
- stop deriving connector session/channel message IDs from connector event hashes
- decouple session submission IDs from user and assistant message IDs so message keys remain chronological UUIDv7s

## Tests
- cargo check
- cargo test --lib
- cargo test --all-targets
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized how IDs and names are generated across sessions, messages, resources, workers, sandboxes, and workflows.
  * New created items now use consistently ordered identifiers, improving traceability and sorting.

* **Bug Fixes**
  * Fixed several flows where fallback identifiers could differ between components.
  * Improved consistency for message delivery, scheduling, and resource updates so related records now stay aligned more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->