### PR TITLE
Support File resources in Sightline

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
 
   ui:
     dependencies:
+      '@codemirror/lang-markdown':
+        specifier: ^6.5.0
+        version: 6.5.0
       '@codemirror/lang-yaml':
         specifier: ^6.1.3
         version: 6.1.3
@@ -155,6 +158,9 @@ importers:
       framer-motion:
         specifier: ^12.29.2
         version: 12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      fzstd:
+        specifier: ^0.1.1
+        version: 0.1.1
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -494,6 +500,18 @@ packages:
 
   '@codemirror/commands@6.10.4':
     resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
 
   '@codemirror/lang-yaml@6.1.3':
     resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
@@ -873,11 +891,23 @@ packages:
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
+  '@lezer/css@1.3.4':
+    resolution: {integrity: sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==}
+
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
 
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
   '@lezer/lr@1.4.10':
     resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.7.1':
+    resolution: {integrity: sha512-MEBZeFSBxgteUjEC3Wxg2Dwld5/JxRKG267L3bMFdibm8KjqSdiJYBeFw1Nt1CM8+zKMpSIEHblY8FD9z38sJQ==}
 
   '@lezer/yaml@1.0.4':
     resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
@@ -4774,6 +4804,46 @@ snapshots:
       '@codemirror/view': 6.43.6
       '@lezer/common': 1.5.2
 
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.4
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.4
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.7.1
+
   '@codemirror/lang-yaml@6.1.3':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
@@ -5214,13 +5284,36 @@ snapshots:
 
   '@lezer/common@1.5.2': {}
 
+  '@lezer/css@1.3.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/highlight@1.2.3':
     dependencies:
       '@lezer/common': 1.5.2
 
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/lr@1.4.10':
     dependencies:
       '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.7.1':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
 
   '@lezer/yaml@1.0.4':
     dependencies:

--- a/src/gateway/rpc/cas.rs
+++ b/src/gateway/rpc/cas.rs
@@ -5,9 +5,36 @@ use super::{proto, GrpcGatewayHandler};
 use crate::control::cas::{
     object_ref_from_metadata, object_ref_from_stored_object, parse_session_object_key, CasStore,
 };
+use crate::control::object_store::ObjectMetadata;
 use std::time::Duration;
 
 const CAS_SIGNED_URL_TTL: Duration = Duration::from_secs(5 * 60);
