### PR TITLE
[codex] Add assistant append connector delivery

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -14,7 +14,7 @@ import {
   type AssistantTimelineItem,
   type CopilotMessage,
 } from "./lib/chatTimeline";
-import { TalonChatComposer } from "./lib/TalonChatComposer";
+import { TalonChatComposer, type TalonChatComposerVariant } from "./lib/TalonChatComposer";
 import {
   findTalonChatCommand,
   parseTalonChatCommandInput,
@@ -140,6 +140,7 @@ export type TalonSessionProps = {
    * must be enforced again by the onImageUpload implementation.
    */
   acceptedImageTypes?: string[];
+  composerVariant?: TalonChatComposerVariant;
   composerStartAdornment?: React.ReactNode;
   composerEndAdornment?: React.ReactNode;
   onSubmitMessage?: (context: TalonSessionSubmitContext) => Promise<boolean | void> | boolean | void;
@@ -575,6 +576,7 @@ export function TalonSession({
   maxImageAttachments = 4,
   maxImageBytes = 20 * 1024 * 1024,
   acceptedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"],
+  composerVariant = "panel",
   composerStartAdornment,
   composerEndAdornment,
   onSubmitMessage,
@@ -1795,12 +1797,13 @@ export function TalonSession({
             backdropFilter: "blur(10px)",
           }}
         >
-          <div style={{ width: "100%", maxWidth: 896, paddingBottom: 8 }}>
+          <div style={{ width: "100%", maxWidth: "var(--talon-chat-composer-max-width, 896px)", paddingBottom: 8 }}>
             <TalonChatComposer
               value={input}
               onValueChange={setInput}
               onSubmit={(nextInput) => void submitMessage(nextInput)}
               placeholder={placeholder}
+              variant={composerVariant}
               autoFocus={autoFocus}
               rows={inputRows}
               canSubmit={Boolean((input || "").trim() || imageAttachments.length > 0) && !isLoading}

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -29,6 +29,7 @@ const useSafeLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : us
 export type SessionServiceClientLike = {
   create(request: { ns: string; agent: string; labels?: Record<string, string> }): Promise<{ sessionId: string }>;
   clear(request: { ns: string; agent: string; sessionId: string }): Promise<any>;
+  appendMessage?(request: any): Promise<any>;
   listMessages(request: {
     ns: string;
     agent: string;
@@ -78,6 +79,32 @@ export type TalonImageUploadResult = TalonChatObjectRef | {
   url?: string;
 };
 
+type TalonSessionHandle = {
+  ns: string;
+  agent: string;
+  sessionId: string;
+};
+
+export type TalonSessionPendingImageAttachment = {
+  id: string;
+  file: File;
+  previewUrl: string;
+  object?: TalonChatObjectRef;
+  status: "queued" | "uploading" | "ready" | "error";
+  error?: string;
+};
+
+export type TalonSessionSubmitContext = {
+  text: string;
+  namespace: string;
+  agent: string;
+  sessionId: string | null;
+  imageAttachments: ReadonlyArray<TalonSessionPendingImageAttachment>;
+  ensureSession: () => Promise<TalonSessionHandle>;
+  clearInput: () => void;
+  refreshSession: () => Promise<void>;
+};
+
 export type TalonSessionProps = {
   namespace: string;
   agent: string;
@@ -113,6 +140,9 @@ export type TalonSessionProps = {
    * must be enforced again by the onImageUpload implementation.
    */
   acceptedImageTypes?: string[];
+  composerStartAdornment?: React.ReactNode;
+  composerEndAdornment?: React.ReactNode;
+  onSubmitMessage?: (context: TalonSessionSubmitContext) => Promise<boolean | void> | boolean | void;
 };
 
 export type TalonCopilotProps = TalonSessionProps;
@@ -206,15 +236,6 @@ type ScrollThumbState = {
   visible: boolean;
   top: number;
   height: number;
-};
-
-type PendingImageAttachment = {
-  id: string;
-  file: File;
-  previewUrl: string;
-  object?: TalonChatObjectRef;
-  status: "queued" | "uploading" | "ready" | "error";
-  error?: string;
 };
 
 function stableStringHash(value: string) {
@@ -554,10 +575,13 @@ export function TalonSession({
   maxImageAttachments = 4,
   maxImageBytes = 20 * 1024 * 1024,
   acceptedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"],
+  composerStartAdornment,
+  composerEndAdornment,
+  onSubmitMessage,
 }: TalonSessionProps) {
   const [messages, setMessages] = useState<CopilotMessage[]>(emptyMessages);
   const [input, setInput] = useState("");
-  const [imageAttachments, setImageAttachments] = useState<PendingImageAttachment[]>([]);
+  const [imageAttachments, setImageAttachments] = useState<TalonSessionPendingImageAttachment[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
   const [loadingNow, setLoadingNow] = useState(Date.now());
@@ -576,7 +600,7 @@ export function TalonSession({
   const resumeAbortControllerRef = useRef<AbortController | null>(null);
   const currentSessionRef = useRef<{ ns: string; agent: string; sessionId: string } | null>(null);
   const messagesRef = useRef<CopilotMessage[]>(emptyMessages);
-  const imageAttachmentsRef = useRef<PendingImageAttachment[]>([]);
+  const imageAttachmentsRef = useRef<TalonSessionPendingImageAttachment[]>([]);
   const submittedPreviewUrlsRef = useRef<string[]>([]);
   const skipNextAutoScrollRef = useRef(false);
   const autoScrollPinnedRef = useRef(true);
@@ -1455,6 +1479,43 @@ export function TalonSession({
     if ((!text && !hasImages) || isLoading || disabled) return;
     let submitTurnStarted = false;
 
+    const ensureSession = async (): Promise<TalonSessionHandle> => {
+      let session = currentSessionRef.current;
+      if (!session) {
+        const sessionRes = await createSession({ ns: namespace, agent });
+        session = { ns: namespace, agent, sessionId: sessionRes.sessionId };
+        currentSessionRef.current = session;
+        setCurrentSession(session);
+        onSessionChange?.(session.sessionId);
+      }
+      return session;
+    };
+
+    if (onSubmitMessage) {
+      setError(null);
+      try {
+        const handled = await onSubmitMessage({
+          text,
+          namespace,
+          agent,
+          sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null,
+          imageAttachments: pendingAttachments,
+          ensureSession,
+          clearInput: () => setInput(""),
+          refreshSession: async () => {
+            const session = await ensureSession();
+            await refreshNewestSessionPage(session);
+          },
+        });
+        if (handled) {
+          return;
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+    }
+
     const parsedCommand = parseTalonChatCommandInput(text);
     const command = findTalonChatCommand(resolvedCommands, parsedCommand);
     if (command && parsedCommand && !hasImages) {
@@ -1493,13 +1554,7 @@ export function TalonSession({
         messagesRef.current.slice(-resolvedHistoryPageSize),
       );
 
-      if (!session) {
-        const sessionRes = await createSession({ ns: namespace, agent });
-        session = { ns: namespace, agent, sessionId: sessionRes.sessionId };
-        currentSessionRef.current = session;
-        setCurrentSession(session);
-        onSessionChange?.(session.sessionId);
-      }
+      session = await ensureSession();
 
       const controller = new AbortController();
       abortControllerRef.current = controller;
@@ -1746,6 +1801,8 @@ export function TalonSession({
               isGenerating={isLoading}
               canStop={Boolean(currentSession)}
               commandMenuItems={commandMenuItems}
+              startAdornment={composerStartAdornment}
+              endAdornment={composerEndAdornment}
               imageAttachments={imageAttachments.map((attachment) => ({
                 id: attachment.id,
                 filename: attachment.file.name,

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -1482,11 +1482,17 @@ export function TalonSession({
     const ensureSession = async (): Promise<TalonSessionHandle> => {
       let session = currentSessionRef.current;
       if (!session) {
-        const sessionRes = await createSession({ ns: namespace, agent });
-        session = { ns: namespace, agent, sessionId: sessionRes.sessionId };
-        currentSessionRef.current = session;
-        setCurrentSession(session);
-        onSessionChange?.(session.sessionId);
+        if (sessionId) {
+          session = { ns: namespace, agent, sessionId };
+          currentSessionRef.current = session;
+          setCurrentSession(session);
+        } else {
+          const sessionRes = await createSession({ ns: namespace, agent });
+          session = { ns: namespace, agent, sessionId: sessionRes.sessionId };
+          currentSessionRef.current = session;
+          setCurrentSession(session);
+          onSessionChange?.(session.sessionId);
+        }
       }
       return session;
     };

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -199,6 +199,7 @@ export type TalonSessionProps = {
    * must be enforced again by the onImageUpload implementation.
    */
   acceptedImageTypes?: string[];
+  composerVariant?: TalonChatComposerVariant;
   composerStartAdornment?: React.ReactNode;
   composerEndAdornment?: React.ReactNode;
   onSubmitMessage?: (context: TalonSessionSubmitContext) => Promise<boolean | void> | boolean | void;

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -4,7 +4,7 @@ import type { TalonClient } from "@impalasys/talon-client";
 export type GatewayClientLike = {
   sessions: Pick<
     TalonClient["sessions"],
-    "create" | "clear" | "listMessages" | "submitTurn" | "streamParts" | "stopGeneration"
+    "create" | "clear" | "appendMessage" | "listMessages" | "submitTurn" | "streamParts" | "stopGeneration"
   >;
 };
 
@@ -100,6 +100,8 @@ export type TalonChatComposerProps = {
   textareaMinHeight?: number;
   textareaMaxHeight?: number | string;
   commandMenuItems?: TalonChatComposerCommandMenuItem[];
+  startAdornment?: React.ReactNode;
+  endAdornment?: React.ReactNode;
   imageAttachments?: TalonChatComposerImageAttachment[];
   imageUploadEnabled?: boolean;
   imageAccept?: string;
@@ -107,6 +109,26 @@ export type TalonChatComposerProps = {
   onImageFilesSelected?: (files: File[]) => void;
   onRemoveImageAttachment?: (id: string) => void;
   style?: React.CSSProperties;
+};
+
+export type TalonSessionPendingImageAttachment = {
+  id: string;
+  file: File;
+  previewUrl: string;
+  object?: TalonChatObjectRef;
+  status: "queued" | "uploading" | "ready" | "error";
+  error?: string;
+};
+
+export type TalonSessionSubmitContext = {
+  text: string;
+  namespace: string;
+  agent: string;
+  sessionId: string | null;
+  imageAttachments: ReadonlyArray<TalonSessionPendingImageAttachment>;
+  ensureSession: () => Promise<{ ns: string; agent: string; sessionId: string }>;
+  clearInput: () => void;
+  refreshSession: () => Promise<void>;
 };
 
 export type TalonSessionCommandTarget = {
@@ -177,6 +199,9 @@ export type TalonSessionProps = {
    * must be enforced again by the onImageUpload implementation.
    */
   acceptedImageTypes?: string[];
+  composerStartAdornment?: React.ReactNode;
+  composerEndAdornment?: React.ReactNode;
+  onSubmitMessage?: (context: TalonSessionSubmitContext) => Promise<boolean | void> | boolean | void;
 };
 
 export type TalonCopilotProps = TalonSessionProps;

--- a/packages/talon-chat/src/index.ts
+++ b/packages/talon-chat/src/index.ts
@@ -5,10 +5,12 @@ export {
   type TalonSessionCommand,
   type TalonSessionCommandTarget,
   type TalonSessionProps,
+  type TalonSessionSubmitContext,
   type TalonCopilotProps,
   type TalonChatObjectRef,
   type TalonImageUploadContext,
   type TalonImageUploadResult,
+  type TalonSessionPendingImageAttachment,
 } from "./TalonSession";
 export {
   TalonChannel,

--- a/packages/talon-chat/src/lib/TalonChatComposer.tsx
+++ b/packages/talon-chat/src/lib/TalonChatComposer.tsx
@@ -116,6 +116,8 @@ export type TalonChatComposerProps = {
   textareaMinHeight?: number;
   textareaMaxHeight?: number | string;
   commandMenuItems?: TalonChatComposerCommandMenuItem[];
+  startAdornment?: React.ReactNode;
+  endAdornment?: React.ReactNode;
   imageAttachments?: TalonChatComposerImageAttachment[];
   imageUploadEnabled?: boolean;
   imageAccept?: string;
@@ -158,6 +160,8 @@ export function TalonChatComposer({
   textareaMinHeight = 24,
   textareaMaxHeight = "40vh",
   commandMenuItems,
+  startAdornment,
+  endAdornment,
   imageAttachments,
   imageUploadEnabled = false,
   imageAccept = "image/png,image/jpeg,image/gif,image/webp",
@@ -616,6 +620,18 @@ export function TalonChatComposer({
             </button>
           </>
         ) : null}
+        {startAdornment ? (
+          <div
+            style={{
+              order: controlsBelow ? 2 : undefined,
+              flexShrink: 0,
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            {startAdornment}
+          </div>
+        ) : null}
         <textarea
           ref={textareaRef}
           className="talon-chat-input-textarea"
@@ -667,6 +683,18 @@ export function TalonChatComposer({
             }
           }}
         />
+        {endAdornment ? (
+          <div
+            style={{
+              order: controlsBelow ? 2 : undefined,
+              flexShrink: 0,
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            {endAdornment}
+          </div>
+        ) : null}
         <button
           type={isStopMode ? "button" : "submit"}
           onClick={isStopMode && onStop ? onStop : undefined}

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -358,7 +358,7 @@ pub fn is_connector_silence_response(text: &str) -> bool {
     )
 }
 
-fn session_message_final_response(message: &data_proto::SessionMessage) -> String {
+pub(crate) fn session_message_final_response(message: &data_proto::SessionMessage) -> String {
     let final_parts_start = message
         .parts
         .iter()

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -24,6 +24,7 @@ const LABEL_EXTERNAL_MESSAGE: &str = "talon.impalasys.com/external-message";
 const LABEL_EXTERNAL_SENDER: &str = "talon.impalasys.com/external-sender";
 const LABEL_CONVERSATION_TYPE: &str = "talon.impalasys.com/conversation-type";
 const LABEL_CONNECTOR_MATCH_PREFIX: &str = "talon.impalasys.com/connector-match/";
+const LABEL_CHANNEL_TRIGGER: &str = "talon.impalasys.com/channel-trigger";
 const CONNECTOR_HTTP_TIMEOUT: Duration = Duration::from_secs(15);
 const CONNECTOR_SESSION_RESERVATION_PREFIX: &str = "reserved:";
 
@@ -355,6 +356,105 @@ pub fn is_connector_silence_response(text: &str) -> bool {
         text.trim().to_ascii_uppercase().as_str(),
         "[SILENT]" | "SILENT" | "NO_REPLY" | "NO REPLY"
     )
+}
+
+fn session_message_final_response(message: &data_proto::SessionMessage) -> String {
+    let final_parts_start = message
+        .parts
+        .iter()
+        .rposition(|part| is_final_response_boundary(part.part_type));
+    let final_parts = match final_parts_start {
+        Some(index) => &message.parts[index + 1..],
+        None => message.parts.as_slice(),
+    };
+
+    final_parts
+        .iter()
+        .filter_map(final_response_text)
+        .filter(|content| !content.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn final_response_text(part: &data_proto::SessionMessagePart) -> Option<&str> {
+    match data_proto::SessionMessagePartType::try_from(part.part_type) {
+        Ok(data_proto::SessionMessagePartType::Text)
+        | Ok(data_proto::SessionMessagePartType::Error) => Some(part.content.trim()),
+        _ => None,
+    }
+}
+
+fn is_final_response_boundary(part_type: i32) -> bool {
+    matches!(
+        data_proto::SessionMessagePartType::try_from(part_type),
+        Ok(data_proto::SessionMessagePartType::Reasoning)
+            | Ok(data_proto::SessionMessagePartType::ToolCall)
+            | Ok(data_proto::SessionMessagePartType::ToolResult)
+            | Ok(data_proto::SessionMessagePartType::RequestPermission)
+            | Ok(data_proto::SessionMessagePartType::PermissionResult)
+    )
+}
+
+pub async fn maybe_deliver_connector_session_message(
+    cp: &ControlPlane,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+    message_id: &str,
+) -> anyhow::Result<()> {
+    let session = cp
+        .kv
+        .get_msg::<data_proto::Session>(&keys::session(ns, agent, session_id))
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("session not found"))?;
+    if !session.labels.contains_key(LABEL_CONNECTOR_REGISTRATION) {
+        return Ok(());
+    }
+    if session
+        .labels
+        .get(LABEL_MESSAGE_SOURCE)
+        .is_some_and(|source| source != "connector")
+    {
+        return Ok(());
+    }
+    if session.labels.contains_key(LABEL_CHANNEL_TRIGGER) {
+        return Ok(());
+    }
+
+    let message = cp
+        .kv
+        .get_msg::<data_proto::SessionMessage>(&keys::session_message(
+            ns, agent, session_id, message_id,
+        ))
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("assistant message not found"))?;
+    if message.role != data_proto::MessageRole::RoleAssistant as i32 {
+        return Ok(());
+    }
+
+    let text = session_message_final_response(&message);
+    if text.trim().is_empty() {
+        tracing::info!(
+            namespace = %ns,
+            agent = %agent,
+            session = %session_id,
+            message_id = %message_id,
+            "connector session reply has no text; skipping outbound delivery"
+        );
+        return Ok(());
+    }
+    if is_connector_silence_response(&text) {
+        tracing::info!(
+            namespace = %ns,
+            agent = %agent,
+            session = %session_id,
+            message_id = %message_id,
+            "connector session reply suppressed by no-reply token"
+        );
+        return Ok(());
+    }
+
+    deliver_connector_session_message(cp, &session, &message, &text).await
 }
 
 pub async fn deliver_connector_session_message(

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::{data_proto, proto, GrpcGatewayHandler};
+use super::{connectors as connector_rpc, data_proto, proto, GrpcGatewayHandler};
 use crate::control::scheduling;
 use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;
@@ -948,7 +948,10 @@ impl GrpcGatewayHandler {
                 "message must contain at least one part",
             ));
         }
+        let should_deliver_connector_reply =
+            message.role == data_proto::MessageRole::RoleAssistant as i32;
         let message_key = keys::session_message(&req.ns, &req.agent, &req.session_id, &message.id);
+        let message_id = message.id.clone();
         let inserted = self
             .gateway
             .kv
@@ -985,6 +988,30 @@ impl GrpcGatewayHandler {
                 message_id = %message.id,
                 "failed to publish search index event for appended session message"
             );
+        }
+
+        if should_deliver_connector_reply {
+            if let Err(error) = connector_rpc::maybe_deliver_connector_session_message(
+                &self.gateway.control_plane(),
+                &req.ns,
+                &req.agent,
+                &req.session_id,
+                &message_id,
+            )
+            .await
+            {
+                tracing::warn!(
+                    error = %error,
+                    namespace = %req.ns,
+                    agent = %req.agent,
+                    session_id = %req.session_id,
+                    message_id = %message_id,
+                    "failed to deliver appended connector session message"
+                );
+                return Err(tonic::Status::internal(format!(
+                    "Failed to deliver connector session message: {error}"
+                )));
+            }
         }
 
         Ok(tonic::Response::new(proto::AppendSessionMessageResponse {

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -47,46 +47,6 @@ fn fanout_subscriber_grace() -> std::time::Duration {
     std::time::Duration::from_millis(millis)
 }
 
-#[cfg(test)]
-fn session_message_final_response(message: &data_proto::SessionMessage) -> String {
-    let final_parts_start = message
-        .parts
-        .iter()
-        .rposition(|part| is_final_response_boundary(part.part_type));
-    let final_parts = match final_parts_start {
-        Some(index) => &message.parts[index + 1..],
-        None => message.parts.as_slice(),
-    };
-
-    final_parts
-        .iter()
-        .filter_map(final_response_text)
-        .filter(|content| !content.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-#[cfg(test)]
-fn final_response_text(part: &data_proto::SessionMessagePart) -> Option<&str> {
-    match data_proto::SessionMessagePartType::try_from(part.part_type) {
-        Ok(data_proto::SessionMessagePartType::Text)
-        | Ok(data_proto::SessionMessagePartType::Error) => Some(part.content.trim()),
-        _ => None,
-    }
-}
-
-#[cfg(test)]
-fn is_final_response_boundary(part_type: i32) -> bool {
-    matches!(
-        data_proto::SessionMessagePartType::try_from(part_type),
-        Ok(data_proto::SessionMessagePartType::Reasoning)
-            | Ok(data_proto::SessionMessagePartType::ToolCall)
-            | Ok(data_proto::SessionMessagePartType::ToolResult)
-            | Ok(data_proto::SessionMessagePartType::RequestPermission)
-            | Ok(data_proto::SessionMessagePartType::PermissionResult)
-    )
-}
-
 async fn execute_with_panic_boundary<F>(
     future: F,
     sink: &dyn ExecutionSink,
@@ -1055,15 +1015,14 @@ impl WorkerEventHandler {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        execute_with_panic_boundary, session_message_final_response, SessionCompletionStatus,
-    };
+    use super::{execute_with_panic_boundary, SessionCompletionStatus};
     use crate::control::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::{
         events::{MessageDirection, SessionMessageEvent},
         keys::{ResourceKey, ResourceList},
         ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
+    use crate::gateway::rpc::connectors::session_message_final_response;
     use crate::gateway::rpc::{data_proto, manifests, resources_proto};
     use crate::harness::executor::ExecutionSink;
     use crate::harness::sessions;

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -47,6 +47,7 @@ fn fanout_subscriber_grace() -> std::time::Duration {
     std::time::Duration::from_millis(millis)
 }
 
+#[cfg(test)]
 fn session_message_final_response(message: &data_proto::SessionMessage) -> String {
     let final_parts_start = message
         .parts
@@ -65,6 +66,7 @@ fn session_message_final_response(message: &data_proto::SessionMessage) -> Strin
         .join("\n")
 }
 
+#[cfg(test)]
 fn final_response_text(part: &data_proto::SessionMessagePart) -> Option<&str> {
     match data_proto::SessionMessagePartType::try_from(part.part_type) {
         Ok(data_proto::SessionMessagePartType::Text)
@@ -73,6 +75,7 @@ fn final_response_text(part: &data_proto::SessionMessagePart) -> Option<&str> {
     }
 }
 
+#[cfg(test)]
 fn is_final_response_boundary(part_type: i32) -> bool {
     matches!(
         data_proto::SessionMessagePartType::try_from(part_type),
@@ -926,57 +929,10 @@ impl WorkerEventHandler {
         session_id: &str,
         message_id: &str,
     ) -> Result<()> {
-        let session = self
-            .cp
-            .kv
-            .get_msg::<data_proto::Session>(&crate::control::keys::session(ns, agent, session_id))
-            .await?
-            .ok_or_else(|| anyhow!("session not found"))?;
-        if !session.labels.contains_key(LABEL_CONNECTOR_REGISTRATION) {
-            return Ok(());
-        }
-        if session
-            .labels
-            .get(LABEL_MESSAGE_SOURCE)
-            .is_some_and(|source| source != "connector")
-        {
-            return Ok(());
-        }
-        if session.labels.contains_key(LABEL_CHANNEL_TRIGGER) {
-            return Ok(());
-        }
-
-        let message = self
-            .cp
-            .kv
-            .get_msg::<data_proto::SessionMessage>(&crate::control::keys::session_message(
-                ns, agent, session_id, message_id,
-            ))
-            .await?
-            .ok_or_else(|| anyhow!("assistant message not found"))?;
-        let text = session_message_final_response(&message);
-        if text.trim().is_empty() {
-            tracing::info!(
-                namespace = %ns,
-                agent = %agent,
-                session = %session_id,
-                message_id = %message_id,
-                "connector session reply has no text; skipping outbound delivery"
-            );
-            return Ok(());
-        }
-        if connector_rpc::is_connector_silence_response(&text) {
-            tracing::info!(
-                namespace = %ns,
-                agent = %agent,
-                session = %session_id,
-                message_id = %message_id,
-                "connector session reply suppressed by no-reply token"
-            );
-            return Ok(());
-        }
-
-        connector_rpc::deliver_connector_session_message(&self.cp, &session, &message, &text).await
+        connector_rpc::maybe_deliver_connector_session_message(
+            &self.cp, ns, agent, session_id, message_id,
+        )
+        .await
     }
 
     pub async fn handle_session_control(
@@ -2036,6 +1992,123 @@ mod tests {
             .as_str()
             .unwrap_or_default()
             .contains("OpenAI provider config is missing api_key"));
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn maybe_deliver_connector_session_message_delivers_appended_assistant_message() {
+        let kv = Arc::new(MockKvStore::default());
+        let deliveries: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(
+                "/v1/deliveries",
+                post(
+                    |State(deliveries): State<Arc<Mutex<Vec<Value>>>>,
+                     Json(payload): Json<Value>| async move {
+                        deliveries.lock().unwrap().push(payload);
+                        Json(json!({
+                            "accepted": true,
+                            "disposition": "accepted",
+                            "error": ""
+                        }))
+                    },
+                ),
+            )
+            .with_state(deliveries.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        put_connector_class_resource(kv.clone(), endpoint).await;
+
+        kv.set_msg(
+            &crate::control::keys::session("conic:test", "assistant", "session-1"),
+            &data_proto::Session {
+                id: "session-1".to_string(),
+                agent: "assistant".to_string(),
+                ns: "conic:test".to_string(),
+                status: "READY".to_string(),
+                created_at: 0,
+                last_active: 123,
+                metadata: HashMap::new(),
+                labels: HashMap::from([
+                    (
+                        "talon.impalasys.com/message-source".to_string(),
+                        "connector".to_string(),
+                    ),
+                    (
+                        "talon.impalasys.com/connector-registration".to_string(),
+                        "Namespace/conic%3Atest/ConnectorClass/slack".to_string(),
+                    ),
+                    (
+                        "talon.impalasys.com/connector".to_string(),
+                        "slack-main".to_string(),
+                    ),
+                    (
+                        "talon.impalasys.com/connector-class".to_string(),
+                        "slack".to_string(),
+                    ),
+                    (
+                        "talon.impalasys.com/external-conversation".to_string(),
+                        "C123".to_string(),
+                    ),
+                    (
+                        "talon.impalasys.com/external-message".to_string(),
+                        "1710000000.000100".to_string(),
+                    ),
+                ]),
+            },
+        )
+        .await
+        .unwrap();
+        kv.set_msg(
+            &crate::control::keys::session_message(
+                "conic:test",
+                "assistant",
+                "session-1",
+                "assistant-1",
+            ),
+            &data_proto::SessionMessage {
+                id: "assistant-1".to_string(),
+                role: data_proto::MessageRole::RoleAssistant as i32,
+                created_at: 1,
+                labels: HashMap::from([(
+                    "talon.impalasys.com/message-source".to_string(),
+                    "sightline".to_string(),
+                )]),
+                parts: vec![data_proto::SessionMessagePart {
+                    id: "000000".to_string(),
+                    part_type: data_proto::SessionMessagePartType::Text as i32,
+                    content: "human-authored reply".to_string(),
+                    name: String::new(),
+                    payload_json: String::new(),
+                    created_at: 1,
+                    object: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let cp = ControlPlane::builder(kv, Arc::new(MockPubSub)).build();
+        crate::gateway::rpc::connectors::maybe_deliver_connector_session_message(
+            &cp,
+            "conic:test",
+            "assistant",
+            "session-1",
+            "assistant-1",
+        )
+        .await
+        .expect("assistant append should deliver");
+
+        let deliveries = deliveries.lock().unwrap().clone();
+        assert_eq!(deliveries.len(), 1);
+        let delivery = &deliveries[0];
+        assert_eq!(delivery["deliveryId"], "assistant-1");
+        assert_eq!(delivery["text"], "human-authored reply");
+        assert_eq!(delivery["externalConversationId"], "C123");
 
         server.abort();
     }

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -575,15 +575,6 @@
   --copilot-attachment-menu-fg: #0f172a;
   --copilot-attachment-menu-hover-bg: rgba(15, 23, 42, 0.06);
   --copilot-attachment-menu-icon-fg: #334155;
-  --sightline-expanded-composer-bg: rgba(255, 255, 255, 0.98);
-  --sightline-expanded-composer-border: rgba(148, 163, 184, 0.34);
-  --sightline-expanded-composer-shadow:
-    0 28px 76px rgba(15, 23, 42, 0.12),
-    0 2px 8px rgba(15, 23, 42, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9);
-  --sightline-expanded-composer-placeholder: rgba(100, 116, 139, 0.86);
-  --sightline-expanded-composer-control-bg: #eef2f7;
-  --sightline-expanded-composer-control-fg: #7c8798;
 }
 
 .dark {
@@ -693,26 +684,6 @@
   --copilot-attachment-menu-fg: #e6edf3;
   --copilot-attachment-menu-hover-bg: rgba(148, 163, 184, 0.14);
   --copilot-attachment-menu-icon-fg: #e6edf3;
-  --sightline-expanded-composer-bg: rgba(15, 23, 42, 0.94);
-  --sightline-expanded-composer-border: rgba(148, 163, 184, 0.32);
-  --sightline-expanded-composer-shadow:
-    0 28px 76px rgba(0, 0, 0, 0.4),
-    0 2px 8px rgba(0, 0, 0, 0.24),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  --sightline-expanded-composer-placeholder: rgba(148, 163, 184, 0.76);
-  --sightline-expanded-composer-control-bg: rgba(226, 232, 240, 0.12);
-  --sightline-expanded-composer-control-fg: rgba(226, 232, 240, 0.72);
-}
-
-.sightline-expanded-session-input {
-  --talon-chat-composer-max-width: min(1792px, calc(100vw - 3rem));
-  --copilot-input-radius: 999px;
-  --copilot-input-bg: var(--sightline-expanded-composer-bg);
-  --copilot-input-border: var(--sightline-expanded-composer-border);
-  --copilot-input-shadow: var(--sightline-expanded-composer-shadow);
-  --copilot-input-placeholder: var(--sightline-expanded-composer-placeholder);
-  --copilot-control-bg: var(--sightline-expanded-composer-control-bg);
-  --copilot-control-fg: var(--sightline-expanded-composer-control-fg);
 }
 
 html,

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -575,6 +575,15 @@
   --copilot-attachment-menu-fg: #0f172a;
   --copilot-attachment-menu-hover-bg: rgba(15, 23, 42, 0.06);
   --copilot-attachment-menu-icon-fg: #334155;
+  --sightline-expanded-composer-bg: rgba(255, 255, 255, 0.98);
+  --sightline-expanded-composer-border: rgba(148, 163, 184, 0.34);
+  --sightline-expanded-composer-shadow:
+    0 28px 76px rgba(15, 23, 42, 0.12),
+    0 2px 8px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  --sightline-expanded-composer-placeholder: rgba(100, 116, 139, 0.86);
+  --sightline-expanded-composer-control-bg: #eef2f7;
+  --sightline-expanded-composer-control-fg: #7c8798;
 }
 
 .dark {
@@ -684,6 +693,26 @@
   --copilot-attachment-menu-fg: #e6edf3;
   --copilot-attachment-menu-hover-bg: rgba(148, 163, 184, 0.14);
   --copilot-attachment-menu-icon-fg: #e6edf3;
+  --sightline-expanded-composer-bg: rgba(15, 23, 42, 0.94);
+  --sightline-expanded-composer-border: rgba(148, 163, 184, 0.32);
+  --sightline-expanded-composer-shadow:
+    0 28px 76px rgba(0, 0, 0, 0.4),
+    0 2px 8px rgba(0, 0, 0, 0.24),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --sightline-expanded-composer-placeholder: rgba(148, 163, 184, 0.76);
+  --sightline-expanded-composer-control-bg: rgba(226, 232, 240, 0.12);
+  --sightline-expanded-composer-control-fg: rgba(226, 232, 240, 0.72);
+}
+
+.sightline-expanded-session-input {
+  --talon-chat-composer-max-width: min(1792px, calc(100vw - 3rem));
+  --copilot-input-radius: 999px;
+  --copilot-input-bg: var(--sightline-expanded-composer-bg);
+  --copilot-input-border: var(--sightline-expanded-composer-border);
+  --copilot-input-shadow: var(--sightline-expanded-composer-shadow);
+  --copilot-input-placeholder: var(--sightline-expanded-composer-placeholder);
+  --copilot-control-bg: var(--sightline-expanded-composer-control-bg);
+  --copilot-control-fg: var(--sightline-expanded-composer-control-fg);
 }
 
 html,

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1539,7 +1539,7 @@ function DebuggerPageContent() {
               ) : null}
               <div className="min-h-0 flex-1 overflow-hidden">
                 <TalonCopilot
-                  className="h-full sightline-expanded-session-input"
+                  className="h-full"
                   namespace={selectedNamespace.ns}
                   agent={selectedNamespace.agent || 'default'}
                   sessionId={selectedNamespace.type === 'session' ? selectedNamespace.sessionId : undefined}
@@ -1549,16 +1549,16 @@ function DebuggerPageContent() {
                   onImageUpload={sessionComposerRole === 'assistant' || isStaticExport ? undefined : uploadTalonImage}
                   objectUrlForRef={isStaticExport ? undefined : talonObjectUrl}
                   disabled={!isConnected}
-                  composerVariant="panel"
+                  composerVariant="expanded"
                   composerStartAdornment={
-                    <div className="flex h-10 overflow-hidden rounded-full border border-slate-200 bg-white p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-slate-700 dark:bg-slate-950/70">
+                    <div className="flex h-8 overflow-hidden rounded-full border border-border bg-background/80 p-0.5">
                       {(['user', 'assistant'] as const).map((role) => (
                         <button
                           key={role}
                           type="button"
                           className={cn(
-                            "rounded-full px-4 text-[14px] font-medium capitalize transition-colors",
-                            sessionComposerRole === role ? "bg-slate-950 text-white dark:bg-white dark:text-slate-950" : "text-slate-500 hover:text-slate-950 dark:text-slate-400 dark:hover:text-white"
+                            "rounded-full px-2.5 text-[11px] font-medium capitalize transition-colors",
+                            sessionComposerRole === role ? "bg-foreground text-background" : "text-muted-foreground hover:text-foreground"
                           )}
                           onClick={() => setSessionComposerRole(role)}
                         >

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1539,7 +1539,7 @@ function DebuggerPageContent() {
               ) : null}
               <div className="min-h-0 flex-1 overflow-hidden">
                 <TalonCopilot
-                  className="h-full"
+                  className="h-full sightline-expanded-session-input"
                   namespace={selectedNamespace.ns}
                   agent={selectedNamespace.agent || 'default'}
                   sessionId={selectedNamespace.type === 'session' ? selectedNamespace.sessionId : undefined}
@@ -1549,15 +1549,16 @@ function DebuggerPageContent() {
                   onImageUpload={sessionComposerRole === 'assistant' || isStaticExport ? undefined : uploadTalonImage}
                   objectUrlForRef={isStaticExport ? undefined : talonObjectUrl}
                   disabled={!isConnected}
+                  composerVariant="panel"
                   composerStartAdornment={
-                    <div className="flex h-8 overflow-hidden rounded-full border border-border bg-background/80 p-0.5">
+                    <div className="flex h-10 overflow-hidden rounded-full border border-slate-200 bg-white p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-slate-700 dark:bg-slate-950/70">
                       {(['user', 'assistant'] as const).map((role) => (
                         <button
                           key={role}
                           type="button"
                           className={cn(
-                            "rounded-full px-2.5 text-[11px] font-medium capitalize transition-colors",
-                            sessionComposerRole === role ? "bg-foreground text-background" : "text-muted-foreground hover:text-foreground"
+                            "rounded-full px-4 text-[14px] font-medium capitalize transition-colors",
+                            sessionComposerRole === role ? "bg-slate-950 text-white dark:bg-white dark:text-slate-950" : "text-slate-500 hover:text-slate-950 dark:text-slate-400 dark:hover:text-white"
                           )}
                           onClick={() => setSessionComposerRole(role)}
                         >

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -36,6 +36,7 @@ import { motion } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { TalonChannel, TalonCopilot, type TalonChatObjectRef, type TalonImageUploadContext } from '@impalasys/talon-chat';
+import { data } from '@impalasys/talon-client';
 import { NamespaceExplorer } from '../components/Namespaces/NamespaceExplorer';
 import { WorkspaceCommandPalette } from '../components/Search/WorkspaceCommandPalette';
 import {
@@ -66,6 +67,15 @@ const isStaticExport = process.env.NEXT_PUBLIC_TALON_STATIC_EXPORT === '1';
 const CONNECT_TIMEOUT_MS = 8000;
 const RUNTIME_AUTH_TOKEN_STORAGE_KEY = 'talon_auth_token';
 const MANUAL_JWT_STORAGE_KEY = 'talon_manual_jwt';
+const LABEL_MESSAGE_SOURCE = 'talon.impalasys.com/message-source';
+const LABEL_AUTHOR_KIND = 'talon.impalasys.com/author-kind';
+const LABEL_AUTHOR = 'talon.impalasys.com/author';
+const LABEL_CONNECTOR = 'talon.impalasys.com/connector';
+const LABEL_CONNECTOR_CLASS = 'talon.impalasys.com/connector-class';
+const LABEL_CONNECTOR_REGISTRATION = 'talon.impalasys.com/connector-registration';
+const LABEL_EXTERNAL_CONVERSATION = 'talon.impalasys.com/external-conversation';
+const LABEL_EXTERNAL_SENDER = 'talon.impalasys.com/external-sender';
+const LABEL_CONVERSATION_TYPE = 'talon.impalasys.com/conversation-type';
 declare global {
   interface Window {
     google?: {
@@ -81,6 +91,37 @@ declare global {
 
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+type SessionConnectorMetadata = {
+  connector: string;
+  connectorClass: string;
+  registration: string;
+  externalConversation: string;
+  externalSender: string;
+  conversationType: string;
+};
+
+function normalizeLabels(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object') return {};
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+  );
+}
+
+function connectorMetadataFromLabels(labels: Record<string, string>): SessionConnectorMetadata | null {
+  if (!labels[LABEL_CONNECTOR_REGISTRATION] || !labels[LABEL_EXTERNAL_CONVERSATION]) {
+    return null;
+  }
+  return {
+    connector: labels[LABEL_CONNECTOR] || '',
+    connectorClass: labels[LABEL_CONNECTOR_CLASS] || '',
+    registration: labels[LABEL_CONNECTOR_REGISTRATION] || '',
+    externalConversation: labels[LABEL_EXTERNAL_CONVERSATION] || '',
+    externalSender: labels[LABEL_EXTERNAL_SENDER] || '',
+    conversationType: labels[LABEL_CONVERSATION_TYPE] || '',
+  };
 }
 
 function positiveIntParam(searchParams: URLSearchParams, name: string) {
@@ -923,6 +964,8 @@ function DebuggerPageContent() {
   const [authScreenOpen, setAuthScreenOpen] = useState(false);
   const [isHoveringConnection, setIsHoveringConnection] = useState(false);
   const [selectedNamespace, setSelectedNamespace] = useState<Selection | null>(null);
+  const [sessionComposerRole, setSessionComposerRole] = useState<'user' | 'assistant'>('user');
+  const [sessionConnectorMetadata, setSessionConnectorMetadata] = useState<SessionConnectorMetadata | null>(null);
   const [isSidebarPinned, setIsSidebarPinned] = useState(true);
   const [isSidebarHovered, setIsSidebarHovered] = useState(false);
   const [isRightSidebarPinned, setIsRightSidebarPinned] = useState(true);
@@ -957,6 +1000,32 @@ function DebuggerPageContent() {
     },
     []
   );
+
+  useEffect(() => {
+    setSessionComposerRole('user');
+    setSessionConnectorMetadata(null);
+    if (!isConnected || selectedNamespace?.type !== 'session') return;
+
+    let canceled = false;
+    getGatewayClient().sessions.get({
+      ns: selectedNamespace.ns,
+      agent: selectedNamespace.agent || 'default',
+      sessionId: selectedNamespace.sessionId,
+      messageLimit: 0,
+    }).then((response: any) => {
+      if (canceled) return;
+      const labels = normalizeLabels(response?.labels);
+      setSessionConnectorMetadata(connectorMetadataFromLabels(labels));
+    }).catch(() => {
+      if (!canceled) {
+        setSessionConnectorMetadata(null);
+      }
+    });
+
+    return () => {
+      canceled = true;
+    };
+  }, [isConnected, selectedNamespace]);
 
   useEffect(() => {
     const savedUrl = localStorage.getItem('talon_gateway_url');
@@ -1457,28 +1526,88 @@ function DebuggerPageContent() {
           {/* Center Pane */}
           <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden bg-transparent">
           {selectedNamespace?.type === 'session' ? (
-            <div className={cn("min-h-0 min-w-0 flex-1 overflow-hidden transition-opacity duration-300", !isConnected && "opacity-20 pointer-events-none")}>
-              <TalonCopilot
-                className="h-full"
-                namespace={selectedNamespace.ns}
-                agent={selectedNamespace.agent || 'default'}
-                sessionId={selectedNamespace.type === 'session' ? selectedNamespace.sessionId : undefined}
-                gatewayClient={getGatewayClient()}
-                historyPageSize={positiveIntParam(searchParams, 'historyPageSize')}
-                enabledBuiltInCommands={['clear']}
-                onImageUpload={isStaticExport ? undefined : uploadTalonImage}
-                objectUrlForRef={isStaticExport ? undefined : talonObjectUrl}
-                disabled={!isConnected}
-                onSessionChange={(nextSessionId) => {
-                  handleSelectionChange({
-                    type: 'session',
-                    ns: selectedNamespace.ns,
-                    agent: selectedNamespace.agent || 'default',
-                    sessionId: nextSessionId,
-                    fullPath: `${selectedNamespace.ns}/${selectedNamespace.agent || 'default'}/${nextSessionId}`,
-                  });
-                }}
-              />
+            <div className={cn("flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden transition-opacity duration-300", !isConnected && "opacity-20 pointer-events-none")}>
+              {sessionConnectorMetadata ? (
+                <div className="mx-auto mt-3 flex w-[calc(100%-2rem)] max-w-4xl flex-wrap items-center gap-2 rounded-lg border border-emerald-500/20 bg-emerald-500/8 px-3 py-2 text-xs text-emerald-200">
+                  <Plug className="h-3.5 w-3.5" />
+                  <span className="font-medium">{sessionConnectorMetadata.connectorClass || 'connector'}</span>
+                  {sessionConnectorMetadata.connector ? <span className="text-emerald-100/70">{sessionConnectorMetadata.connector}</span> : null}
+                  <span className="min-w-0 truncate text-emerald-100/80">{sessionConnectorMetadata.externalConversation}</span>
+                  {sessionConnectorMetadata.externalSender ? <span className="text-emerald-100/60">from {sessionConnectorMetadata.externalSender}</span> : null}
+                  {sessionConnectorMetadata.conversationType ? <span className="ml-auto rounded-full bg-emerald-400/10 px-2 py-0.5 text-[11px] text-emerald-100/80">{sessionConnectorMetadata.conversationType}</span> : null}
+                </div>
+              ) : null}
+              <div className="min-h-0 flex-1 overflow-hidden">
+                <TalonCopilot
+                  className="h-full"
+                  namespace={selectedNamespace.ns}
+                  agent={selectedNamespace.agent || 'default'}
+                  sessionId={selectedNamespace.type === 'session' ? selectedNamespace.sessionId : undefined}
+                  gatewayClient={getGatewayClient()}
+                  historyPageSize={positiveIntParam(searchParams, 'historyPageSize')}
+                  enabledBuiltInCommands={['clear']}
+                  onImageUpload={sessionComposerRole === 'assistant' || isStaticExport ? undefined : uploadTalonImage}
+                  objectUrlForRef={isStaticExport ? undefined : talonObjectUrl}
+                  disabled={!isConnected}
+                  composerStartAdornment={
+                    <div className="flex h-8 overflow-hidden rounded-full border border-border bg-background/80 p-0.5">
+                      {(['user', 'assistant'] as const).map((role) => (
+                        <button
+                          key={role}
+                          type="button"
+                          className={cn(
+                            "rounded-full px-2.5 text-[11px] font-medium capitalize transition-colors",
+                            sessionComposerRole === role ? "bg-foreground text-background" : "text-muted-foreground hover:text-foreground"
+                          )}
+                          onClick={() => setSessionComposerRole(role)}
+                        >
+                          {role}
+                        </button>
+                      ))}
+                    </div>
+                  }
+                  onSubmitMessage={async ({ text, imageAttachments, ensureSession, clearInput, refreshSession }) => {
+                    if (sessionComposerRole !== 'assistant') return false;
+                    if (imageAttachments.length > 0) {
+                      throw new Error('Assistant-mode image delivery is not supported yet.');
+                    }
+                    const session = await ensureSession();
+                    const sessions = getGatewayClient().sessions as any;
+                    if (!sessions.appendMessage) {
+                      throw new Error('Gateway client does not support sessions.appendMessage().');
+                    }
+                    await sessions.appendMessage({
+                      ns: session.ns,
+                      agent: session.agent,
+                      sessionId: session.sessionId,
+                      message: {
+                        role: data.MessageRole.ROLE_ASSISTANT,
+                        labels: {
+                          [LABEL_MESSAGE_SOURCE]: 'sightline',
+                          [LABEL_AUTHOR_KIND]: 'human',
+                          [LABEL_AUTHOR]: 'sightline',
+                        },
+                        parts: [{
+                          partType: data.SessionMessagePartType.TEXT,
+                          content: text,
+                        }],
+                      },
+                    });
+                    clearInput();
+                    await refreshSession();
+                    return true;
+                  }}
+                  onSessionChange={(nextSessionId) => {
+                    handleSelectionChange({
+                      type: 'session',
+                      ns: selectedNamespace.ns,
+                      agent: selectedNamespace.agent || 'default',
+                      sessionId: nextSessionId,
+                      fullPath: `${selectedNamespace.ns}/${selectedNamespace.agent || 'default'}/${nextSessionId}`,
+                    });
+                  }}
+                />
+              </div>
             </div>
           ) : (
             <div className={cn("flex-1 overflow-y-auto overflow-x-hidden transition-opacity duration-300 elegant-scrollbar", !isConnected && "opacity-20 pointer-events-none")}>

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -188,6 +188,9 @@ function makeGatewayClient(raw: any = {}, gatewayUrl = 'http://localhost:18789',
       const response = await fetcher(`${gatewayUrl}/v1/ns/${request.ns}/agents/${request.agent}/sessions/${request.sessionId}`, expect.anything());
       return response.json();
     }),
+    appendMessage: raw.appendMessage ?? jest.fn(async (request: any) => {
+      return { sessionId: request.sessionId, message: request.message };
+    }),
     submitTurn: raw.submitTurn ?? jest.fn(async function* (request: any, options?: any) {
       const bodyParts = (request.message?.parts ?? []).map((part: any) => {
         const partType = part?.partType ?? part?.part_type;
@@ -966,6 +969,68 @@ describe('TalonCopilot', () => {
       },
       messages: [],
     }));
+  });
+
+  it('renders composer adornments and allows custom submit handling', async () => {
+    const appendMessage = jest.fn().mockResolvedValue({ sessionId: 'sess-custom' });
+    const submitTurn = jest.fn(async function* () {});
+    const gatewayClient = {
+      sessions: {
+        create: jest.fn(),
+        clear: jest.fn(),
+        appendMessage,
+        listMessages: jest.fn().mockResolvedValue({
+          sessionId: 'sess-custom',
+          state: 'IDLE',
+          items: [],
+        }),
+        submitTurn,
+        streamParts: jest.fn(async function* () {}),
+        stopGeneration: jest.fn(),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-custom"
+        composerStartAdornment={<button type="button">Assistant</button>}
+        onSubmitMessage={async ({ text, ensureSession, clearInput }) => {
+          const session = await ensureSession();
+          await appendMessage({
+            ns: session.ns,
+            agent: session.agent,
+            sessionId: session.sessionId,
+            message: {
+              role: 2,
+              parts: [{ partType: 1, content: text }],
+            },
+          });
+          clearInput();
+          return true;
+        }}
+      />,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Assistant' })).toBeInTheDocument();
+    const input = screen.getByPlaceholderText('Ask Talon to perform a task...');
+    fireEvent.change(input, { target: { value: 'human reply' } });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => expect(appendMessage).toHaveBeenCalled());
+    expect(appendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      ns: 'ops',
+      agent: 'copilot',
+      sessionId: 'sess-custom',
+      message: expect.objectContaining({
+        role: 2,
+        parts: [expect.objectContaining({ content: 'human reply' })],
+      }),
+    }));
+    expect(submitTurn).not.toHaveBeenCalled();
+    expect(input).toHaveValue('');
   });
 
   it('scrolls the transcript container as streamed output arrives', async () => {


### PR DESCRIPTION
## Summary
- make `AppendMessage(ROLE_ASSISTANT)` auto-deliver for connector-backed direct sessions through the shared connector delivery path
- add generic talon-chat composer extension hooks and custom submit handling
- add Sightline-only assistant/user composer mode with connector metadata display and human provenance labels

## Validation
- `cargo check`
- `cargo fmt`
- `git diff --check`
- `pnpm --dir packages/talon-chat build`
- `pnpm --dir ui build`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`
- `cargo test worker::sessions::tests::maybe_deliver_connector_session_message_delivers_appended_assistant_message -- --nocapture`
- `cargo test worker::sessions::tests::handle_session_message_delivers_connector_error_reply -- --nocapture`

Notes: `ui build` completed with the existing Turbopack NFT warning, and the focused Jest run emitted existing React `act(...)` warnings from async session refreshes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added composer customization options, including variant selection and optional content at the start or end of the input area.
  * Added a submission override hook for custom message handling.
  * Enabled support for appending assistant messages and carrying connector metadata in the chat UI.

* **Bug Fixes**
  * Improved assistant message delivery for connector-managed sessions.
  * Better handles message submission errors and session refresh behavior.

* **Tests**
  * Updated and expanded coverage for custom submission flows and composer adornments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->