### PR TITLE
Decode zstd CAS objects in Sightline

### DIFF
--- a/packages/talon-chat/package.json
+++ b/packages/talon-chat/package.json
@@ -50,6 +50,7 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
+    "fzstd": "^0.1.1",
     "lucide-react": "^0.400.0",
     "streamdown": "^2.5.0"
   },

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { data, type TalonClient } from "@impalasys/talon-client";
+import { decompress as decompressZstd } from "fzstd";
 import { Activity, Check, ChevronRight, Copy, Pencil, X, Wrench } from "lucide-react";
 import {
   formatUsageSummary,
@@ -432,6 +433,19 @@ async function decompressCasObjectData(data: Uint8Array, encoding: string): Prom
   return new Uint8Array(await new Response(stream).arrayBuffer());
 }
 
+async function decompressZstdCasObjectData(data: Uint8Array): Promise<Uint8Array> {
+  if (typeof DecompressionStream !== "undefined") {
+    try {
+      return await decompressCasObjectData(data, "zstd");
+    } catch (err) {
+      if (!(err instanceof TypeError)) {
+        throw err;
+      }
+    }
+  }
+  return decompressZstd(data);
+}
+
 async function casObjectData(response: any): Promise<Uint8Array> {
   const signedUrl = typeof response?.signedUrl === "string"
     ? response.signedUrl
@@ -456,9 +470,9 @@ async function toolResultObjectData(response: any, fallbackObject?: TalonChatObj
     ?? response?.metadata?.contentEncoding;
   const encoding = typeof responseEncoding === "string" ? responseEncoding : objectRefContentEncoding(fallbackObject);
   const normalized = encoding.toLowerCase();
-  return normalized === "zstd" || normalized === "gzip"
-    ? decompressCasObjectData(bytes, normalized)
-    : bytes;
+  if (normalized === "zstd") return decompressZstdCasObjectData(bytes);
+  if (normalized === "gzip") return decompressCasObjectData(bytes, normalized);
+  return bytes;
 }
 
 async function hydrateCasToolResultObjects(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   packages/talon-chat:
     dependencies:
+      fzstd:
+        specifier: ^0.1.1
+        version: 0.1.1
       lucide-react:
         specifier: ^0.400.0
         version: 0.400.0(react@19.2.3)
@@ -2781,6 +2784,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fzstd@0.1.1:
+    resolution: {integrity: sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -6907,6 +6913,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  fzstd@0.1.1: {}
 
   gensync@1.0.0-beta.2: {}
 

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -4,6 +4,10 @@ import {
   TalonCopilot as RawTalonCopilot,
 } from '@impalasys/talon-chat';
 
+jest.mock('fzstd', () => ({
+  decompress: jest.fn((bytes: Uint8Array) => bytes),
+}));
+
 function makeJsonResponse(payload: any, ok = true) {
   return {
     ok,
@@ -260,7 +264,7 @@ function makeGatewayClient(raw: any = {}, gatewayUrl = 'http://localhost:18789',
       return response.json();
     }),
   };
-  return { sessions, channels };
+  return { sessions, channels, cas: raw.cas };
 }
 
 function TalonCopilot(props: any) {
@@ -333,6 +337,94 @@ describe('TalonCopilot', () => {
       });
     });
     expect(await screen.findByText('Hello from history')).toBeInTheDocument();
+  });
+
+  it('hydrates zstd CAS tool results with a library fallback when the browser stream rejects zstd', async () => {
+    const decodedOutput = new TextEncoder().encode('zstd hydrated tool output');
+    const decompressZstd = jest.requireMock('fzstd').decompress as jest.Mock;
+    decompressZstd.mockReturnValueOnce(decodedOutput);
+    const originalDecompressionStream = global.DecompressionStream;
+    global.DecompressionStream = jest.fn().mockImplementation((format: string) => {
+      if (format === 'zstd') {
+        throw new TypeError("DecompressionStream does not support 'zstd'");
+      }
+      return {};
+    }) as any;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-zstd',
+        state: 'IDLE',
+        items: [
+          {
+            message: {
+              id: 'assistant-zstd',
+              role: 'ROLE_ASSISTANT',
+              parts: [
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                  name: 'knowledge_search',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-zstd', input: { query: 'docs' } }),
+                  createdAt: String(Date.now() * 1000),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                  name: 'knowledge_search',
+                  content: '',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-zstd' }),
+                  object: {
+                    key: 'cas/ops/sessions/sess-zstd/messages/assistant-zstd/000001.txt',
+                    contentEncoding: 'zstd',
+                  },
+                  createdAt: String(Date.now() * 1000),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                  content: 'Done',
+                  createdAt: String(Date.now() * 1000),
+                },
+              ],
+              createdAt: String(Date.now() * 1000),
+            },
+            steps: [],
+          },
+        ],
+        hasMore: false,
+      }),
+      getSession: jest.fn(),
+      cas: {
+        getObject: jest.fn().mockResolvedValue({
+          data: new Uint8Array([0x28, 0xb5, 0x2f, 0xfd]),
+          contentEncoding: 'zstd',
+        }),
+      },
+    };
+
+    try {
+      render(
+        <TalonCopilot
+          namespace="ops"
+          agent="copilot"
+          gatewayClient={gatewayClient}
+          sessionId="sess-zstd"
+        />,
+      );
+
+      expect(await screen.findByText('Done')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+      fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
+      expect(await screen.findByText('zstd hydrated tool output')).toBeInTheDocument();
+      expect(decompressZstd).toHaveBeenCalledWith(new Uint8Array([0x28, 0xb5, 0x2f, 0xfd]));
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Could not hydrate CAS tool-result object'),
+        expect.anything(),
+        expect.anything(),
+      );
+    } finally {
+      global.DecompressionStream = originalDecompressionStream;
+      warnSpy.mockRestore();
+    }
   });
 
   it('shows pending connector replies and requests delivery by updating message labels', async () => {


### PR DESCRIPTION
## Summary
- add `fzstd` as a zstd fallback for CAS tool-result hydration in `@impalasys/talon-chat`
- prefer native `DecompressionStream("zstd")` when the browser supports it, then fall back to the library when the constructor rejects the format
- add a Sightline history replay regression test for object-backed zstd tool results

## Root cause
Large tool results can be stored as zstd-compressed CAS objects. Sightline was passing `zstd` directly to `DecompressionStream`; in the affected browser runtime that constructor throws `TypeError`, so hydration failed and the tool output stayed empty.

## Validation
- pnpm --dir ui exec jest --runTestsByPath lib/talonCopilot.test.tsx --runInBand --coverage=false
- pnpm --dir ui lint
- pnpm --dir packages/talon-chat build
- cargo fmt --check && cargo test -p talon gateway::rpc::cas::tests::get_cas_object_returns_stored_tool_result_bytes -- --exact