+
+fn parse_file_object_namespace(key: &str) -> anyhow::Result<Option<String>> {
+    let parts: Vec<&str> = key.split('/').collect();
+    let ["cas", encoded_ns, "files", file_uid, sha] = parts.as_slice() else {
+        return Ok(None);
+    };
+    let ns = urlencoding::decode(encoded_ns)
+        .map_err(|err| {
+            anyhow::anyhow!("CAS file object namespace is not valid percent-encoding: {err}")
+        })?
+        .into_owned();
+    if urlencoding::encode(&ns) != *encoded_ns {
+        anyhow::bail!("CAS file object namespace is not canonical");
+    }
+    for (field, value) in [("file_uid", *file_uid), ("sha", *sha)] {
+        if value.is_empty() || value.contains('/') || value.contains("..") {
+            anyhow::bail!("CAS file object field '{field}' contains unsafe characters");
+        }
+    }
+    Ok(Some(ns))
+}
+
+fn is_file_object_metadata(metadata: &ObjectMetadata, ns: &str) -> bool {
+    metadata.metadata.get("kind").map(String::as_str) == Some("file")
+        && metadata.metadata.get("namespace").map(String::as_str) == Some(ns)
+}
 
 impl GrpcGatewayHandler {
     #[allow(deprecated)]
@@ -19,6 +46,74 @@ impl GrpcGatewayHandler {
 
         if body.key.trim().is_empty() {
             return Err(tonic::Status::invalid_argument("key is required"));
+        }
+        if let Some(ns) = parse_file_object_namespace(&body.key)
+            .map_err(|err| tonic::Status::invalid_argument(format!("Invalid CAS key: {err}")))?
+        {
+            crate::require_auth!(read, self, req, &ns);
+            let metadata = self
+                .gateway
+                .objects
+                .head(&body.key)
+                .await
+                .map_err(|err| {
+                    tonic::Status::internal(format!("Failed to load CAS object metadata: {err}"))
+                })?
+                .ok_or_else(|| tonic::Status::not_found("CAS object not found"))?;
+            if !is_file_object_metadata(&metadata, &ns) {
+                return Err(tonic::Status::permission_denied(
+                    "CAS object is outside the authorized file namespace",
+                ));
+            }
+            let signed = self
+                .gateway
+                .objects
+                .signed_get_url(&body.key, CAS_SIGNED_URL_TTL)
+                .await
+                .map_err(|err| {
+                    tonic::Status::internal(format!("Failed to sign CAS object URL: {err}"))
+                })?;
+            let (data, signed_url, signed_url_expires_at_unix_seconds, object_ref) =
+                if let Some(signed) = signed {
+                    (
+                        Vec::new(),
+                        signed.url,
+                        signed.expires_at_unix_seconds,
+                        object_ref_from_metadata(&body.key, &metadata),
+                    )
+                } else {
+                    let object = self
+                        .gateway
+                        .objects
+                        .get(&body.key)
+                        .await
+                        .map_err(|err| {
+                            tonic::Status::internal(format!("Failed to load CAS object: {err}"))
+                        })?
+                        .ok_or_else(|| tonic::Status::not_found("CAS object not found"))?;
+                    if !is_file_object_metadata(&object.metadata, &ns) {
+                        return Err(tonic::Status::permission_denied(
+                            "CAS object is outside the authorized file namespace",
+                        ));
+                    }
+                    (
+                        object.bytes.clone(),
+                        String::new(),
+                        0,
+                        object_ref_from_stored_object(&body.key, &object),
+                    )
+                };
+            return Ok(tonic::Response::new(proto::GetCasObjectResponse {
+                data,
+                signed_url,
+                signed_url_expires_at_unix_seconds,
+                metadata: object_ref.metadata,
+                media_type: object_ref.media_type,
+                size_bytes: object_ref.size_bytes,
+                sha256: object_ref.sha256,
+                filename: object_ref.filename,
+                content_encoding: object_ref.content_encoding,
+            }));
         }
         parse_session_object_key(&body.key)
             .map_err(|err| tonic::Status::invalid_argument(format!("Invalid CAS key: {err}")))?;

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1466,6 +1466,7 @@ function DebuggerPageContent() {
               selectedNode={selectedNamespace}
               isLoading={resourceLoading}
               error={resourceError}
+              document={resourceDocument}
               yaml={resourceYaml}
               dedicatedInspector={
                 selectedNamespace?.type === 'schedule' && resourceDocument ? (

--- a/ui/components/MainPanel/MarkdownEditor.tsx
+++ b/ui/components/MainPanel/MarkdownEditor.tsx
@@ -1,0 +1,59 @@
+import CodeMirror from '@uiw/react-codemirror';
+import { markdown } from '@codemirror/lang-markdown';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { oneDark } from '@codemirror/theme-one-dark';
+
+type MarkdownEditorProps = {
+  value: string;
+  className?: string;
+  language?: 'markdown' | 'text';
+};
+
+export function MarkdownEditor({ value, className, language = 'markdown' }: MarkdownEditorProps) {
+  return (
+    <div className={`sightline-markdown-editor ${className || ''} overflow-hidden`}>
+      <CodeMirror
+        className="h-full"
+        value={value}
+        height="100%"
+        basicSetup={{
+          foldGutter: true,
+          highlightActiveLine: false,
+          highlightActiveLineGutter: false,
+        }}
+        editable={false}
+        theme={typeof document !== 'undefined' && document.documentElement.classList.contains('dark') ? oneDark : 'light'}
+        extensions={[
+          ...(language === 'markdown' ? [markdown()] : []),
+          EditorState.readOnly.of(true),
+          EditorView.lineWrapping,
+          EditorView.theme({
+            '&': {
+              height: '100%',
+              background: 'transparent',
+              fontSize: '13px',
+            },
+            '.cm-editor': {
+              height: '100%',
+            },
+            '.cm-editor .cm-scroller': {
+              overflow: 'auto',
+            },
+            '.cm-scroller': {
+              fontFamily:
+                'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+            },
+            '.cm-content': {
+              padding: '0.75rem 0 4.5rem',
+            },
+            '.cm-gutters': {
+              background: 'transparent',
+              borderRightColor: 'var(--border)',
+            },
+          }),
+        ]}
+      />
+    </div>
+  );
+}

--- a/ui/components/MainPanel/ResourceInspector.tsx
+++ b/ui/components/MainPanel/ResourceInspector.tsx
@@ -1,6 +1,11 @@
-import type { ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { decompress as decompressZstd } from 'fzstd';
 import { FileText } from 'lucide-react';
 import type { Selection } from '../../lib/selection';
+import { getGatewayClient } from '../../lib/grpc';
+import { cn } from '../../utils/cn';
+import { MarkdownEditor } from './MarkdownEditor';
 import { YamlEditor } from './YamlEditor';
 
 type ResourceInspectorProps = {
@@ -8,21 +13,176 @@ type ResourceInspectorProps = {
   selectedNode: Selection | null;
   isLoading: boolean;
   error: string | null;
+  document?: any;
   yaml: string;
   dedicatedInspector?: ReactNode;
 };
+
+type InspectorMode = 'yaml' | 'inspector';
+
+function field(value: any, camelName: string, snakeName: string = camelName) {
+  return value?.[camelName] ?? value?.[snakeName];
+}
+
+function fileDescriptor(document: any) {
+  if (document?.kind !== 'File') return null;
+  const spec = document.spec || {};
+  const status = document.status || {};
+  const objectRef = field(status, 'objectRef', 'object_ref');
+
+  const mediaType = String(spec.mediaType || spec.mimeType || spec.contentType || '').toLowerCase();
+  const objectMediaType = String(field(objectRef, 'mediaType', 'media_type') || '').toLowerCase();
+  const effectiveMediaType = mediaType || objectMediaType;
+  const path = String(spec.path || field(objectRef, 'filename') || document.metadata?.name || '').toLowerCase();
+  const isMarkdown =
+    effectiveMediaType.includes('markdown') ||
+    effectiveMediaType === 'text/md' ||
+    path.endsWith('.md') ||
+    path.endsWith('.markdown') ||
+    path.endsWith('.mdx');
+  const isText =
+    isMarkdown ||
+    effectiveMediaType.startsWith('text/') ||
+    effectiveMediaType === 'application/json' ||
+    effectiveMediaType.endsWith('+json');
+  if (!isText) return null;
+
+  return {
+    inlineContent: typeof spec.content === 'string' ? spec.content : undefined,
+    objectKey: String(field(objectRef, 'key') || ''),
+    language: isMarkdown ? 'markdown' as const : 'text' as const,
+    mediaType: effectiveMediaType || (isMarkdown ? 'text/markdown' : 'text/plain'),
+  };
+}
+
+async function decompressCasObjectData(data: Uint8Array, encoding: string): Promise<Uint8Array> {
+  if (typeof DecompressionStream === 'undefined') {
+    throw new Error(`${encoding} CAS object requires DecompressionStream support`);
+  }
+  const stream = new Blob([data as unknown as BlobPart]).stream().pipeThrough(new DecompressionStream(encoding as any));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+async function decompressZstdCasObjectData(data: Uint8Array): Promise<Uint8Array> {
+  if (typeof DecompressionStream !== 'undefined') {
+    try {
+      return await decompressCasObjectData(data, 'zstd');
+    } catch (err) {
+      if (!(err instanceof TypeError)) throw err;
+    }
+  }
+  return decompressZstd(data);
+}
+
+async function casObjectData(response: any): Promise<Uint8Array> {
+  const signedUrl = typeof response?.signedUrl === 'string'
+    ? response.signedUrl
+    : typeof response?.signed_url === 'string'
+      ? response.signed_url
+      : '';
+  if (signedUrl) {
+    const fetched = await fetch(signedUrl);
+    if (!fetched.ok) throw new Error(`Failed to fetch CAS object: HTTP ${fetched.status}`);
+    return new Uint8Array(await fetched.arrayBuffer());
+  }
+  return response.data ?? new Uint8Array();
+}
+
+async function decodeCasObjectText(response: any) {
+  const bytes = await casObjectData(response);
+  const encoding = String(response?.contentEncoding ?? response?.content_encoding ?? response?.metadata?.content_encoding ?? '').toLowerCase();
+  const decoded =
+    encoding === 'zstd'
+      ? await decompressZstdCasObjectData(bytes)
+      : encoding === 'gzip'
+        ? await decompressCasObjectData(bytes, 'gzip')
+        : bytes;
+  return new TextDecoder().decode(decoded);
+}
+
+function FileContentInspector({ document }: { document: any }) {
+  const file = useMemo(() => fileDescriptor(document), [document]);
+  const inlineContentVersion = file?.objectKey
+    ? ''
+    : String(field(document?.metadata, 'resourceVersion', 'resource_version') || field(document?.metadata, 'generation') || '');
+  const contentQuery = useQuery({
+    queryKey: ['file-content', file?.objectKey || '', inlineContentVersion],
+    queryFn: async () => {
+      if (typeof file?.inlineContent === 'string') return file.inlineContent;
+      if (!file?.objectKey) return '';
+      const response = await getGatewayClient().cas.getObject({ key: file.objectKey });
+      return decodeCasObjectText(response);
+    },
+    enabled: Boolean(file && (typeof file.inlineContent === 'string' || file.objectKey)),
+  });
+  if (!file) return null;
+
+  if (contentQuery.isLoading) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-background text-sm text-muted-foreground">
+        Loading file...
+      </div>
+    );
+  }
+
+  if (contentQuery.error) {
+    return (
+      <div className="m-4 rounded-lg border border-red-200/60 bg-red-50/60 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-400">
+        {contentQuery.error instanceof Error ? contentQuery.error.message : 'Failed to load file content'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+      <MarkdownEditor value={contentQuery.data || ''} language={file.language} className="h-full min-h-0" />
+    </div>
+  );
+}
+
+function ViewToggle({ mode, onModeChange }: { mode: InspectorMode; onModeChange: (mode: InspectorMode) => void }) {
+  return (
+    <div className="pointer-events-auto absolute bottom-5 left-1/2 z-20 -translate-x-1/2 rounded-full border border-border/80 bg-background/90 p-1 shadow-lg shadow-slate-950/10 backdrop-blur-xl">
+      {(['yaml', 'inspector'] as const).map((nextMode) => (
+        <button
+          key={nextMode}
+          type="button"
+          className={cn(
+            'h-8 rounded-full px-4 text-xs font-semibold capitalize transition-colors',
+            mode === nextMode ? 'bg-foreground text-background' : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+          )}
+          onClick={() => onModeChange(nextMode)}
+        >
+          {nextMode === 'yaml' ? 'YAML' : 'Inspector'}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 export function ResourceInspector({
   isConnected,
   selectedNode,
   isLoading,
   error,
+  document,
   yaml,
   dedicatedInspector,
 }: ResourceInspectorProps) {
+  const [mode, setMode] = useState<InspectorMode>('yaml');
+
+  useEffect(() => {
+    setMode('yaml');
+  }, [selectedNode?.fullPath]);
+
+  const inspector =
+    dedicatedInspector ||
+    (selectedNode?.type === 'file' && document && fileDescriptor(document) ? <FileContentInspector document={document} /> : null);
+  const canToggle = Boolean(selectedNode && !isLoading && !error && yaml && inspector);
+
   return (
     <div className={`min-h-0 flex-1 overflow-hidden transition-opacity duration-300 ${!isConnected ? 'pointer-events-none opacity-20' : ''}`}>
-      <div className="flex h-full min-h-0 w-full flex-col">
+      <div className="relative flex h-full min-h-0 w-full flex-col">
         {!selectedNode ? (
           <div className="m-4 flex flex-1 items-center justify-center rounded-2xl border border-dashed border-border bg-muted/20 md:m-6">
             <div className="text-center">
@@ -39,13 +199,14 @@ export function ResourceInspector({
           <div className="m-4 rounded-2xl border border-red-200/60 bg-red-50/60 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-400 md:m-6">
             {error}
           </div>
-        ) : dedicatedInspector ? (
-          dedicatedInspector
+        ) : mode === 'inspector' && inspector ? (
+          inspector
         ) : (
           <div className="min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
             <YamlEditor value={yaml} className="h-full min-h-0" />
           </div>
         )}
+        {canToggle ? <ViewToggle mode={mode} onModeChange={setMode} /> : null}
       </div>
     </div>
   );

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@10.17.1",
   "dependencies": {
+    "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-yaml": "^6.1.3",
     "@codemirror/state": "^6.7.1",
     "@codemirror/theme-one-dark": "^6.1.3",
@@ -33,6 +34,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.29.2",
+    "fzstd": "^0.1.1",
     "js-yaml": "^4.1.1",
     "lucide-react": "^0.400.0",
     "react": "19.2.3",


### PR DESCRIPTION
## Summary
- add File proto/client support and surface File resources in Sightline navigation, search, and resource descriptors
- add a bottom-centered mode toggle only when an alternate view exists
- replace the File inspector view for text/Markdown files with a read-only CodeMirror Markdown/text editor
- allow gateway CAS reads for File object keys under cas/{namespace}/files/... with namespace auth and metadata scope checks

## Validation
- pnpm --filter @impalasys/talon-client build
- pnpm --dir ui exec tsc -p tsconfig.json --noEmit
- pnpm --dir ui exec jest ui/lib/talon/resourceDescriptors.test.ts ui/components/Explorer/explorerModel.test.ts ui/lib/selection.test.ts --runInBand --coverage=false
- cargo check -q

## Note
The previous in-browser File content load failed because the gateway treated File CAS object keys as session object keys. This PR adds the File-object path so the Markdown editor can load the actual content once the gateway is running this code.