### PR TITLE
Balance streaming part buffering

### DIFF
--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -287,14 +287,6 @@ async fn stream_message(
                     let part_type = part.map(|part| part.part_type).unwrap_or_default();
                     let content = part.map(|part| part.content.as_str()).unwrap_or_default();
                     if event.kind == SessionMessagePartEventKind::Done as i32 {
-                        if !stream_artifact_started
-                            && part_type == data_proto::SessionMessagePartType::Text as i32
-                            && !content.is_empty()
-                            && (pending_artifact_text.is_empty()
-                                || content.ends_with(&pending_artifact_text))
-                        {
-                            pending_artifact_text = content.to_string();
-                        }
                         break;
                     } else if event.kind == SessionMessagePartEventKind::Error as i32 {
                         if !pending_artifact_text.is_empty() {

--- a/src/harness/acp.rs
+++ b/src/harness/acp.rs
@@ -370,7 +370,7 @@ impl AcpAgentRuntime {
                 .await?;
             return Err(anyhow!(message));
         }
-        sink.on_done(&reply).await;
+        sink.on_done().await;
         lease_service
             .release(&leased.sandbox, &leased.token)
             .await?;

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -109,7 +109,7 @@ pub enum AgentEvent {
     },
     Token(String),
     Usage(ChatUsage),
-    Done(String),
+    Done,
     Error(String),
 }
 
@@ -308,10 +308,7 @@ impl ExecutionSink for CaptureSink {
             .push(AgentEvent::Usage(usage.clone()));
     }
     async fn on_done(&self) {
-        self.events
-            .lock()
-            .unwrap()
-            .push(AgentEvent::Done(String::new()));
+        self.events.lock().unwrap().push(AgentEvent::Done);
     }
     async fn on_error(&self, err: &str) {
         self.events
@@ -1703,10 +1700,7 @@ mod tests {
                 .count(),
             1
         );
-        assert!(matches!(
-            sink.events().last(),
-            Some(AgentEvent::Done(content)) if content.is_empty()
-        ));
+        assert!(matches!(sink.events().last(), Some(AgentEvent::Done)));
     }
 
     #[tokio::test]
@@ -1751,7 +1745,7 @@ mod tests {
                     name: "tool".to_string(),
                     output: "result".to_string(),
                 },
-                AgentEvent::Done(String::new()),
+                AgentEvent::Done,
                 AgentEvent::Error("boom".to_string()),
             ]
         );

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -206,8 +206,8 @@ pub trait ExecutionSink: Send + Sync {
     async fn on_permission_result(&self, _: &str, _: &Value) {}
     /// Usage metadata for the completed model turn.
     async fn on_usage(&self, usage: &ChatUsage);
-    /// The execution completed successfully with a final reply.
-    async fn on_done(&self, reply: &str);
+    /// The execution completed successfully.
+    async fn on_done(&self);
     /// The execution failed.
     async fn on_error(&self, err: &str);
 }
@@ -230,7 +230,7 @@ impl ExecutionSink for NullSink {
     async fn on_request_permission(&self, _: &str, _: &str, _: &Value) {}
     async fn on_permission_result(&self, _: &str, _: &Value) {}
     async fn on_usage(&self, _: &ChatUsage) {}
-    async fn on_done(&self, _: &str) {}
+    async fn on_done(&self) {}
     async fn on_error(&self, _: &str) {}
 }
 
@@ -307,11 +307,11 @@ impl ExecutionSink for CaptureSink {
             .unwrap()
             .push(AgentEvent::Usage(usage.clone()));
     }
-    async fn on_done(&self, reply: &str) {
+    async fn on_done(&self) {
         self.events
             .lock()
             .unwrap()
-            .push(AgentEvent::Done(reply.to_string()));
+            .push(AgentEvent::Done(String::new()));
     }
     async fn on_error(&self, err: &str) {
         self.events
@@ -622,7 +622,7 @@ impl AgentExecutor {
                             tracing::info!(agent_id = %context.agent_id, "Generation interrupted by user");
                             telemetry::record_chat_output(&llm_span, &final_reply, &[]);
                             context.push(LoopMessage::text("assistant", final_reply.clone()));
-                            sink.on_done(&final_reply).await;
+                            sink.on_done().await;
                             return Ok(final_reply);
                         }
                         chunk = stream.next() => chunk,
@@ -772,7 +772,7 @@ impl AgentExecutor {
                 continue;
             }
 
-            sink.on_done(&final_reply).await;
+            sink.on_done().await;
             return Ok(final_reply);
         }
     }
@@ -1705,7 +1705,7 @@ mod tests {
         );
         assert!(matches!(
             sink.events().last(),
-            Some(AgentEvent::Done(content)) if content == "Hello"
+            Some(AgentEvent::Done(content)) if content.is_empty()
         ));
     }
 
