### PR TITLE
Resolve connector session delivery from Connector spec

### DIFF
--- a/src/control/manifest/tests.rs
+++ b/src/control/manifest/tests.rs
@@ -285,6 +285,46 @@ spec:
     }
 
     #[test]
+    fn connector_manifest_maps_session_consumer_reply_mode() {
+        let manifest = parse_resource_manifest(
+            r#"
+apiVersion: talon.impalasys.com/v1
+kind: Connector
+metadata:
+  name: nimbus-shukant
+  namespace: Tenant:conic:Nimbus
+spec:
+  classRef:
+    name: nimbus-imessage
+  enabled: true
+  matchFields:
+    lineId: shared
+    participantId: "+16146863949"
+  consumer:
+    session:
+      agent:
+        name: nimbus
+      continuity: reuse
+      replyMode: hold_for_review
+"#,
+        )
+        .expect("connector manifest parses");
+
+        let Some(resource_spec::Kind::Connector(spec)) =
+            manifest.spec.clone().and_then(|spec| spec.kind)
+        else {
+            panic!("expected Connector spec");
+        };
+        let consumer = spec.consumer.expect("consumer");
+        assert!(consumer.channel.is_none());
+        assert!(consumer.workflow.is_none());
+        let session = consumer.session.expect("session consumer");
+        assert_eq!(session.agent.unwrap().name, "nimbus");
+        assert_eq!(session.continuity, "reuse");
+        assert_eq!(session.reply_mode, "hold_for_review");
+    }
+
+    #[test]
     fn agent_manifest_maps_a2a_target_payload_shape() {
         let manifest = parse_resource_manifest(
             r#"

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -548,6 +548,7 @@ pub async fn maybe_deliver_connector_session_message(
         &message,
         &text,
         &delivery_context_labels,
+        Some(connector_context),
     )
     .await;
     if status == Some(CONNECTOR_DELIVERY_REQUESTED) {
@@ -590,7 +591,8 @@ pub async fn deliver_connector_session_message(
     message: &data_proto::SessionMessage,
     text: &str,
 ) -> anyhow::Result<()> {
-    deliver_connector_session_message_with_labels(cp, session, message, text, &session.labels).await
+    deliver_connector_session_message_with_labels(cp, session, message, text, &session.labels, None)
+        .await
 }
 
 async fn deliver_connector_session_message_with_labels(
@@ -599,8 +601,12 @@ async fn deliver_connector_session_message_with_labels(
     message: &data_proto::SessionMessage,
     text: &str,
     labels: &HashMap<String, String>,
+    connector_context: Option<ConnectorDeliveryContext>,
 ) -> anyhow::Result<()> {
-    let connector_context = connector_delivery_context_from_labels(cp, &session.ns, labels).await?;
+    let connector_context = match connector_context {
+        Some(context) => context,
+        None => connector_delivery_context_from_labels(cp, &session.ns, labels).await?,
+    };
     let external_conversation_id = required_label(labels, LABEL_EXTERNAL_CONVERSATION)?;
     let (runtime_endpoint, api_key) = connector_runtime_endpoint_and_api_key(
         cp,
@@ -752,15 +758,16 @@ fn resolve_connector_class_ref(
     connector_namespace: &str,
     class_ref: &resources_proto::ResourceRef,
 ) -> Result<(String, String), String> {
-    if class_ref.name.trim().is_empty() {
+    let class_name = class_ref.name.trim();
+    if class_name.is_empty() {
         return Err("Connector spec.classRef.name is required".to_string());
     }
     let class_namespace = class_ref.namespace.trim();
     if class_namespace.is_empty() {
-        return Ok((connector_namespace.to_string(), class_ref.name.clone()));
+        return Ok((connector_namespace.to_string(), class_name.to_string()));
     }
     if namespace_is_self_or_ancestor(connector_namespace, class_namespace) {
-        return Ok((class_namespace.to_string(), class_ref.name.clone()));
+        return Ok((class_namespace.to_string(), class_name.to_string()));
     }
     Err("Connector spec.classRef.namespace must be empty, match Connector namespace, or name an ancestor namespace".to_string())
 }

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -41,6 +41,15 @@ const CONNECTOR_DELIVERY_DELIVERED: &str = "delivered";
 const CONNECTOR_DELIVERY_FAILED: &str = "failed";
 const CONNECTOR_DELIVERY_SKIPPED: &str = "skipped";
 
+#[derive(Clone, Debug)]
+struct ConnectorDeliveryContext {
+    registration_id: String,
+    connector_name: String,
+    connector_class: String,
+    match_fields: HashMap<String, String>,
+    reply_mode: Option<String>,
+}
+
 struct ConnectorClassRegistration {
     namespace: String,
     name: String,
@@ -420,7 +429,9 @@ pub async fn maybe_deliver_connector_session_message(
         .get_msg::<data_proto::Session>(&keys::session(ns, agent, session_id))
         .await?
         .ok_or_else(|| anyhow::anyhow!("session not found"))?;
-    if !session.labels.contains_key(LABEL_CONNECTOR_REGISTRATION) {
+    if !session.labels.contains_key(LABEL_CONNECTOR)
+        && !session.labels.contains_key(LABEL_CONNECTOR_REGISTRATION)
+    {
         return Ok(());
     }
     if session
@@ -430,7 +441,8 @@ pub async fn maybe_deliver_connector_session_message(
     {
         return Ok(());
     }
-    let hold_for_review = connector_reply_mode_from_labels(&session.labels).as_deref()
+    let connector_context = connector_delivery_context_from_session(cp, &session).await?;
+    let hold_for_review = connector_context.reply_mode.as_deref()
         == Some(CONNECTOR_REPLY_MODE_HOLD_FOR_REVIEW)
         || connector_channel_reply_mode_from_labels(&session.labels).as_deref()
             == Some(CONNECTOR_REPLY_MODE_HOLD_FOR_REVIEW);
@@ -588,19 +600,14 @@ async fn deliver_connector_session_message_with_labels(
     text: &str,
     labels: &HashMap<String, String>,
 ) -> anyhow::Result<()> {
-    let registration_id = required_label(labels, LABEL_CONNECTOR_REGISTRATION)?;
-    let connector_name = required_label(labels, LABEL_CONNECTOR)?;
-    let connector_class = required_label(labels, LABEL_CONNECTOR_CLASS)?;
+    let connector_context = connector_delivery_context_from_labels(cp, &session.ns, labels).await?;
     let external_conversation_id = required_label(labels, LABEL_EXTERNAL_CONVERSATION)?;
-    let (runtime_endpoint, api_key) =
-        connector_runtime_endpoint_and_api_key(cp, registration_id, connector_class).await?;
-
-    let mut match_fields = HashMap::new();
-    for (key, value) in labels {
-        if let Some(field) = key.strip_prefix(LABEL_CONNECTOR_MATCH_PREFIX) {
-            match_fields.insert(field.to_string(), value.clone());
-        }
-    }
+    let (runtime_endpoint, api_key) = connector_runtime_endpoint_and_api_key(
+        cp,
+        &connector_context.registration_id,
+        &connector_context.connector_class,
+    )
+    .await?;
 
     let mut delivery_labels = HashMap::new();
     delivery_labels.insert("talon.session".to_string(), session.id.clone());
@@ -616,11 +623,11 @@ async fn deliver_connector_session_message_with_labels(
         .bearer_auth(api_key)
         .json(&external_proto::ConnectorDeliveryRequest {
             delivery_id: message.id.clone(),
-            registration_id: registration_id.to_string(),
-            connector_class: connector_class.to_string(),
+            registration_id: connector_context.registration_id,
+            connector_class: connector_context.connector_class,
             namespace: session.ns.clone(),
-            connector_name: connector_name.to_string(),
-            match_fields,
+            connector_name: connector_context.connector_name,
+            match_fields: connector_context.match_fields,
             external_conversation_id: external_conversation_id.to_string(),
             external_thread_id: labels
                 .get(LABEL_EXTERNAL_THREAD)
@@ -647,6 +654,122 @@ async fn deliver_connector_session_message_with_labels(
         );
     }
     Ok(())
+}
+
+async fn connector_delivery_context_from_session(
+    cp: &ControlPlane,
+    session: &data_proto::Session,
+) -> anyhow::Result<ConnectorDeliveryContext> {
+    connector_delivery_context_from_labels(cp, &session.ns, &session.labels).await
+}
+
+async fn connector_delivery_context_from_labels(
+    cp: &ControlPlane,
+    namespace: &str,
+    labels: &HashMap<String, String>,
+) -> anyhow::Result<ConnectorDeliveryContext> {
+    if let Some(connector_name) = labels
+        .get(LABEL_CONNECTOR)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+        if let Some(connector) = store.get(namespace, "Connector", connector_name).await? {
+            match connector_delivery_context_from_resource(namespace, &connector) {
+                Ok(Some(context)) => return Ok(context),
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        namespace = %namespace,
+                        connector = %connector_name,
+                        "falling back to legacy connector session labels"
+                    );
+                }
+            }
+        }
+    }
+    connector_delivery_context_from_legacy_labels(labels)
+}
+
+fn connector_delivery_context_from_resource(
+    namespace: &str,
+    connector: &resources_proto::Resource,
+) -> anyhow::Result<Option<ConnectorDeliveryContext>> {
+    let meta = connector
+        .metadata
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Connector metadata is required"))?;
+    let spec = match connector.spec.as_ref().and_then(|spec| spec.kind.as_ref()) {
+        Some(resources_proto::resource_spec::Kind::Connector(spec)) => spec,
+        _ => anyhow::bail!("Connector resource is missing Connector spec"),
+    };
+    let Some(class_ref) = spec.class_ref.as_ref() else {
+        return Ok(None);
+    };
+    let (class_namespace, class_name) =
+        resolve_connector_class_ref(namespace, class_ref).map_err(anyhow::Error::msg)?;
+    let Some(session_consumer) = spec
+        .consumer
+        .as_ref()
+        .and_then(|consumer| consumer.session.as_ref())
+    else {
+        return Ok(None);
+    };
+    let reply_mode = {
+        let reply_mode = normalize_connector_reply_mode(&session_consumer.reply_mode);
+        (!reply_mode.is_empty()).then_some(reply_mode)
+    };
+    let registration_id = keys::connector_registration_id(&class_namespace, &class_name);
+    Ok(Some(ConnectorDeliveryContext {
+        registration_id,
+        connector_name: meta.name.clone(),
+        connector_class: class_name,
+        match_fields: spec.match_fields.clone(),
+        reply_mode,
+    }))
+}
+
+fn connector_delivery_context_from_legacy_labels(
+    labels: &HashMap<String, String>,
+) -> anyhow::Result<ConnectorDeliveryContext> {
+    let mut match_fields = HashMap::new();
+    for (key, value) in labels {
+        if let Some(field) = key.strip_prefix(LABEL_CONNECTOR_MATCH_PREFIX) {
+            match_fields.insert(field.to_string(), value.clone());
+        }
+    }
+    Ok(ConnectorDeliveryContext {
+        registration_id: required_label(labels, LABEL_CONNECTOR_REGISTRATION)?.to_string(),
+        connector_name: required_label(labels, LABEL_CONNECTOR)?.to_string(),
+        connector_class: required_label(labels, LABEL_CONNECTOR_CLASS)?.to_string(),
+        match_fields,
+        reply_mode: connector_reply_mode_from_labels(labels),
+    })
+}
+
+fn resolve_connector_class_ref(
+    connector_namespace: &str,
+    class_ref: &resources_proto::ResourceRef,
+) -> Result<(String, String), String> {
+    if class_ref.name.trim().is_empty() {
+        return Err("Connector spec.classRef.name is required".to_string());
+    }
+    let class_namespace = class_ref.namespace.trim();
+    if class_namespace.is_empty() {
+        return Ok((connector_namespace.to_string(), class_ref.name.clone()));
+    }
+    if namespace_is_self_or_ancestor(connector_namespace, class_namespace) {
+        return Ok((class_namespace.to_string(), class_ref.name.clone()));
+    }
+    Err("Connector spec.classRef.namespace must be empty, match Connector namespace, or name an ancestor namespace".to_string())
+}
+
+fn namespace_is_self_or_ancestor(namespace: &str, candidate_ancestor: &str) -> bool {
+    namespace == candidate_ancestor
+        || namespace
+            .strip_prefix(candidate_ancestor)
+            .is_some_and(|suffix| suffix.starts_with(':'))
 }
 
 fn connector_reply_mode_from_labels(labels: &HashMap<String, String>) -> Option<String> {
@@ -774,19 +897,14 @@ pub async fn send_connector_session_activity(
     phase: &str,
     status_text: &str,
 ) -> anyhow::Result<()> {
-    let registration_id = required_label(&session.labels, LABEL_CONNECTOR_REGISTRATION)?;
-    let connector_name = required_label(&session.labels, LABEL_CONNECTOR)?;
-    let connector_class = required_label(&session.labels, LABEL_CONNECTOR_CLASS)?;
+    let connector_context = connector_delivery_context_from_session(cp, session).await?;
     let external_conversation_id = required_label(&session.labels, LABEL_EXTERNAL_CONVERSATION)?;
-    let (runtime_endpoint, api_key) =
-        connector_runtime_endpoint_and_api_key(cp, registration_id, connector_class).await?;
-
-    let mut match_fields = HashMap::new();
-    for (key, value) in &session.labels {
-        if let Some(field) = key.strip_prefix(LABEL_CONNECTOR_MATCH_PREFIX) {
-            match_fields.insert(field.to_string(), value.clone());
-        }
-    }
+    let (runtime_endpoint, api_key) = connector_runtime_endpoint_and_api_key(
+        cp,
+        &connector_context.registration_id,
+        &connector_context.connector_class,
+    )
+    .await?;
 
     let mut labels = HashMap::new();
     labels.insert("talon.session".to_string(), session.id.clone());
@@ -800,11 +918,11 @@ pub async fn send_connector_session_activity(
         .bearer_auth(api_key)
         .json(&external_proto::ConnectorActivityRequest {
             activity_id: activity_id.to_string(),
-            registration_id: registration_id.to_string(),
-            connector_class: connector_class.to_string(),
+            registration_id: connector_context.registration_id,
+            connector_class: connector_context.connector_class,
             namespace: session.ns.clone(),
-            connector_name: connector_name.to_string(),
-            match_fields,
+            connector_name: connector_context.connector_name,
+            match_fields: connector_context.match_fields,
             external_conversation_id: external_conversation_id.to_string(),
             external_thread_id: session
                 .labels

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -1255,6 +1255,68 @@ mod tests {
             .unwrap();
     }
 
+    async fn put_connector_resource(
+        kv: Arc<MockKvStore>,
+        reply_mode: &str,
+        match_fields: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) {
+        let store = crate::control::resources::ResourceStore::new(kv, Arc::new(MockPubSub));
+        store
+            .upsert(
+                "conic:test",
+                resources_proto::Resource {
+                    api_version: "talon.impalasys.com/v1".to_string(),
+                    kind: "Connector".to_string(),
+                    metadata: Some(resources_proto::ResourceMeta {
+                        name: "slack-main".to_string(),
+                        namespace: "conic:test".to_string(),
+                        uid: "connector-uid-1".to_string(),
+                        ..Default::default()
+                    }),
+                    spec: Some(resources_proto::ResourceSpec {
+                        kind: Some(resources_proto::resource_spec::Kind::Connector(
+                            resources_proto::ConnectorSpec {
+                                class_ref: Some(resources_proto::ResourceRef {
+                                    name: "slack".to_string(),
+                                    namespace: String::new(),
+                                }),
+                                enabled: true,
+                                match_fields: match_fields
+                                    .into_iter()
+                                    .map(|(key, value)| (key.to_string(), value.to_string()))
+                                    .collect(),
+                                consumer: Some(data_proto::MessageConsumer {
+                                    session: Some(data_proto::SessionMessageConsumer {
+                                        agent: Some(data_proto::ResourceRef {
+                                            name: "assistant".to_string(),
+                                            namespace: String::new(),
+                                        }),
+                                        continuity: "reuse".to_string(),
+                                        session_id: String::new(),
+                                        reply_mode: reply_mode.to_string(),
+                                    }),
+                                    channel: None,
+                                    workflow: None,
+                                }),
+                            },
+                        )),
+                    }),
+                    status: Some(resources_proto::ResourceStatus {
+                        kind: Some(resources_proto::resource_status::Kind::Connector(
+                            resources_proto::ConnectorStatus {
+                                observed_generation: 1,
+                                phase: "Ready".to_string(),
+                                conditions: Vec::new(),
+                                compiled_route_ids: Vec::new(),
+                            },
+                        )),
+                    }),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
     fn connector_session_labels(
         extra: impl IntoIterator<Item = (&'static str, &'static str)>,
     ) -> HashMap<String, String> {
@@ -2158,6 +2220,149 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn maybe_deliver_connector_session_message_derives_delivery_request_from_connector() {
+        let kv = Arc::new(MockKvStore::default());
+        let deliveries: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(
+                "/v1/deliveries",
+                post(
+                    |State(deliveries): State<Arc<Mutex<Vec<Value>>>>,
+                     Json(payload): Json<Value>| async move {
+                        deliveries.lock().unwrap().push(payload);
+                        Json(json!({
+                            "accepted": true,
+                            "disposition": "accepted",
+                            "error": ""
+                        }))
+                    },
+                ),
+            )
+            .with_state(deliveries.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        put_connector_class_resource(kv.clone(), endpoint).await;
+        put_connector_resource(
+            kv.clone(),
+            "",
+            [("teamId", "fresh-team"), ("channelId", "fresh-channel")],
+        )
+        .await;
+        put_connector_session_and_assistant_message(
+            kv.clone(),
+            connector_session_labels([
+                (
+                    "talon.impalasys.com/connector-registration",
+                    "Namespace/conic%3Atest/ConnectorClass/stale-class",
+                ),
+                ("talon.impalasys.com/connector-class", "stale-class"),
+                ("talon.impalasys.com/connector-match/teamId", "stale-team"),
+            ]),
+            HashMap::new(),
+            "freshly routed reply",
+        )
+        .await;
+
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
+        crate::gateway::rpc::connectors::maybe_deliver_connector_session_message(
+            &cp,
+            "conic:test",
+            "assistant",
+            "session-1",
+            "assistant-1",
+        )
+        .await
+        .expect("delivery should use current Connector context");
+
+        let deliveries = deliveries.lock().unwrap().clone();
+        assert_eq!(deliveries.len(), 1);
+        let delivery = &deliveries[0];
+        assert_eq!(
+            delivery["registrationId"],
+            "Namespace/conic%3Atest/ConnectorClass/slack"
+        );
+        assert_eq!(delivery["connectorClass"], "slack");
+        assert_eq!(delivery["connectorName"], "slack-main");
+        assert_eq!(delivery["matchFields"]["teamId"], "fresh-team");
+        assert_eq!(delivery["matchFields"]["channelId"], "fresh-channel");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn send_connector_session_activity_derives_request_from_connector() {
+        let kv = Arc::new(MockKvStore::default());
+        let activities: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(
+                "/v1/activities",
+                post(
+                    |State(activities): State<Arc<Mutex<Vec<Value>>>>,
+                     Json(payload): Json<Value>| async move {
+                        activities.lock().unwrap().push(payload);
+                        Json(json!({
+                            "accepted": true,
+                            "disposition": "accepted",
+                            "error": ""
+                        }))
+                    },
+                ),
+            )
+            .with_state(activities.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        put_connector_class_resource(kv.clone(), endpoint).await;
+        put_connector_resource(kv.clone(), "", [("teamId", "fresh-team")]).await;
+        let session = data_proto::Session {
+            id: "session-1".to_string(),
+            agent: "assistant".to_string(),
+            ns: "conic:test".to_string(),
+            status: "PROCESSING".to_string(),
+            created_at: 0,
+            last_active: 123,
+            metadata: HashMap::new(),
+            labels: connector_session_labels([
+                (
+                    "talon.impalasys.com/connector-registration",
+                    "Namespace/conic%3Atest/ConnectorClass/stale-class",
+                ),
+                ("talon.impalasys.com/connector-class", "stale-class"),
+                ("talon.impalasys.com/connector-match/teamId", "stale-team"),
+            ]),
+        };
+
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
+        crate::gateway::rpc::connectors::send_connector_session_activity(
+            &cp,
+            &session,
+            "activity-1",
+            "started",
+            "typing",
+        )
+        .await
+        .expect("activity should use current Connector context");
+
+        let activities = activities.lock().unwrap().clone();
+        assert_eq!(activities.len(), 1);
+        let activity = &activities[0];
+        assert_eq!(
+            activity["registrationId"],
+            "Namespace/conic%3Atest/ConnectorClass/slack"
+        );
+        assert_eq!(activity["connectorClass"], "slack");
+        assert_eq!(activity["connectorName"], "slack-main");
+        assert_eq!(activity["matchFields"]["teamId"], "fresh-team");
+
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn maybe_deliver_connector_session_message_marks_hold_for_review_pending() {
         let kv = Arc::new(MockKvStore::default());
         put_connector_session_and_assistant_message(
@@ -2203,6 +2408,127 @@ mod tests {
                 .map(String::as_str),
             Some("slack-main")
         );
+    }
+
+    #[tokio::test]
+    async fn maybe_deliver_connector_session_message_uses_connector_reply_mode_over_stale_label() {
+        let kv = Arc::new(MockKvStore::default());
+        put_connector_resource(
+            kv.clone(),
+            "hold_for_review",
+            [("teamId", "fresh-team"), ("channelId", "fresh-channel")],
+        )
+        .await;
+        put_connector_session_and_assistant_message(
+            kv.clone(),
+            connector_session_labels([("talon.impalasys.com/connector-reply-mode", "")]),
+            HashMap::new(),
+            "draft reply",
+        )
+        .await;
+
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
+        crate::gateway::rpc::connectors::maybe_deliver_connector_session_message(
+            &cp,
+            "conic:test",
+            "assistant",
+            "session-1",
+            "assistant-1",
+        )
+        .await
+        .expect("current Connector replyMode should require review");
+
+        let message = kv
+            .get_msg::<data_proto::SessionMessage>(&crate::control::keys::session_message(
+                "conic:test",
+                "assistant",
+                "session-1",
+                "assistant-1",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            message
+                .labels
+                .get("talon.impalasys.com/connector-delivery-status")
+                .map(String::as_str),
+            Some("pending_review")
+        );
+    }
+
+    #[tokio::test]
+    async fn maybe_deliver_connector_session_message_uses_connector_to_disable_stale_review_label()
+    {
+        let kv = Arc::new(MockKvStore::default());
+        let deliveries: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(
+                "/v1/deliveries",
+                post(
+                    |State(deliveries): State<Arc<Mutex<Vec<Value>>>>,
+                     Json(payload): Json<Value>| async move {
+                        deliveries.lock().unwrap().push(payload);
+                        Json(json!({
+                            "accepted": true,
+                            "disposition": "accepted",
+                            "error": ""
+                        }))
+                    },
+                ),
+            )
+            .with_state(deliveries.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        put_connector_class_resource(kv.clone(), endpoint).await;
+        put_connector_resource(kv.clone(), "", [("teamId", "fresh-team")]).await;
+        put_connector_session_and_assistant_message(
+            kv.clone(),
+            connector_session_labels([(
+                "talon.impalasys.com/connector-reply-mode",
+                "hold_for_review",
+            )]),
+            HashMap::new(),
+            "send now",
+        )
+        .await;
+
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(MockPubSub)).build();
+        crate::gateway::rpc::connectors::maybe_deliver_connector_session_message(
+            &cp,
+            "conic:test",
+            "assistant",
+            "session-1",
+            "assistant-1",
+        )
+        .await
+        .expect("current Connector should disable stale review label");
+
+        let deliveries = deliveries.lock().unwrap().clone();
+        assert_eq!(deliveries.len(), 1);
+        assert_eq!(deliveries[0]["text"], "send now");
+        let message = kv
+            .get_msg::<data_proto::SessionMessage>(&crate::control::keys::session_message(
+                "conic:test",
+                "assistant",
+                "session-1",
+                "assistant-1",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            message
+                .labels
+                .get("talon.impalasys.com/connector-delivery-status")
+                .map(String::as_str),
+            None
+        );
+
+        server.abort();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- derive connector session delivery/activity config from the current Connector resource when available
- keep legacy session-label fallback for old or missing Connector resources
- add coverage for stale replyMode labels, derived delivery/activity request shape, and session replyMode manifest parsing

## Tests
- cargo test connector_session
- cargo test connector_manifest_maps_session_consumer_reply_mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connector session deliveries now derive routing details from the current connector configuration, including registration, connector identity, and match fields.
  * Connector review behavior now respects the configured reply mode, including “hold for review.”

* **Bug Fixes**
  * Prevented outdated session labels from overriding current connector settings.
  * Improved fallback handling for legacy connector session metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->