### PR TITLE
[codex] Add ACP harness modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
           cache-from: type=gha,scope=talon-runtime
           cache-to: type=gha,mode=max,scope=talon-runtime
 
-  codex_acp_image:
-    name: Codex ACP Sandbox Image
+  acp_harness_image:
+    name: ACP Harness Sandbox Image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -106,7 +106,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Codex ACP sandbox image
+      - name: Build ACP harness sandbox image
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -114,8 +114,14 @@ jobs:
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           load: false
           tags: |
+            ghcr.io/impalasys/talon-acp-harness:latest
+            ghcr.io/impalasys/talon-acp-harness:sha-${{ github.sha }}
             ghcr.io/impalasys/talon-codex-acp:latest
             ghcr.io/impalasys/talon-codex-acp:sha-${{ github.sha }}
+            ghcr.io/impalasys/talon-claude-code-acp:latest
+            ghcr.io/impalasys/talon-claude-code-acp:sha-${{ github.sha }}
+            ghcr.io/impalasys/talon-opencode-acp:latest
+            ghcr.io/impalasys/talon-opencode-acp:sha-${{ github.sha }}
 
   ui:
     name: UI

--- a/dockerfiles/codex-acp.Dockerfile
+++ b/dockerfiles/codex-acp.Dockerfile
@@ -4,9 +4,12 @@ FROM node:22-bookworm-slim
 
 ARG CODEX_CLI_VERSION=latest
 ARG CODEX_ACP_VERSION=0.16.0
+ARG CLAUDE_CODE_VERSION=latest
+ARG CLAUDE_CODE_ACP_VERSION=0.16.2
+ARG OPENCODE_VERSION=latest
 
-LABEL org.opencontainers.image.title="Talon Codex ACP Sandbox"
-LABEL org.opencontainers.image.description="Codex CLI plus the Zed Codex ACP adapter for Talon Docker sandboxes"
+LABEL org.opencontainers.image.title="Talon ACP Harness Sandbox"
+LABEL org.opencontainers.image.description="ACP-compatible coding harnesses for Talon Docker sandboxes"
 LABEL org.opencontainers.image.source="https://github.com/impala-systems/talon"
 
 ENV NODE_ENV=production
@@ -15,6 +18,8 @@ ENV NPM_CONFIG_FUND=false
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ENV CODEX_HOME=/home/codex/.codex
+ENV CLAUDE_CONFIG_DIR=/home/codex/.claude
+ENV OPENCODE_CONFIG_DIR=/home/codex/.config/opencode
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -34,10 +39,13 @@ RUN apt-get update \
 RUN npm install -g \
         "@openai/codex@${CODEX_CLI_VERSION}" \
         "@zed-industries/codex-acp@${CODEX_ACP_VERSION}" \
+        "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+        "@zed-industries/claude-code-acp@${CLAUDE_CODE_ACP_VERSION}" \
+        "opencode-ai@${OPENCODE_VERSION}" \
     && npm cache clean --force
 
 RUN useradd --create-home --shell /bin/bash codex \
-    && mkdir -p /workspace "${CODEX_HOME}" \
+    && mkdir -p /workspace "${CODEX_HOME}" "${CLAUDE_CONFIG_DIR}" "${OPENCODE_CONFIG_DIR}" \
     && chown -R codex:codex /workspace /home/codex
 
 USER codex

--- a/docs/operations/codex-acp-docker-sandbox.md
+++ b/docs/operations/codex-acp-docker-sandbox.md
@@ -1,25 +1,34 @@
-# Codex ACP Docker Sandbox
+# ACP Harness Docker Sandbox
 
-Talon does not depend on a third-party Codex ACP Docker image. Build the local sandbox image from this repository, then reference that image from a `SandboxClass`.
+Talon does not depend on third-party ACP Docker images. Build the local sandbox image from this repository, then reference that image from a `SandboxClass`.
 
 ```bash
 docker build \
   -f dockerfiles/codex-acp.Dockerfile \
-  -t talon-codex-acp:local \
+  -t talon-acp-harness:local \
   .
 ```
 
 Main branch publishes the same image to GHCR:
 
 ```text
+ghcr.io/impalasys/talon-acp-harness:latest
+ghcr.io/impalasys/talon-acp-harness:sha-<git-sha>
 ghcr.io/impalasys/talon-codex-acp:latest
 ghcr.io/impalasys/talon-codex-acp:sha-<git-sha>
+ghcr.io/impalasys/talon-claude-code-acp:latest
+ghcr.io/impalasys/talon-claude-code-acp:sha-<git-sha>
+ghcr.io/impalasys/talon-opencode-acp:latest
+ghcr.io/impalasys/talon-opencode-acp:sha-<git-sha>
 ```
 
 The image contains:
 
 - OpenAI Codex CLI from `@openai/codex`
 - Zed's Codex ACP adapter from `@zed-industries/codex-acp`
