### PR TITLE
Fix Sightline schedule resource crash

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -287,7 +287,7 @@ type ChannelSubscriptionDocument = {
 };
 
 function formatMicros(value: unknown) {
-  const normalized = typeof value === 'string' ? Number(value) : value;
+  const normalized = typeof value === 'bigint' || typeof value === 'string' ? Number(value) : value;
   if (typeof normalized !== 'number' || !Number.isFinite(normalized) || normalized <= 0) {
     return '—';
   }

--- a/ui/e2e/explorer.spec.ts
+++ b/ui/e2e/explorer.spec.ts
@@ -59,4 +59,87 @@ test.describe('Explorer navigation', () => {
     await expect(page.locator('.truncate', { hasText: '13' }).first()).toBeVisible({ timeout: 15000 });
     await expect(page.locator('.truncate', { hasText: 'cmo' }).first()).toBeVisible({ timeout: 15000 });
   });
+
+  test('opens schedule resource details without crashing', async ({ page }) => {
+    const gatewayUrl = e2eGatewayUrl();
+    const client = createE2ETalonClient(gatewayUrl);
+    const testNs = `sightline-schedule-${Date.now()}`;
+    const agentName = 'scheduler-agent';
+    const scheduleName = 'hourly-check';
+    const pageErrors: string[] = [];
+    const runAt = new Date(Date.now() + 60 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.message);
+    });
+
+    await expect(async () => {
+      await client.namespaces.create({ name: testNs, recursive: true });
+    }).toPass({ timeout: 60000 });
+
+    await client.resources.create({
+      ns: testNs,
+      manifest: {
+        apiVersion: "talon.impalasys.com/v1",
+        kind: "Agent",
+        metadata: { name: agentName, namespace: testNs, labels: {}, annotations: {}, ownerReferences: [], finalizers: [], generation: BigInt(0), resourceVersion: "", uid: "" },
+        spec: {
+          kind: {
+            case: "agent",
+            value: {
+              modelPolicy: {
+                profiles: [
+                  {
+                    name: "default",
+                    model: { provider: "mock", name: "minimax", temperature: 0.7 },
+                  },
+                ],
+              },
+              systemPrompt: "Schedule explorer test",
+              mcpServerRefs: [],
+            },
+          },
+        },
+      },
+    });
+
+    await client.resources.create({
+      ns: testNs,
+      manifest: {
+        apiVersion: "talon.impalasys.com/v1",
+        kind: "Schedule",
+        metadata: { name: scheduleName, namespace: testNs, labels: {}, annotations: {}, ownerReferences: [], finalizers: [], generation: BigInt(0), resourceVersion: "", uid: "" },
+        spec: {
+          kind: {
+            case: "schedule",
+            value: {
+              kind: "at",
+              runAt,
+              timezone: "UTC",
+              target: { agent: agentName, sessionMode: "new", sessionId: "", workflow: "" },
+              inputMessage: "Run the scheduled explorer smoke test.",
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    const params = new URLSearchParams({
+      connected: 'true',
+      ns: testNs,
+      type: 'schedule',
+      name: scheduleName,
+    });
+
+    await installBrowserAuth(page, gatewayUrl);
+    await page.goto(`/?${params.toString()}`);
+
+    await expect(page.locator('text=Connected')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(scheduleName).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Overview').first()).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Next run')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: 'Raw YAML' })).toBeVisible();
+    expect(pageErrors).toEqual([]);
+  });
 });

--- a/ui/lib/talon/resourceMappers.test.ts
+++ b/ui/lib/talon/resourceMappers.test.ts
@@ -82,7 +82,24 @@ describe('resource mappers', () => {
       spec: { kind: 'cron', enabled: true },
       status: { nextRunAt: 20n },
     });
-    expect(scheduleDocumentFromResource(schedule).spec.kind).toBe('cron');
+    expect(scheduleDocumentFromResource(schedule)).toMatchObject({
+      spec: { kind: 'cron', enabled: true },
+      status: { nextRunAt: '20' },
+    });
+
+    const bytes = new Uint8Array([12, 34]);
+    expect(scheduleDocumentFromResource(resource('schedule', { payload: bytes })).spec.payload).toBe(bytes);
+
+    const protobufScheduleSpec = Object.assign(Object.create({}), {
+      $typeName: 'talon.resources.ScheduleSpec',
+      nextRunAt: 30n,
+      payload: bytes,
+    });
+    expect(scheduleDocumentFromResource(resource('schedule', protobufScheduleSpec)).spec).toEqual({
+      nextRunAt: '30',
+      payload: bytes,
+    });
+
     expect(knowledgeFromResource(resource('knowledge', { path: '/docs', content: 'hello' })).spec).toEqual({
       path: '/docs',
       content: 'hello',

--- a/ui/lib/talon/resourceMappers.ts
+++ b/ui/lib/talon/resourceMappers.ts
@@ -113,6 +113,31 @@ export function parseJsonObject(value: string | undefined) {
   }
 }
 
+function renderSafeValue(value: any): any {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(renderSafeValue);
+  if (value && typeof value === 'object') {
+    if (
+      ArrayBuffer.isView(value) ||
+      value instanceof ArrayBuffer ||
+      value instanceof Date ||
+      value instanceof RegExp ||
+      value instanceof Map ||
+      value instanceof Set ||
+      value instanceof WeakMap ||
+      value instanceof WeakSet
+    ) {
+      return value;
+    }
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key, entryValue]) => key !== '$typeName' && typeof entryValue !== 'undefined')
+        .map(([key, entryValue]) => [key, renderSafeValue(entryValue)]),
+    );
+  }
+  return value;
+}
+
 export function resourceMetadata(name: string, namespace: string) {
   return {
     name,
@@ -195,13 +220,13 @@ export function scheduleFromResource(resource: ResourceEnvelope): ExplorerSchedu
 }
 
 export function scheduleDocumentFromResource(resource: ResourceEnvelope): ScheduleDocument {
-  return {
+  return renderSafeValue({
     name: resource.metadata?.name,
     ns: resource.metadata?.namespace,
     labels: resource.metadata?.labels,
     spec: resourceSpec(resource, 'schedule'),
     status: resourceStatus(resource, 'schedule'),
-  };
+  });
 }
 
 export function knowledgeFromResource(resource: ResourceEnvelope): ExplorerKnowledge {


### PR DESCRIPTION
## Summary

- Sanitize Sightline schedule detail documents so protobuf `bigint` fields are safe for YAML dumping and React rendering.
- Make the schedule timestamp formatter tolerate raw `bigint` values.
- Add a Playwright e2e test that creates a real `Schedule`, deep-links to the schedule resource view, and asserts the page opens without browser errors.

## Root Cause

Schedule resources expose protobuf `uint64`/`int64` fields as JavaScript `bigint`s. The dedicated schedule inspector bypassed the generic manifest sanitization path, so opening a schedule resource could crash while rendering or dumping the document.

## Validation

- `pnpm jest lib/talon/resourceMappers.test.ts --runInBand --coverage=false`
- `GRPC_PORT=55051 API_PORT=55051 READY_PORT=8990 WEB_PORT=3300 PYTHON_BIN=/tmp/talon-e2e-venv/bin/python pnpm exec playwright test e2e/explorer.spec.ts -g "opens schedule resource details without crashing"`