@@ -1734,7 +1734,7 @@ mod tests {
         sink.on_token("tok").await;
         sink.on_tool_call("id-1", "tool", &json!({"x": 1})).await;
         sink.on_tool_result("id-1", "tool", "result").await;
-        sink.on_done("done").await;
+        sink.on_done().await;
         sink.on_error("boom").await;
 
         assert_eq!(
@@ -1751,7 +1751,7 @@ mod tests {
                     name: "tool".to_string(),
                     output: "result".to_string(),
                 },
-                AgentEvent::Done("done".to_string()),
+                AgentEvent::Done(String::new()),
                 AgentEvent::Error("boom".to_string()),
             ]
         );

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -673,7 +673,8 @@ impl WorkerEventHandler {
             if let PreparedSubmissionState::FinalResponseReady { content } =
                 prepared_submission.state
             {
-                sink.on_done(&content).await;
+                sink.seed_recovered_text_part(&content);
+                sink.on_done().await;
                 return Ok((SessionCompletionStatus::Completed, sink.summary()));
             }
 
@@ -1068,7 +1069,7 @@ mod tests {
         async fn on_tool_call(&self, _: &str, _: &str, _: &Value) {}
         async fn on_tool_result(&self, _: &str, _: &str, _: &str) {}
         async fn on_usage(&self, _: &crate::harness::llm::ChatUsage) {}
-        async fn on_done(&self, _: &str) {}
+        async fn on_done(&self) {}
         async fn on_error(&self, err: &str) {
             self.errors.lock().unwrap().push(err.to_string());
         }

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1032,6 +1032,8 @@ impl ExecutionSink for PubSubSessionSink {
 
     async fn on_usage(&self, usage: &ChatUsage) {
         *self.usage_events.lock().unwrap() += 1;
+        self.flush_token_event_buffer().await;
+        self.close_text_part();
         self.flush_reasoning_event_buffer().await;
         self.close_reasoning_part();
         self.record_part(
@@ -1199,6 +1201,7 @@ mod tests {
     use crate::control::{KeyValueStore, MessagePublisher};
     use crate::gateway::rpc::data_proto;
     use crate::harness::executor::ExecutionSink;
+    use crate::harness::llm::ChatUsage;
     use crate::harness::sessions;
     use async_trait::async_trait;
     use futures::StreamExt;
@@ -1732,6 +1735,14 @@ mod tests {
         sink.on_tool_result("tool-1", "create_prompt", "created")
             .await;
         sink.on_reasoning("checking ").await;
+        sink.on_token("final").await;
+        sink.on_usage(&ChatUsage {
+            input_tokens: 10,
+            output_tokens: 5,
+            reasoning_tokens: 2,
+            total_tokens: 17,
+        })
+        .await;
         sink.on_done("drafting final").await;
 
         let entries = kv.entries.lock().await.clone();
@@ -1760,6 +1771,7 @@ mod tests {
                 (data_proto::SessionMessagePartType::ToolResult, "created"),
                 (data_proto::SessionMessagePartType::Reasoning, "checking "),
                 (data_proto::SessionMessagePartType::Text, "final"),
+                (data_proto::SessionMessagePartType::Usage, ""),
             ]
         );
     }

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -28,12 +28,23 @@ fn chat_usage_payload_json(usage: &ChatUsage) -> String {
     .unwrap_or_else(|_| "{}".to_string())
 }
 
+/// Shared buffering state for append-only streamed message parts.
+///
+/// This intentionally keeps the live fanout lifecycle separate from durable
+/// `SessionMessage.parts` assembly: `live_buffer` is drained often for small UI
+/// deltas, while `accumulated` is closed only at semantic transcript boundaries.
 struct StreamingPartBuffer {
+    /// The durable/live part kind represented by this buffer, currently text or reasoning.
     part_type: data_proto::SessionMessagePartType,
+    /// Pending content for the next live delta event; drained without changing durable state.
     live_buffer: String,
+    /// Full streamed content for the current semantic part segment.
     accumulated: String,
+    /// Byte offset in `accumulated` that has already been committed durably.
     durable_bytes: usize,
+    /// Stable ID for the in-progress projection part so repeated writes update the same logical part.
     active_part_id: Option<String>,
+    /// Last live publish timestamp used to throttle fanout batching.
     last_publish: Instant,
 }
 

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -243,12 +243,16 @@ pub struct PubSubSessionSink {
     // Live UI event batching.
     token_publish_interval: Duration,
     started_at: Instant,
-    text_buffer: Mutex<StreamingPartBuffer>,
-    reasoning_buffer: Mutex<StreamingPartBuffer>,
+    // At most one streamed semantic part can be open. Switching between text
+    // and reasoning closes the previous buffer before opening the next.
+    active_stream_buffer: Mutex<Option<StreamingPartBuffer>>,
 
     // Canonical assistant message assembly. `durable_parts` holds non-streaming
     // parts and streaming segments already closed by a semantic boundary.
     durable_parts: Mutex<Vec<data_proto::SessionMessagePart>>,
+    // Text prefix already committed into durable parts. Used only to trim
+    // whole-turn final replies after text was closed at a semantic boundary.
+    durable_text: Mutex<String>,
     next_part_index: Mutex<u64>,
 
     // Mutable projection state. Projection writes are UI-only and fenced by the
@@ -397,13 +401,9 @@ impl PubSubSessionSink {
             attempt_id,
             token_publish_interval,
             started_at: Instant::now(),
-            text_buffer: Mutex::new(StreamingPartBuffer::new(
-                data_proto::SessionMessagePartType::Text,
-            )),
-            reasoning_buffer: Mutex::new(StreamingPartBuffer::new(
-                data_proto::SessionMessagePartType::Reasoning,
-            )),
+            active_stream_buffer: Mutex::new(None),
             durable_parts: Mutex::new(Vec::new()),
+            durable_text: Mutex::new(String::new()),
             next_part_index: Mutex::new(0),
             last_flush: Mutex::new(Instant::now()),
             latest_journal_entry_id: Mutex::new(None),
@@ -434,6 +434,9 @@ impl PubSubSessionSink {
         content: String,
         payload_json: String,
     ) {
+        if part_type == data_proto::SessionMessagePartType::Text {
+            self.durable_text.lock().unwrap().push_str(&content);
+        }
         self.durable_parts
             .lock()
             .unwrap()
@@ -446,6 +449,55 @@ impl PubSubSessionSink {
                 created_at: chrono::Utc::now().timestamp_micros(),
                 object: None,
             });
+    }
+
+    fn record_durable_stream_part(&self, part: data_proto::SessionMessagePart) {
+        if part.part_type == data_proto::SessionMessagePartType::Text as i32 {
+            self.durable_text.lock().unwrap().push_str(&part.content);
+        }
+        self.durable_parts.lock().unwrap().push(part);
+    }
+
+    fn final_text_fallback(&self, reply: &str) -> Option<String> {
+        if reply.is_empty() {
+            return None;
+        }
+        let durable_text = self.durable_text.lock().unwrap().clone();
+        if durable_text.is_empty() {
+            Some(reply.to_string())
+        } else if reply.starts_with(&durable_text) {
+            let suffix = reply[durable_text.len()..].to_string();
+            (!suffix.is_empty()).then_some(suffix)
+        } else {
+            Some(reply.to_string())
+        }
+    }
+
+    fn done_event_text_fallback(&self) -> String {
+        let active_text = self
+            .active_stream_buffer
+            .lock()
+            .unwrap()
+            .as_ref()
+            .filter(|buffer| buffer.part_type == data_proto::SessionMessagePartType::Text)
+            .map(|buffer| buffer.accumulated().to_string());
+        active_text.unwrap_or_else(|| self.durable_text.lock().unwrap().clone())
+    }
+
+    fn fallback_text_part(&self, content: Option<&str>) -> Option<data_proto::SessionMessagePart> {
+        let content = content?;
+        if content.is_empty() {
+            return None;
+        }
+        Some(data_proto::SessionMessagePart {
+            id: self.next_part_id(),
+            part_type: data_proto::SessionMessagePartType::Text as i32,
+            content: content.to_string(),
+            name: String::new(),
+            payload_json: String::new(),
+            created_at: chrono::Utc::now().timestamp_micros(),
+            object: None,
+        })
     }
 
     pub(crate) fn seed_recovered_text_part(&self, content: &str) {
@@ -493,66 +545,110 @@ impl PubSubSessionSink {
         reply: &str,
     ) -> anyhow::Result<Vec<data_proto::SessionMessagePart>> {
         let mut parts = self.durable_parts.lock().unwrap().clone();
-        if let Some(part) = self
-            .reasoning_buffer
-            .lock()
-            .unwrap()
-            .close_durable_part(|| self.next_part_id())
-        {
-            parts.push(part);
-        }
-        if let Some(part) = self
-            .text_buffer
-            .lock()
-            .unwrap()
-            .final_part(|| self.next_part_id(), Some(reply))?
-        {
-            parts.push(part);
+        let fallback = self.final_text_fallback(reply);
+        let active = self.active_stream_buffer.lock().unwrap().take();
+        match active {
+            Some(mut buffer) if buffer.part_type == data_proto::SessionMessagePartType::Text => {
+                if let Some(part) =
+                    buffer.final_part(|| self.next_part_id(), fallback.as_deref())?
+                {
+                    parts.push(part);
+                }
+            }
+            Some(mut buffer) => {
+                if let Some(part) = buffer.close_durable_part(|| self.next_part_id()) {
+                    parts.push(part);
+                }
+                if let Some(part) = self.fallback_text_part(fallback.as_deref()) {
+                    parts.push(part);
+                }
+            }
+            None => {
+                if let Some(part) = self.fallback_text_part(fallback.as_deref()) {
+                    parts.push(part);
+                }
+            }
         }
         Ok(parts)
     }
 
-    fn close_text_part(&self) {
-        self.close_streaming_part(&self.text_buffer);
-    }
-
-    fn close_reasoning_part(&self) {
-        self.close_streaming_part(&self.reasoning_buffer);
-    }
-
-    fn close_streaming_part(&self, buffer: &Mutex<StreamingPartBuffer>) {
-        if let Some(part) = buffer
+    fn close_active_stream_part(&self) {
+        let part = self
+            .active_stream_buffer
             .lock()
             .unwrap()
-            .close_durable_part(|| self.next_part_id())
-        {
-            self.durable_parts.lock().unwrap().push(part);
+            .take()
+            .and_then(|mut buffer| buffer.close_durable_part(|| self.next_part_id()));
+        if let Some(part) = part {
+            self.record_durable_stream_part(part);
         }
     }
 
-    async fn flush_token_event_buffer(&self) {
-        let content = {
-            self.text_buffer
-                .lock()
-                .unwrap()
-                .take_live_batch(Instant::now())
+    fn push_active_stream_part(&self, part_type: data_proto::SessionMessagePartType, chunk: &str) {
+        let closed_part = {
+            let mut active = self.active_stream_buffer.lock().unwrap();
+            if active
+                .as_ref()
+                .is_some_and(|buffer| buffer.part_type != part_type)
+            {
+                active
+                    .take()
+                    .and_then(|mut buffer| buffer.close_durable_part(|| self.next_part_id()))
+            } else {
+                None
+            }
         };
-        if let Some(content) = content {
-            *self.published_token_batches.lock().unwrap() += 1;
-            *self.published_token_chars.lock().unwrap() += content.len();
-            self.publish_event(AgentEvent::Token(content)).await;
+        if let Some(part) = closed_part {
+            self.record_durable_stream_part(part);
         }
+
+        let mut active = self.active_stream_buffer.lock().unwrap();
+        let buffer = active.get_or_insert_with(|| StreamingPartBuffer::new(part_type));
+        buffer.push(chunk);
     }
 
-    async fn flush_reasoning_event_buffer(&self) {
-        let content = {
-            self.reasoning_buffer
-                .lock()
-                .unwrap()
-                .take_live_batch(Instant::now())
-        };
-        if let Some(content) = content {
-            self.publish_event(AgentEvent::Reasoning(content)).await;
+    fn should_flush_active_stream_event(&self) -> bool {
+        self.active_stream_buffer
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|buffer| {
+                buffer.should_publish(Instant::now(), self.token_publish_interval)
+            })
+    }
+
+    fn active_stream_type(&self) -> Option<data_proto::SessionMessagePartType> {
+        self.active_stream_buffer
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|buffer| buffer.part_type)
+    }
+
+    async fn flush_active_stream_event_buffer(&self) {
+        let event = self
+            .active_stream_buffer
+            .lock()
+            .unwrap()
+            .as_mut()
+            .and_then(|buffer| {
+                let part_type = buffer.part_type;
+                buffer
+                    .take_live_batch(Instant::now())
+                    .map(|content| (part_type, content))
+            });
+        if let Some((part_type, content)) = event {
+            match part_type {
+                data_proto::SessionMessagePartType::Text => {
+                    *self.published_token_batches.lock().unwrap() += 1;
+                    *self.published_token_chars.lock().unwrap() += content.len();
+                    self.publish_event(AgentEvent::Token(content)).await;
+                }
+                data_proto::SessionMessagePartType::Reasoning => {
+                    self.publish_event(AgentEvent::Reasoning(content)).await;
+                }
+                _ => {}
+            }
         }
     }
 
@@ -706,30 +802,26 @@ impl PubSubSessionSink {
 
     fn projection_message_parts(&self, reply: &str) -> Vec<data_proto::SessionMessagePart> {
         let mut parts = self.durable_parts.lock().unwrap().clone();
-        if let Some(part) = self
-            .reasoning_buffer
-            .lock()
-            .unwrap()
-            .projection_part(|| self.next_part_id())
-        {
+        let fallback = self.final_text_fallback(reply);
+        let mut active_is_text = false;
+        let active_part = {
+            let mut active = self.active_stream_buffer.lock().unwrap();
+            active.as_mut().and_then(|buffer| {
+                active_is_text = buffer.part_type == data_proto::SessionMessagePartType::Text;
+                if active_is_text && !reply.is_empty() {
+                    buffer.peek_final_part(|| self.next_part_id(), fallback.as_deref())
+                } else {
+                    buffer.projection_part(|| self.next_part_id())
+                }
+            })
+        };
+        if let Some(part) = active_part {
             parts.push(part);
         }
-        if reply.is_empty() {
-            if let Some(part) = self
-                .text_buffer
-                .lock()
-                .unwrap()
-                .projection_part(|| self.next_part_id())
-            {
+        if !reply.is_empty() && !active_is_text {
+            if let Some(part) = self.fallback_text_part(fallback.as_deref()) {
                 parts.push(part);
             }
-        } else if let Some(part) = self
-            .text_buffer
-            .lock()
-            .unwrap()
-            .peek_final_part(|| self.next_part_id(), Some(reply))
-        {
-            parts.push(part);
         }
         parts
     }
@@ -896,20 +988,6 @@ impl PubSubSessionSink {
         }
     }
 
-    fn should_flush_token_event(&self) -> bool {
-        self.text_buffer
-            .lock()
-            .unwrap()
-            .should_publish(Instant::now(), self.token_publish_interval)
-    }
-
-    fn should_flush_reasoning_event(&self) -> bool {
-        self.reasoning_buffer
-            .lock()
-            .unwrap()
-            .should_publish(Instant::now(), self.token_publish_interval)
-    }
-
     pub fn summary(&self) -> SessionRunSummary {
         SessionRunSummary {
             duration_ms: self.started_at.elapsed().as_millis(),
@@ -947,35 +1025,39 @@ impl ExecutionSink for PubSubSessionSink {
     async fn on_token(&self, token: &str) {
         *self.input_token_chunks.lock().unwrap() += 1;
         *self.input_token_chars.lock().unwrap() += token.len();
-        self.flush_reasoning_event_buffer().await;
+        if self
+            .active_stream_type()
+            .is_some_and(|part_type| part_type != data_proto::SessionMessagePartType::Text)
         {
-            self.close_reasoning_part();
-            self.text_buffer.lock().unwrap().push(token);
+            self.flush_active_stream_event_buffer().await;
         }
+        self.push_active_stream_part(data_proto::SessionMessagePartType::Text, token);
         self.maybe_flush_kv().await;
-        if self.should_flush_token_event() {
-            self.flush_token_event_buffer().await;
+        if self.should_flush_active_stream_event() {
+            self.flush_active_stream_event_buffer().await;
         }
     }
 
     async fn on_reasoning(&self, reasoning: &str) {
         *self.reasoning_chunks.lock().unwrap() += 1;
         *self.reasoning_chars.lock().unwrap() += reasoning.len();
-        self.flush_token_event_buffer().await;
-        self.close_text_part();
-        self.reasoning_buffer.lock().unwrap().push(reasoning);
+        if self
+            .active_stream_type()
+            .is_some_and(|part_type| part_type != data_proto::SessionMessagePartType::Reasoning)
+        {
+            self.flush_active_stream_event_buffer().await;
+        }
+        self.push_active_stream_part(data_proto::SessionMessagePartType::Reasoning, reasoning);
         self.maybe_flush_kv().await;
-        if self.should_flush_reasoning_event() {
-            self.flush_reasoning_event_buffer().await;
+        if self.should_flush_active_stream_event() {
+            self.flush_active_stream_event_buffer().await;
         }
     }
 
     async fn on_tool_call(&self, id: &str, name: &str, input: &Value) {
         *self.tool_calls.lock().unwrap() += 1;
-        self.flush_token_event_buffer().await;
-        self.close_text_part();
-        self.flush_reasoning_event_buffer().await;
-        self.close_reasoning_part();
+        self.flush_active_stream_event_buffer().await;
+        self.close_active_stream_part();
         self.record_part(
             data_proto::SessionMessagePartType::ToolCall,
             name.to_string(),
@@ -1014,10 +1096,8 @@ impl ExecutionSink for PubSubSessionSink {
 
     async fn on_tool_result(&self, id: &str, name: &str, result: &str) {
         *self.tool_results.lock().unwrap() += 1;
-        self.flush_token_event_buffer().await;
-        self.close_text_part();
-        self.flush_reasoning_event_buffer().await;
-        self.close_reasoning_part();
+        self.flush_active_stream_event_buffer().await;
+        self.close_active_stream_part();
         let preview = tool_result_preview(result);
         self.record_part(
             data_proto::SessionMessagePartType::ToolResult,
@@ -1039,10 +1119,8 @@ impl ExecutionSink for PubSubSessionSink {
     }
 
     async fn on_request_permission(&self, id: &str, action: &str, payload: &Value) {
-        self.flush_token_event_buffer().await;
-        self.close_text_part();
-        self.flush_reasoning_event_buffer().await;
-        self.close_reasoning_part();
+        self.flush_active_stream_event_buffer().await;
+        self.close_active_stream_part();
         self.record_part(
             data_proto::SessionMessagePartType::RequestPermission,
             action.to_string(),
@@ -1064,10 +1142,8 @@ impl ExecutionSink for PubSubSessionSink {
     }
 
     async fn on_permission_result(&self, id: &str, outcome: &Value) {
-        self.flush_token_event_buffer().await;
-        self.close_text_part();
-        self.flush_reasoning_event_buffer().await;
-        self.close_reasoning_part();
+        self.flush_active_stream_event_buffer().await;
+        self.close_active_stream_part();
         self.record_part(
             data_proto::SessionMessagePartType::PermissionResult,
             String::new(),
@@ -1092,10 +1168,8 @@ impl ExecutionSink for PubSubSessionSink {
 
     async fn on_usage(&self, usage: &ChatUsage) {
         *self.usage_events.lock().unwrap() += 1;
-        self.flush_token_event_buffer().await;
-        self.close_text_part();
-        self.flush_reasoning_event_buffer().await;
-        self.close_reasoning_part();
+        self.flush_active_stream_event_buffer().await;
+        self.close_active_stream_part();
         self.record_part(
             data_proto::SessionMessagePartType::Usage,
             String::new(),
@@ -1106,10 +1180,9 @@ impl ExecutionSink for PubSubSessionSink {
     }
 
     async fn on_done(&self, reply: &str) {
-        self.flush_token_event_buffer().await;
-        self.flush_reasoning_event_buffer().await;
+        self.flush_active_stream_event_buffer().await;
         // Final KV write (complete message)
-        let accumulated_text = self.text_buffer.lock().unwrap().accumulated().to_string();
+        let accumulated_text = self.done_event_text_fallback();
         let reply_for_event = if reply.is_empty() && !accumulated_text.is_empty() {
             accumulated_text
         } else {
@@ -1198,10 +1271,8 @@ impl ExecutionSink for PubSubSessionSink {
     }
 
     async fn on_error(&self, err: &str) {
-        self.flush_token_event_buffer().await;
-        self.close_text_part();
-        self.flush_reasoning_event_buffer().await;
-        self.close_reasoning_part();
+        self.flush_active_stream_event_buffer().await;
+        self.close_active_stream_part();
 
         self.record_part(
             data_proto::SessionMessagePartType::Error,

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -134,10 +134,6 @@ impl StreamingPartBuffer {
         Ok(Some(self.part(id, content)))
     }
 
-    fn accumulated(&self) -> &str {
-        self.accumulated.as_str()
-    }
-
     fn unclosed_content(&self) -> &str {
         let start = self.durable_bytes.min(self.accumulated.len());
         &self.accumulated[start..]
@@ -406,25 +402,6 @@ impl PubSubSessionSink {
         self.durable_parts.lock().unwrap().push(part);
     }
 
-    fn done_event_text_fallback(&self) -> String {
-        let active_text = self
-            .active_stream_buffer
-            .lock()
-            .unwrap()
-            .as_ref()
-            .filter(|buffer| buffer.part_type == data_proto::SessionMessagePartType::Text)
-            .map(|buffer| buffer.accumulated().to_string());
-        active_text.unwrap_or_else(|| {
-            self.durable_parts
-                .lock()
-                .unwrap()
-                .iter()
-                .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
-                .map(|part| part.content.as_str())
-                .collect::<String>()
-        })
-    }
-
     pub(crate) fn seed_recovered_text_part(&self, content: &str) {
         if content.is_empty() {
             return;
@@ -632,11 +609,11 @@ impl PubSubSessionSink {
                 String::new(),
                 chat_usage_payload_json(&usage),
             ),
-            AgentEvent::Done(reply) => (
+            AgentEvent::Done => (
                 SessionMessagePartEventKind::Done,
                 data_proto::SessionMessagePartType::Text,
                 String::new(),
-                reply,
+                String::new(),
                 String::new(),
             ),
             AgentEvent::Error(err) => (
@@ -1074,7 +1051,6 @@ impl ExecutionSink for PubSubSessionSink {
     async fn on_done(&self) {
         self.flush_active_stream_event_buffer().await;
         // Final KV write (complete message)
-        let reply_for_event = self.done_event_text_fallback();
         let parts = match self.final_message_parts() {
             Ok(parts) => parts,
             Err(err) => {
@@ -1139,7 +1115,7 @@ impl ExecutionSink for PubSubSessionSink {
                         return;
                     }
                     self.publish_reply_index_event().await;
-                    self.publish_event(AgentEvent::Done(reply_for_event)).await;
+                    self.publish_event(AgentEvent::Done).await;
                 } else {
                     self.publish_event(AgentEvent::Error(
                         "Error: failed to mark session submission terminal".to_string(),
@@ -1416,6 +1392,17 @@ mod tests {
     async fn token_events_are_batched_by_time_window() {
         let events = Arc::new(Mutex::new(Vec::new()));
         let kv = Arc::new(MockKvStore::default());
+        let mut submission =
+            sessions::pending_submission("submission-1", "session-1", "user-1", 100);
+        submission.status = data_proto::SessionSubmissionStatus::Claimed as i32;
+        submission.attempt_id = "attempt-1".to_string();
+        crate::control::ProtoKeyValueStoreExt::set_msg(
+            kv.as_ref(),
+            &keys::session_submission("conic", "infra", "session-1", "submission-1"),
+            &submission,
+        )
+        .await
+        .unwrap();
         let sink = PubSubSessionSink::new_with_token_publish_interval(
             kv.clone(),
             Arc::new(MockPubSub {
@@ -1448,14 +1435,18 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(token_events, vec!["hello world".to_string()]);
-
-        let entries = kv.entries.lock().await.clone();
-        let persisted_text = entries
+        let done_event = events
             .iter()
-            .filter_map(|(_, value)| data_proto::SessionMessage::decode(value.as_slice()).ok())
-            .flat_map(|message| message.parts)
+            .find(|event| event.kind == SessionMessagePartEventKind::Done as i32)
+            .expect("done event should be published");
+        assert_eq!(event_part(done_event).content, "");
+
+        let final_message = latest_reply_message(kv.as_ref()).await;
+        let persisted_text = final_message
+            .parts
+            .iter()
             .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
-            .map(|part| part.content)
+            .map(|part| part.content.clone())
             .collect::<Vec<_>>();
         assert_eq!(persisted_text, vec!["hello world".to_string()]);
     }

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -55,7 +55,7 @@ impl StreamingPartBuffer {
     }
 
     fn should_publish(&self, now: Instant, interval: Duration) -> bool {
-        !self.live_buffer.is_empty() && now.duration_since(self.last_publish) >= interval
+        !self.live_buffer.is_empty() && now.saturating_duration_since(self.last_publish) >= interval
     }
 
     fn take_live_batch(&mut self, now: Instant) -> Option<String> {

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -164,16 +164,22 @@ impl StreamingPartBuffer {
     }
 
     fn final_content(&self, final_content_override: Option<&str>) -> String {
-        let effective = final_content_override.unwrap_or(self.accumulated.as_str());
-        // Final replies usually duplicate the streamed text we already saw.
-        // In that common case, only commit the unclosed suffix. If there was no
-        // streamed text, or the provider returns a replacement final reply that
-        // does not extend the stream, treat the effective reply as authoritative.
+        let content = self.unclosed_content();
+        if !content.is_empty() {
+            return content.to_string();
+        }
+        let Some(effective) = final_content_override else {
+            return String::new();
+        };
+        // `on_done(reply)` is shared by streaming LLM turns and producers that
+        // only emit a final reply. Active streamed text wins above. This fallback
+        // only fills an empty current segment; if earlier text was already
+        // durably closed, trim that prefix when the final reply is a whole-turn
+        // transcript rather than just the missing suffix.
         if self.accumulated.is_empty() {
             effective.to_string()
         } else if effective.starts_with(self.accumulated.as_str()) {
-            let start = self.durable_bytes.min(effective.len());
-            effective[start..].to_string()
+            effective[self.accumulated.len()..].to_string()
         } else {
             effective.to_string()
         }
@@ -1103,16 +1109,13 @@ impl ExecutionSink for PubSubSessionSink {
         self.flush_token_event_buffer().await;
         self.flush_reasoning_event_buffer().await;
         // Final KV write (complete message)
-        let accumulated = self.text_buffer.lock().unwrap().accumulated().to_string();
-        let reply = if accumulated.is_empty() {
-            reply.to_string()
-        } else if reply.is_empty() || accumulated.ends_with(reply) {
-            accumulated
+        let accumulated_text = self.text_buffer.lock().unwrap().accumulated().to_string();
+        let reply_for_event = if reply.is_empty() && !accumulated_text.is_empty() {
+            accumulated_text
         } else {
             reply.to_string()
         };
-        let reply_for_event = reply.clone();
-        let parts = match self.final_message_parts(&reply) {
+        let parts = match self.final_message_parts(reply) {
             Ok(parts) => parts,
             Err(err) => {
                 tracing::error!(error = %err, "Failed to assemble final assistant message parts");
@@ -1537,7 +1540,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn final_message_persists_accumulated_streamed_text_when_done_reply_is_tail() {
+    async fn final_message_uses_streamed_text_when_done_reply_differs() {
         let events = Arc::new(Mutex::new(Vec::new()));
         let kv = Arc::new(MockKvStore::default());
         let sink = PubSubSessionSink::new_with_token_publish_interval(
@@ -1553,9 +1556,9 @@ mod tests {
             Duration::from_secs(10),
         );
 
-        sink.on_token("Hello! I am a mock LLM. How can ").await;
-        sink.on_token("I assist you today?").await;
-        sink.on_done("I assist you today?").await;
+        sink.on_token("streamed ").await;
+        sink.on_token("answer").await;
+        sink.on_done("replacement answer").await;
 
         let entries = kv.entries.lock().await.clone();
         let reply = entries
@@ -1570,10 +1573,7 @@ mod tests {
             .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
             .map(|part| part.content.as_str())
             .collect::<String>();
-        assert_eq!(
-            reply_text,
-            "Hello! I am a mock LLM. How can I assist you today?"
-        );
+        assert_eq!(reply_text, "streamed answer");
     }
 
     #[tokio::test]
@@ -2063,8 +2063,8 @@ mod tests {
             .parts
             .iter()
             .find(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
-            .expect("projection should include final reply preview");
-        assert_eq!(projection_text.content, "hello world");
+            .expect("projection should include streamed text");
+        assert_eq!(projection_text.content, "hello");
 
         sink.on_token(" world").await;
         sink.on_done("hello world").await;

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -46,6 +46,8 @@ struct StreamingPartBuffer {
     active_part_id: Option<String>,
     /// Last live publish timestamp used to throttle fanout batching.
     last_publish: Instant,
+    /// Whether the terminal durable close has already consumed this buffer.
+    final_closed: bool,
 }
 
 impl StreamingPartBuffer {
@@ -57,10 +59,15 @@ impl StreamingPartBuffer {
             durable_bytes: 0,
             active_part_id: None,
             last_publish: Instant::now(),
+            final_closed: false,
         }
     }
 
     fn push(&mut self, chunk: &str) {
+        debug_assert!(
+            !self.final_closed,
+            "cannot append to a stream buffer after final close"
+        );
         self.accumulated.push_str(chunk);
         self.live_buffer.push_str(chunk);
     }
@@ -105,7 +112,7 @@ impl StreamingPartBuffer {
         Some(self.part(id, content))
     }
 
-    fn final_part<F>(
+    fn peek_final_part<F>(
         &mut self,
         mut id_factory: F,
         final_content_override: Option<&str>,
@@ -113,21 +120,38 @@ impl StreamingPartBuffer {
     where
         F: FnMut() -> String,
     {
-        let effective = final_content_override.unwrap_or(self.accumulated.as_str());
-        let content = if self.accumulated.is_empty() {
-            effective.to_string()
-        } else if effective.starts_with(self.accumulated.as_str()) {
-            let start = self.durable_bytes.min(effective.len());
-            effective[start..].to_string()
-        } else {
-            effective.to_string()
-        };
+        let content = self.final_content(final_content_override);
         if content.is_empty() {
             return None;
         }
-        self.durable_bytes = self.accumulated.len();
-        let id = self.active_part_id.take().unwrap_or_else(&mut id_factory);
+        let id = self
+            .active_part_id
+            .get_or_insert_with(&mut id_factory)
+            .clone();
         Some(self.part(id, content))
+    }
+
+    fn final_part<F>(
+        &mut self,
+        mut id_factory: F,
+        final_content_override: Option<&str>,
+    ) -> anyhow::Result<Option<data_proto::SessionMessagePart>>
+    where
+        F: FnMut() -> String,
+    {
+        anyhow::ensure!(
+            !self.final_closed,
+            "streaming part buffer was finalized more than once"
+        );
+        let content = self.final_content(final_content_override);
+        if content.is_empty() {
+            self.final_closed = true;
+            return Ok(None);
+        }
+        self.durable_bytes = self.accumulated.len();
+        self.final_closed = true;
+        let id = self.active_part_id.take().unwrap_or_else(&mut id_factory);
+        Ok(Some(self.part(id, content)))
     }
 
     fn accumulated(&self) -> &str {
@@ -137,6 +161,18 @@ impl StreamingPartBuffer {
     fn unclosed_content(&self) -> &str {
         let start = self.durable_bytes.min(self.accumulated.len());
         &self.accumulated[start..]
+    }
+
+    fn final_content(&self, final_content_override: Option<&str>) -> String {
+        let effective = final_content_override.unwrap_or(self.accumulated.as_str());
+        if self.accumulated.is_empty() {
+            effective.to_string()
+        } else if effective.starts_with(self.accumulated.as_str()) {
+            let start = self.durable_bytes.min(effective.len());
+            effective[start..].to_string()
+        } else {
+            effective.to_string()
+        }
     }
 
     fn part(&self, id: String, content: String) -> data_proto::SessionMessagePart {
@@ -442,7 +478,10 @@ impl PubSubSessionSink {
         );
     }
 
-    fn final_message_parts(&self, reply: &str) -> Vec<data_proto::SessionMessagePart> {
+    fn final_message_parts(
+        &self,
+        reply: &str,
+    ) -> anyhow::Result<Vec<data_proto::SessionMessagePart>> {
         let mut parts = self.durable_parts.lock().unwrap().clone();
         if let Some(part) = self
             .reasoning_buffer
@@ -456,11 +495,11 @@ impl PubSubSessionSink {
             .text_buffer
             .lock()
             .unwrap()
-            .final_part(|| self.next_part_id(), Some(reply))
+            .final_part(|| self.next_part_id(), Some(reply))?
         {
             parts.push(part);
         }
-        parts
+        Ok(parts)
     }
 
     fn close_text_part(&self) {
@@ -678,7 +717,7 @@ impl PubSubSessionSink {
             .text_buffer
             .lock()
             .unwrap()
-            .final_part(|| self.next_part_id(), Some(reply))
+            .peek_final_part(|| self.next_part_id(), Some(reply))
         {
             parts.push(part);
         }
@@ -1069,12 +1108,23 @@ impl ExecutionSink for PubSubSessionSink {
             reply.to_string()
         };
         let reply_for_event = reply.clone();
+        let parts = match self.final_message_parts(&reply) {
+            Ok(parts) => parts,
+            Err(err) => {
+                tracing::error!(error = %err, "Failed to assemble final assistant message parts");
+                self.publish_event(AgentEvent::Error(
+                    "Error: failed to assemble final assistant message".to_string(),
+                ))
+                .await;
+                return;
+            }
+        };
         let msg = data_proto::SessionMessage {
             id: self.reply_msg_id.clone(),
             role: data_proto::MessageRole::RoleAssistant as i32,
             created_at: chrono::Utc::now().timestamp_micros(),
             labels: self.projection_labels(sessions::SESSION_PROJECTION_STATE_COMPLETE_UNCOMMITTED),
-            parts: self.final_message_parts(&reply),
+            parts,
         };
         let result = async {
             let _guard = self.persist_lock.lock().await;
@@ -1204,7 +1254,7 @@ fn token_publish_interval() -> Duration {
 
 #[cfg(test)]
 mod tests {
-    use super::{token_publish_interval, PubSubSessionSink};
+    use super::{token_publish_interval, PubSubSessionSink, StreamingPartBuffer};
     use crate::control::events::{
         IndexEvent, SessionMessagePartEvent, SessionMessagePartEventKind,
     };
@@ -1982,6 +2032,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn final_reply_projection_does_not_commit_streaming_text() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let kv = Arc::new(MockKvStore::default());
+        let sink = PubSubSessionSink::new_with_token_publish_interval(
+            kv.clone(),
+            Arc::new(MockPubSub {
+                events: events.clone(),
+            }),
+            "conic",
+            "session-1",
+            "infra",
+            "reply-1",
+            reply_key(),
+            "submission-1",
+            "attempt-1",
+            Duration::from_secs(10),
+        );
+
+        sink.on_token("hello").await;
+        let projection = sink.projection_message(
+            sessions::SESSION_PROJECTION_STATE_IN_PROGRESS,
+            "hello world",
+        );
+        let projection_text = projection
+            .parts
+            .iter()
+            .find(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+            .expect("projection should include final reply preview");
+        assert_eq!(projection_text.content, "hello world");
+
+        sink.on_token(" world").await;
+        sink.on_done("hello world").await;
+
+        let final_message = latest_reply_message(kv.as_ref()).await;
+        let final_text = final_message
+            .parts
+            .iter()
+            .find(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+            .expect("final message should include text");
+        assert_eq!(final_text.content, "hello world");
+    }
+
+    #[tokio::test]
     async fn journal_boundaries_record_stable_llm_responses_and_tool_results() {
         use crate::control::ProtoKeyValueStoreExt;
         use crate::harness::llm::{ChatResponse, ToolCall};
@@ -2330,5 +2423,19 @@ mod tests {
         assert_eq!(token_publish_interval(), Duration::from_millis(250));
 
         std::env::remove_var("TALON_TOKEN_BATCH_MS");
+    }
+
+    #[test]
+    fn streaming_part_buffer_rejects_repeated_final_close() {
+        let mut buffer = StreamingPartBuffer::new(data_proto::SessionMessagePartType::Text);
+        buffer.push("hello");
+
+        let first = buffer
+            .final_part(|| "part-1".to_string(), Some("hello"))
+            .expect("first final close should succeed");
+        assert!(first.is_some());
+
+        let second = buffer.final_part(|| "part-2".to_string(), Some("hello"));
+        assert!(second.is_err());
     }
 }

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -112,29 +112,9 @@ impl StreamingPartBuffer {
         Some(self.part(id, content))
     }
 
-    fn peek_final_part<F>(
-        &mut self,
-        mut id_factory: F,
-        final_content_override: Option<&str>,
-    ) -> Option<data_proto::SessionMessagePart>
-    where
-        F: FnMut() -> String,
-    {
-        let content = self.final_content(final_content_override);
-        if content.is_empty() {
-            return None;
-        }
-        let id = self
-            .active_part_id
-            .get_or_insert_with(&mut id_factory)
-            .clone();
-        Some(self.part(id, content))
-    }
-
     fn final_part<F>(
         &mut self,
         mut id_factory: F,
-        final_content_override: Option<&str>,
     ) -> anyhow::Result<Option<data_proto::SessionMessagePart>>
     where
         F: FnMut() -> String,
@@ -143,7 +123,7 @@ impl StreamingPartBuffer {
             !self.final_closed,
             "streaming part buffer was finalized more than once"
         );
-        let content = self.final_content(final_content_override);
+        let content = self.unclosed_content().to_string();
         if content.is_empty() {
             self.final_closed = true;
             return Ok(None);
@@ -161,28 +141,6 @@ impl StreamingPartBuffer {
     fn unclosed_content(&self) -> &str {
         let start = self.durable_bytes.min(self.accumulated.len());
         &self.accumulated[start..]
-    }
-
-    fn final_content(&self, final_content_override: Option<&str>) -> String {
-        let content = self.unclosed_content();
-        if !content.is_empty() {
-            return content.to_string();
-        }
-        let Some(effective) = final_content_override else {
-            return String::new();
-        };
-        // `on_done(reply)` is shared by streaming LLM turns and producers that
-        // only emit a final reply. Active streamed text wins above. This fallback
-        // only fills an empty current segment; if earlier text was already
-        // durably closed, trim that prefix when the final reply is a whole-turn
-        // transcript rather than just the missing suffix.
-        if self.accumulated.is_empty() {
-            effective.to_string()
-        } else if effective.starts_with(self.accumulated.as_str()) {
-            effective[self.accumulated.len()..].to_string()
-        } else {
-            effective.to_string()
-        }
     }
 
     fn part(&self, id: String, content: String) -> data_proto::SessionMessagePart {
@@ -250,9 +208,6 @@ pub struct PubSubSessionSink {
     // Canonical assistant message assembly. `durable_parts` holds non-streaming
     // parts and streaming segments already closed by a semantic boundary.
     durable_parts: Mutex<Vec<data_proto::SessionMessagePart>>,
-    // Text prefix already committed into durable parts. Used only to trim
-    // whole-turn final replies after text was closed at a semantic boundary.
-    durable_text: Mutex<String>,
     next_part_index: Mutex<u64>,
 
     // Mutable projection state. Projection writes are UI-only and fenced by the
@@ -403,7 +358,6 @@ impl PubSubSessionSink {
             started_at: Instant::now(),
             active_stream_buffer: Mutex::new(None),
             durable_parts: Mutex::new(Vec::new()),
-            durable_text: Mutex::new(String::new()),
             next_part_index: Mutex::new(0),
             last_flush: Mutex::new(Instant::now()),
             latest_journal_entry_id: Mutex::new(None),
@@ -434,9 +388,6 @@ impl PubSubSessionSink {
         content: String,
         payload_json: String,
     ) {
-        if part_type == data_proto::SessionMessagePartType::Text {
-            self.durable_text.lock().unwrap().push_str(&content);
-        }
         self.durable_parts
             .lock()
             .unwrap()
@@ -452,25 +403,7 @@ impl PubSubSessionSink {
     }
 
     fn record_durable_stream_part(&self, part: data_proto::SessionMessagePart) {
-        if part.part_type == data_proto::SessionMessagePartType::Text as i32 {
-            self.durable_text.lock().unwrap().push_str(&part.content);
-        }
         self.durable_parts.lock().unwrap().push(part);
-    }
-
-    fn final_text_fallback(&self, reply: &str) -> Option<String> {
-        if reply.is_empty() {
-            return None;
-        }
-        let durable_text = self.durable_text.lock().unwrap().clone();
-        if durable_text.is_empty() {
-            Some(reply.to_string())
-        } else if reply.starts_with(&durable_text) {
-            let suffix = reply[durable_text.len()..].to_string();
-            (!suffix.is_empty()).then_some(suffix)
-        } else {
-            Some(reply.to_string())
-        }
     }
 
     fn done_event_text_fallback(&self) -> String {
@@ -481,22 +414,14 @@ impl PubSubSessionSink {
             .as_ref()
             .filter(|buffer| buffer.part_type == data_proto::SessionMessagePartType::Text)
             .map(|buffer| buffer.accumulated().to_string());
-        active_text.unwrap_or_else(|| self.durable_text.lock().unwrap().clone())
-    }
-
-    fn fallback_text_part(&self, content: Option<&str>) -> Option<data_proto::SessionMessagePart> {
-        let content = content?;
-        if content.is_empty() {
-            return None;
-        }
-        Some(data_proto::SessionMessagePart {
-            id: self.next_part_id(),
-            part_type: data_proto::SessionMessagePartType::Text as i32,
-            content: content.to_string(),
-            name: String::new(),
-            payload_json: String::new(),
-            created_at: chrono::Utc::now().timestamp_micros(),
-            object: None,
+        active_text.unwrap_or_else(|| {
+            self.durable_parts
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+                .map(|part| part.content.as_str())
+                .collect::<String>()
         })
     }
 
@@ -540,33 +465,12 @@ impl PubSubSessionSink {
         );
     }
 
-    fn final_message_parts(
-        &self,
-        reply: &str,
-    ) -> anyhow::Result<Vec<data_proto::SessionMessagePart>> {
+    fn final_message_parts(&self) -> anyhow::Result<Vec<data_proto::SessionMessagePart>> {
         let mut parts = self.durable_parts.lock().unwrap().clone();
-        let fallback = self.final_text_fallback(reply);
         let active = self.active_stream_buffer.lock().unwrap().take();
-        match active {
-            Some(mut buffer) if buffer.part_type == data_proto::SessionMessagePartType::Text => {
-                if let Some(part) =
-                    buffer.final_part(|| self.next_part_id(), fallback.as_deref())?
-                {
-                    parts.push(part);
-                }
-            }
-            Some(mut buffer) => {
-                if let Some(part) = buffer.close_durable_part(|| self.next_part_id()) {
-                    parts.push(part);
-                }
-                if let Some(part) = self.fallback_text_part(fallback.as_deref()) {
-                    parts.push(part);
-                }
-            }
-            None => {
-                if let Some(part) = self.fallback_text_part(fallback.as_deref()) {
-                    parts.push(part);
-                }
+        if let Some(mut buffer) = active {
+            if let Some(part) = buffer.final_part(|| self.next_part_id())? {
+                parts.push(part);
             }
         }
         Ok(parts)
@@ -800,39 +704,27 @@ impl PubSubSessionSink {
         labels
     }
 
-    fn projection_message_parts(&self, reply: &str) -> Vec<data_proto::SessionMessagePart> {
+    fn projection_message_parts(&self) -> Vec<data_proto::SessionMessagePart> {
         let mut parts = self.durable_parts.lock().unwrap().clone();
-        let fallback = self.final_text_fallback(reply);
-        let mut active_is_text = false;
         let active_part = {
             let mut active = self.active_stream_buffer.lock().unwrap();
-            active.as_mut().and_then(|buffer| {
-                active_is_text = buffer.part_type == data_proto::SessionMessagePartType::Text;
-                if active_is_text && !reply.is_empty() {
-                    buffer.peek_final_part(|| self.next_part_id(), fallback.as_deref())
-                } else {
-                    buffer.projection_part(|| self.next_part_id())
-                }
-            })
+            active
+                .as_mut()
+                .and_then(|buffer| buffer.projection_part(|| self.next_part_id()))
         };
         if let Some(part) = active_part {
             parts.push(part);
         }
-        if !reply.is_empty() && !active_is_text {
-            if let Some(part) = self.fallback_text_part(fallback.as_deref()) {
-                parts.push(part);
-            }
-        }
         parts
     }
 
-    fn projection_message(&self, state: &str, reply: &str) -> data_proto::SessionMessage {
+    fn projection_message(&self, state: &str) -> data_proto::SessionMessage {
         data_proto::SessionMessage {
             id: self.reply_msg_id.clone(),
             role: data_proto::MessageRole::RoleAssistant as i32,
             created_at: chrono::Utc::now().timestamp_micros(),
             labels: self.projection_labels(state),
-            parts: self.projection_message_parts(reply),
+            parts: self.projection_message_parts(),
         }
     }
 
@@ -869,7 +761,7 @@ impl PubSubSessionSink {
             }
         };
         if should_flush {
-            let msg = self.projection_message(sessions::SESSION_PROJECTION_STATE_IN_PROGRESS, "");
+            let msg = self.projection_message(sessions::SESSION_PROJECTION_STATE_IN_PROGRESS);
             let span = tracing::info_span!(
                 "PubSubSessionSink.persist_projection_message",
                 namespace = %self.ns,
@@ -1179,16 +1071,11 @@ impl ExecutionSink for PubSubSessionSink {
         self.publish_event(AgentEvent::Usage(usage.clone())).await;
     }
 
-    async fn on_done(&self, reply: &str) {
+    async fn on_done(&self) {
         self.flush_active_stream_event_buffer().await;
         // Final KV write (complete message)
-        let accumulated_text = self.done_event_text_fallback();
-        let reply_for_event = if reply.is_empty() && !accumulated_text.is_empty() {
-            accumulated_text
-        } else {
-            reply.to_string()
-        };
-        let parts = match self.final_message_parts(reply) {
+        let reply_for_event = self.done_event_text_fallback();
+        let parts = match self.final_message_parts() {
             Ok(parts) => parts,
             Err(err) => {
                 tracing::error!(error = %err, "Failed to assemble final assistant message parts");
@@ -1548,7 +1435,7 @@ mod tests {
         sink.on_token("hello").await;
         tokio::time::sleep(Duration::from_millis(10)).await;
         sink.on_token(" world").await;
-        sink.on_done("hello world").await;
+        sink.on_done().await;
 
         let events = fanout_events_until_terminal(&mut fanout).await;
         let token_events = events
@@ -1592,7 +1479,7 @@ mod tests {
 
         sink.on_token("The answer is ").await;
         sink.on_token("12.").await;
-        sink.on_done("").await;
+        sink.on_done().await;
 
         let entries = kv.entries.lock().await.clone();
         let reply = entries
@@ -1611,7 +1498,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn final_message_uses_streamed_text_when_done_reply_differs() {
+    async fn final_message_uses_streamed_text_before_done() {
         let events = Arc::new(Mutex::new(Vec::new()));
         let kv = Arc::new(MockKvStore::default());
         let sink = PubSubSessionSink::new_with_token_publish_interval(
@@ -1629,7 +1516,7 @@ mod tests {
 
         sink.on_token("streamed ").await;
         sink.on_token("answer").await;
-        sink.on_done("replacement answer").await;
+        sink.on_done().await;
 
         let entries = kv.entries.lock().await.clone();
         let reply = entries
@@ -1675,7 +1562,8 @@ mod tests {
             Duration::from_secs(10),
         );
 
-        sink.on_done("assistant searchable reply").await;
+        sink.on_token("final").await;
+        sink.on_done().await;
 
         let published = pubsub.published.lock().await.clone();
         let index_event = published
@@ -1729,7 +1617,8 @@ mod tests {
         );
         assert_eq!(event_part(&events[1]).name, "create_prompt");
 
-        sink.on_done("drafting requestfinal").await;
+        sink.on_token("final").await;
+        sink.on_done().await;
         let entries = kv.entries.lock().await.clone();
         let reply = entries
             .iter()
@@ -1771,7 +1660,7 @@ mod tests {
         sink.on_reasoning("first").await;
         tokio::time::sleep(Duration::from_millis(10)).await;
         sink.on_reasoning(" second").await;
-        sink.on_done("final reply").await;
+        sink.on_done().await;
 
         let events = fanout_events_until_terminal(&mut fanout).await;
         let reasoning_events = events
@@ -1819,7 +1708,7 @@ mod tests {
         sink.on_reasoning(" second").await;
         tokio::time::sleep(Duration::from_millis(10)).await;
         sink.on_reasoning(" third").await;
-        sink.on_done("final reply").await;
+        sink.on_done().await;
 
         let events = fanout_events_until_terminal(&mut fanout).await;
         let reasoning_events = events
@@ -1879,7 +1768,7 @@ mod tests {
             total_tokens: 17,
         })
         .await;
-        sink.on_done("drafting final").await;
+        sink.on_done().await;
 
         let entries = kv.entries.lock().await.clone();
         let reply = entries
@@ -1937,7 +1826,7 @@ mod tests {
 
         sink.on_tool_result("tool-1", "mcp_github_get_file_contents", &raw_output)
             .await;
-        sink.on_done("final").await;
+        sink.on_done().await;
 
         let entries = kv.entries.lock().await.clone();
         let persisted = entries
@@ -2013,7 +1902,7 @@ mod tests {
             .collect::<String>();
         assert_eq!(projection_text, "partial response");
 
-        sink.on_done("partial response").await;
+        sink.on_done().await;
         let entries = kv.entries.lock().await.clone();
         let reply = entries
             .iter()
@@ -2126,10 +2015,7 @@ mod tests {
         );
 
         sink.on_token("hello").await;
-        let projection = sink.projection_message(
-            sessions::SESSION_PROJECTION_STATE_IN_PROGRESS,
-            "hello world",
-        );
+        let projection = sink.projection_message(sessions::SESSION_PROJECTION_STATE_IN_PROGRESS);
         let projection_text = projection
             .parts
             .iter()
@@ -2138,7 +2024,7 @@ mod tests {
         assert_eq!(projection_text.content, "hello");
 
         sink.on_token(" world").await;
-        sink.on_done("hello world").await;
+        sink.on_done().await;
 
         let final_message = latest_reply_message(kv.as_ref()).await;
         let final_text = final_message
@@ -2210,7 +2096,7 @@ mod tests {
         })
         .await
         .unwrap();
-        sink.on_done("final").await;
+        sink.on_done().await;
 
         let entry_keys = kv
             .list_keys(&keys::session_journal_entry_prefix(
@@ -2317,7 +2203,8 @@ mod tests {
         let mut fanout = fanout_stream(&sink).await;
         sink.on_token("partial ").await;
         sink.on_error("tool failed").await;
-        sink.on_done("final reply").await;
+        sink.on_token("final reply").await;
+        sink.on_done().await;
         tokio::time::sleep(Duration::from_millis(25)).await;
 
         let events = fanout_events_until_terminal(&mut fanout).await;
@@ -2386,7 +2273,7 @@ mod tests {
         );
 
         let mut fanout = fanout_stream(&sink).await;
-        sink.on_done("final reply").await;
+        sink.on_done().await;
 
         let events = fanout_events_until_terminal(&mut fanout).await;
         assert!(events.iter().any(
@@ -2432,7 +2319,7 @@ mod tests {
         );
 
         let mut fanout = fanout_stream(&sink).await;
-        sink.on_done("final reply").await;
+        sink.on_done().await;
 
         let events = fanout_events_until_terminal(&mut fanout).await;
         assert!(events.iter().any(
@@ -2470,7 +2357,7 @@ mod tests {
         sink.on_tool_call("tool-1", "search", &json!({"q": "talon"}))
             .await;
         sink.on_tool_result("tool-1", "search", "result body").await;
-        sink.on_done("hi there").await;
+        sink.on_done().await;
 
         let summary = sink.summary();
         assert_eq!(summary.input_token_chunks, 2);
@@ -2506,11 +2393,11 @@ mod tests {
         buffer.push("hello");
 
         let first = buffer
-            .final_part(|| "part-1".to_string(), Some("hello"))
+            .final_part(|| "part-1".to_string())
             .expect("first final close should succeed");
         assert!(first.is_some());
 
-        let second = buffer.final_part(|| "part-2".to_string(), Some("hello"));
+        let second = buffer.final_part(|| "part-2".to_string());
         assert!(second.is_err());
     }
 }

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -28,6 +28,119 @@ fn chat_usage_payload_json(usage: &ChatUsage) -> String {
     .unwrap_or_else(|_| "{}".to_string())
 }
 
+struct StreamingPartBuffer {
+    part_type: data_proto::SessionMessagePartType,
+    live_buffer: String,
+    accumulated: String,
+    durable_bytes: usize,
+    active_part_id: Option<String>,
+    last_publish: Instant,
+}
+
+impl StreamingPartBuffer {
+    fn new(part_type: data_proto::SessionMessagePartType) -> Self {
+        Self {
+            part_type,
+            live_buffer: String::new(),
+            accumulated: String::new(),
+            durable_bytes: 0,
+            active_part_id: None,
+            last_publish: Instant::now(),
+        }
+    }
+
+    fn push(&mut self, chunk: &str) {
+        self.accumulated.push_str(chunk);
+        self.live_buffer.push_str(chunk);
+    }
+
+    fn should_publish(&self, now: Instant, interval: Duration) -> bool {
+        !self.live_buffer.is_empty() && now.duration_since(self.last_publish) >= interval
+    }
+
+    fn take_live_batch(&mut self, now: Instant) -> Option<String> {
+        if self.live_buffer.is_empty() {
+            return None;
+        }
+        self.last_publish = now;
+        Some(std::mem::take(&mut self.live_buffer))
+    }
+
+    fn projection_part<F>(&mut self, mut id_factory: F) -> Option<data_proto::SessionMessagePart>
+    where
+        F: FnMut() -> String,
+    {
+        let content = self.unclosed_content().to_string();
+        if content.is_empty() {
+            return None;
+        }
+        let id = self
+            .active_part_id
+            .get_or_insert_with(&mut id_factory)
+            .clone();
+        Some(self.part(id, content))
+    }
+
+    fn close_durable_part<F>(&mut self, mut id_factory: F) -> Option<data_proto::SessionMessagePart>
+    where
+        F: FnMut() -> String,
+    {
+        let content = self.unclosed_content().to_string();
+        if content.is_empty() {
+            return None;
+        }
+        self.durable_bytes = self.accumulated.len();
+        let id = self.active_part_id.take().unwrap_or_else(&mut id_factory);
+        Some(self.part(id, content))
+    }
+
+    fn final_part<F>(
+        &mut self,
+        mut id_factory: F,
+        final_content_override: Option<&str>,
+    ) -> Option<data_proto::SessionMessagePart>
+    where
+        F: FnMut() -> String,
+    {
+        let effective = final_content_override.unwrap_or(self.accumulated.as_str());
+        let content = if self.accumulated.is_empty() {
+            effective.to_string()
+        } else if effective.starts_with(self.accumulated.as_str()) {
+            let start = self.durable_bytes.min(effective.len());
+            effective[start..].to_string()
+        } else {
+            effective.to_string()
+        };
+        if content.is_empty() {
+            return None;
+        }
+        self.durable_bytes = self.accumulated.len();
+        let id = self.active_part_id.take().unwrap_or_else(&mut id_factory);
+        Some(self.part(id, content))
+    }
+
+    fn accumulated(&self) -> &str {
+        self.accumulated.as_str()
+    }
+
+    fn unclosed_content(&self) -> &str {
+        let start = self.durable_bytes.min(self.accumulated.len());
+        &self.accumulated[start..]
+    }
+
+    fn part(&self, id: String, content: String) -> data_proto::SessionMessagePart {
+        data_proto::SessionMessagePart {
+            id,
+            part_type: self.part_type as i32,
+            content,
+            name: String::new(),
+            payload_json: String::new(),
+            created_at: chrono::Utc::now().timestamp_micros(),
+            object: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SessionRunSummary {
     pub duration_ms: u128,
@@ -73,23 +186,17 @@ pub struct PubSubSessionSink {
     // Live UI event batching.
     token_publish_interval: Duration,
     started_at: Instant,
-    pending_token_event_buffer: Mutex<String>,
-    pending_reasoning_event_buffer: Mutex<String>,
-    last_token_publish: Mutex<Instant>,
-    last_reasoning_publish: Mutex<Instant>,
+    text_buffer: Mutex<StreamingPartBuffer>,
+    reasoning_buffer: Mutex<StreamingPartBuffer>,
 
     // Canonical assistant message assembly. `durable_parts` holds non-streaming
-    // parts and text segments already closed by a tool/reasoning boundary.
-    // `accumulated` is the full streamed assistant text seen so far.
-    accumulated: Mutex<String>,
+    // parts and streaming segments already closed by a semantic boundary.
     durable_parts: Mutex<Vec<data_proto::SessionMessagePart>>,
-    durable_text_bytes: Mutex<usize>,
     next_part_index: Mutex<u64>,
 
     // Mutable projection state. Projection writes are UI-only and fenced by the
     // current submission attempt; journal entries remain the backend authority.
     last_flush: Mutex<Instant>, // Last time the UI projection was considered for persistence.
-    active_text_part_id: Mutex<Option<String>>, // Stable id for the currently streaming text part.
     latest_journal_entry_id: Mutex<Option<String>>, // Latest durable boundary reflected in projection labels.
     persist_lock: Arc<AsyncMutex<()>>, // Serializes projection writes with final message commit.
 
@@ -233,18 +340,17 @@ impl PubSubSessionSink {
             attempt_id,
             token_publish_interval,
             started_at: Instant::now(),
-            accumulated: Mutex::new(String::new()),
-            pending_token_event_buffer: Mutex::new(String::new()),
-            pending_reasoning_event_buffer: Mutex::new(String::new()),
+            text_buffer: Mutex::new(StreamingPartBuffer::new(
+                data_proto::SessionMessagePartType::Text,
+            )),
+            reasoning_buffer: Mutex::new(StreamingPartBuffer::new(
+                data_proto::SessionMessagePartType::Reasoning,
+            )),
             durable_parts: Mutex::new(Vec::new()),
-            durable_text_bytes: Mutex::new(0),
             next_part_index: Mutex::new(0),
             last_flush: Mutex::new(Instant::now()),
-            active_text_part_id: Mutex::new(None),
             latest_journal_entry_id: Mutex::new(None),
             persist_lock: Arc::new(AsyncMutex::new(())),
-            last_token_publish: Mutex::new(Instant::now()),
-            last_reasoning_publish: Mutex::new(Instant::now()),
             input_token_chunks: Mutex::new(0),
             input_token_chars: Mutex::new(0),
             published_token_batches: Mutex::new(0),
@@ -271,24 +377,11 @@ impl PubSubSessionSink {
         content: String,
         payload_json: String,
     ) {
-        self.record_part_with_id(self.next_part_id(), part_type, name, content, payload_json);
-    }
-
-    // Used when provisional stream chunks have already reserved the logical
-    // final SessionMessagePart id for a text segment.
-    fn record_part_with_id(
-        &self,
-        id: String,
-        part_type: data_proto::SessionMessagePartType,
-        name: String,
-        content: String,
-        payload_json: String,
-    ) {
         self.durable_parts
             .lock()
             .unwrap()
             .push(data_proto::SessionMessagePart {
-                id,
+                id: self.next_part_id(),
                 part_type: part_type as i32,
                 content,
                 name,
@@ -340,117 +433,67 @@ impl PubSubSessionSink {
 
     fn final_message_parts(&self, reply: &str) -> Vec<data_proto::SessionMessagePart> {
         let mut parts = self.durable_parts.lock().unwrap().clone();
-        let accumulated = self.accumulated.lock().unwrap().clone();
-        let effective_reply = if reply.is_empty() {
-            accumulated.as_str()
-        } else {
-            reply
-        };
-        let text = {
-            if accumulated.is_empty() {
-                effective_reply.to_string()
-            } else if effective_reply.starts_with(accumulated.as_str()) {
-                self.text_since_last_durable_part(effective_reply)
-            } else {
-                effective_reply.to_string()
-            }
-        };
-        if !text.is_empty() {
-            parts.push(data_proto::SessionMessagePart {
-                id: self.take_or_next_text_part_id(),
-                part_type: data_proto::SessionMessagePartType::Text as i32,
-                content: text,
-                name: String::new(),
-                payload_json: String::new(),
-                created_at: chrono::Utc::now().timestamp_micros(),
-                object: None,
-            });
+        if let Some(part) = self
+            .reasoning_buffer
+            .lock()
+            .unwrap()
+            .close_durable_part(|| self.next_part_id())
+        {
+            parts.push(part);
+        }
+        if let Some(part) = self
+            .text_buffer
+            .lock()
+            .unwrap()
+            .final_part(|| self.next_part_id(), Some(reply))
+        {
+            parts.push(part);
         }
         parts
     }
 
-    // Reserve the logical final text part id before persisting an in-progress
-    // projection. All projections for the same text segment share this id.
-    fn ensure_active_text_part_id(&self) -> String {
-        let mut active = self.active_text_part_id.lock().unwrap();
-        if let Some(id) = active.as_ref() {
-            return id.clone();
-        }
-        let id = self.next_part_id();
-        *active = Some(id.clone());
-        id
+    fn close_text_part(&self) {
+        self.close_streaming_part(&self.text_buffer);
     }
 
-    // Close the active text segment and return the id that provisional chunks
-    // used for it. If no chunks were persisted, allocate the final id here.
-    fn take_or_next_text_part_id(&self) -> String {
-        self.active_text_part_id
+    fn close_reasoning_part(&self) {
+        self.close_streaming_part(&self.reasoning_buffer);
+    }
+
+    fn close_streaming_part(&self, buffer: &Mutex<StreamingPartBuffer>) {
+        if let Some(part) = buffer
             .lock()
             .unwrap()
-            .take()
-            .unwrap_or_else(|| self.next_part_id())
-    }
-
-    // Return only the text not already closed into a durable final-message part.
-    fn text_since_last_durable_part(&self, current_text: &str) -> String {
-        let durable_bytes = *self.durable_text_bytes.lock().unwrap();
-        let start = durable_bytes.min(current_text.len());
-        current_text[start..].to_string()
-    }
-
-    // Tool calls close the current assistant text segment before tool-call parts
-    // are appended, preserving final SessionMessagePart ordering.
-    fn record_accumulated_text_part(&self) {
-        let pending_text = {
-            let accumulated = self.accumulated.lock().unwrap();
-            let mut durable_bytes = self.durable_text_bytes.lock().unwrap();
-            let start = (*durable_bytes).min(accumulated.len());
-            let pending_text = accumulated[start..].to_string();
-            *durable_bytes = accumulated.len();
-            pending_text
-        };
-        if !pending_text.is_empty() {
-            self.record_part_with_id(
-                self.take_or_next_text_part_id(),
-                data_proto::SessionMessagePartType::Text,
-                String::new(),
-                pending_text,
-                String::new(),
-            );
+            .close_durable_part(|| self.next_part_id())
+        {
+            self.durable_parts.lock().unwrap().push(part);
         }
     }
 
     async fn flush_token_event_buffer(&self) {
         let content = {
-            let mut buffer = self.pending_token_event_buffer.lock().unwrap();
-            if buffer.is_empty() {
-                return;
-            }
-            std::mem::take(&mut *buffer)
+            self.text_buffer
+                .lock()
+                .unwrap()
+                .take_live_batch(Instant::now())
         };
-
-        *self.last_token_publish.lock().unwrap() = Instant::now();
-        *self.published_token_batches.lock().unwrap() += 1;
-        *self.published_token_chars.lock().unwrap() += content.len();
-        self.publish_event(AgentEvent::Token(content)).await;
+        if let Some(content) = content {
+            *self.published_token_batches.lock().unwrap() += 1;
+            *self.published_token_chars.lock().unwrap() += content.len();
+            self.publish_event(AgentEvent::Token(content)).await;
+        }
     }
 
-    async fn flush_reasoning_part_and_event(&self) {
+    async fn flush_reasoning_event_buffer(&self) {
         let content = {
-            let mut buffer = self.pending_reasoning_event_buffer.lock().unwrap();
-            if buffer.is_empty() {
-                return;
-            }
-            std::mem::take(&mut *buffer)
+            self.reasoning_buffer
+                .lock()
+                .unwrap()
+                .take_live_batch(Instant::now())
         };
-
-        self.record_part(
-            data_proto::SessionMessagePartType::Reasoning,
-            String::new(),
-            content.clone(),
-            String::new(),
-        );
-        self.publish_event(AgentEvent::Reasoning(content)).await;
+        if let Some(content) = content {
+            self.publish_event(AgentEvent::Reasoning(content)).await;
+        }
     }
 
     async fn publish_event(&self, event: AgentEvent) {
@@ -603,29 +646,30 @@ impl PubSubSessionSink {
 
     fn projection_message_parts(&self, reply: &str) -> Vec<data_proto::SessionMessagePart> {
         let mut parts = self.durable_parts.lock().unwrap().clone();
-        let accumulated = self.accumulated.lock().unwrap().clone();
-        let effective_reply = if reply.is_empty() {
-            accumulated.as_str()
-        } else {
-            reply
-        };
-        let text = if accumulated.is_empty() {
-            effective_reply.to_string()
-        } else if effective_reply.starts_with(accumulated.as_str()) {
-            self.text_since_last_durable_part(effective_reply)
-        } else {
-            effective_reply.to_string()
-        };
-        if !text.is_empty() {
-            parts.push(data_proto::SessionMessagePart {
-                id: self.ensure_active_text_part_id(),
-                part_type: data_proto::SessionMessagePartType::Text as i32,
-                content: text,
-                name: String::new(),
-                payload_json: String::new(),
-                created_at: chrono::Utc::now().timestamp_micros(),
-                object: None,
-            });
+        if let Some(part) = self
+            .reasoning_buffer
+            .lock()
+            .unwrap()
+            .projection_part(|| self.next_part_id())
+        {
+            parts.push(part);
+        }
+        if reply.is_empty() {
+            if let Some(part) = self
+                .text_buffer
+                .lock()
+                .unwrap()
+                .projection_part(|| self.next_part_id())
+            {
+                parts.push(part);
+            }
+        } else if let Some(part) = self
+            .text_buffer
+            .lock()
+            .unwrap()
+            .final_part(|| self.next_part_id(), Some(reply))
+        {
+            parts.push(part);
         }
         parts
     }
@@ -793,13 +837,17 @@ impl PubSubSessionSink {
     }
 
     fn should_flush_token_event(&self) -> bool {
-        let last = self.last_token_publish.lock().unwrap();
-        last.elapsed() >= self.token_publish_interval
+        self.text_buffer
+            .lock()
+            .unwrap()
+            .should_publish(Instant::now(), self.token_publish_interval)
     }
 
     fn should_flush_reasoning_event(&self) -> bool {
-        let last = self.last_reasoning_publish.lock().unwrap();
-        last.elapsed() >= self.token_publish_interval
+        self.reasoning_buffer
+            .lock()
+            .unwrap()
+            .should_publish(Instant::now(), self.token_publish_interval)
     }
 
     pub fn summary(&self) -> SessionRunSummary {
@@ -839,14 +887,11 @@ impl ExecutionSink for PubSubSessionSink {
     async fn on_token(&self, token: &str) {
         *self.input_token_chunks.lock().unwrap() += 1;
         *self.input_token_chars.lock().unwrap() += token.len();
+        self.flush_reasoning_event_buffer().await;
         {
-            let mut acc = self.accumulated.lock().unwrap();
-            acc.push_str(token);
+            self.close_reasoning_part();
+            self.text_buffer.lock().unwrap().push(token);
         }
-        self.pending_token_event_buffer
-            .lock()
-            .unwrap()
-            .push_str(token);
         self.maybe_flush_kv().await;
         if self.should_flush_token_event() {
             self.flush_token_event_buffer().await;
@@ -856,20 +901,21 @@ impl ExecutionSink for PubSubSessionSink {
     async fn on_reasoning(&self, reasoning: &str) {
         *self.reasoning_chunks.lock().unwrap() += 1;
         *self.reasoning_chars.lock().unwrap() += reasoning.len();
-        self.pending_reasoning_event_buffer
-            .lock()
-            .unwrap()
-            .push_str(reasoning);
+        self.flush_token_event_buffer().await;
+        self.close_text_part();
+        self.reasoning_buffer.lock().unwrap().push(reasoning);
+        self.maybe_flush_kv().await;
         if self.should_flush_reasoning_event() {
-            self.flush_reasoning_part_and_event().await;
+            self.flush_reasoning_event_buffer().await;
         }
     }
 
     async fn on_tool_call(&self, id: &str, name: &str, input: &Value) {
         *self.tool_calls.lock().unwrap() += 1;
         self.flush_token_event_buffer().await;
-        self.record_accumulated_text_part();
-        self.flush_reasoning_part_and_event().await;
+        self.close_text_part();
+        self.flush_reasoning_event_buffer().await;
+        self.close_reasoning_part();
         self.record_part(
             data_proto::SessionMessagePartType::ToolCall,
             name.to_string(),
@@ -908,7 +954,10 @@ impl ExecutionSink for PubSubSessionSink {
 
     async fn on_tool_result(&self, id: &str, name: &str, result: &str) {
         *self.tool_results.lock().unwrap() += 1;
-        self.flush_reasoning_part_and_event().await;
+        self.flush_token_event_buffer().await;
+        self.close_text_part();
+        self.flush_reasoning_event_buffer().await;
+        self.close_reasoning_part();
         let preview = tool_result_preview(result);
         self.record_part(
             data_proto::SessionMessagePartType::ToolResult,
@@ -931,8 +980,9 @@ impl ExecutionSink for PubSubSessionSink {
 
     async fn on_request_permission(&self, id: &str, action: &str, payload: &Value) {
         self.flush_token_event_buffer().await;
-        self.record_accumulated_text_part();
-        self.flush_reasoning_part_and_event().await;
+        self.close_text_part();
+        self.flush_reasoning_event_buffer().await;
+        self.close_reasoning_part();
         self.record_part(
             data_proto::SessionMessagePartType::RequestPermission,
             action.to_string(),
@@ -954,7 +1004,10 @@ impl ExecutionSink for PubSubSessionSink {
     }
 
     async fn on_permission_result(&self, id: &str, outcome: &Value) {
-        self.flush_reasoning_part_and_event().await;
+        self.flush_token_event_buffer().await;
+        self.close_text_part();
+        self.flush_reasoning_event_buffer().await;
+        self.close_reasoning_part();
         self.record_part(
             data_proto::SessionMessagePartType::PermissionResult,
             String::new(),
@@ -979,7 +1032,8 @@ impl ExecutionSink for PubSubSessionSink {
 
     async fn on_usage(&self, usage: &ChatUsage) {
         *self.usage_events.lock().unwrap() += 1;
-        self.flush_reasoning_part_and_event().await;
+        self.flush_reasoning_event_buffer().await;
+        self.close_reasoning_part();
         self.record_part(
             data_proto::SessionMessagePartType::Usage,
             String::new(),
@@ -991,9 +1045,9 @@ impl ExecutionSink for PubSubSessionSink {
 
     async fn on_done(&self, reply: &str) {
         self.flush_token_event_buffer().await;
-        self.flush_reasoning_part_and_event().await;
+        self.flush_reasoning_event_buffer().await;
         // Final KV write (complete message)
-        let accumulated = self.accumulated.lock().unwrap().clone();
+        let accumulated = self.text_buffer.lock().unwrap().accumulated().to_string();
         let reply = if accumulated.is_empty() {
             reply.to_string()
         } else if reply.is_empty() || accumulated.ends_with(reply) {
@@ -1075,9 +1129,10 @@ impl ExecutionSink for PubSubSessionSink {
 
     async fn on_error(&self, err: &str) {
         self.flush_token_event_buffer().await;
-        self.flush_reasoning_part_and_event().await;
+        self.close_text_part();
+        self.flush_reasoning_event_buffer().await;
+        self.close_reasoning_part();
 
-        self.record_accumulated_text_part();
         self.record_part(
             data_proto::SessionMessagePartType::Error,
             String::new(),
@@ -1230,6 +1285,17 @@ mod tests {
         event.part.as_ref().expect("event part")
     }
 
+    async fn latest_reply_message(kv: &MockKvStore) -> data_proto::SessionMessage {
+        kv.entries
+            .lock()
+            .await
+            .iter()
+            .filter_map(|(_, value)| data_proto::SessionMessage::decode(value.as_slice()).ok())
+            .rev()
+            .find(|message| message.id == "reply-1")
+            .expect("reply message should be persisted")
+    }
+
     type TestFanoutStream = std::pin::Pin<
         Box<
             dyn futures::Stream<
@@ -1353,6 +1419,16 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(token_events, vec!["hello world".to_string()]);
+
+        let entries = kv.entries.lock().await.clone();
+        let persisted_text = entries
+            .iter()
+            .filter_map(|(_, value)| data_proto::SessionMessage::decode(value.as_slice()).ok())
+            .flat_map(|message| message.parts)
+            .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+            .map(|part| part.content)
+            .collect::<Vec<_>>();
+        assert_eq!(persisted_text, vec!["hello world".to_string()]);
     }
 
     #[tokio::test]
@@ -1580,6 +1656,115 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reasoning_live_batches_do_not_become_durable_parts() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let kv = Arc::new(MockKvStore::default());
+        let sink = PubSubSessionSink::new_with_token_publish_interval(
+            kv.clone(),
+            Arc::new(MockPubSub {
+                events: events.clone(),
+            }),
+            "conic",
+            "session-1",
+            "infra",
+            "reply-1",
+            reply_key(),
+            "submission-1",
+            "attempt-1",
+            Duration::from_millis(5),
+        );
+
+        let mut fanout = fanout_stream(&sink).await;
+        sink.on_reasoning("first").await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        sink.on_reasoning(" second").await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        sink.on_reasoning(" third").await;
+        sink.on_done("final reply").await;
+
+        let events = fanout_events_until_terminal(&mut fanout).await;
+        let reasoning_events = events
+            .iter()
+            .filter(|event| {
+                event_part(event).part_type == data_proto::SessionMessagePartType::Reasoning as i32
+            })
+            .map(|event| event_part(event).content.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            reasoning_events,
+            vec!["first second".to_string(), " third".to_string()]
+        );
+
+        let entries = kv.entries.lock().await.clone();
+        let persisted_reasoning = entries
+            .iter()
+            .filter_map(|(_, value)| data_proto::SessionMessage::decode(value.as_slice()).ok())
+            .flat_map(|message| message.parts)
+            .filter(|part| part.part_type == data_proto::SessionMessagePartType::Reasoning as i32)
+            .map(|part| part.content)
+            .collect::<Vec<_>>();
+        assert_eq!(persisted_reasoning, vec!["first second third".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn streaming_part_boundaries_preserve_mixed_order() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let kv = Arc::new(MockKvStore::default());
+        let sink = PubSubSessionSink::new_with_token_publish_interval(
+            kv.clone(),
+            Arc::new(MockPubSub {
+                events: events.clone(),
+            }),
+            "conic",
+            "session-1",
+            "infra",
+            "reply-1",
+            reply_key(),
+            "submission-1",
+            "attempt-1",
+            Duration::from_secs(10),
+        );
+
+        sink.on_reasoning("planning ").await;
+        sink.on_token("drafting ").await;
+        sink.on_tool_call("tool-1", "create_prompt", &json!({"content": "x"}))
+            .await;
+        sink.on_tool_result("tool-1", "create_prompt", "created")
+            .await;
+        sink.on_reasoning("checking ").await;
+        sink.on_done("drafting final").await;
+
+        let entries = kv.entries.lock().await.clone();
+        let reply = entries
+            .iter()
+            .filter_map(|(_, value)| data_proto::SessionMessage::decode(value.as_slice()).ok())
+            .rev()
+            .find(|message| message.id == "reply-1")
+            .expect("reply message should be persisted");
+        let reply_parts = reply
+            .parts
+            .iter()
+            .map(|part| {
+                (
+                    data_proto::SessionMessagePartType::try_from(part.part_type).unwrap(),
+                    part.content.as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            reply_parts,
+            vec![
+                (data_proto::SessionMessagePartType::Reasoning, "planning "),
+                (data_proto::SessionMessagePartType::Text, "drafting "),
+                (data_proto::SessionMessagePartType::ToolCall, "Tool call"),
+                (data_proto::SessionMessagePartType::ToolResult, "created"),
+                (data_proto::SessionMessagePartType::Reasoning, "checking "),
+                (data_proto::SessionMessagePartType::Text, "final"),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn tool_results_store_preview_in_content_and_raw_output_in_payload() {
         let events = Arc::new(Mutex::new(Vec::new()));
         let kv = Arc::new(MockKvStore::default());
@@ -1694,6 +1879,83 @@ mod tests {
             .find(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
             .expect("final text part should exist");
         assert_eq!(final_text_part.content, "partial response");
+    }
+
+    #[tokio::test]
+    async fn projection_uses_stable_streaming_part_ids() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let kv = Arc::new(MockKvStore::default());
+        let mut submission =
+            sessions::pending_submission("submission-1", "session-1", "user-1", 100);
+        submission.status = data_proto::SessionSubmissionStatus::Claimed as i32;
+        submission.attempt_id = "attempt-1".to_string();
+        crate::control::ProtoKeyValueStoreExt::set_msg(
+            kv.as_ref(),
+            &keys::session_submission("conic", "infra", "session-1", "submission-1"),
+            &submission,
+        )
+        .await
+        .unwrap();
+        let sink = PubSubSessionSink::new_with_token_publish_interval(
+            kv.clone(),
+            Arc::new(MockPubSub {
+                events: events.clone(),
+            }),
+            "conic",
+            "session-1",
+            "infra",
+            "reply-1",
+            reply_key(),
+            "submission-1",
+            "attempt-1",
+            Duration::from_secs(10),
+        );
+
+        *sink.last_flush.lock().unwrap() = Instant::now() - Duration::from_secs(2);
+        sink.on_reasoning("thinking").await;
+        let first_reasoning = latest_reply_message(kv.as_ref())
+            .await
+            .parts
+            .into_iter()
+            .find(|part| part.part_type == data_proto::SessionMessagePartType::Reasoning as i32)
+            .expect("projection should include reasoning");
+
+        *sink.last_flush.lock().unwrap() = Instant::now() - Duration::from_secs(2);
+        sink.on_reasoning(" more").await;
+        let second_reasoning = latest_reply_message(kv.as_ref())
+            .await
+            .parts
+            .into_iter()
+            .find(|part| part.part_type == data_proto::SessionMessagePartType::Reasoning as i32)
+            .expect("projection should include updated reasoning");
+        assert_eq!(second_reasoning.id, first_reasoning.id);
+        assert_eq!(second_reasoning.content, "thinking more");
+
+        *sink.last_flush.lock().unwrap() = Instant::now() - Duration::from_secs(2);
+        sink.on_token("answer").await;
+        let projection = latest_reply_message(kv.as_ref()).await;
+        let closed_reasoning = projection
+            .parts
+            .iter()
+            .find(|part| part.part_type == data_proto::SessionMessagePartType::Reasoning as i32)
+            .expect("projection should keep closed reasoning");
+        let first_text = projection
+            .parts
+            .iter()
+            .find(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+            .expect("projection should include text");
+        assert_eq!(closed_reasoning.id, first_reasoning.id);
+
+        *sink.last_flush.lock().unwrap() = Instant::now() - Duration::from_secs(2);
+        sink.on_token(" now").await;
+        let second_text = latest_reply_message(kv.as_ref())
+            .await
+            .parts
+            .into_iter()
+            .find(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+            .expect("projection should include updated text");
+        assert_eq!(second_text.id, first_text.id);
+        assert_eq!(second_text.content, "answer now");
     }
 
     #[tokio::test]

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -165,6 +165,10 @@ impl StreamingPartBuffer {
 
     fn final_content(&self, final_content_override: Option<&str>) -> String {
         let effective = final_content_override.unwrap_or(self.accumulated.as_str());
+        // Final replies usually duplicate the streamed text we already saw.
+        // In that common case, only commit the unclosed suffix. If there was no
+        // streamed text, or the provider returns a replacement final reply that
+        // does not extend the stream, treat the effective reply as authoritative.
         if self.accumulated.is_empty() {
             effective.to_string()
         } else if effective.starts_with(self.accumulated.as_str()) {

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -187,3 +187,118 @@ def test_streaming_chat(
     assert "received" in streamed_text
     usage_payload = json.loads(usage_events[0].part.payload_json)
     assert usage_payload["reasoning_tokens"] == 6
+
+
+def test_streaming_chat_persists_coarse_session_message_parts(
+    stack: E2EStack,
+    client: TalonClient,
+) -> None:
+    # Regression coverage for streamed durable assembly: live reasoning/text
+    # deltas may be emitted in several batches, but the committed assistant
+    # message should retain coarse semantic parts.
+    namespace = f"talon-stream-parts-{stack.name}-{uuid.uuid4().hex[:8]}"
+    ensure_namespace(client, namespace)
+    create_agent_resource(
+        client,
+        namespace,
+        "stream-parts-agent",
+        AgentSpec(
+            model_policy={
+                "profiles": [
+                    {
+                        "name": "default",
+                        "model": Model(
+                            provider="mock",
+                            name="minimax",
+                            temperature=0.7,
+                        ),
+                    }
+                ]
+            },
+            system_prompt="Stream durable parts.",
+        ),
+    )
+
+    session_id = client.sessions.Create(
+        CreateSessionRequest(agent="stream-parts-agent", ns=namespace)
+    ).session_id
+
+    def send_msg() -> None:
+        time.sleep(2.0)
+        client.sessions.SendMessage(
+            SendMessageRequest(
+                agent="stream-parts-agent",
+                session_id=session_id,
+                ns=namespace,
+                message="hello",
+            )
+        )
+
+    sender = threading.Thread(target=send_msg)
+    sender.start()
+
+    stream_req = StreamSessionPartsRequest(
+        agent="stream-parts-agent",
+        session_id=session_id,
+        ns=namespace,
+    )
+    live_reasoning_events = []
+    live_text_events = []
+    try:
+        for idx, event in enumerate(
+            client.sessions.StreamParts(stream_req, timeout=STREAM_TIMEOUT_SECONDS)
+        ):
+            if event.part.part_type == PART_TYPE_REASONING:
+                live_reasoning_events.append(event)
+            if event.part.part_type == PART_TYPE_TEXT:
+                live_text_events.append(event)
+            if event.part.part_type == PART_TYPE_USAGE:
+                break
+            if idx > 30:
+                break
+    except grpc.RpcError as err:
+        logger.debug("stream ended: %s", err)
+    sender.join()
+
+    assert len(live_reasoning_events) >= 1
+    assert len(live_text_events) >= 1
+
+    response = None
+    for _ in range(30):
+        response = client.sessions.Get(
+            GetSessionRequest(
+                agent="stream-parts-agent",
+                session_id=session_id,
+                ns=namespace,
+            )
+        )
+        if response.state == "IDLE" and last_assistant_message(response.messages):
+            break
+        time.sleep(1)
+
+    assert response is not None
+    assert response.state == "IDLE"
+    assistant = last_assistant_message(response.messages)
+    assert assistant is not None
+
+    reasoning_parts = [
+        part for part in assistant.parts if part.part_type == PART_TYPE_REASONING
+    ]
+    text_parts = [part for part in assistant.parts if part.part_type == PART_TYPE_TEXT]
+    usage_parts = [part for part in assistant.parts if part.part_type == PART_TYPE_USAGE]
+
+    assert [part.part_type for part in assistant.parts] == [
+        PART_TYPE_REASONING,
+        PART_TYPE_TEXT,
+        PART_TYPE_USAGE,
+    ]
+    assert len(reasoning_parts) == 1
+    assert reasoning_parts[0].content == (
+        "Inspecting the request. Planning a concise answer. "
+    )
+    assert len(text_parts) == 1
+    assert text_parts[0].content == (
+        "Hello! I am a mock LLM. How can I assist you today?"
+    )
+    assert len(usage_parts) == 1
+    assert json.loads(usage_parts[0].payload_json)["reasoning_tokens"] == 6

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -140,6 +140,25 @@ function hasReasoningPart(message: any): boolean {
   });
 }
 
+function sessionPartType(part: any): unknown {
+  return part?.partType ?? part?.part_type ?? part?.type;
+}
+
+function sessionPartContent(part: any): string {
+  return typeof part?.content === 'string' ? part.content : typeof part?.text === 'string' ? part.text : '';
+}
+
+function sessionPartsOfType(message: any, expectedType: 'text' | 'reasoning' | 'usage') {
+  const typeValues = {
+    text: new Set([1, 'SESSION_MESSAGE_PART_TYPE_TEXT', 'text']),
+    reasoning: new Set([2, 'SESSION_MESSAGE_PART_TYPE_REASONING', 'reasoning']),
+    usage: new Set([5, 'SESSION_MESSAGE_PART_TYPE_USAGE', 'usage']),
+  }[expectedType];
+  return Array.isArray(message?.parts)
+    ? message.parts.filter((part: any) => typeValues.has(sessionPartType(part) as any))
+    : [];
+}
+
 async function rootCssVar(page: Page, name: string) {
   return page.evaluate((variableName) => {
     return getComputedStyle(document.documentElement).getPropertyValue(variableName).trim();
@@ -358,6 +377,49 @@ test.describe('Chat Streaming', () => {
     await expect(replayedWorkToggle).toBeVisible({ timeout: 30000 });
     await replayedWorkToggle.click();
     await expect(page.getByText('Inspecting the request.', { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should persist streamed reasoning and text as coarse session message parts', async ({ page }) => {
+    const { client, sessionId, testNs, testAgent } = await provisionSession(page);
+    const target = { ns: testNs, agent: testAgent, sessionId };
+    const expectedText = 'Hello! I am a mock LLM. How can I assist you today?';
+    const expectedReasoning = 'Inspecting the request. Planning a concise answer. ';
+
+    await client.sessions.sendMessage({
+      ...target,
+      message: 'hello',
+      labels: {},
+    });
+
+    await expect(async () => {
+      const history = await client.sessions.listMessages({
+        ...target,
+        pageSize: 50,
+      }) as any;
+      const message = (history.items ?? [])
+        .map((item: any) => item.message)
+        .find((candidate: any) => sessionMessageText(candidate) === expectedText);
+
+      expect(message).toBeTruthy();
+      expect(sessionMessageProjectionState(message)).toBe('committed');
+      expect(history.state).toBe('IDLE');
+
+      const reasoningParts = sessionPartsOfType(message, 'reasoning');
+      const textParts = sessionPartsOfType(message, 'text');
+      const usageParts = sessionPartsOfType(message, 'usage');
+
+      expect(reasoningParts.map(sessionPartContent).join('')).toBe(expectedReasoning);
+      expect(reasoningParts).toHaveLength(1);
+      expect(textParts.map(sessionPartContent).join('')).toBe(expectedText);
+      expect(textParts).toHaveLength(1);
+      expect(usageParts).toHaveLength(1);
+      expect(message.parts.indexOf(reasoningParts[0])).toBeLessThan(message.parts.indexOf(textParts[0]));
+      expect(message.parts.map(sessionPartType).map(String)).toEqual(expect.arrayContaining([
+        expect.stringMatching(/REASONING|^2$/),
+        expect.stringMatching(/TEXT|^1$/),
+        expect.stringMatching(/USAGE|^5$/),
+      ]));
+    }).toPass({ timeout: 30000 });
   });
 
   test('should render tool calls interleaved with the answer live', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Add a shared streaming part buffer abstraction for assistant text and reasoning deltas.
- Separate live fanout batching from durable `SessionMessagePart` creation.
- Preserve stable in-progress projection part IDs while keeping final reasoning/text parts coarse.
- Add browser and backend e2e coverage for the persisted session message part shape after streaming.
- Close pending streamed text before usage parts so durable order remains reasoning/text/usage after terminal usage events.

## Root Cause

Reasoning used its live publish buffer as the durable part boundary, so once reasoning crossed the publish interval each subsequent batch could become a tiny persisted `SessionMessagePart`. Text already had separate live and durable assembly paths.

The new backend e2e also caught a terminal ordering edge: usage is emitted before done, so pending text must be closed before recording the usage part.

## Validation

- `rustfmt --edition 2021 src/worker/sink.rs`
- `git diff --check`
- `cargo test worker::sink`
- `TALON_E2E_STACKS=sqlite uv run --with pytest --with grpcio --with fastapi --with uvicorn --with pyyaml --with pyjwt --with cryptography --with protobuf --with boto3 --with testcontainers python -m pytest tests/test_chat.py::test_streaming_chat_persists_coarse_session_message_parts -q`
- Attempted `pnpm --dir ui exec tsc --noEmit`, but the repo-level UI tsconfig currently fails on pre-existing workspace/test typings and unresolved `@impalasys/talon-client` imports before isolating this spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved streaming message handling by separately tracking live text and reasoning content.
  * Preserved stable message-part identities during repeated projections.
  * Final assistant messages now assemble reasoning, text, and usage parts more consistently.

* **Bug Fixes**
  * Prevented streamed text from being committed prematurely during final reply projection.
  * Improved persistence across token, reasoning, and tool boundaries.

* **Tests**
  * Added coverage for streamed message persistence, part ordering, stable identifiers, and finalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->