+- Anthropic Claude Code CLI from `@anthropic-ai/claude-code`
+- Zed's Claude Code ACP adapter from `@zed-industries/claude-code-acp`
+- OpenCode CLI from `opencode-ai`
 - Common coding tools: Git, SSH client, Python, ripgrep, jq, curl, and a build toolchain
 
 Do not bake API keys into the image. Pass credentials at runtime through the Talon sandbox backend or local Docker environment.
@@ -41,11 +50,42 @@ metadata:
 spec:
   provider: docker
   providerConfig:
-    image: talon-codex-acp:local
+    image: talon-acp-harness:local
   credentials: {}
 ```
 
-When Talon leases a Docker sandbox from a `SandboxPolicy` that points at this class, the Docker backend starts the container and the ACP runtime launches `codex-acp` inside it.
+When Talon leases a Docker sandbox from a `SandboxPolicy` that points at this class, the Docker backend starts the container and the ACP runtime launches the configured ACP harness inside it.
+
+Talon recognizes these `harnessRef` aliases:
+
+```yaml
+runtime:
+  kind: acp
+  acp:
+    harnessRef: codex
+    cwd: /workspace
+    sandboxPolicyRef: coding
+```
+
+```yaml
+runtime:
+  kind: acp
+  acp:
+    harnessRef: claude-code
+    cwd: /workspace
+    sandboxPolicyRef: coding
+```
+
+```yaml
+runtime:
+  kind: acp
+  acp:
+    harnessRef: opencode
+    cwd: /workspace
+    sandboxPolicyRef: coding
+```
+
+`codex` resolves to `codex-acp`, `claude-code` resolves to `claude-code-acp`, and `opencode` resolves to `opencode acp`. Talon forwards matching process environment keys when present: `OPENAI_API_KEY` and `CODEX_API_KEY` for Codex, `ANTHROPIC_API_KEY` for Claude Code, and `OPENCODE_API_KEY` plus common provider keys for OpenCode.
 
 The opt-in smoke test uses the same default image:
 
@@ -54,3 +94,14 @@ TALON_CODEX_ACP_TEST=1 cargo test harness::acp::tests::codex_acp_starts_inside_d
 ```
 
 Override the image with `TALON_CODEX_ACP_IMAGE` when testing a registry-published build. Set `TALON_CODEX_ACP_PLATFORM` only when you intentionally want Docker to pull or run a specific image platform.
+
+The live Python e2e can run any supported harness:
+
+```bash
+TALON_ACP_DOCKER_E2E=1 \
+TALON_ACP_E2E_HARNESS=codex \
+TALON_ACP_E2E_IMAGE=ghcr.io/impalasys/talon-acp-harness:latest \
+pytest tests/test_chat_sqlite.py -k live_acp
+```
+
+For the pytest path, set `TALON_ACP_E2E_HARNESS` to `codex`, `claude-code`, or `opencode`, and provide the matching credential in the environment or repo `.env`: `CODEX_API_KEY`/`OPENAI_API_KEY` for Codex, `ANTHROPIC_API_KEY` for Claude Code, or `OPENCODE_API_KEY` plus provider keys for OpenCode. The legacy `TALON_CODEX_DOCKER_E2E` and `TALON_CODEX_ACP_IMAGE` variables still work for Codex mode.

--- a/manifests/examples/acp-agents/README.md
+++ b/manifests/examples/acp-agents/README.md
@@ -6,7 +6,7 @@ ACP coding agent.
 Build the local sandbox image before starting a session:
 
 ```bash
-docker build -f dockerfiles/codex-acp.Dockerfile -t talon-codex-acp:local .
+docker build -f dockerfiles/codex-acp.Dockerfile -t talon-acp-harness:local .
 ```
 
 Then apply the manifests:
