### PR TITLE
Release stopped sessions from processing

### DIFF
--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -974,7 +974,65 @@ impl WorkerEventHandler {
                 "Session stop requested, but no in-flight generation was registered"
             );
         }
+        self.clear_pending_async_a2a_wakeups(&event.ns, &event.agent, &event.session_id)
+            .await?;
+        self.release_stopped_session(&event.ns, &event.agent, &event.session_id)
+            .await?;
         Ok(())
+    }
+
+    async fn clear_pending_async_a2a_wakeups(
+        &self,
+        ns: &str,
+        agent_id: &str,
+        session_id: &str,
+    ) -> Result<()> {
+        let entries = self
+            .cp
+            .kv
+            .list_entries(&crate::control::keys::async_a2a_wakeup_prefix(
+                ns, agent_id, session_id,
+            ))
+            .await?;
+        for (key, _) in entries {
+            self.cp.kv.delete(&key).await?;
+        }
+        Ok(())
+    }
+
+    async fn release_stopped_session(
+        &self,
+        ns: &str,
+        agent_id: &str,
+        session_id: &str,
+    ) -> Result<()> {
+        let key = crate::control::keys::session(ns, agent_id, session_id);
+        for _ in 0..MAX_SESSION_RELEASE_CAS_RETRIES {
+            let Some(current) = self.cp.kv.get(&key).await? else {
+                return Ok(());
+            };
+            let mut session = data_proto::Session::decode(current.as_slice())?;
+            if session.status != "PROCESSING" {
+                return Ok(());
+            }
+            session.status = "IDLE".to_string();
+            session.last_active = chrono::Utc::now().timestamp_micros();
+            let updated = session.encode_to_vec();
+            if self
+                .cp
+                .kv
+                .compare_and_swap(&key, Some(current.as_slice()), &updated)
+                .await?
+            {
+                return Ok(());
+            }
+        }
+        Err(anyhow!(
+            "failed to atomically release stopped session {}/{}/{}",
+            ns,
+            agent_id,
+            session_id
+        ))
     }
 
     async fn release_session_lock(
@@ -1991,7 +2049,42 @@ mod tests {
     #[tokio::test]
     async fn handle_session_control_cancels_registered_session() {
         let kv = Arc::new(MockKvStore::default());
-        let handler = handler_with_kv(kv);
+        let handler = handler_with_kv(kv.clone());
+        let session = data_proto::Session {
+            id: "session-1".to_string(),
+            agent: "assistant".to_string(),
+            ns: "conic:test".to_string(),
+            status: "PROCESSING".to_string(),
+            created_at: 0,
+            last_active: 123,
+            metadata: HashMap::new(),
+            labels: HashMap::new(),
+        };
+        kv.set_msg(
+            &crate::control::keys::session("conic:test", "assistant", "session-1"),
+            &session,
+        )
+        .await
+        .expect("session should persist");
+        let wakeup = SessionMessageEvent {
+            ns: "conic:test".to_string(),
+            agent: "assistant".to_string(),
+            session_id: "session-1".to_string(),
+            message_id: "message-1".to_string(),
+            submission_id: "wakeup-1".to_string(),
+            direction: MessageDirection::Inbound as i32,
+            message: "wake up".to_string(),
+            timestamp: 0,
+        };
+        let wakeup_key = crate::control::keys::async_a2a_wakeup(
+            "conic:test",
+            "assistant",
+            "session-1",
+            "wakeup-1",
+        );
+        kv.set_msg(&wakeup_key, &wakeup)
+            .await
+            .expect("wakeup should persist");
         let token = CancellationToken::new();
         handler
             .session_cancellations
@@ -2011,6 +2104,21 @@ mod tests {
             .expect("stop generation should succeed");
 
         assert!(token.is_cancelled());
+        let stored_session = kv
+            .get_msg::<data_proto::Session>(&crate::control::keys::session(
+                "conic:test",
+                "assistant",
+                "session-1",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored_session.status, "IDLE");
+        assert!(kv
+            .get_msg::<SessionMessageEvent>(&wakeup_key)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -24,6 +24,7 @@ from talon_client import (
     GetCasObjectRequest,
     GetSessionRequest,
     SendMessageRequest,
+    StopSessionGenerationRequest,
     StreamSessionPartsRequest,
     TalonClient,
 )
@@ -38,6 +39,57 @@ STREAM_TIMEOUT_SECONDS = 30
 
 
 logger = logging.getLogger(__name__)
+
+
+def _mock_control(method: str, path: str, payload: dict | None = None) -> dict:
+    response = requests.request(
+        method,
+        f"http://127.0.0.1:{MOCK_LLM_PORT}{path}",
+        json=payload,
+        timeout=10,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _wait_for_session_state(
+    client: TalonClient,
+    *,
+    namespace: str,
+    agent: str,
+    session_id: str,
+    state: str,
+    attempts: int = 60,
+    delay: float = 0.2,
+) -> None:
+    last_state = ""
+    for _ in range(attempts):
+        res = client.sessions.Get(
+            GetSessionRequest(
+                agent=agent,
+                session_id=session_id,
+                ns=namespace,
+                message_limit=-1,
+            )
+        )
+        last_state = res.state
+        if last_state == state:
+            return
+        time.sleep(delay)
+    raise AssertionError(
+        f"session {namespace}/{agent}/{session_id} did not reach {state}; "
+        f"last state={last_state}"
+    )
+
+
+def _wait_for_mock_stream_blocked(*, attempts: int = 80, delay: float = 0.1) -> dict:
+    state = {}
+    for _ in range(attempts):
+        state = _mock_control("GET", "/__control/state")
+        if state.get("blocked"):
+            return state
+        time.sleep(delay)
+    raise AssertionError(f"mock LLM did not block; final state={state}")
 
 
 def _cas_response_bytes(response) -> bytes:
@@ -442,6 +494,99 @@ def test_large_tool_result_is_fetched_from_cas(
     hydrated = _cas_tool_result_text(fetched)
     assert hydrated.startswith("blocking_lookup result for docs.example.com")
     assert "reference section 079" in hydrated
+
+
+def test_stop_generation_releases_processing_session_on_aws_stack(
+    aws_local_stack: E2EStack,
+) -> None:
+    raw_channel, channel = aws_local_stack.channel()
+    try:
+        client = TalonClient(channel)
+        namespace = f"talon-stop-aws-{uuid.uuid4().hex[:8]}"
+        agent_name = "stop-agent"
+        ensure_namespace(client, namespace)
+        create_agent_resource(
+            client,
+            namespace,
+            agent_name,
+            AgentSpec(
+                model_policy={
+                    "profiles": [
+                        {
+                            "name": "default",
+                            "model": Model(
+                                provider="mock",
+                                name="minimax-m2.7",
+                                temperature=0.7,
+                            ),
+                        }
+                    ]
+                },
+                system_prompt="You are a helpful test assistant.",
+            ),
+        )
+
+        _mock_control("POST", "/__control/reset")
+        _mock_control("POST", "/__control/block_stream_after_chunks", {"chunks": 1})
+
+        session_id = client.sessions.Create(
+            CreateSessionRequest(agent=agent_name, ns=namespace)
+        ).session_id
+        client.sessions.SendMessage(
+            SendMessageRequest(
+                agent=agent_name,
+                session_id=session_id,
+                ns=namespace,
+                message="Please stream a long response about local session cancellation.",
+            )
+        )
+
+        _wait_for_session_state(
+            client,
+            namespace=namespace,
+            agent=agent_name,
+            session_id=session_id,
+            state="PROCESSING",
+        )
+        _wait_for_mock_stream_blocked()
+
+        stopped = client.sessions.StopGeneration(
+            StopSessionGenerationRequest(
+                agent=agent_name,
+                session_id=session_id,
+                ns=namespace,
+            )
+        )
+        assert stopped.success
+
+        _wait_for_session_state(
+            client,
+            namespace=namespace,
+            agent=agent_name,
+            session_id=session_id,
+            state="IDLE",
+        )
+
+        # If stop failed to release the processing lock, this second turn would
+        # remain blocked behind the stale PROCESSING state.
+        _mock_control("POST", "/__control/unblock_stream")
+        client.sessions.SendMessage(
+            SendMessageRequest(
+                agent=agent_name,
+                session_id=session_id,
+                ns=namespace,
+                message="hello",
+            )
+        )
+        _wait_for_session_state(
+            client,
+            namespace=namespace,
+            agent=agent_name,
+            session_id=session_id,
+            state="IDLE",
+        )
+    finally:
+        raw_channel.close()
 
 
 def test_super_large_tool_result_uses_s3_object_store_on_aws_stack(


### PR DESCRIPTION
## Summary

This PR fixes the session stop path for async/delegated work. `StopGeneration`
now does the durable cleanup that production expected it to do:

- cancels any in-process generation token when the worker has one registered
- deletes pending async A2A wakeups for the stopped session
- atomically releases a stopped session from `PROCESSING` back to `IDLE`
- adds an AWS LocalStack + mock LLM e2e that blocks a streaming response,
  stops generation, and proves the same session can accept another turn

This PR intentionally does **not** change reasoning, usage, or session projection
semantics.

## What Pending Async A2A Wakeups Are

I introduced pending async A2A wakeups in the Files/Artifacts work, not in a
separate clearly named async-A2A PR. They were merged through #117, `Add File and
Artifact storage primitives`, whose merge commit is `ff695d01`.

The mechanism exists so a child/delegated agent can notify its parent session
when the child finishes, without synchronously blocking the child on the parent
being immediately available.

The flow is:

1. A child agent completes and needs to wake the parent session.
2. The worker tries to dispatch a `SessionMessageEvent` to the parent session.
3. If the parent session is currently busy/locked, the worker cannot dispatch
   the event immediately.
4. Instead, it stores that `SessionMessageEvent` in KV as an `AsyncA2AWakeup`
   child record under the parent `Agent/Session` key:
   `namespace / Agent:<parent-agent> / Session:<parent-session> /
   AsyncA2AWakeup:<wakeup-id>`.
5. Later, after the parent session completes a turn and the worker can acquire
   the parent session lock, `dispatch_next_pending_async_a2a_wakeup` lists those
   child records, republishes the stored `SessionMessageEvent` to the session
   dispatch topic, and deletes the KV record.

They are in KV because they are durable deferred dispatch records. If they only
lived in memory, worker restarts or SQS delivery timing would lose the parent
wake-up. KV made the deferred parent notification durable, but it also meant
`StopGeneration` needed to understand and clean up those records.

## Why This Is Needed

The bug is that the async A2A wakeup mechanism I added was not integrated with
session stop. `StopGeneration` cancelled any in-memory cancellation token for the
worker process that happened to be running the session, but it did not clean up
the durable state introduced by async delegation.

That left three failure modes:

1. The session record could remain in `PROCESSING` after stop.
   A later user message would then be queued behind stale session state instead
   of running normally.

2. Pending async A2A wakeups were left in KV.
   A delegated child completion could dispatch a stored wakeup after the parent
   was stopped, effectively reviving work the user had already cancelled.

3. Stop could be a no-op when the handling worker did not have a local
   cancellation token registered.
   This can happen naturally with queue delivery, worker restarts, or control
   events landing outside the exact in-flight execution window.

The fix makes stop durable: it still cancels the best-effort in-memory token,
but it also clears queued async wakeups and releases the persisted session state
with compare-and-swap so future turns are not blocked by a stale `PROCESSING`
lock.

## What Was Happening In Production

During the copywriter/delegation tests, stopping sessions did not fully stop the
session lifecycle. Logs showed generation interruption, followed by pending async
A2A wakeups being dispatched afterward. The worker could continue processing or
re-enter the parent session even though the user had asked for the session to
stop.

Operationally this showed up as sessions that looked stopped from the client
side but still had durable work queued or stayed stuck as `PROCESSING`. That is
why subsequent attempts to drive the agent loop were unreliable and why we had to
stop production workers and move validation to LocalStack.

## Why Existing Tests Missed This

The original async delegation work did not include a stop/cancel integration
test. The old focused stop test only asserted that an already-registered
in-memory `CancellationToken` was cancelled. It did not model the durable state
that matters in production:

- no persisted `Session` record in `PROCESSING`
- no pending async A2A wakeup keys
- no SQS/worker dispatch loop
- no blocked streaming LLM call
- no follow-up turn after stop to prove the session lock was actually released

That meant the test covered the easiest local branch of stop handling, but not
the AWS/SQS durable path we actually run internally.

## Test Coverage Added

The unit test now creates the durable state that the previous test skipped: a
`PROCESSING` session record plus a pending async A2A wakeup. It verifies that
`StopGeneration` cancels the token, deletes the wakeup, and releases the session
back to `IDLE`.

The new e2e runs against the AWS LocalStack stack with the mock LLM provider. It:

1. creates a namespace and agent
2. configures the mock LLM to block mid-stream
3. sends a message and waits until the session is `PROCESSING`
4. calls `StopGeneration`
5. verifies the session returns to `IDLE`
6. sends a follow-up message in the same session to prove the stale processing
   lock is gone

This is the regression path we should use for this class of bug instead of
burning production tokens or relying on live provider behavior.

## Validation

- `cargo fmt --check`
- `cargo test handle_session_control_cancels_registered_session -- --nocapture`
- `cargo build --features aws --bin talon-server --bin talon-worker`
- `TALON_E2E_STACKS=aws_local .venv-e2e/bin/python -m pytest tests/test_chat.py -k test_stop_generation_releases_processing_session_on_aws_stack -vv -s`
