### PR TITLE
Fix Sightline Cloudflare deploy artifact path

### DIFF
--- a/.github/workflows/talon-sightline-cloudflare.yml
+++ b/.github/workflows/talon-sightline-cloudflare.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: sightline-static-export
-          path: ui/out
+          path: ui/dist
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
## Summary\n- Download the Sightline static artifact into ui/dist so Wrangler deploys the directory produced by the Vite build.\n\n## Verification\n- pnpm build (ui)\n\n## Context\nThe post-merge main deploy failed because the build uploaded ui/dist, the deploy job downloaded the artifact into ui/out, and Wrangler was invoked against ui/dist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Cloudflare Pages deployments to use the correct generated output directory, ensuring the intended static site files are deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->