@@ -15,6 +15,13 @@ Then apply the manifests:
 talon-cli apply -f manifests/examples/acp-agents
 ```
 
-The `coding` agent runs `codex-acp` inside a sandbox leased from the `coding`
-`SandboxPolicy`. Provide `OPENAI_API_KEY` to the Talon worker or Docker runtime
-environment; do not commit API keys into these manifests.
+The `coding` agent uses `harnessRef: codex`, which resolves to `codex-acp`
+inside a sandbox leased from the `coding` `SandboxPolicy`. The same image also
+contains Claude Code and OpenCode ACP harnesses:
+
+- `claude-code` resolves to `claude-code-acp`
+- `opencode` resolves to `opencode acp`
+
+Provide the matching credential to the Talon worker or Docker runtime
+environment, for example `OPENAI_API_KEY`, `CODEX_API_KEY`, `ANTHROPIC_API_KEY`,
+or `OPENCODE_API_KEY`. Do not commit API keys into these manifests.

--- a/manifests/examples/acp-agents/claude-code-agent.yaml
+++ b/manifests/examples/acp-agents/claude-code-agent.yaml
@@ -1,7 +1,7 @@
 apiVersion: talon.impalasys.com/v1
 kind: Agent
 metadata:
-  name: coding
+  name: claude-code
   namespace: Example
   labels:
     example: acp-agents
@@ -9,7 +9,7 @@ spec:
   runtime:
     kind: acp
     acp:
-      harnessRef: codex
+      harnessRef: claude-code
       cwd: /workspace
       sandboxPolicyRef: coding
       persistSession: true
@@ -19,6 +19,6 @@ spec:
         filesystemWrite: ask
         terminal: ask
   systemPrompt: |
-    You are the ACP-backed coding agent for the Example namespace.
+    You are the Claude Code ACP-backed coding agent for the Example namespace.
     Work inside /workspace, explain meaningful file changes, and ask before
     taking actions that require elevated permission.

--- a/manifests/examples/acp-agents/opencode-agent.yaml
+++ b/manifests/examples/acp-agents/opencode-agent.yaml
@@ -1,7 +1,7 @@
 apiVersion: talon.impalasys.com/v1
 kind: Agent
 metadata:
-  name: coding
+  name: opencode
   namespace: Example
   labels:
     example: acp-agents
@@ -9,7 +9,7 @@ spec:
   runtime:
     kind: acp
     acp:
-      harnessRef: codex
+      harnessRef: opencode
       cwd: /workspace
       sandboxPolicyRef: coding
       persistSession: true
@@ -19,6 +19,6 @@ spec:
         filesystemWrite: ask
         terminal: ask
   systemPrompt: |
-    You are the ACP-backed coding agent for the Example namespace.
+    You are the OpenCode ACP-backed coding agent for the Example namespace.
     Work inside /workspace, explain meaningful file changes, and ask before
     taking actions that require elevated permission.

--- a/manifests/examples/acp-agents/sandbox-class.yaml
+++ b/manifests/examples/acp-agents/sandbox-class.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   provider: docker
   providerConfig:
-    image: talon-codex-acp:local
+    image: talon-acp-harness:local
   credentials: {}

--- a/manifests/examples/v2-company-builder/sandbox-class-docker.yaml
+++ b/manifests/examples/v2-company-builder/sandbox-class-docker.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   provider: docker
   providerConfig:
-    image: talon-zed-codex-acp:local
+    image: talon-acp-harness:local
   credentials: {}

--- a/src/harness/acp.rs
+++ b/src/harness/acp.rs
@@ -123,16 +123,11 @@ impl AcpAgentRuntime {
             .await?;
         let sandbox_backend_id = sandbox_backend_id(&leased.sandbox)?;
 
-        let command = if self.acp.command.trim().is_empty() {
-            self.acp.harness_ref.clone()
-        } else {
-            self.acp.command.clone()
-        };
+        let (effective_acp, command) = effective_acp_runtime(&self.acp);
         if command.trim().is_empty() {
             let _ = lease_service.release(&leased.sandbox, &leased.token).await;
             return Err(anyhow!("ACP runtime requires command or harnessRef"));
         }
-        let effective_acp = effective_acp_runtime(&self.acp, &command);
 
         let mut child = acp_harness_command(&effective_acp, &sandbox_backend_id, &command)
             .stdin(std::process::Stdio::piped())
@@ -181,16 +176,19 @@ impl AcpAgentRuntime {
             }),
         )
         .await?;
-        let _ = read_response(&mut lines, 1).await?;
-        send_request(
-            &mut stdin,
-            2,
-            "authenticate",
-            json!({ "methodId": acp_auth_method(&effective_acp) }),
-        )
-        .await?;
-        let _ = read_optional_capability_response(&mut lines, 2).await?;
-        let mut open_request_id = 3;
+        let initialize = read_response(&mut lines, 1).await?;
+        let mut open_request_id = 2;
+        if let Some(method_id) = acp_auth_method(&effective_acp, &initialize.result) {
+            send_request(
+                &mut stdin,
+                open_request_id,
+                "authenticate",
+                json!({ "methodId": method_id }),
+            )
+            .await?;
+            let _ = read_optional_capability_response(&mut lines, open_request_id).await?;
+            open_request_id += 1;
+        }
         let mut opened_new_session = false;
         let open_response = if effective_acp.persist_session {
             send_request(
@@ -722,36 +720,156 @@ fn acp_harness_command(
     local
 }
 
-fn effective_acp_runtime(acp: &manifests::AcpRuntime, command: &str) -> manifests::AcpRuntime {
-    let mut effective = acp.clone();
-    let command_name = if command.trim().is_empty() {
-        effective.harness_ref.as_str()
-    } else {
-        command
-    };
-    if !command_name.contains("codex") && !effective.harness_ref.contains("codex") {
-        return effective;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum KnownAcpHarness {
+    Codex,
+    ClaudeCode,
+    OpenCode,
+}
+
+impl KnownAcpHarness {
+    fn command(self) -> &'static str {
+        match self {
+            Self::Codex => "codex-acp",
+            Self::ClaudeCode => "claude-code-acp",
+            Self::OpenCode => "opencode",
+        }
     }
 
-    for key in ["OPENAI_API_KEY", "CODEX_API_KEY"] {
-        if effective.env.contains_key(key) {
+    fn default_args(self) -> &'static [&'static str] {
+        match self {
+            Self::OpenCode => &["acp"],
+            Self::Codex | Self::ClaudeCode => &[],
+        }
+    }
+
+    fn env_keys(self) -> &'static [&'static str] {
+        match self {
+            Self::Codex => &["OPENAI_API_KEY", "CODEX_API_KEY"],
+            Self::ClaudeCode => &["ANTHROPIC_API_KEY"],
+            Self::OpenCode => &[
+                "OPENCODE_API_KEY",
+                "ANTHROPIC_API_KEY",
+                "OPENAI_API_KEY",
+                "GOOGLE_AI_API_KEY",
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+            ],
+        }
+    }
+
+    fn auth_method_candidates(self, acp: &manifests::AcpRuntime) -> Vec<&'static str> {
+        match self {
+            Self::Codex => {
+                let mut candidates = Vec::new();
+                if acp.env.contains_key("CODEX_API_KEY") {
+                    candidates.push("codex-api-key");
+                }
+                if acp.env.contains_key("OPENAI_API_KEY") {
+                    candidates.push("openai-api-key");
+                }
+                candidates.extend(["codex-api-key", "openai-api-key"]);
+                candidates
+            }
+            Self::ClaudeCode => {
+                let mut candidates = Vec::new();
+                if acp.env.contains_key("ANTHROPIC_API_KEY") {
+                    candidates.push("anthropic-api-key");
+                    candidates.push("api-key");
+                }
+                candidates
+            }
+            Self::OpenCode => {
+                let mut candidates = Vec::new();
+                if acp.env.contains_key("OPENCODE_API_KEY") {
+                    candidates.push("opencode-api-key");
+                    candidates.push("api-key");
+                }
+                candidates
+            }
+        }
+    }
+}
+
+fn known_acp_harness(name: &str) -> Option<KnownAcpHarness> {
+    let normalized = name
+        .trim()
+        .trim_start_matches("@zed-industries/")
+        .trim_start_matches("@anthropic-ai/")
+        .to_ascii_lowercase()
+        .replace(['_', ' '], "-");
+    match normalized.as_str() {
+        "codex" | "codex-acp" => Some(KnownAcpHarness::Codex),
+        "claude" | "claude-code" | "claude-code-acp" => Some(KnownAcpHarness::ClaudeCode),
+        "opencode" | "opencode-ai" | "opencode-acp" | "open-code" | "open-code-acp" => {
+            Some(KnownAcpHarness::OpenCode)
+        }
+        _ => None,
+    }
+}
+
+fn effective_acp_runtime(acp: &manifests::AcpRuntime) -> (manifests::AcpRuntime, String) {
+    let mut effective = acp.clone();
+    let profile =
+        known_acp_harness(&effective.harness_ref).or_else(|| known_acp_harness(&effective.command));
+    let command = if effective.command.trim().is_empty() {
+        profile
+            .map(KnownAcpHarness::command)
+            .unwrap_or(effective.harness_ref.as_str())
+            .to_string()
+    } else {
+        effective.command.clone()
+    };
+
+    if let Some(profile) = profile {
+        let default_args = profile.default_args();
+        if !default_args.is_empty()
+            && !effective
+                .args
+                .iter()
+                .take(default_args.len())
+                .map(String::as_str)
+                .eq(default_args.iter().copied())
+        {
+            let mut args = default_args
+                .iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>();
+            args.extend(effective.args);
+            effective.args = args;
+        }
+        copy_env_from_process(&mut effective, profile.env_keys());
+    } else if command.contains("codex") || effective.harness_ref.contains("codex") {
+        copy_env_from_process(&mut effective, &["OPENAI_API_KEY", "CODEX_API_KEY"]);
+    }
+
+    if matches!(profile, Some(KnownAcpHarness::Codex))
+        || command.contains("codex")
+        || effective.harness_ref.contains("codex")
+    {
+        alias_openai_api_key_to_codex_key(&mut effective);
+    }
+    (effective, command)
+}
+
+fn copy_env_from_process(acp: &mut manifests::AcpRuntime, keys: &[&str]) {
+    for key in keys {
+        if acp.env.contains_key(*key) {
             continue;
         }
         if let Ok(value) = std::env::var(key) {
             if !value.is_empty() {
-                effective.env.insert(key.to_string(), value);
+                acp.env.insert((*key).to_string(), value);
             }
         }
     }
+}
 
-    if !effective.env.contains_key("CODEX_API_KEY") {
-        if let Some(openai_api_key) = effective.env.get("OPENAI_API_KEY").cloned() {
-            effective
-                .env
-                .insert("CODEX_API_KEY".to_string(), openai_api_key);
+fn alias_openai_api_key_to_codex_key(acp: &mut manifests::AcpRuntime) {
+    if !acp.env.contains_key("CODEX_API_KEY") {
+        if let Some(openai_api_key) = acp.env.get("OPENAI_API_KEY").cloned() {
+            acp.env.insert("CODEX_API_KEY".to_string(), openai_api_key);
         }
     }
-    effective
 }
 
 async fn send_request(
@@ -881,14 +999,62 @@ fn session_prompt_params(
     }))
 }
 
-fn acp_auth_method(acp: &manifests::AcpRuntime) -> &'static str {
-    if acp.env.contains_key("CODEX_API_KEY") {
-        "codex-api-key"
-    } else if acp.env.contains_key("OPENAI_API_KEY") {
-        "openai-api-key"
-    } else {
-        "codex-api-key"
+fn acp_auth_method(acp: &manifests::AcpRuntime, initialize_result: &Value) -> Option<String> {
+    let advertised = advertised_auth_methods(initialize_result);
+    let profile = known_acp_harness(&acp.harness_ref).or_else(|| known_acp_harness(&acp.command));
+    let candidates = profile
+        .map(|profile| profile.auth_method_candidates(acp))
+        .unwrap_or_else(|| {
+            let mut candidates = Vec::new();
+            if acp.env.contains_key("CODEX_API_KEY") {
+                candidates.push("codex-api-key");
+            }
+            if acp.env.contains_key("OPENAI_API_KEY") {
+                candidates.push("openai-api-key");
+            }
+            if acp.env.contains_key("ANTHROPIC_API_KEY") {
+                candidates.push("anthropic-api-key");
+            }
+            if acp.env.contains_key("OPENCODE_API_KEY") {
+                candidates.push("opencode-api-key");
+            }
+            candidates
+        });
+    if advertised.is_empty() {
+        if matches!(profile, Some(KnownAcpHarness::Codex))
+            || acp.command.contains("codex")
+            || acp.harness_ref.contains("codex")
+        {
+            return candidates.first().map(|candidate| (*candidate).to_string());
+        }
+        return None;
     }
+
+    for candidate in candidates {
+        if advertised.iter().any(|method| method == candidate) {
+            return Some(candidate.to_string());
+        }
+    }
+    (advertised.len() == 1).then(|| advertised[0].clone())
+}
+
+fn advertised_auth_methods(initialize_result: &Value) -> Vec<String> {
+    initialize_result
+        .get("authMethods")
+        .or_else(|| initialize_result.get("auth_methods"))
+        .and_then(|methods| methods.as_array())
+        .map(|methods| {
+            methods
+                .iter()
+                .filter_map(|method| {
+                    method
+                        .as_str()
+                        .or_else(|| method.get("id").and_then(|id| id.as_str()))
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn acp_full_access_allowed(acp: &manifests::AcpRuntime) -> bool {
@@ -987,12 +1153,95 @@ mod tests {
             permission_policy: Default::default(),
         };
 
-        let effective = effective_acp_runtime(&acp, "codex-acp");
+        let (effective, command) = effective_acp_runtime(&acp);
 
+        assert_eq!(command, "codex-acp");
         assert_eq!(
             effective.env.get("CODEX_API_KEY").map(String::as_str),
             Some("test-openai-key")
         );
+    }
+
+    #[test]
+    fn claude_code_harness_ref_resolves_command_and_env() {
+        let acp = manifests::AcpRuntime {
+            harness_ref: "claude-code".to_string(),
+            command: String::new(),
+            args: Vec::new(),
+            cwd: "/workspace".to_string(),
+            sandbox_policy_ref: "coding".to_string(),
+            persist_session: false,
+            env: std::collections::HashMap::from([(
+                "ANTHROPIC_API_KEY".to_string(),
+                "test-anthropic-key".to_string(),
+            )]),
+            permission_policy: Default::default(),
+        };
+
+        let (effective, command) = effective_acp_runtime(&acp);
+
+        assert_eq!(command, "claude-code-acp");
+        assert!(effective.args.is_empty());
+        assert_eq!(
+            effective.env.get("ANTHROPIC_API_KEY").map(String::as_str),
+            Some("test-anthropic-key")
+        );
+    }
+
+    #[test]
+    fn opencode_harness_ref_resolves_command_and_acp_arg() {
+        let acp = manifests::AcpRuntime {
+            harness_ref: "opencode".to_string(),
+            command: String::new(),
+            args: Vec::new(),
+            cwd: "/workspace".to_string(),
+            sandbox_policy_ref: "coding".to_string(),
+            persist_session: false,
+            env: std::collections::HashMap::from([(
+                "OPENCODE_API_KEY".to_string(),
+                "test-opencode-key".to_string(),
+            )]),
+            permission_policy: Default::default(),
+        };
+
+        let (effective, command) = effective_acp_runtime(&acp);
+
+        assert_eq!(command, "opencode");
+        assert_eq!(effective.args, vec!["acp"]);
+        assert_eq!(
+            effective.env.get("OPENCODE_API_KEY").map(String::as_str),
+            Some("test-opencode-key")
+        );
+    }
+
+    #[test]
+    fn acp_auth_method_uses_advertised_methods() {
+        let acp = manifests::AcpRuntime {
+            harness_ref: "claude-code".to_string(),
+            command: String::new(),
+            args: Vec::new(),
+            cwd: "/workspace".to_string(),
+            sandbox_policy_ref: "coding".to_string(),
+            persist_session: false,
+            env: std::collections::HashMap::from([(
+                "ANTHROPIC_API_KEY".to_string(),
+                "test-anthropic-key".to_string(),
+            )]),
+            permission_policy: Default::default(),
+        };
+
+        let initialize_result = json!({
+            "authMethods": [
+                { "id": "login", "name": "Login" },
+                { "id": "anthropic-api-key", "name": "Anthropic API key" }
+            ]
+        });
+
+        assert_eq!(
+            acp_auth_method(&acp, &initialize_result).as_deref(),
+            Some("anthropic-api-key")
+        );
+        assert_eq!(acp_auth_method(&acp, &json!({})), None);
     }
 
     #[test]
@@ -1070,7 +1319,7 @@ mod tests {
         }
         load_dotenv_for_codex_smoke();
         let image = std::env::var("TALON_CODEX_ACP_IMAGE")
-            .unwrap_or_else(|_| "talon-zed-codex-acp:local".into());
+            .unwrap_or_else(|_| "talon-acp-harness:local".into());
         let platform = std::env::var("TALON_CODEX_ACP_PLATFORM").ok();
         let command =
             std::env::var("TALON_CODEX_ACP_COMMAND").unwrap_or_else(|_| "codex-acp".into());

--- a/tests/e2e/manifests/acp/acp-harness-agent.template.yaml
+++ b/tests/e2e/manifests/acp/acp-harness-agent.template.yaml
@@ -11,18 +11,18 @@ spec:
     runtime:
       kind: acp
       acp:
-        command: codex-acp
-        args: []
+        command: "{{ vars.acp_command }}"
+        args:
+{{ vars.acp_args_yaml }}
         cwd: /workspace
         sandboxPolicyRef: coding
         persistSession: false
         env:
-          OPENAI_API_KEY: "{{ vars.openai_api_key }}"
-          CODEX_API_KEY: "{{ vars.openai_api_key }}"
+{{ vars.acp_env_yaml }}
         permissionPolicy:
           default: allow
           filesystemWrite: allow
           filesystemRead: allow
           terminal: allow
     systemPrompt: |
-      You are the upstream Zed Codex ACP coding agent for {% raw %}{{ namespace.name }}{% endraw %}.
+      You are the {{ vars.acp_harness_label }} ACP coding agent for {% raw %}{{ namespace.name }}{% endraw %}.

--- a/tests/test_chat_sqlite.py
+++ b/tests/test_chat_sqlite.py
@@ -460,7 +460,27 @@ def wait_for_resources(stub, namespace, kind, expected_names):
     )
 
 
-def ensure_docker_codex_image(image):
+def yaml_scalar(value):
+    return json.dumps(value)
+
+
+def yaml_list_snippet(values, indent=10):
+    prefix = " " * indent
+    if not values:
+        return f"{prefix}[]"
+    return "\n".join(f"{prefix}- {yaml_scalar(value)}" for value in values)
+
+
+def yaml_map_snippet(values, indent=10):
+    prefix = " " * indent
+    if not values:
+        return f"{prefix}{{}}"
+    return "\n".join(
+        f"{prefix}{key}: {yaml_scalar(value)}" for key, value in values.items()
+    )
+
+
+def ensure_docker_acp_image(image):
     if not shutil.which("docker"):
         pytest.skip("docker is not installed")
     inspect = subprocess.run(
@@ -471,7 +491,12 @@ def ensure_docker_codex_image(image):
     )
     if inspect.returncode == 0:
         return
-    if image != "talon-zed-codex-acp:local":
+    local_images = {
+        "talon-acp-harness:local",
+        "talon-codex-acp:local",
+        "talon-zed-codex-acp:local",
+    }
+    if image not in local_images:
         pytest.skip(f"Docker image {image} is not available locally")
 
     dockerfile = conftest.REPO_ROOT / "dockerfiles" / "codex-acp.Dockerfile"
@@ -491,6 +516,93 @@ def ensure_docker_codex_image(image):
     )
     assert build.returncode == 0, (
         f"failed to build {image}\nstdout:\n{build.stdout}\nstderr:\n{build.stderr}"
+    )
+
+
+def live_acp_e2e_enabled():
+    return (
+        os.environ.get("TALON_ACP_DOCKER_E2E") == "1"
+        or os.environ.get("TALON_CODEX_DOCKER_E2E") == "1"
+    )
+
+
+def live_acp_harness_config():
+    dotenv = conftest.load_repo_dotenv_values()
+    harness = os.environ.get("TALON_ACP_E2E_HARNESS", "codex")
+    harness = harness.strip().lower().replace("_", "-")
+    if harness in {"claude", "claude-code-acp"}:
+        harness = "claude-code"
+    elif harness in {"open-code", "opencode-acp", "opencode-ai"}:
+        harness = "opencode"
+    elif harness == "codex-acp":
+        harness = "codex"
+
+    def credential(*keys):
+        for key in keys:
+            value = os.environ.get(key) or dotenv.get(key)
+            if value:
+                return key, value
+        return None, None
+
+    image = os.environ.get("TALON_ACP_E2E_IMAGE")
+    if harness == "codex":
+        _, value = credential("CODEX_API_KEY", "OPENAI_API_KEY")
+        if not value:
+            pytest.skip("CODEX_API_KEY or OPENAI_API_KEY is not available")
+        return {
+            "harness": harness,
+            "label": "Codex",
+            "command": "codex-acp",
+            "args": [],
+            "env": {
+                "OPENAI_API_KEY": value,
+                "CODEX_API_KEY": value,
+            },
+            "image": image
+            or os.environ.get("TALON_CODEX_ACP_IMAGE")
+            or "talon-acp-harness:local",
+            "marker": "TALON_CODEX_ACP_CODE_OK",
+        }
+    if harness == "claude-code":
+        _, value = credential("ANTHROPIC_API_KEY")
+        if not value:
+            pytest.skip("ANTHROPIC_API_KEY is not available")
+        return {
+            "harness": harness,
+            "label": "Claude Code",
+            "command": "claude-code-acp",
+            "args": [],
+            "env": {"ANTHROPIC_API_KEY": value},
+            "image": image
+            or os.environ.get("TALON_CLAUDE_CODE_ACP_IMAGE")
+            or "talon-acp-harness:local",
+            "marker": "TALON_CLAUDE_CODE_ACP_CODE_OK",
+        }
+    if harness == "opencode":
+        key, value = credential(
+            "OPENCODE_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_AI_API_KEY",
+            "GOOGLE_GENERATIVE_AI_API_KEY",
+        )
+        if not value:
+            pytest.skip(
+                "OPENCODE_API_KEY or a supported provider API key is not available"
+            )
+        return {
+            "harness": harness,
+            "label": "OpenCode",
+            "command": "opencode",
+            "args": ["acp"],
+            "env": {key: value},
+            "image": image
+            or os.environ.get("TALON_OPENCODE_ACP_IMAGE")
+            or "talon-acp-harness:local",
+            "marker": "TALON_OPENCODE_ACP_CODE_OK",
+        }
+    pytest.skip(
+        "TALON_ACP_E2E_HARNESS must be one of codex, claude-code, or opencode"
     )
 
 
@@ -742,37 +854,39 @@ def test_cli_apply_acp_deployment_starts_session_sqlite_local_socket(
     assert process["phase"] == "Succeeded"
 
 
-def test_cli_apply_zed_codex_acp_deployment_runs_code_in_sandbox_sqlite_local_socket(
+def test_cli_apply_live_acp_deployment_runs_code_in_sandbox_sqlite_local_socket(
     sqlite_test_grpc_port,
 ):
-    if os.environ.get("TALON_CODEX_DOCKER_E2E") != "1":
-        pytest.skip("set TALON_CODEX_DOCKER_E2E=1 to run the live Zed Codex ACP e2e")
-    dotenv = conftest.load_repo_dotenv_values()
-    openai_api_key = os.environ.get("OPENAI_API_KEY") or dotenv.get("OPENAI_API_KEY")
-    if not openai_api_key:
-        pytest.skip("OPENAI_API_KEY is not available in environment or repo .env")
-
-    image = os.environ.get("TALON_CODEX_ACP_IMAGE", "talon-zed-codex-acp:local")
-    ensure_docker_codex_image(image)
+    if not live_acp_e2e_enabled():
+        pytest.skip(
+            "set TALON_ACP_DOCKER_E2E=1 to run the live ACP harness Docker e2e"
+        )
+    harness = live_acp_harness_config()
+    ensure_docker_acp_image(harness["image"])
 
     cli = cli_for_grpc_port(sqlite_test_grpc_port)
     suffix = uuid.uuid4().hex[:8]
-    source_ns = f"zed-codex-customers-{suffix}"
+    harness_slug = harness["harness"].replace("-", "_")
+    source_ns = f"{harness['harness']}-customers-{suffix}"
     target_ns = f"{source_ns}:acme"
-    deployment_name = f"zed-codex-company-builder-{suffix}"
+    deployment_name = f"{harness['harness']}-company-builder-{suffix}"
+    workspace_file = f"/workspace/{harness_slug}_e2e.py"
     variables = acp_vars(
         suffix,
         source_ns,
         target_ns,
         deployment_name,
-        docker_image=image,
-        openai_api_key=openai_api_key,
+        docker_image=harness["image"],
+        acp_command=harness["command"],
+        acp_args_yaml=yaml_list_snippet(harness["args"]),
+        acp_env_yaml=yaml_map_snippet(harness["env"]),
+        acp_harness_label=harness["label"],
     )
     apply_acp_stack(
         cli,
         [
             "docker-sandbox-class.yaml",
-            "zed-codex-agent.template.yaml",
+            "acp-harness-agent.template.yaml",
             "docker-coding-sandbox-policy.template.yaml",
             "target-namespace.yaml",
             "deployment.yaml",
@@ -792,9 +906,12 @@ def test_cli_apply_zed_codex_acp_deployment_runs_code_in_sandbox_sqlite_local_so
     rendered_agent = next(
         resource for resource in agents if resource["metadata"]["name"] == "coding"
     )
-    assert rendered_agent["spec"]["runtime"]["acp"]["command"] == "codex-acp"
-    assert rendered_agent["spec"]["runtime"]["acp"]["cwd"] == "/workspace"
-    assert rendered_agent["spec"]["runtime"]["acp"]["env"]["CODEX_API_KEY"] == openai_api_key
+    rendered_acp = rendered_agent["spec"]["runtime"]["acp"]
+    assert rendered_acp["command"] == harness["command"]
+    assert rendered_acp.get("args", []) == harness["args"]
+    assert rendered_acp["cwd"] == "/workspace"
+    for key, value in harness["env"].items():
+        assert rendered_acp["env"][key] == value
     rendered_policy = next(
         resource for resource in policies if resource["metadata"]["name"] == "coding"
     )
@@ -808,11 +925,12 @@ def test_cli_apply_zed_codex_acp_deployment_runs_code_in_sandbox_sqlite_local_so
         "coding",
         session_id,
         (
-            "Create /workspace/zed_codex_e2e.py with a complete Python program that defines "
+            f"Create {workspace_file} with a complete Python program that defines "
             "a function named talon_value, asserts talon_value() == 42, and prints exactly "
-            "TALON_ZED_CODEX_CODE_OK. Then run python3 /workspace/zed_codex_e2e.py. "
-            "End your final answer with TALON_ZED_CODEX_CODE_OK."
+            f"{harness['marker']}. Then run python3 {workspace_file}. "
+            f"End your final answer with {harness['marker']}."
         ),
+        timeout=300,
     )
 
     completed = e2e.wait_for_session_text(
@@ -820,12 +938,12 @@ def test_cli_apply_zed_codex_acp_deployment_runs_code_in_sandbox_sqlite_local_so
         target_ns,
         "coding",
         session_id,
-        "TALON_ZED_CODEX_CODE_OK",
+        harness["marker"],
         attempts=240,
     )
     assistant = e2e.assistant_messages(completed)[-1]
     assistant_text = e2e.message_text(assistant)
-    assert "TALON_ZED_CODEX_CODE_OK" in assistant_text
+    assert harness["marker"] in assistant_text
 
     sandbox = wait_for_cli_sandbox(cli, target_ns)
     sandbox_status = sandbox["status"]
@@ -841,7 +959,7 @@ def test_cli_apply_zed_codex_acp_deployment_runs_code_in_sandbox_sqlite_local_so
             container_id,
             "sh",
             "-lc",
-            "cat /workspace/zed_codex_e2e.py && printf '\\n---\\n' && python3 /workspace/zed_codex_e2e.py",
+            f"cat {workspace_file} && printf '\\n---\\n' && python3 {workspace_file}",
         ],
         text=True,
         capture_output=True,
@@ -852,8 +970,8 @@ def test_cli_apply_zed_codex_acp_deployment_runs_code_in_sandbox_sqlite_local_so
             f"failed to inspect Docker sandbox\nstdout:\n{inspect.stdout}\nstderr:\n{inspect.stderr}"
         )
         assert "def talon_value" in inspect.stdout
-        assert "TALON_ZED_CODEX_CODE_OK" in inspect.stdout
-        assert inspect.stdout.rstrip().endswith("TALON_ZED_CODEX_CODE_OK")
+        assert harness["marker"] in inspect.stdout
+        assert inspect.stdout.rstrip().endswith(harness["marker"])
     finally:
         subprocess.run(
             ["docker", "rm", "-f", container_id],


### PR DESCRIPTION
## Summary

Adds first-class ACP harness support for Codex, Claude Code, and OpenCode.

- Resolves `harnessRef` aliases for `codex`, `claude-code`, and `opencode` into their concrete commands and default args.
- Negotiates ACP authentication from advertised initialize auth methods while keeping the existing Codex fallback behavior.
- Expands the ACP Docker sandbox image to include Claude Code, Claude Code ACP, and OpenCode alongside Codex.
- Publishes reference GHCR tags for the generic harness image and harness-specific aliases.
- Generalizes the live Docker ACP e2e so `TALON_ACP_E2E_HARNESS=codex|claude-code|opencode` selects the harness, env, image, and marker.
- Adds Claude Code and OpenCode example agents.

## Validation

- `cargo fmt`
- `cargo test harness::acp::tests`
- `cargo test control::manifest::tests`
- `python3 -m py_compile tests/test_chat_sqlite.py`
- `git diff --check`

Could not run pytest collection locally because `pytest` is not installed in this environment (`python3: No module named pytest`).