### PR TITLE
Add durable task delegation E2E coverage

### DIFF
--- a/docs/contributing/runtime-state.md
+++ b/docs/contributing/runtime-state.md
@@ -1,0 +1,85 @@
+---
+title: Runtime State Design
+sidebar_position: 2
+---
+
+Talon has several persistence layers. New runtime features should choose the
+smallest layer that matches the product semantics, and pull requests should make
+that choice visible.
+
+## Session replay and side effects
+
+Model tool calls are replayed through the session submission journal. A native
+tool should not add its own idempotency keys, claim records, or deterministic
+resource names just to survive worker redelivery.
+
+Use the journal when the question is:
+
+- Did this submitted LLM tool call already produce a tool result?
+- Can recovery rebuild a committed message without executing the tool again?
+- Can a stale worker be fenced from appending more results?
+
+Use the domain resource itself when the question is:
+
+- What durable object did the user or agent create?
+- What state should an operator, CLI, workflow, or another agent inspect?
+- What events should resource watchers observe?
+
+For example, `delegate_task` creates a normal `Task` and child `Session`. If a
+worker crashes after the tool result is journaled, recovery should reuse the
+journaled result. The `Task` layer should not maintain a separate
+tool-call-to-task mapping.
+
+## Session inbox limitation
+
+Today, sending a message to a session is also a request to drive that session.
+If the target session is already `PROCESSING`, `send_message` rejects instead of
+durably appending the message to a pending inbox.
+
+That means runtime code cannot currently say: "append this message now, process
+it after the current turn commits." Until Talon has that primitive, features
+that need to notify a busy session must either fail visibly or arrange a retry
+from an existing durable transition.
+
+Delegated Task owner wakeups use that second option as a stopgap:
+
+- the delegate session finishes and updates the `Task` to `NEEDS_REVIEW` or
+  `FAILED`
+- Talon tries to send a wake message to the owner session
+- if the owner session is busy, the `Task` records `OwnerWake=False`
+- when any session releases its lock, Talon checks whether that released
+  session is the owner for delegated Tasks with `OwnerWake=False`
+- matching Tasks retry the owner wake from the release path
+
+This is intentionally not a general queue, not a hidden KV side table, and not
+the long-term inbox design. The long-term fix is a session inbox where
+`AppendMessage` can persist an inbound message and pending submission while a
+session is busy, and the worker claims the next pending submission when the
+current turn releases.
+
+## Hidden KV state
+
+Avoid hidden KV records when a first-class resource, child record, label, or
+session journal entry can express the relationship. Hidden KV writes are harder
+to discover, harder to clean up, and easy to miss in code review.
+
+If a feature really needs hidden KV state, the pull request should explain:
+
+- the exact key shape and owner
+- why a resource, label, or journal entry is insufficient
+- how stale records expire or are deleted
+- how tests prove replay, retry, and cleanup behavior
+
+## Resource names and indexes
+
+Resource names should be stable, readable enough for operators, and compatible
+with the resource API. Do not encode private lookup indexes into resource names
+unless the user-facing identity truly requires it.
+
+If a feature needs efficient lookup by a second dimension, prefer one of:
+
+- labels on the resource when eventual list-and-filter behavior is acceptable
+- a documented index record owned by that resource type
+- a storage-level query capability added deliberately to the resource store
+
+Do not add ad hoc hash names or side tables only to make one tool call easier.

--- a/proto/resources/tasks.proto
+++ b/proto/resources/tasks.proto
@@ -21,9 +21,9 @@ message TaskSpec {
   // application-specific string when the caller needs a stable category.
   string type = 3;
   // Agent resource that created and owns follow-up responsibility for the task.
-  ResourceRef requester = 4;
+  ResourceRef owner = 4;
   // Agent resource intended to perform the work.
-  ResourceRef assignee = 5;
+  ResourceRef delegate = 5;
 }
 
 // Runtime location of the work that is fulfilling the task. This may be absent
@@ -41,14 +41,14 @@ enum TaskPhase {
   // No phase has been set. Writers should avoid persisting this outside
   // partially initialized records.
   TASK_PHASE_UNSPECIFIED = 0;
-  // The task exists but no assignee execution has started.
+  // The task exists but no delegate execution has started.
   TASK_PHASE_QUEUED = 1;
-  // The assignee is actively working on the task.
+  // The delegate is actively working on the task.
   TASK_PHASE_RUNNING = 2;
   // Progress is blocked on user input, permissions, dependencies, or another
   // external condition.
   TASK_PHASE_BLOCKED = 3;
-  // Work is complete enough for the requester or another reviewer to inspect.
+  // Work is complete enough for the owner or another reviewer to inspect.
   TASK_PHASE_NEEDS_REVIEW = 4;
   // The task completed successfully.
   TASK_PHASE_SUCCEEDED = 5;
@@ -70,6 +70,6 @@ message TaskStatus {
   int64 updated_at = 7;
   int64 completed_at = 8;
   int64 expires_at = 9;
-  // Concrete runtime execution once an assignee session or run is known.
+  // Concrete runtime execution once a delegate session or run is known.
   TaskExecutionRef execution_ref = 10;
 }

--- a/sdk/go/talon-client/talon/resources/tasks.pb.go
+++ b/sdk/go/talon-client/talon/resources/tasks.pb.go
@@ -28,14 +28,14 @@ const (
 	// No phase has been set. Writers should avoid persisting this outside
 	// partially initialized records.
 	TaskPhase_TASK_PHASE_UNSPECIFIED TaskPhase = 0
-	// The task exists but no assignee execution has started.
+	// The task exists but no delegate execution has started.
 	TaskPhase_TASK_PHASE_QUEUED TaskPhase = 1
-	// The assignee is actively working on the task.
+	// The delegate is actively working on the task.
 	TaskPhase_TASK_PHASE_RUNNING TaskPhase = 2
 	// Progress is blocked on user input, permissions, dependencies, or another
 	// external condition.
 	TaskPhase_TASK_PHASE_BLOCKED TaskPhase = 3
-	// Work is complete enough for the requester or another reviewer to inspect.
+	// Work is complete enough for the owner or another reviewer to inspect.
 	TaskPhase_TASK_PHASE_NEEDS_REVIEW TaskPhase = 4
 	// The task completed successfully.
 	TaskPhase_TASK_PHASE_SUCCEEDED TaskPhase = 5
@@ -171,9 +171,9 @@ type TaskSpec struct {
 	// application-specific string when the caller needs a stable category.
 	Type string `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
 	// Agent resource that created and owns follow-up responsibility for the task.
-	Requester *ResourceRef `protobuf:"bytes,4,opt,name=requester,proto3" json:"requester,omitempty"`
+	Owner *ResourceRef `protobuf:"bytes,4,opt,name=owner,proto3" json:"owner,omitempty"`
 	// Agent resource intended to perform the work.
-	Assignee      *ResourceRef `protobuf:"bytes,5,opt,name=assignee,proto3" json:"assignee,omitempty"`
+	Delegate      *ResourceRef `protobuf:"bytes,5,opt,name=delegate,proto3" json:"delegate,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -229,16 +229,16 @@ func (x *TaskSpec) GetType() string {
 	return ""
 }
 
-func (x *TaskSpec) GetRequester() *ResourceRef {
+func (x *TaskSpec) GetOwner() *ResourceRef {
 	if x != nil {
-		return x.Requester
+		return x.Owner
 	}
 	return nil
 }
 
-func (x *TaskSpec) GetAssignee() *ResourceRef {
+func (x *TaskSpec) GetDelegate() *ResourceRef {
 	if x != nil {
-		return x.Assignee
+		return x.Delegate
 	}
 	return nil
 }
@@ -332,7 +332,7 @@ type TaskStatus struct {
 	UpdatedAt          int64                  `protobuf:"varint,7,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
 	CompletedAt        int64                  `protobuf:"varint,8,opt,name=completed_at,json=completedAt,proto3" json:"completed_at,omitempty"`
 	ExpiresAt          int64                  `protobuf:"varint,9,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
-	// Concrete runtime execution once an assignee session or run is known.
+	// Concrete runtime execution once a delegate session or run is known.
 	ExecutionRef  *TaskExecutionRef `protobuf:"bytes,10,opt,name=execution_ref,json=executionRef,proto3" json:"execution_ref,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -446,13 +446,13 @@ const file_proto_resources_tasks_proto_rawDesc = "" +
 	"\x04Task\x129\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x1d.talon.resources.ResourceMetaR\bmetadata\x12-\n" +
 	"\x04spec\x18\x02 \x01(\v2\x19.talon.resources.TaskSpecR\x04spec\x123\n" +
-	"\x06status\x18\x03 \x01(\v2\x1b.talon.resources.TaskStatusR\x06status\"\xcc\x01\n" +
+	"\x06status\x18\x03 \x01(\v2\x1b.talon.resources.TaskStatusR\x06status\"\xc4\x01\n" +
 	"\bTaskSpec\x12\x14\n" +
 	"\x05title\x18\x01 \x01(\tR\x05title\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x12\n" +
-	"\x04type\x18\x03 \x01(\tR\x04type\x12:\n" +
-	"\trequester\x18\x04 \x01(\v2\x1c.talon.resources.ResourceRefR\trequester\x128\n" +
-	"\bassignee\x18\x05 \x01(\v2\x1c.talon.resources.ResourceRefR\bassignee\"\x8e\x01\n" +
+	"\x04type\x18\x03 \x01(\tR\x04type\x122\n" +
+	"\x05owner\x18\x04 \x01(\v2\x1c.talon.resources.ResourceRefR\x05owner\x128\n" +
+	"\bdelegate\x18\x05 \x01(\v2\x1c.talon.resources.ResourceRefR\bdelegate\"\x8e\x01\n" +
 	"\x10TaskExecutionRef\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x12\n" +
@@ -518,8 +518,8 @@ var file_proto_resources_tasks_proto_depIdxs = []int32{
 	5, // 0: talon.resources.Task.metadata:type_name -> talon.resources.ResourceMeta
 	2, // 1: talon.resources.Task.spec:type_name -> talon.resources.TaskSpec
 	4, // 2: talon.resources.Task.status:type_name -> talon.resources.TaskStatus
-	6, // 3: talon.resources.TaskSpec.requester:type_name -> talon.resources.ResourceRef
-	6, // 4: talon.resources.TaskSpec.assignee:type_name -> talon.resources.ResourceRef
+	6, // 3: talon.resources.TaskSpec.owner:type_name -> talon.resources.ResourceRef
+	6, // 4: talon.resources.TaskSpec.delegate:type_name -> talon.resources.ResourceRef
 	0, // 5: talon.resources.TaskStatus.phase:type_name -> talon.resources.TaskPhase
 	7, // 6: talon.resources.TaskStatus.conditions:type_name -> talon.resources.ResourceCondition
 	8, // 7: talon.resources.TaskStatus.result_artifacts:type_name -> talon.resources.FileObjectRef

--- a/sdk/java/talon-client/src/main/java/talon/resources/Tasks.java
+++ b/sdk/java/talon-client/src/main/java/talon/resources/Tasks.java
@@ -46,7 +46,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     TASK_PHASE_UNSPECIFIED(0),
     /**
      * <pre>
-     * The task exists but no assignee execution has started.
+     * The task exists but no delegate execution has started.
      * </pre>
      *
      * <code>TASK_PHASE_QUEUED = 1;</code>
@@ -54,7 +54,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     TASK_PHASE_QUEUED(1),
     /**
      * <pre>
-     * The assignee is actively working on the task.
+     * The delegate is actively working on the task.
      * </pre>
      *
      * <code>TASK_PHASE_RUNNING = 2;</code>
@@ -71,7 +71,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     TASK_PHASE_BLOCKED(3),
     /**
      * <pre>
-     * Work is complete enough for the requester or another reviewer to inspect.
+     * Work is complete enough for the owner or another reviewer to inspect.
      * </pre>
      *
      * <code>TASK_PHASE_NEEDS_REVIEW = 4;</code>
@@ -132,7 +132,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     public static final int TASK_PHASE_UNSPECIFIED_VALUE = 0;
     /**
      * <pre>
-     * The task exists but no assignee execution has started.
+     * The task exists but no delegate execution has started.
      * </pre>
      *
      * <code>TASK_PHASE_QUEUED = 1;</code>
@@ -140,7 +140,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     public static final int TASK_PHASE_QUEUED_VALUE = 1;
     /**
      * <pre>
-     * The assignee is actively working on the task.
+     * The delegate is actively working on the task.
      * </pre>
      *
      * <code>TASK_PHASE_RUNNING = 2;</code>
@@ -157,7 +157,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     public static final int TASK_PHASE_BLOCKED_VALUE = 3;
     /**
      * <pre>
-     * Work is complete enough for the requester or another reviewer to inspect.
+     * Work is complete enough for the owner or another reviewer to inspect.
      * </pre>
      *
      * <code>TASK_PHASE_NEEDS_REVIEW = 4;</code>
@@ -1322,54 +1322,54 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
      * Agent resource that created and owns follow-up responsibility for the task.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef requester = 4;</code>
-     * @return Whether the requester field is set.
+     * <code>.talon.resources.ResourceRef owner = 4;</code>
+     * @return Whether the owner field is set.
      */
-    boolean hasRequester();
+    boolean hasOwner();
     /**
      * <pre>
      * Agent resource that created and owns follow-up responsibility for the task.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef requester = 4;</code>
-     * @return The requester.
+     * <code>.talon.resources.ResourceRef owner = 4;</code>
+     * @return The owner.
      */
-    talon.resources.Common.ResourceRef getRequester();
+    talon.resources.Common.ResourceRef getOwner();
     /**
      * <pre>
      * Agent resource that created and owns follow-up responsibility for the task.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef requester = 4;</code>
+     * <code>.talon.resources.ResourceRef owner = 4;</code>
      */
-    talon.resources.Common.ResourceRefOrBuilder getRequesterOrBuilder();
+    talon.resources.Common.ResourceRefOrBuilder getOwnerOrBuilder();
 
     /**
      * <pre>
      * Agent resource intended to perform the work.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef assignee = 5;</code>
-     * @return Whether the assignee field is set.
+     * <code>.talon.resources.ResourceRef delegate = 5;</code>
+     * @return Whether the delegate field is set.
      */
-    boolean hasAssignee();
+    boolean hasDelegate();
     /**
      * <pre>
      * Agent resource intended to perform the work.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef assignee = 5;</code>
-     * @return The assignee.
+     * <code>.talon.resources.ResourceRef delegate = 5;</code>
+     * @return The delegate.
      */
-    talon.resources.Common.ResourceRef getAssignee();
+    talon.resources.Common.ResourceRef getDelegate();
     /**
      * <pre>
      * Agent resource intended to perform the work.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef assignee = 5;</code>
+     * <code>.talon.resources.ResourceRef delegate = 5;</code>
      */
-    talon.resources.Common.ResourceRefOrBuilder getAssigneeOrBuilder();
+    talon.resources.Common.ResourceRefOrBuilder getDelegateOrBuilder();
   }
   /**
    * Protobuf type {@code talon.resources.TaskSpec}
@@ -1550,18 +1550,18 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
     }
 
-    public static final int REQUESTER_FIELD_NUMBER = 4;
-    private talon.resources.Common.ResourceRef requester_;
+    public static final int OWNER_FIELD_NUMBER = 4;
+    private talon.resources.Common.ResourceRef owner_;
     /**
      * <pre>
      * Agent resource that created and owns follow-up responsibility for the task.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef requester = 4;</code>
-     * @return Whether the requester field is set.
+     * <code>.talon.resources.ResourceRef owner = 4;</code>
+     * @return Whether the owner field is set.
      */
     @java.lang.Override
-    public boolean hasRequester() {
+    public boolean hasOwner() {
       return ((bitField0_ & 0x00000001) != 0);
     }
     /**
@@ -1569,37 +1569,37 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
      * Agent resource that created and owns follow-up responsibility for the task.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef requester = 4;</code>
-     * @return The requester.
+     * <code>.talon.resources.ResourceRef owner = 4;</code>
+     * @return The owner.
      */
     @java.lang.Override
-    public talon.resources.Common.ResourceRef getRequester() {
-      return requester_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : requester_;
+    public talon.resources.Common.ResourceRef getOwner() {
+      return owner_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : owner_;
     }
     /**
      * <pre>
      * Agent resource that created and owns follow-up responsibility for the task.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef requester = 4;</code>
+     * <code>.talon.resources.ResourceRef owner = 4;</code>
      */
     @java.lang.Override
-    public talon.resources.Common.ResourceRefOrBuilder getRequesterOrBuilder() {
-      return requester_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : requester_;
+    public talon.resources.Common.ResourceRefOrBuilder getOwnerOrBuilder() {
+      return owner_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : owner_;
     }
 
-    public static final int ASSIGNEE_FIELD_NUMBER = 5;
-    private talon.resources.Common.ResourceRef assignee_;
+    public static final int DELEGATE_FIELD_NUMBER = 5;
+    private talon.resources.Common.ResourceRef delegate_;
     /**
      * <pre>
      * Agent resource intended to perform the work.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef assignee = 5;</code>
-     * @return Whether the assignee field is set.
+     * <code>.talon.resources.ResourceRef delegate = 5;</code>
+     * @return Whether the delegate field is set.
      */
     @java.lang.Override
-    public boolean hasAssignee() {
+    public boolean hasDelegate() {
       return ((bitField0_ & 0x00000002) != 0);
     }
     /**
@@ -1607,23 +1607,23 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
      * Agent resource intended to perform the work.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef assignee = 5;</code>
-     * @return The assignee.
+     * <code>.talon.resources.ResourceRef delegate = 5;</code>
+     * @return The delegate.
      */
     @java.lang.Override
-    public talon.resources.Common.ResourceRef getAssignee() {
-      return assignee_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : assignee_;
+    public talon.resources.Common.ResourceRef getDelegate() {
+      return delegate_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : delegate_;
     }
     /**
      * <pre>
      * Agent resource intended to perform the work.
      * </pre>
      *
-     * <code>.talon.resources.ResourceRef assignee = 5;</code>
+     * <code>.talon.resources.ResourceRef delegate = 5;</code>
      */
     @java.lang.Override
-    public talon.resources.Common.ResourceRefOrBuilder getAssigneeOrBuilder() {
-      return assignee_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : assignee_;
+    public talon.resources.Common.ResourceRefOrBuilder getDelegateOrBuilder() {
+      return delegate_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : delegate_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -1650,10 +1650,10 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
         com.google.protobuf.GeneratedMessage.writeString(output, 3, type_);
       }
       if (((bitField0_ & 0x00000001) != 0)) {
-        output.writeMessage(4, getRequester());
+        output.writeMessage(4, getOwner());
       }
       if (((bitField0_ & 0x00000002) != 0)) {
-        output.writeMessage(5, getAssignee());
+        output.writeMessage(5, getDelegate());
       }
       getUnknownFields().writeTo(output);
     }
@@ -1675,11 +1675,11 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
       if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(4, getRequester());
+          .computeMessageSize(4, getOwner());
       }
       if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(5, getAssignee());
+          .computeMessageSize(5, getDelegate());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -1702,15 +1702,15 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
           .equals(other.getDescription())) return false;
       if (!getType()
           .equals(other.getType())) return false;
-      if (hasRequester() != other.hasRequester()) return false;
-      if (hasRequester()) {
-        if (!getRequester()
-            .equals(other.getRequester())) return false;
+      if (hasOwner() != other.hasOwner()) return false;
+      if (hasOwner()) {
+        if (!getOwner()
+            .equals(other.getOwner())) return false;
       }
-      if (hasAssignee() != other.hasAssignee()) return false;
-      if (hasAssignee()) {
-        if (!getAssignee()
-            .equals(other.getAssignee())) return false;
+      if (hasDelegate() != other.hasDelegate()) return false;
+      if (hasDelegate()) {
+        if (!getDelegate()
+            .equals(other.getDelegate())) return false;
       }
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
@@ -1729,13 +1729,13 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       hash = (53 * hash) + getDescription().hashCode();
       hash = (37 * hash) + TYPE_FIELD_NUMBER;
       hash = (53 * hash) + getType().hashCode();
-      if (hasRequester()) {
-        hash = (37 * hash) + REQUESTER_FIELD_NUMBER;
-        hash = (53 * hash) + getRequester().hashCode();
+      if (hasOwner()) {
+        hash = (37 * hash) + OWNER_FIELD_NUMBER;
+        hash = (53 * hash) + getOwner().hashCode();
       }
-      if (hasAssignee()) {
-        hash = (37 * hash) + ASSIGNEE_FIELD_NUMBER;
-        hash = (53 * hash) + getAssignee().hashCode();
+      if (hasDelegate()) {
+        hash = (37 * hash) + DELEGATE_FIELD_NUMBER;
+        hash = (53 * hash) + getDelegate().hashCode();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -1867,8 +1867,8 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage
                 .alwaysUseFieldBuilders) {
-          internalGetRequesterFieldBuilder();
-          internalGetAssigneeFieldBuilder();
+          internalGetOwnerFieldBuilder();
+          internalGetDelegateFieldBuilder();
         }
       }
       @java.lang.Override
@@ -1878,15 +1878,15 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
         title_ = "";
         description_ = "";
         type_ = "";
-        requester_ = null;
-        if (requesterBuilder_ != null) {
-          requesterBuilder_.dispose();
-          requesterBuilder_ = null;
+        owner_ = null;
+        if (ownerBuilder_ != null) {
+          ownerBuilder_.dispose();
+          ownerBuilder_ = null;
         }
-        assignee_ = null;
-        if (assigneeBuilder_ != null) {
-          assigneeBuilder_.dispose();
-          assigneeBuilder_ = null;
+        delegate_ = null;
+        if (delegateBuilder_ != null) {
+          delegateBuilder_.dispose();
+          delegateBuilder_ = null;
         }
         return this;
       }
@@ -1932,15 +1932,15 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
         }
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000008) != 0)) {
-          result.requester_ = requesterBuilder_ == null
-              ? requester_
-              : requesterBuilder_.build();
+          result.owner_ = ownerBuilder_ == null
+              ? owner_
+              : ownerBuilder_.build();
           to_bitField0_ |= 0x00000001;
         }
         if (((from_bitField0_ & 0x00000010) != 0)) {
-          result.assignee_ = assigneeBuilder_ == null
-              ? assignee_
-              : assigneeBuilder_.build();
+          result.delegate_ = delegateBuilder_ == null
+              ? delegate_
+              : delegateBuilder_.build();
           to_bitField0_ |= 0x00000002;
         }
         result.bitField0_ |= to_bitField0_;
@@ -1973,11 +1973,11 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
           bitField0_ |= 0x00000004;
           onChanged();
         }
-        if (other.hasRequester()) {
-          mergeRequester(other.getRequester());
+        if (other.hasOwner()) {
+          mergeOwner(other.getOwner());
         }
-        if (other.hasAssignee()) {
-          mergeAssignee(other.getAssignee());
+        if (other.hasDelegate()) {
+          mergeDelegate(other.getDelegate());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
@@ -2022,14 +2022,14 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
               } // case 26
               case 34: {
                 input.readMessage(
-                    internalGetRequesterFieldBuilder().getBuilder(),
+                    internalGetOwnerFieldBuilder().getBuilder(),
                     extensionRegistry);
                 bitField0_ |= 0x00000008;
                 break;
               } // case 34
               case 42: {
                 input.readMessage(
-                    internalGetAssigneeFieldBuilder().getBuilder(),
+                    internalGetDelegateFieldBuilder().getBuilder(),
                     extensionRegistry);
                 bitField0_ |= 0x00000010;
                 break;
@@ -2307,18 +2307,18 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
         return this;
       }
 
-      private talon.resources.Common.ResourceRef requester_;
+      private talon.resources.Common.ResourceRef owner_;
       private com.google.protobuf.SingleFieldBuilder<
-          talon.resources.Common.ResourceRef, talon.resources.Common.ResourceRef.Builder, talon.resources.Common.ResourceRefOrBuilder> requesterBuilder_;
+          talon.resources.Common.ResourceRef, talon.resources.Common.ResourceRef.Builder, talon.resources.Common.ResourceRefOrBuilder> ownerBuilder_;
       /**
        * <pre>
        * Agent resource that created and owns follow-up responsibility for the task.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef requester = 4;</code>
-       * @return Whether the requester field is set.
+       * <code>.talon.resources.ResourceRef owner = 4;</code>
+       * @return Whether the owner field is set.
        */
-      public boolean hasRequester() {
+      public boolean hasOwner() {
         return ((bitField0_ & 0x00000008) != 0);
       }
       /**
@@ -2326,14 +2326,14 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource that created and owns follow-up responsibility for the task.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef requester = 4;</code>
-       * @return The requester.
+       * <code>.talon.resources.ResourceRef owner = 4;</code>
+       * @return The owner.
        */
-      public talon.resources.Common.ResourceRef getRequester() {
-        if (requesterBuilder_ == null) {
-          return requester_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : requester_;
+      public talon.resources.Common.ResourceRef getOwner() {
+        if (ownerBuilder_ == null) {
+          return owner_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : owner_;
         } else {
-          return requesterBuilder_.getMessage();
+          return ownerBuilder_.getMessage();
         }
       }
       /**
@@ -2341,16 +2341,16 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource that created and owns follow-up responsibility for the task.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef requester = 4;</code>
+       * <code>.talon.resources.ResourceRef owner = 4;</code>
        */
-      public Builder setRequester(talon.resources.Common.ResourceRef value) {
-        if (requesterBuilder_ == null) {
+      public Builder setOwner(talon.resources.Common.ResourceRef value) {
+        if (ownerBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          requester_ = value;
+          owner_ = value;
         } else {
-          requesterBuilder_.setMessage(value);
+          ownerBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000008;
         onChanged();
@@ -2361,14 +2361,14 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource that created and owns follow-up responsibility for the task.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef requester = 4;</code>
+       * <code>.talon.resources.ResourceRef owner = 4;</code>
        */
-      public Builder setRequester(
+      public Builder setOwner(
           talon.resources.Common.ResourceRef.Builder builderForValue) {
-        if (requesterBuilder_ == null) {
-          requester_ = builderForValue.build();
+        if (ownerBuilder_ == null) {
+          owner_ = builderForValue.build();
         } else {
-          requesterBuilder_.setMessage(builderForValue.build());
+          ownerBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000008;
         onChanged();
@@ -2379,21 +2379,21 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource that created and owns follow-up responsibility for the task.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef requester = 4;</code>
+       * <code>.talon.resources.ResourceRef owner = 4;</code>
        */
-      public Builder mergeRequester(talon.resources.Common.ResourceRef value) {
-        if (requesterBuilder_ == null) {
+      public Builder mergeOwner(talon.resources.Common.ResourceRef value) {
+        if (ownerBuilder_ == null) {
           if (((bitField0_ & 0x00000008) != 0) &&
-            requester_ != null &&
-            requester_ != talon.resources.Common.ResourceRef.getDefaultInstance()) {
-            getRequesterBuilder().mergeFrom(value);
+            owner_ != null &&
+            owner_ != talon.resources.Common.ResourceRef.getDefaultInstance()) {
+            getOwnerBuilder().mergeFrom(value);
           } else {
-            requester_ = value;
+            owner_ = value;
           }
         } else {
-          requesterBuilder_.mergeFrom(value);
+          ownerBuilder_.mergeFrom(value);
         }
-        if (requester_ != null) {
+        if (owner_ != null) {
           bitField0_ |= 0x00000008;
           onChanged();
         }
@@ -2404,14 +2404,14 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource that created and owns follow-up responsibility for the task.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef requester = 4;</code>
+       * <code>.talon.resources.ResourceRef owner = 4;</code>
        */
-      public Builder clearRequester() {
+      public Builder clearOwner() {
         bitField0_ = (bitField0_ & ~0x00000008);
-        requester_ = null;
-        if (requesterBuilder_ != null) {
-          requesterBuilder_.dispose();
-          requesterBuilder_ = null;
+        owner_ = null;
+        if (ownerBuilder_ != null) {
+          ownerBuilder_.dispose();
+          ownerBuilder_ = null;
         }
         onChanged();
         return this;
@@ -2421,26 +2421,26 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource that created and owns follow-up responsibility for the task.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef requester = 4;</code>
+       * <code>.talon.resources.ResourceRef owner = 4;</code>
        */
-      public talon.resources.Common.ResourceRef.Builder getRequesterBuilder() {
+      public talon.resources.Common.ResourceRef.Builder getOwnerBuilder() {
         bitField0_ |= 0x00000008;
         onChanged();
-        return internalGetRequesterFieldBuilder().getBuilder();
+        return internalGetOwnerFieldBuilder().getBuilder();
       }
       /**
        * <pre>
        * Agent resource that created and owns follow-up responsibility for the task.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef requester = 4;</code>
+       * <code>.talon.resources.ResourceRef owner = 4;</code>
        */
-      public talon.resources.Common.ResourceRefOrBuilder getRequesterOrBuilder() {
-        if (requesterBuilder_ != null) {
-          return requesterBuilder_.getMessageOrBuilder();
+      public talon.resources.Common.ResourceRefOrBuilder getOwnerOrBuilder() {
+        if (ownerBuilder_ != null) {
+          return ownerBuilder_.getMessageOrBuilder();
         } else {
-          return requester_ == null ?
-              talon.resources.Common.ResourceRef.getDefaultInstance() : requester_;
+          return owner_ == null ?
+              talon.resources.Common.ResourceRef.getDefaultInstance() : owner_;
         }
       }
       /**
@@ -2448,34 +2448,34 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource that created and owns follow-up responsibility for the task.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef requester = 4;</code>
+       * <code>.talon.resources.ResourceRef owner = 4;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           talon.resources.Common.ResourceRef, talon.resources.Common.ResourceRef.Builder, talon.resources.Common.ResourceRefOrBuilder>
-          internalGetRequesterFieldBuilder() {
-        if (requesterBuilder_ == null) {
-          requesterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          internalGetOwnerFieldBuilder() {
+        if (ownerBuilder_ == null) {
+          ownerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               talon.resources.Common.ResourceRef, talon.resources.Common.ResourceRef.Builder, talon.resources.Common.ResourceRefOrBuilder>(
-                  getRequester(),
+                  getOwner(),
                   getParentForChildren(),
                   isClean());
-          requester_ = null;
+          owner_ = null;
         }
-        return requesterBuilder_;
+        return ownerBuilder_;
       }
 
-      private talon.resources.Common.ResourceRef assignee_;
+      private talon.resources.Common.ResourceRef delegate_;
       private com.google.protobuf.SingleFieldBuilder<
-          talon.resources.Common.ResourceRef, talon.resources.Common.ResourceRef.Builder, talon.resources.Common.ResourceRefOrBuilder> assigneeBuilder_;
+          talon.resources.Common.ResourceRef, talon.resources.Common.ResourceRef.Builder, talon.resources.Common.ResourceRefOrBuilder> delegateBuilder_;
       /**
        * <pre>
        * Agent resource intended to perform the work.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef assignee = 5;</code>
-       * @return Whether the assignee field is set.
+       * <code>.talon.resources.ResourceRef delegate = 5;</code>
+       * @return Whether the delegate field is set.
        */
-      public boolean hasAssignee() {
+      public boolean hasDelegate() {
         return ((bitField0_ & 0x00000010) != 0);
       }
       /**
@@ -2483,14 +2483,14 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource intended to perform the work.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef assignee = 5;</code>
-       * @return The assignee.
+       * <code>.talon.resources.ResourceRef delegate = 5;</code>
+       * @return The delegate.
        */
-      public talon.resources.Common.ResourceRef getAssignee() {
-        if (assigneeBuilder_ == null) {
-          return assignee_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : assignee_;
+      public talon.resources.Common.ResourceRef getDelegate() {
+        if (delegateBuilder_ == null) {
+          return delegate_ == null ? talon.resources.Common.ResourceRef.getDefaultInstance() : delegate_;
         } else {
-          return assigneeBuilder_.getMessage();
+          return delegateBuilder_.getMessage();
         }
       }
       /**
@@ -2498,16 +2498,16 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource intended to perform the work.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef assignee = 5;</code>
+       * <code>.talon.resources.ResourceRef delegate = 5;</code>
        */
-      public Builder setAssignee(talon.resources.Common.ResourceRef value) {
-        if (assigneeBuilder_ == null) {
+      public Builder setDelegate(talon.resources.Common.ResourceRef value) {
+        if (delegateBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          assignee_ = value;
+          delegate_ = value;
         } else {
-          assigneeBuilder_.setMessage(value);
+          delegateBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000010;
         onChanged();
@@ -2518,14 +2518,14 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource intended to perform the work.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef assignee = 5;</code>
+       * <code>.talon.resources.ResourceRef delegate = 5;</code>
        */
-      public Builder setAssignee(
+      public Builder setDelegate(
           talon.resources.Common.ResourceRef.Builder builderForValue) {
-        if (assigneeBuilder_ == null) {
-          assignee_ = builderForValue.build();
+        if (delegateBuilder_ == null) {
+          delegate_ = builderForValue.build();
         } else {
-          assigneeBuilder_.setMessage(builderForValue.build());
+          delegateBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000010;
         onChanged();
@@ -2536,21 +2536,21 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource intended to perform the work.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef assignee = 5;</code>
+       * <code>.talon.resources.ResourceRef delegate = 5;</code>
        */
-      public Builder mergeAssignee(talon.resources.Common.ResourceRef value) {
-        if (assigneeBuilder_ == null) {
+      public Builder mergeDelegate(talon.resources.Common.ResourceRef value) {
+        if (delegateBuilder_ == null) {
           if (((bitField0_ & 0x00000010) != 0) &&
-            assignee_ != null &&
-            assignee_ != talon.resources.Common.ResourceRef.getDefaultInstance()) {
-            getAssigneeBuilder().mergeFrom(value);
+            delegate_ != null &&
+            delegate_ != talon.resources.Common.ResourceRef.getDefaultInstance()) {
+            getDelegateBuilder().mergeFrom(value);
           } else {
-            assignee_ = value;
+            delegate_ = value;
           }
         } else {
-          assigneeBuilder_.mergeFrom(value);
+          delegateBuilder_.mergeFrom(value);
         }
-        if (assignee_ != null) {
+        if (delegate_ != null) {
           bitField0_ |= 0x00000010;
           onChanged();
         }
@@ -2561,14 +2561,14 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource intended to perform the work.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef assignee = 5;</code>
+       * <code>.talon.resources.ResourceRef delegate = 5;</code>
        */
-      public Builder clearAssignee() {
+      public Builder clearDelegate() {
         bitField0_ = (bitField0_ & ~0x00000010);
-        assignee_ = null;
-        if (assigneeBuilder_ != null) {
-          assigneeBuilder_.dispose();
-          assigneeBuilder_ = null;
+        delegate_ = null;
+        if (delegateBuilder_ != null) {
+          delegateBuilder_.dispose();
+          delegateBuilder_ = null;
         }
         onChanged();
         return this;
@@ -2578,26 +2578,26 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource intended to perform the work.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef assignee = 5;</code>
+       * <code>.talon.resources.ResourceRef delegate = 5;</code>
        */
-      public talon.resources.Common.ResourceRef.Builder getAssigneeBuilder() {
+      public talon.resources.Common.ResourceRef.Builder getDelegateBuilder() {
         bitField0_ |= 0x00000010;
         onChanged();
-        return internalGetAssigneeFieldBuilder().getBuilder();
+        return internalGetDelegateFieldBuilder().getBuilder();
       }
       /**
        * <pre>
        * Agent resource intended to perform the work.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef assignee = 5;</code>
+       * <code>.talon.resources.ResourceRef delegate = 5;</code>
        */
-      public talon.resources.Common.ResourceRefOrBuilder getAssigneeOrBuilder() {
-        if (assigneeBuilder_ != null) {
-          return assigneeBuilder_.getMessageOrBuilder();
+      public talon.resources.Common.ResourceRefOrBuilder getDelegateOrBuilder() {
+        if (delegateBuilder_ != null) {
+          return delegateBuilder_.getMessageOrBuilder();
         } else {
-          return assignee_ == null ?
-              talon.resources.Common.ResourceRef.getDefaultInstance() : assignee_;
+          return delegate_ == null ?
+              talon.resources.Common.ResourceRef.getDefaultInstance() : delegate_;
         }
       }
       /**
@@ -2605,20 +2605,20 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
        * Agent resource intended to perform the work.
        * </pre>
        *
-       * <code>.talon.resources.ResourceRef assignee = 5;</code>
+       * <code>.talon.resources.ResourceRef delegate = 5;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           talon.resources.Common.ResourceRef, talon.resources.Common.ResourceRef.Builder, talon.resources.Common.ResourceRefOrBuilder>
-          internalGetAssigneeFieldBuilder() {
-        if (assigneeBuilder_ == null) {
-          assigneeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          internalGetDelegateFieldBuilder() {
+        if (delegateBuilder_ == null) {
+          delegateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               talon.resources.Common.ResourceRef, talon.resources.Common.ResourceRef.Builder, talon.resources.Common.ResourceRefOrBuilder>(
-                  getAssignee(),
+                  getDelegate(),
                   getParentForChildren(),
                   isClean());
-          assignee_ = null;
+          delegate_ = null;
         }
-        return assigneeBuilder_;
+        return delegateBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:talon.resources.TaskSpec)
@@ -3896,7 +3896,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
 
     /**
      * <pre>
-     * Concrete runtime execution once an assignee session or run is known.
+     * Concrete runtime execution once a delegate session or run is known.
      * </pre>
      *
      * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -3905,7 +3905,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     boolean hasExecutionRef();
     /**
      * <pre>
-     * Concrete runtime execution once an assignee session or run is known.
+     * Concrete runtime execution once a delegate session or run is known.
      * </pre>
      *
      * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -3914,7 +3914,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     talon.resources.Tasks.TaskExecutionRef getExecutionRef();
     /**
      * <pre>
-     * Concrete runtime execution once an assignee session or run is known.
+     * Concrete runtime execution once a delegate session or run is known.
      * </pre>
      *
      * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -4166,7 +4166,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     private talon.resources.Tasks.TaskExecutionRef executionRef_;
     /**
      * <pre>
-     * Concrete runtime execution once an assignee session or run is known.
+     * Concrete runtime execution once a delegate session or run is known.
      * </pre>
      *
      * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -4178,7 +4178,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     }
     /**
      * <pre>
-     * Concrete runtime execution once an assignee session or run is known.
+     * Concrete runtime execution once a delegate session or run is known.
      * </pre>
      *
      * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -4190,7 +4190,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     }
     /**
      * <pre>
-     * Concrete runtime execution once an assignee session or run is known.
+     * Concrete runtime execution once a delegate session or run is known.
      * </pre>
      *
      * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5602,7 +5602,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
           talon.resources.Tasks.TaskExecutionRef, talon.resources.Tasks.TaskExecutionRef.Builder, talon.resources.Tasks.TaskExecutionRefOrBuilder> executionRefBuilder_;
       /**
        * <pre>
-       * Concrete runtime execution once an assignee session or run is known.
+       * Concrete runtime execution once a delegate session or run is known.
        * </pre>
        *
        * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5613,7 +5613,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
       /**
        * <pre>
-       * Concrete runtime execution once an assignee session or run is known.
+       * Concrete runtime execution once a delegate session or run is known.
        * </pre>
        *
        * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5628,7 +5628,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
       /**
        * <pre>
-       * Concrete runtime execution once an assignee session or run is known.
+       * Concrete runtime execution once a delegate session or run is known.
        * </pre>
        *
        * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5648,7 +5648,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
       /**
        * <pre>
-       * Concrete runtime execution once an assignee session or run is known.
+       * Concrete runtime execution once a delegate session or run is known.
        * </pre>
        *
        * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5666,7 +5666,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
       /**
        * <pre>
-       * Concrete runtime execution once an assignee session or run is known.
+       * Concrete runtime execution once a delegate session or run is known.
        * </pre>
        *
        * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5691,7 +5691,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
       /**
        * <pre>
-       * Concrete runtime execution once an assignee session or run is known.
+       * Concrete runtime execution once a delegate session or run is known.
        * </pre>
        *
        * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5708,7 +5708,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
       /**
        * <pre>
-       * Concrete runtime execution once an assignee session or run is known.
+       * Concrete runtime execution once a delegate session or run is known.
        * </pre>
        *
        * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5720,7 +5720,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
       /**
        * <pre>
-       * Concrete runtime execution once an assignee session or run is known.
+       * Concrete runtime execution once a delegate session or run is known.
        * </pre>
        *
        * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5735,7 +5735,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       }
       /**
        * <pre>
-       * Concrete runtime execution once an assignee session or run is known.
+       * Concrete runtime execution once a delegate session or run is known.
        * </pre>
        *
        * <code>.talon.resources.TaskExecutionRef execution_ref = 10;</code>
@@ -5840,29 +5840,29 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
       "tadata\030\001 \001(\0132\035.talon.resources.ResourceM" +
       "eta\022\'\n\004spec\030\002 \001(\0132\031.talon.resources.Task" +
       "Spec\022+\n\006status\030\003 \001(\0132\033.talon.resources.T" +
-      "askStatus\"\235\001\n\010TaskSpec\022\r\n\005title\030\001 \001(\t\022\023\n" +
-      "\013description\030\002 \001(\t\022\014\n\004type\030\003 \001(\t\022/\n\trequ" +
-      "ester\030\004 \001(\0132\034.talon.resources.ResourceRe" +
-      "f\022.\n\010assignee\030\005 \001(\0132\034.talon.resources.Re" +
-      "sourceRef\"e\n\020TaskExecutionRef\022\014\n\004kind\030\001 " +
-      "\001(\t\022\021\n\tnamespace\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\022\022\n\n" +
-      "session_id\030\004 \001(\t\022\016\n\006run_id\030\005 \001(\t\"\354\002\n\nTas" +
-      "kStatus\022\033\n\023observed_generation\030\001 \001(\004\022)\n\005" +
-      "phase\030\002 \001(\0162\032.talon.resources.TaskPhase\022" +
-      "6\n\nconditions\030\003 \003(\0132\".talon.resources.Re" +
-      "sourceCondition\022\030\n\020progress_summary\030\004 \001(" +
-      "\t\0228\n\020result_artifacts\030\005 \003(\0132\036.talon.reso" +
-      "urces.FileObjectRef\022\022\n\ncreated_at\030\006 \001(\003\022" +
-      "\022\n\nupdated_at\030\007 \001(\003\022\024\n\014completed_at\030\010 \001(" +
-      "\003\022\022\n\nexpires_at\030\t \001(\003\0228\n\rexecution_ref\030\n" +
-      " \001(\0132!.talon.resources.TaskExecutionRef*" +
-      "\355\001\n\tTaskPhase\022\032\n\026TASK_PHASE_UNSPECIFIED\020" +
-      "\000\022\025\n\021TASK_PHASE_QUEUED\020\001\022\026\n\022TASK_PHASE_R" +
-      "UNNING\020\002\022\026\n\022TASK_PHASE_BLOCKED\020\003\022\033\n\027TASK" +
-      "_PHASE_NEEDS_REVIEW\020\004\022\030\n\024TASK_PHASE_SUCC" +
-      "EEDED\020\005\022\025\n\021TASK_PHASE_FAILED\020\006\022\027\n\023TASK_P" +
-      "HASE_CANCELED\020\007\022\026\n\022TASK_PHASE_EXPIRED\020\010b" +
-      "\006proto3"
+      "askStatus\"\231\001\n\010TaskSpec\022\r\n\005title\030\001 \001(\t\022\023\n" +
+      "\013description\030\002 \001(\t\022\014\n\004type\030\003 \001(\t\022+\n\005owne" +
+      "r\030\004 \001(\0132\034.talon.resources.ResourceRef\022.\n" +
+      "\010delegate\030\005 \001(\0132\034.talon.resources.Resour" +
+      "ceRef\"e\n\020TaskExecutionRef\022\014\n\004kind\030\001 \001(\t\022" +
+      "\021\n\tnamespace\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\022\022\n\nsess" +
+      "ion_id\030\004 \001(\t\022\016\n\006run_id\030\005 \001(\t\"\354\002\n\nTaskSta" +
+      "tus\022\033\n\023observed_generation\030\001 \001(\004\022)\n\005phas" +
+      "e\030\002 \001(\0162\032.talon.resources.TaskPhase\0226\n\nc" +
+      "onditions\030\003 \003(\0132\".talon.resources.Resour" +
+      "ceCondition\022\030\n\020progress_summary\030\004 \001(\t\0228\n" +
+      "\020result_artifacts\030\005 \003(\0132\036.talon.resource" +
+      "s.FileObjectRef\022\022\n\ncreated_at\030\006 \001(\003\022\022\n\nu" +
+      "pdated_at\030\007 \001(\003\022\024\n\014completed_at\030\010 \001(\003\022\022\n" +
+      "\nexpires_at\030\t \001(\003\0228\n\rexecution_ref\030\n \001(\013" +
+      "2!.talon.resources.TaskExecutionRef*\355\001\n\t" +
+      "TaskPhase\022\032\n\026TASK_PHASE_UNSPECIFIED\020\000\022\025\n" +
+      "\021TASK_PHASE_QUEUED\020\001\022\026\n\022TASK_PHASE_RUNNI" +
+      "NG\020\002\022\026\n\022TASK_PHASE_BLOCKED\020\003\022\033\n\027TASK_PHA" +
+      "SE_NEEDS_REVIEW\020\004\022\030\n\024TASK_PHASE_SUCCEEDE" +
+      "D\020\005\022\025\n\021TASK_PHASE_FAILED\020\006\022\027\n\023TASK_PHASE" +
+      "_CANCELED\020\007\022\026\n\022TASK_PHASE_EXPIRED\020\010b\006pro" +
+      "to3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -5881,7 +5881,7 @@ public final class Tasks extends com.google.protobuf.GeneratedFile {
     internal_static_talon_resources_TaskSpec_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_talon_resources_TaskSpec_descriptor,
-        new java.lang.String[] { "Title", "Description", "Type", "Requester", "Assignee", });
+        new java.lang.String[] { "Title", "Description", "Type", "Owner", "Delegate", });
     internal_static_talon_resources_TaskExecutionRef_descriptor =
       getDescriptor().getMessageType(2);
     internal_static_talon_resources_TaskExecutionRef_fieldAccessorTable = new

--- a/sdk/js/talon-client/src/gen/proto/resources/tasks_pb.ts
+++ b/sdk/js/talon-client/src/gen/proto/resources/tasks_pb.ts
@@ -23,14 +23,14 @@ export enum TaskPhase {
   UNSPECIFIED = 0,
 
   /**
-   * The task exists but no assignee execution has started.
+   * The task exists but no delegate execution has started.
    *
    * @generated from enum value: TASK_PHASE_QUEUED = 1;
    */
   QUEUED = 1,
 
   /**
-   * The assignee is actively working on the task.
+   * The delegate is actively working on the task.
    *
    * @generated from enum value: TASK_PHASE_RUNNING = 2;
    */
@@ -45,7 +45,7 @@ export enum TaskPhase {
   BLOCKED = 3,
 
   /**
-   * Work is complete enough for the requester or another reviewer to inspect.
+   * Work is complete enough for the owner or another reviewer to inspect.
    *
    * @generated from enum value: TASK_PHASE_NEEDS_REVIEW = 4;
    */
@@ -169,16 +169,16 @@ export class TaskSpec extends Message<TaskSpec> {
   /**
    * Agent resource that created and owns follow-up responsibility for the task.
    *
-   * @generated from field: talon.resources.ResourceRef requester = 4;
+   * @generated from field: talon.resources.ResourceRef owner = 4;
    */
-  requester?: ResourceRef;
+  owner?: ResourceRef;
 
   /**
    * Agent resource intended to perform the work.
    *
-   * @generated from field: talon.resources.ResourceRef assignee = 5;
+   * @generated from field: talon.resources.ResourceRef delegate = 5;
    */
-  assignee?: ResourceRef;
+  delegate?: ResourceRef;
 
   constructor(data?: PartialMessage<TaskSpec>) {
     super();
@@ -191,8 +191,8 @@ export class TaskSpec extends Message<TaskSpec> {
     { no: 1, name: "title", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "description", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 4, name: "requester", kind: "message", T: ResourceRef },
-    { no: 5, name: "assignee", kind: "message", T: ResourceRef },
+    { no: 4, name: "owner", kind: "message", T: ResourceRef },
+    { no: 5, name: "delegate", kind: "message", T: ResourceRef },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TaskSpec {
@@ -326,7 +326,7 @@ export class TaskStatus extends Message<TaskStatus> {
   expiresAt = protoInt64.zero;
 
   /**
-   * Concrete runtime execution once an assignee session or run is known.
+   * Concrete runtime execution once a delegate session or run is known.
    *
    * @generated from field: talon.resources.TaskExecutionRef execution_ref = 10;
    */

--- a/sdk/python/talon-client/src/talon_client/proto/resources/tasks_pb2.py
+++ b/sdk/python/talon-client/src/talon_client/proto/resources/tasks_pb2.py
@@ -26,21 +26,21 @@ from talon_client.proto.resources import common_pb2 as proto_dot_resources_dot_c
 from talon_client.proto.resources import files_pb2 as proto_dot_resources_dot_files__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1bproto/resources/tasks.proto\x12\x0ftalon.resources\x1a\x1cproto/resources/common.proto\x1a\x1bproto/resources/files.proto\"\x8d\x01\n\x04Task\x12/\n\x08metadata\x18\x01 \x01(\x0b\x32\x1d.talon.resources.ResourceMeta\x12\'\n\x04spec\x18\x02 \x01(\x0b\x32\x19.talon.resources.TaskSpec\x12+\n\x06status\x18\x03 \x01(\x0b\x32\x1b.talon.resources.TaskStatus\"\x9d\x01\n\x08TaskSpec\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0c\n\x04type\x18\x03 \x01(\t\x12/\n\trequester\x18\x04 \x01(\x0b\x32\x1c.talon.resources.ResourceRef\x12.\n\x08\x61ssignee\x18\x05 \x01(\x0b\x32\x1c.talon.resources.ResourceRef\"e\n\x10TaskExecutionRef\x12\x0c\n\x04kind\x18\x01 \x01(\t\x12\x11\n\tnamespace\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x12\n\nsession_id\x18\x04 \x01(\t\x12\x0e\n\x06run_id\x18\x05 \x01(\t\"\xec\x02\n\nTaskStatus\x12\x1b\n\x13observed_generation\x18\x01 \x01(\x04\x12)\n\x05phase\x18\x02 \x01(\x0e\x32\x1a.talon.resources.TaskPhase\x12\x36\n\nconditions\x18\x03 \x03(\x0b\x32\".talon.resources.ResourceCondition\x12\x18\n\x10progress_summary\x18\x04 \x01(\t\x12\x38\n\x10result_artifacts\x18\x05 \x03(\x0b\x32\x1e.talon.resources.FileObjectRef\x12\x12\n\ncreated_at\x18\x06 \x01(\x03\x12\x12\n\nupdated_at\x18\x07 \x01(\x03\x12\x14\n\x0c\x63ompleted_at\x18\x08 \x01(\x03\x12\x12\n\nexpires_at\x18\t \x01(\x03\x12\x38\n\rexecution_ref\x18\n \x01(\x0b\x32!.talon.resources.TaskExecutionRef*\xed\x01\n\tTaskPhase\x12\x1a\n\x16TASK_PHASE_UNSPECIFIED\x10\x00\x12\x15\n\x11TASK_PHASE_QUEUED\x10\x01\x12\x16\n\x12TASK_PHASE_RUNNING\x10\x02\x12\x16\n\x12TASK_PHASE_BLOCKED\x10\x03\x12\x1b\n\x17TASK_PHASE_NEEDS_REVIEW\x10\x04\x12\x18\n\x14TASK_PHASE_SUCCEEDED\x10\x05\x12\x15\n\x11TASK_PHASE_FAILED\x10\x06\x12\x17\n\x13TASK_PHASE_CANCELED\x10\x07\x12\x16\n\x12TASK_PHASE_EXPIRED\x10\x08\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1bproto/resources/tasks.proto\x12\x0ftalon.resources\x1a\x1cproto/resources/common.proto\x1a\x1bproto/resources/files.proto\"\x8d\x01\n\x04Task\x12/\n\x08metadata\x18\x01 \x01(\x0b\x32\x1d.talon.resources.ResourceMeta\x12\'\n\x04spec\x18\x02 \x01(\x0b\x32\x19.talon.resources.TaskSpec\x12+\n\x06status\x18\x03 \x01(\x0b\x32\x1b.talon.resources.TaskStatus\"\x99\x01\n\x08TaskSpec\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0c\n\x04type\x18\x03 \x01(\t\x12+\n\x05owner\x18\x04 \x01(\x0b\x32\x1c.talon.resources.ResourceRef\x12.\n\x08\x64\x65legate\x18\x05 \x01(\x0b\x32\x1c.talon.resources.ResourceRef\"e\n\x10TaskExecutionRef\x12\x0c\n\x04kind\x18\x01 \x01(\t\x12\x11\n\tnamespace\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x12\n\nsession_id\x18\x04 \x01(\t\x12\x0e\n\x06run_id\x18\x05 \x01(\t\"\xec\x02\n\nTaskStatus\x12\x1b\n\x13observed_generation\x18\x01 \x01(\x04\x12)\n\x05phase\x18\x02 \x01(\x0e\x32\x1a.talon.resources.TaskPhase\x12\x36\n\nconditions\x18\x03 \x03(\x0b\x32\".talon.resources.ResourceCondition\x12\x18\n\x10progress_summary\x18\x04 \x01(\t\x12\x38\n\x10result_artifacts\x18\x05 \x03(\x0b\x32\x1e.talon.resources.FileObjectRef\x12\x12\n\ncreated_at\x18\x06 \x01(\x03\x12\x12\n\nupdated_at\x18\x07 \x01(\x03\x12\x14\n\x0c\x63ompleted_at\x18\x08 \x01(\x03\x12\x12\n\nexpires_at\x18\t \x01(\x03\x12\x38\n\rexecution_ref\x18\n \x01(\x0b\x32!.talon.resources.TaskExecutionRef*\xed\x01\n\tTaskPhase\x12\x1a\n\x16TASK_PHASE_UNSPECIFIED\x10\x00\x12\x15\n\x11TASK_PHASE_QUEUED\x10\x01\x12\x16\n\x12TASK_PHASE_RUNNING\x10\x02\x12\x16\n\x12TASK_PHASE_BLOCKED\x10\x03\x12\x1b\n\x17TASK_PHASE_NEEDS_REVIEW\x10\x04\x12\x18\n\x14TASK_PHASE_SUCCEEDED\x10\x05\x12\x15\n\x11TASK_PHASE_FAILED\x10\x06\x12\x17\n\x13TASK_PHASE_CANCELED\x10\x07\x12\x16\n\x12TASK_PHASE_EXPIRED\x10\x08\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'proto.resources.tasks_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_TASKPHASE']._serialized_start=882
-  _globals['_TASKPHASE']._serialized_end=1119
+  _globals['_TASKPHASE']._serialized_start=878
+  _globals['_TASKPHASE']._serialized_end=1115
   _globals['_TASK']._serialized_start=108
   _globals['_TASK']._serialized_end=249
   _globals['_TASKSPEC']._serialized_start=252
-  _globals['_TASKSPEC']._serialized_end=409
-  _globals['_TASKEXECUTIONREF']._serialized_start=411
-  _globals['_TASKEXECUTIONREF']._serialized_end=512
-  _globals['_TASKSTATUS']._serialized_start=515
-  _globals['_TASKSTATUS']._serialized_end=879
+  _globals['_TASKSPEC']._serialized_end=405
+  _globals['_TASKEXECUTIONREF']._serialized_start=407
+  _globals['_TASKEXECUTIONREF']._serialized_end=508
+  _globals['_TASKSTATUS']._serialized_start=511
+  _globals['_TASKSTATUS']._serialized_end=875
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/talon-client/src/talon_client/proto/resources/tasks_pb2.pyi
+++ b/sdk/python/talon-client/src/talon_client/proto/resources/tasks_pb2.pyi
@@ -41,18 +41,18 @@ class Task(_message.Message):
     def __init__(self, metadata: _Optional[_Union[_common_pb2.ResourceMeta, _Mapping]] = ..., spec: _Optional[_Union[TaskSpec, _Mapping]] = ..., status: _Optional[_Union[TaskStatus, _Mapping]] = ...) -> None: ...
 
 class TaskSpec(_message.Message):
-    __slots__ = ("title", "description", "type", "requester", "assignee")
+    __slots__ = ("title", "description", "type", "owner", "delegate")
     TITLE_FIELD_NUMBER: _ClassVar[int]
     DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
     TYPE_FIELD_NUMBER: _ClassVar[int]
-    REQUESTER_FIELD_NUMBER: _ClassVar[int]
-    ASSIGNEE_FIELD_NUMBER: _ClassVar[int]
+    OWNER_FIELD_NUMBER: _ClassVar[int]
+    DELEGATE_FIELD_NUMBER: _ClassVar[int]
     title: str
     description: str
     type: str
-    requester: _common_pb2.ResourceRef
-    assignee: _common_pb2.ResourceRef
-    def __init__(self, title: _Optional[str] = ..., description: _Optional[str] = ..., type: _Optional[str] = ..., requester: _Optional[_Union[_common_pb2.ResourceRef, _Mapping]] = ..., assignee: _Optional[_Union[_common_pb2.ResourceRef, _Mapping]] = ...) -> None: ...
+    owner: _common_pb2.ResourceRef
+    delegate: _common_pb2.ResourceRef
+    def __init__(self, title: _Optional[str] = ..., description: _Optional[str] = ..., type: _Optional[str] = ..., owner: _Optional[_Union[_common_pb2.ResourceRef, _Mapping]] = ..., delegate: _Optional[_Union[_common_pb2.ResourceRef, _Mapping]] = ...) -> None: ...
 
 class TaskExecutionRef(_message.Message):
     __slots__ = ("kind", "namespace", "name", "session_id", "run_id")

--- a/sdk/rust/talon-client/src/generated/talon.resources.rs
+++ b/sdk/rust/talon-client/src/generated/talon.resources.rs
@@ -1150,10 +1150,10 @@ pub struct TaskSpec {
     pub r#type: ::prost::alloc::string::String,
     /// Agent resource that created and owns follow-up responsibility for the task.
     #[prost(message, optional, tag = "4")]
-    pub requester: ::core::option::Option<ResourceRef>,
+    pub owner: ::core::option::Option<ResourceRef>,
     /// Agent resource intended to perform the work.
     #[prost(message, optional, tag = "5")]
-    pub assignee: ::core::option::Option<ResourceRef>,
+    pub delegate: ::core::option::Option<ResourceRef>,
 }
 /// Runtime location of the work that is fulfilling the task. This may be absent
 /// while queued and filled in after async delegation starts.
@@ -1190,7 +1190,7 @@ pub struct TaskStatus {
     pub completed_at: i64,
     #[prost(int64, tag = "9")]
     pub expires_at: i64,
-    /// Concrete runtime execution once an assignee session or run is known.
+    /// Concrete runtime execution once a delegate session or run is known.
     #[prost(message, optional, tag = "10")]
     pub execution_ref: ::core::option::Option<TaskExecutionRef>,
 }
@@ -1201,14 +1201,14 @@ pub enum TaskPhase {
     /// No phase has been set. Writers should avoid persisting this outside
     /// partially initialized records.
     Unspecified = 0,
-    /// The task exists but no assignee execution has started.
+    /// The task exists but no delegate execution has started.
     Queued = 1,
-    /// The assignee is actively working on the task.
+    /// The delegate is actively working on the task.
     Running = 2,
     /// Progress is blocked on user input, permissions, dependencies, or another
     /// external condition.
     Blocked = 3,
-    /// Work is complete enough for the requester or another reviewer to inspect.
+    /// Work is complete enough for the owner or another reviewer to inspect.
     NeedsReview = 4,
     /// The task completed successfully.
     Succeeded = 5,

--- a/src/control/delegation.rs
+++ b/src/control/delegation.rs
@@ -1,0 +1,914 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use anyhow::{Context, Result};
+use prost::Message;
+use std::collections::HashMap;
+
+use crate::control::resource_model::{self, TypedResource};
+use crate::control::resources::ResourceStore;
+use crate::control::{keys, scheduling, ControlPlane, ProtoKeyValueStoreExt};
+use crate::gateway::rpc::{data_proto, resources_proto};
+
+// Task resource label: marks a Task as created through agent delegation.
+pub const LABEL_DELEGATION: &str = "talon.impalasys.com/delegation";
+// Task resource label: namespace of the agent that owns the delegated Task.
+// Also copied onto delegate sessions/messages for wakeup routing.
+pub const LABEL_OWNER_NAMESPACE: &str = "talon.impalasys.com/owner-namespace";
+// Task resource label: name of the agent that owns the delegated Task.
+// Also copied onto delegate sessions/messages for wakeup routing.
+pub const LABEL_OWNER_NAME: &str = "talon.impalasys.com/owner-name";
+// Task resource label: owner session that should receive review/failure wakeups.
+// Also copied onto delegate sessions/messages for wakeup routing.
+pub const LABEL_OWNER_SESSION_ID: &str = "talon.impalasys.com/owner-session-id";
+// Task resource label: namespace of the agent assigned to execute the Task.
+// Also copied onto owner wake messages to identify the delegate.
+pub const LABEL_DELEGATE_NAMESPACE: &str = "talon.impalasys.com/delegate-namespace";
+// Task resource label: name of the agent assigned to execute the Task.
+// Also copied onto owner wake messages to identify the delegate.
+pub const LABEL_DELEGATE_NAME: &str = "talon.impalasys.com/delegate-name";
+// Task resource label: declared A2A connection used to resolve the delegate.
+// Also copied onto delegate sessions/messages for traceability.
+pub const LABEL_A2A_CONNECTION: &str = "talon.impalasys.com/a2a-connection";
+
+// Delegate session/message label: namespace of the associated Task resource.
+// Also copied onto owner wake messages so review messages point back to Task.
+pub const LABEL_TASK_NAMESPACE: &str = "talon.impalasys.com/task-namespace";
+// Delegate session/message label: name of the associated Task resource.
+// Also copied onto owner wake messages so review messages point back to Task.
+pub const LABEL_TASK_NAME: &str = "talon.impalasys.com/task-name";
+// Session/message label: role in the delegation flow, such as delegate or
+// owner-review.
+pub const LABEL_TASK_ROLE: &str = "talon.impalasys.com/task-role";
+
+// Task status condition: tracks whether delegate execution is running,
+// completed, or failed.
+pub const CONDITION_DELEGATED_EXECUTION: &str = "DelegatedExecution";
+// Task status condition: tracks whether the owner session has been notified of
+// review/failure.
+pub const CONDITION_OWNER_WAKE: &str = "OwnerWake";
+
+#[derive(Clone, Debug)]
+pub struct TaskDelegationRequest {
+    pub namespace: String,
+    pub name: String,
+    pub title: String,
+    pub description: String,
+    pub task_type: String,
+    pub owner_namespace: String,
+    pub owner_name: String,
+    pub owner_session_id: String,
+    pub connection_name: String,
+    pub delegate_namespace: String,
+    pub delegate_name: String,
+}
+
+pub async fn create_delegated_task(
+    cp: &ControlPlane,
+    req: TaskDelegationRequest,
+) -> Result<resources_proto::Task> {
+    let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let task_resource = resource_model::task_resource(
+        req.namespace.clone(),
+        req.name.clone(),
+        resources_proto::TaskSpec {
+            title: req.title.clone(),
+            description: req.description.clone(),
+            r#type: req.task_type.clone(),
+            owner: Some(resources_proto::ResourceRef {
+                namespace: req.owner_namespace.clone(),
+                name: req.owner_name.clone(),
+            }),
+            delegate: Some(resources_proto::ResourceRef {
+                namespace: req.delegate_namespace.clone(),
+                name: req.delegate_name.clone(),
+            }),
+        },
+        resources_proto::TaskStatus {
+            observed_generation: 0,
+            phase: resources_proto::TaskPhase::Queued as i32,
+            conditions: Vec::new(),
+            progress_summary: "Task created; waiting for delegated execution.".to_string(),
+            result_artifacts: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            completed_at: 0,
+            expires_at: 0,
+            execution_ref: Some(resources_proto::TaskExecutionRef {
+                kind: "AGENT_SESSION".to_string(),
+                namespace: req.delegate_namespace.clone(),
+                name: req.delegate_name.clone(),
+                session_id: String::new(),
+                run_id: String::new(),
+            }),
+        },
+        task_resource_labels(&req),
+    );
+    let created = store.upsert(&req.namespace, task_resource).await?;
+    let task = task_from_resource(created).context("invalid Task after create")?;
+
+    match start_task_execution(cp, &store, &req, task).await {
+        Ok(task) => Ok(task),
+        Err(err) => {
+            let failed =
+                mark_task_failed(&store, &req.namespace, &req.name, &err.to_string()).await;
+            if let Err(mark_err) = failed {
+                tracing::warn!(
+                    task_namespace = %req.namespace,
+                    task_name = %req.name,
+                    error = %mark_err,
+                    "failed to mark delegated Task failed after dispatch error"
+                );
+            }
+            Err(err)
+        }
+    }
+}
+
+pub async fn complete_delegated_task_from_session(
+    cp: &ControlPlane,
+    session: &data_proto::Session,
+    completion_status: DelegatedSessionCompletion,
+) -> Result<Option<resources_proto::Task>> {
+    if session.labels.get(LABEL_TASK_ROLE).map(String::as_str) != Some("delegate") {
+        return Ok(None);
+    }
+    let Some(task_namespace) = session.labels.get(LABEL_TASK_NAMESPACE) else {
+        return Ok(None);
+    };
+    let Some(task_name) = session.labels.get(LABEL_TASK_NAME) else {
+        return Ok(None);
+    };
+
+    let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+    let task_resource = store.get(task_namespace, "Task", task_name).await?;
+    let Some(task) = task_resource.and_then(task_from_resource) else {
+        tracing::warn!(
+            task_namespace = %task_namespace,
+            task_name = %task_name,
+            session = %session.id,
+            "delegated session completed but Task was not found"
+        );
+        return Ok(None);
+    };
+    let current_session_id = task
+        .status
+        .as_ref()
+        .and_then(|status| status.execution_ref.as_ref())
+        .map(|execution| execution.session_id.as_str())
+        .unwrap_or("");
+    if current_session_id != session.id {
+        tracing::info!(
+            task_namespace = %task_namespace,
+            task_name = %task_name,
+            stale_session = %session.id,
+            active_session = %current_session_id,
+            "ignoring completion event from stale delegated session"
+        );
+        return Ok(Some(task));
+    }
+    let current_phase = task
+        .status
+        .as_ref()
+        .map(|status| status.phase)
+        .unwrap_or(resources_proto::TaskPhase::Unspecified as i32);
+    if current_phase == resources_proto::TaskPhase::NeedsReview as i32
+        && completion_status == DelegatedSessionCompletion::Completed
+    {
+        let task = wake_owner_for_task_review(cp, &store, session, task).await?;
+        return Ok(Some(task));
+    }
+    if current_phase == resources_proto::TaskPhase::Failed as i32
+        && !owner_wake_sent(task.status.as_ref())
+    {
+        let task = wake_owner_for_task_review(cp, &store, session, task).await?;
+        return Ok(Some(task));
+    }
+    if task_phase_is_terminal(current_phase) {
+        return Ok(Some(task));
+    }
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let (result_artifacts, progress_summary) = match completion_status {
+        DelegatedSessionCompletion::Completed => {
+            let result_artifacts = grant_child_artifacts_to_owner(cp, session).await?;
+            let mut progress_summary =
+                latest_assistant_text(cp, &session.ns, &session.agent, &session.id)
+                    .await?
+                    .map(|text| text_preview(&text, 1200))
+                    .unwrap_or_else(|| {
+                        "Delegated execution completed; no assistant text was produced.".to_string()
+                    });
+            let granted_artifacts = result_artifacts.len();
+            if granted_artifacts > 0 {
+                progress_summary = format!(
+                    "{progress_summary}\n\nGranted owner access to {granted_artifacts} artifact(s)."
+                );
+            }
+            (result_artifacts, progress_summary)
+        }
+        DelegatedSessionCompletion::Failed => (
+            Vec::new(),
+            "Delegated session failed before completing the Task.".to_string(),
+        ),
+    };
+
+    let mut skipped_stale = false;
+    let mut skipped_existing_phase = false;
+    let mut skipped_should_wake = false;
+    let updated =
+        patch_task_status_with(&store, task_namespace, task_name, |status, generation| {
+            let current_session_id = status
+                .execution_ref
+                .as_ref()
+                .map(|execution| execution.session_id.as_str())
+                .unwrap_or("");
+            if current_session_id != session.id {
+                skipped_stale = true;
+                return Ok(());
+            }
+            if status.phase == resources_proto::TaskPhase::NeedsReview as i32
+                && completion_status == DelegatedSessionCompletion::Completed
+            {
+                skipped_existing_phase = true;
+                skipped_should_wake = !owner_wake_sent(Some(status));
+                return Ok(());
+            }
+            if task_phase_is_terminal(status.phase) {
+                skipped_existing_phase = true;
+                skipped_should_wake = status.phase == resources_proto::TaskPhase::Failed as i32
+                    && !owner_wake_sent(Some(status));
+                return Ok(());
+            }
+            status.updated_at = now;
+            match completion_status {
+                DelegatedSessionCompletion::Completed => {
+                    status.phase = resources_proto::TaskPhase::NeedsReview as i32;
+                    status.result_artifacts = result_artifacts.clone();
+                    status.progress_summary = progress_summary.clone();
+                    set_condition(
+                        status,
+                        resources_proto::ResourceCondition {
+                            r#type: CONDITION_DELEGATED_EXECUTION.to_string(),
+                            status: "True".to_string(),
+                            reason: "SessionCompleted".to_string(),
+                            message: "Delegated session completed.".to_string(),
+                            last_transition_time: now,
+                            observed_generation: generation,
+                        },
+                    );
+                }
+                DelegatedSessionCompletion::Failed => {
+                    status.phase = resources_proto::TaskPhase::Failed as i32;
+                    status.completed_at = now;
+                    status.progress_summary = progress_summary.clone();
+                    set_condition(
+                        status,
+                        resources_proto::ResourceCondition {
+                            r#type: CONDITION_DELEGATED_EXECUTION.to_string(),
+                            status: "False".to_string(),
+                            reason: "SessionFailed".to_string(),
+                            message: "Delegated session failed.".to_string(),
+                            last_transition_time: now,
+                            observed_generation: generation,
+                        },
+                    );
+                }
+            }
+            Ok(())
+        })
+        .await?;
+    let task = task_from_resource(updated).context("invalid Task after delegated completion")?;
+    if skipped_stale {
+        return Ok(Some(task));
+    }
+    if skipped_existing_phase && skipped_should_wake {
+        let task = wake_owner_for_task_review(cp, &store, session, task).await?;
+        return Ok(Some(task));
+    }
+    if skipped_existing_phase {
+        return Ok(Some(task));
+    }
+    let task = wake_owner_for_task_review(cp, &store, session, task).await?;
+    Ok(Some(task))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DelegatedSessionCompletion {
+    Completed,
+    Failed,
+}
+
+async fn start_task_execution(
+    cp: &ControlPlane,
+    store: &ResourceStore,
+    req: &TaskDelegationRequest,
+    task: resources_proto::Task,
+) -> Result<resources_proto::Task> {
+    let labels = task_execution_labels(&req);
+    let session_id = scheduling::create_session_with_labels(
+        cp,
+        &req.delegate_namespace,
+        &req.delegate_name,
+        labels.clone(),
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "failed to create delegated session for {}/{}",
+            req.delegate_namespace, req.delegate_name
+        )
+    })?;
+
+    let now = chrono::Utc::now().timestamp_micros();
+    let task_name = task.name().to_string();
+    patch_task_status_with(store, &req.namespace, &task_name, |status, generation| {
+        status.phase = resources_proto::TaskPhase::Running as i32;
+        status.progress_summary = "Delegated execution started.".to_string();
+        status.updated_at = now;
+        status.execution_ref = Some(resources_proto::TaskExecutionRef {
+            kind: "AGENT_SESSION".to_string(),
+            namespace: req.delegate_namespace.clone(),
+            name: req.delegate_name.clone(),
+            session_id: session_id.clone(),
+            run_id: String::new(),
+        });
+        set_condition(
+            status,
+            resources_proto::ResourceCondition {
+                r#type: CONDITION_DELEGATED_EXECUTION.to_string(),
+                status: "Unknown".to_string(),
+                reason: "SessionRunning".to_string(),
+                message: "Delegated session is running.".to_string(),
+                last_transition_time: now,
+                observed_generation: generation,
+            },
+        );
+        set_condition(
+            status,
+            resources_proto::ResourceCondition {
+                r#type: CONDITION_OWNER_WAKE.to_string(),
+                status: "False".to_string(),
+                reason: "ExecutionStarted".to_string(),
+                message: "Owner has not yet been notified for this delegated execution."
+                    .to_string(),
+                last_transition_time: now,
+                observed_generation: generation,
+            },
+        );
+        Ok(())
+    })
+    .await?;
+
+    let message = delegated_task_message(&req);
+    let submission_id = scheduling::send_message(
+        cp.kv.as_ref(),
+        cp.pubsub.as_ref(),
+        &req.delegate_namespace,
+        &req.delegate_name,
+        &session_id,
+        &message,
+        labels,
+        chrono::Utc::now(),
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "failed to enqueue delegated Task message for session {}",
+            session_id
+        )
+    })?;
+
+    let updated = patch_task_status_with(store, &req.namespace, &task_name, |status, _| {
+        if let Some(execution_ref) = status.execution_ref.as_mut() {
+            if execution_ref.session_id == session_id {
+                execution_ref.run_id = submission_id.clone();
+            }
+        }
+        Ok(())
+    })
+    .await?;
+    task_from_resource(updated).context("invalid Task after execution start")
+}
+
+async fn mark_task_failed(
+    store: &ResourceStore,
+    namespace: &str,
+    name: &str,
+    message: &str,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp_micros();
+    patch_task_status_with(store, namespace, name, |status, generation| {
+        status.phase = resources_proto::TaskPhase::Failed as i32;
+        status.progress_summary = message.to_string();
+        status.updated_at = now;
+        status.completed_at = now;
+        set_condition(
+            status,
+            resources_proto::ResourceCondition {
+                r#type: CONDITION_DELEGATED_EXECUTION.to_string(),
+                status: "False".to_string(),
+                reason: "DispatchFailed".to_string(),
+                message: message.to_string(),
+                last_transition_time: now,
+                observed_generation: generation,
+            },
+        );
+        Ok(())
+    })
+    .await?;
+    Ok(())
+}
+
+async fn patch_task_status_with<F>(
+    store: &ResourceStore,
+    namespace: &str,
+    name: &str,
+    mut update: F,
+) -> Result<resources_proto::Resource>
+where
+    F: FnMut(&mut resources_proto::TaskStatus, u64) -> Result<()>,
+{
+    store
+        .patch_status_with(namespace, "Task", name, None, |metadata, status| {
+            let observed_generation = metadata.map(|metadata| metadata.generation).unwrap_or(0);
+            let mut task_status = match status.kind.take() {
+                Some(resources_proto::resource_status::Kind::Task(status)) => status,
+                _ => resources_proto::TaskStatus::default(),
+            };
+            update(&mut task_status, observed_generation)?;
+            status.kind = Some(resources_proto::resource_status::Kind::Task(task_status));
+            Ok(())
+        })
+        .await
+}
+
+fn task_from_resource(resource: resources_proto::Resource) -> Option<resources_proto::Task> {
+    let spec = match resource.spec?.kind? {
+        resources_proto::resource_spec::Kind::Task(spec) => spec,
+        _ => return None,
+    };
+    let status = match resource.status.and_then(|status| status.kind) {
+        Some(resources_proto::resource_status::Kind::Task(status)) => Some(status),
+        _ => None,
+    };
+    Some(resources_proto::Task {
+        metadata: resource.metadata,
+        spec: Some(spec),
+        status,
+    })
+}
+
+fn task_resource_labels(req: &TaskDelegationRequest) -> HashMap<String, String> {
+    HashMap::from([
+        (LABEL_DELEGATION.to_string(), "true".to_string()),
+        (
+            LABEL_OWNER_NAMESPACE.to_string(),
+            req.owner_namespace.clone(),
+        ),
+        (LABEL_OWNER_NAME.to_string(), req.owner_name.clone()),
+        (
+            LABEL_OWNER_SESSION_ID.to_string(),
+            req.owner_session_id.clone(),
+        ),
+        (
+            LABEL_DELEGATE_NAMESPACE.to_string(),
+            req.delegate_namespace.clone(),
+        ),
+        (LABEL_DELEGATE_NAME.to_string(), req.delegate_name.clone()),
+        (
+            LABEL_A2A_CONNECTION.to_string(),
+            req.connection_name.clone(),
+        ),
+    ])
+}
+
+fn task_execution_labels(req: &TaskDelegationRequest) -> HashMap<String, String> {
+    let mut labels = task_resource_labels(req);
+    labels.extend([
+        (LABEL_TASK_NAMESPACE.to_string(), req.namespace.clone()),
+        (LABEL_TASK_NAME.to_string(), req.name.clone()),
+        (LABEL_TASK_ROLE.to_string(), "delegate".to_string()),
+        (
+            LABEL_OWNER_SESSION_ID.to_string(),
+            req.owner_session_id.clone(),
+        ),
+    ]);
+    labels
+}
+
+fn set_condition(
+    status: &mut resources_proto::TaskStatus,
+    condition: resources_proto::ResourceCondition,
+) {
+    if let Some(existing) = status
+        .conditions
+        .iter_mut()
+        .find(|existing| existing.r#type == condition.r#type)
+    {
+        *existing = condition;
+    } else {
+        status.conditions.push(condition);
+    }
+}
+
+fn delegated_task_message(req: &TaskDelegationRequest) -> String {
+    format!(
+        "You have been assigned a Talon Task.\n\nTask: {}\nTask ID: {}/{}\nOwner: {}/{}\n\nInstructions:\n{}",
+        req.title,
+        req.namespace,
+        req.name,
+        req.owner_namespace,
+        req.owner_name,
+        req.description
+    )
+}
+
+async fn latest_assistant_text(
+    cp: &ControlPlane,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+) -> Result<Option<String>> {
+    let mut entries = cp
+        .kv
+        .list_entries(&keys::session_message_prefix(ns, agent, session_id))
+        .await?;
+    entries.sort_by(|left, right| right.0.name.cmp(&left.0.name));
+    for (_, bytes) in entries {
+        let message = data_proto::SessionMessage::decode(bytes.as_slice())?;
+        if message.role != data_proto::MessageRole::RoleAssistant as i32 {
+            continue;
+        }
+        let text = message
+            .parts
+            .iter()
+            .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+            .map(|part| part.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string();
+        if !text.is_empty() {
+            return Ok(Some(text));
+        }
+    }
+    Ok(None)
+}
+
+async fn grant_child_artifacts_to_owner(
+    cp: &ControlPlane,
+    session: &data_proto::Session,
+) -> Result<Vec<resources_proto::FileObjectRef>> {
+    let Some(owner_agent) = session.labels.get(LABEL_OWNER_NAME) else {
+        return Ok(Vec::new());
+    };
+    let owner_namespace = session
+        .labels
+        .get(LABEL_OWNER_NAMESPACE)
+        .map(String::as_str)
+        .unwrap_or(session.ns.as_str());
+    let Some(owner_session_id) = session.labels.get(LABEL_OWNER_SESSION_ID) else {
+        return Ok(Vec::new());
+    };
+    if owner_namespace.trim().is_empty()
+        || owner_agent.trim().is_empty()
+        || owner_session_id.trim().is_empty()
+    {
+        return Ok(Vec::new());
+    }
+
+    let entries = cp
+        .kv
+        .list_entries(&keys::artifact_prefix(
+            &session.ns,
+            &session.agent,
+            &session.id,
+        ))
+        .await?;
+    let mut result_artifacts = Vec::new();
+    let now = chrono::Utc::now().timestamp_micros();
+    for (_, bytes) in entries {
+        let artifact = data_proto::Artifact::decode(bytes.as_slice())?;
+        let Some(object_ref) = artifact.object_ref.as_ref() else {
+            continue;
+        };
+        cp.kv
+            .set_msg(
+                &keys::artifact_access(
+                    &session.ns,
+                    &session.agent,
+                    &session.id,
+                    &artifact.id,
+                    owner_agent,
+                    owner_session_id,
+                ),
+                &data_proto::ArtifactAccess {
+                    target_agent: owner_agent.clone(),
+                    target_session_id: owner_session_id.clone(),
+                    operations: vec![
+                        "read".to_string(),
+                        "metadata".to_string(),
+                        "promote".to_string(),
+                    ],
+                    expires_at: 0,
+                    granted_by_agent: session.agent.clone(),
+                    granted_by_session_id: session.id.clone(),
+                    created_at: now,
+                },
+            )
+            .await?;
+        result_artifacts.push(file_object_ref_for_artifact(session, &artifact, object_ref));
+    }
+    Ok(result_artifacts)
+}
+
+fn file_object_ref_for_artifact(
+    session: &data_proto::Session,
+    artifact: &data_proto::Artifact,
+    object_ref: &data_proto::ObjectRef,
+) -> resources_proto::FileObjectRef {
+    let artifact_uri = format!(
+        "artifact://{}/{}/{}/{}",
+        session.ns, session.agent, session.id, artifact.id
+    );
+    let mut metadata = object_ref.metadata.clone();
+    metadata.insert("artifact_uri".to_string(), artifact_uri);
+    metadata.insert("artifact_id".to_string(), artifact.id.clone());
+    metadata.insert("session_id".to_string(), session.id.clone());
+    metadata.insert("agent".to_string(), session.agent.clone());
+    metadata.insert("title".to_string(), artifact.title.clone());
+    resources_proto::FileObjectRef {
+        key: object_ref.key.clone(),
+        media_type: object_ref.media_type.clone(),
+        size_bytes: object_ref.size_bytes,
+        sha256: object_ref.sha256.clone(),
+        filename: object_ref.filename.clone(),
+        metadata,
+    }
+}
+
+async fn wake_owner_for_task_review(
+    cp: &ControlPlane,
+    store: &ResourceStore,
+    session: &data_proto::Session,
+    task: resources_proto::Task,
+) -> Result<resources_proto::Task> {
+    let Some(owner_agent) = session.labels.get(LABEL_OWNER_NAME) else {
+        return Ok(task);
+    };
+    let owner_namespace = session
+        .labels
+        .get(LABEL_OWNER_NAMESPACE)
+        .map(String::as_str)
+        .unwrap_or(session.ns.as_str());
+    let Some(owner_session_id) = session.labels.get(LABEL_OWNER_SESSION_ID) else {
+        return Ok(task);
+    };
+    if owner_namespace.trim().is_empty()
+        || owner_agent.trim().is_empty()
+        || owner_session_id.trim().is_empty()
+    {
+        return Ok(task);
+    }
+
+    if task
+        .status
+        .as_ref()
+        .is_some_and(|status| condition_status(status, CONDITION_OWNER_WAKE) == Some("True"))
+    {
+        return Ok(task);
+    }
+
+    let message = task_review_message(&task);
+    let labels = HashMap::from([
+        (
+            LABEL_TASK_NAMESPACE.to_string(),
+            task.namespace().to_string(),
+        ),
+        (LABEL_TASK_NAME.to_string(), task.name().to_string()),
+        (LABEL_TASK_ROLE.to_string(), "owner-review".to_string()),
+        (LABEL_DELEGATE_NAMESPACE.to_string(), session.ns.clone()),
+        (LABEL_DELEGATE_NAME.to_string(), session.agent.clone()),
+    ]);
+    match scheduling::send_message(
+        cp.kv.as_ref(),
+        cp.pubsub.as_ref(),
+        owner_namespace,
+        owner_agent,
+        owner_session_id,
+        &message,
+        labels,
+        chrono::Utc::now(),
+    )
+    .await
+    {
+        Ok(_) => {
+            let now = chrono::Utc::now().timestamp_micros();
+            let task_name = task.name().to_string();
+            let task_namespace = task.namespace().to_string();
+            let updated =
+                patch_task_status_with(store, &task_namespace, &task_name, |status, generation| {
+                    set_condition(
+                        status,
+                        resources_proto::ResourceCondition {
+                            r#type: CONDITION_OWNER_WAKE.to_string(),
+                            status: "True".to_string(),
+                            reason: "SessionMessageSent".to_string(),
+                            message: "Owner session was notified that delegated Task needs review."
+                                .to_string(),
+                            last_transition_time: now,
+                            observed_generation: generation,
+                        },
+                    );
+                    Ok(())
+                })
+                .await?;
+            task_from_resource(updated).context("invalid Task after owner wake status")
+        }
+        Err(err) => {
+            let now = chrono::Utc::now().timestamp_micros();
+            let task_name = task.name().to_string();
+            let task_namespace = task.namespace().to_string();
+            let error_message = err.to_string();
+            let updated =
+                patch_task_status_with(store, &task_namespace, &task_name, |status, generation| {
+                    set_condition(
+                        status,
+                        resources_proto::ResourceCondition {
+                            r#type: CONDITION_OWNER_WAKE.to_string(),
+                            status: "False".to_string(),
+                            reason: "SessionMessageFailed".to_string(),
+                            message: error_message.clone(),
+                            last_transition_time: now,
+                            observed_generation: generation,
+                        },
+                    );
+                    Ok(())
+                })
+                .await?;
+            tracing::warn!(
+                namespace = %session.ns,
+                owner_namespace = %owner_namespace,
+                owner_agent = %owner_agent,
+                owner_session_id = %owner_session_id,
+                task_namespace = %task_namespace,
+                task_name = %task_name,
+                error = %err,
+                "failed to wake owner session for delegated Task review"
+            );
+            task_from_resource(updated).context("invalid Task after owner wake failure status")
+        }
+    }
+}
+
+pub async fn retry_owner_wakes_for_session(
+    cp: &ControlPlane,
+    owner_session: &data_proto::Session,
+) -> Result<()> {
+    // Stopgap until sessions have a durable inbox: wake messages cannot be
+    // appended while a owner session is PROCESSING, so retry after release.
+    let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+    for resource in store.list(&owner_session.ns, Some("Task")).await? {
+        let Some(task) = task_from_resource(resource.clone()) else {
+            continue;
+        };
+        let labels = resource
+            .metadata
+            .as_ref()
+            .map(|metadata| &metadata.labels)
+            .context("Task metadata missing")?;
+        if labels.get(LABEL_DELEGATION).map(String::as_str) != Some("true")
+            || labels.get(LABEL_OWNER_NAME).map(String::as_str)
+                != Some(owner_session.agent.as_str())
+            || labels.get(LABEL_OWNER_SESSION_ID).map(String::as_str)
+                != Some(owner_session.id.as_str())
+            || owner_wake_sent(task.status.as_ref())
+        {
+            continue;
+        }
+        let phase = task
+            .status
+            .as_ref()
+            .map(|status| status.phase)
+            .unwrap_or(resources_proto::TaskPhase::Unspecified as i32);
+        if phase != resources_proto::TaskPhase::NeedsReview as i32
+            && phase != resources_proto::TaskPhase::Failed as i32
+        {
+            continue;
+        }
+        let delegate_session = data_proto::Session {
+            id: task
+                .status
+                .as_ref()
+                .and_then(|status| status.execution_ref.as_ref())
+                .map(|execution| execution.session_id.clone())
+                .unwrap_or_default(),
+            agent: labels.get(LABEL_DELEGATE_NAME).cloned().unwrap_or_default(),
+            ns: labels
+                .get(LABEL_DELEGATE_NAMESPACE)
+                .cloned()
+                .unwrap_or_else(|| owner_session.ns.clone()),
+            status: String::new(),
+            created_at: 0,
+            last_active: 0,
+            metadata: HashMap::new(),
+            labels: HashMap::from([
+                (LABEL_OWNER_NAMESPACE.to_string(), owner_session.ns.clone()),
+                (LABEL_OWNER_NAME.to_string(), owner_session.agent.clone()),
+                (LABEL_OWNER_SESSION_ID.to_string(), owner_session.id.clone()),
+            ]),
+        };
+        let task_namespace = task.namespace().to_string();
+        let task_name = task.name().to_string();
+        if let Err(err) = wake_owner_for_task_review(cp, &store, &delegate_session, task).await {
+            tracing::warn!(
+                namespace = %owner_session.ns,
+                agent = %owner_session.agent,
+                session = %owner_session.id,
+                task_namespace = %task_namespace,
+                task_name = %task_name,
+                error = %err,
+                "failed to retry delegated Task owner wake"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn condition_status<'a>(
+    status: &'a resources_proto::TaskStatus,
+    condition_type: &str,
+) -> Option<&'a str> {
+    status
+        .conditions
+        .iter()
+        .find(|condition| condition.r#type == condition_type)
+        .map(|condition| condition.status.as_str())
+}
+
+fn owner_wake_sent(status: Option<&resources_proto::TaskStatus>) -> bool {
+    status.is_some_and(|status| condition_status(status, CONDITION_OWNER_WAKE) == Some("True"))
+}
+
+fn task_review_message(task: &resources_proto::Task) -> String {
+    let title = task
+        .spec
+        .as_ref()
+        .map(|spec| spec.title.as_str())
+        .unwrap_or("Delegated task");
+    let phase = task
+        .status
+        .as_ref()
+        .map(|status| status.phase)
+        .unwrap_or(resources_proto::TaskPhase::Unspecified as i32);
+    let heading = if phase == resources_proto::TaskPhase::Failed as i32 {
+        "Delegated Task failed."
+    } else {
+        "Delegated Task is ready for review."
+    };
+    let mut message = format!(
+        "{heading}\n\nTask: {title}\nTask ID: {}/{}",
+        task.namespace(),
+        task.name()
+    );
+    let artifact_uris = task
+        .status
+        .as_ref()
+        .map(|status| {
+            status
+                .result_artifacts
+                .iter()
+                .filter_map(|artifact| artifact.metadata.get("artifact_uri"))
+                .filter(|uri| !uri.trim().is_empty())
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !artifact_uris.is_empty() {
+        message.push_str("\n\nArtifacts:");
+        for uri in artifact_uris {
+            message.push_str("\n- ");
+            message.push_str(&uri);
+        }
+    }
+    message
+}
+
+fn task_phase_is_terminal(phase: i32) -> bool {
+    phase == resources_proto::TaskPhase::Succeeded as i32
+        || phase == resources_proto::TaskPhase::Failed as i32
+        || phase == resources_proto::TaskPhase::Canceled as i32
+        || phase == resources_proto::TaskPhase::Expired as i32
+}
+
+fn text_preview(text: &str, max_chars: usize) -> String {
+    let mut chars = text.chars();
+    let mut preview = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        preview.push_str("...");
+    }
+    preview
+}

--- a/src/control/manifest/tests.rs
+++ b/src/control/manifest/tests.rs
@@ -726,10 +726,10 @@ spec:
   title: Launch copy
   description: Draft launch copy.
   type: agent_delegation
-  requester:
+  owner:
     namespace: Tenant:acme:Workspace:main
     name: cmo
-  assignee:
+  delegate:
     namespace: Tenant:acme:Workspace:main
     name: writer
 "#,
@@ -741,8 +741,8 @@ spec:
             panic!("expected Task spec");
         };
         assert_eq!(spec.r#type, "agent_delegation");
-        assert_eq!(spec.requester.as_ref().unwrap().name, "cmo");
-        assert_eq!(spec.assignee.as_ref().unwrap().name, "writer");
+        assert_eq!(spec.owner.as_ref().unwrap().name, "cmo");
+        assert_eq!(spec.delegate.as_ref().unwrap().name, "writer");
 
         let rendered = render_resource_yaml(&resources_proto::Resource {
             api_version: manifest.api_version,

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -4,6 +4,7 @@
 use std::{pin::Pin, sync::Arc};
 pub mod cas;
 pub mod config;
+pub mod delegation;
 pub mod events;
 pub mod keys;
 pub mod kv;

--- a/src/control/resources.rs
+++ b/src/control/resources.rs
@@ -310,6 +310,35 @@ impl ResourceStore {
         .await
     }
 
+    pub async fn patch_status_with<F>(
+        &self,
+        namespace: &str,
+        kind: &str,
+        name: &str,
+        expected_resource_version: Option<&str>,
+        mut update: F,
+    ) -> Result<resources_proto::Resource>
+    where
+        F: FnMut(
+            Option<&resources_proto::ResourceMeta>,
+            &mut resources_proto::ResourceStatus,
+        ) -> Result<()>,
+    {
+        self.patch_resource(
+            namespace,
+            kind,
+            name,
+            expected_resource_version,
+            |resource| {
+                let mut status = resource.status.take().unwrap_or_default();
+                update(resource.metadata.as_ref(), &mut status)?;
+                resource.status = Some(status);
+                Ok(vec!["metadata", "status"])
+            },
+        )
+        .await
+    }
+
     async fn patch_resource<F>(
         &self,
         namespace: &str,

--- a/src/harness/a2a.rs
+++ b/src/harness/a2a.rs
@@ -1,0 +1,204 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use anyhow::{anyhow, Result};
+
+use crate::gateway::rpc::manifests;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedInternalConnection {
+    pub connection_name: String,
+    pub target_namespace: String,
+    pub target_agent: String,
+}
+
+pub fn internal_connection_names(spec: &manifests::AgentSpec) -> Vec<String> {
+    spec.a2a
+        .as_ref()
+        .map(|a2a| {
+            a2a.connections
+                .iter()
+                .filter(|connection| {
+                    connection
+                        .target
+                        .as_ref()
+                        .and_then(|target| target.internal.as_ref())
+                        .is_some()
+                })
+                .map(|connection| connection.name.clone())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub fn resolve_internal_connection(
+    spec: &manifests::AgentSpec,
+    name: &str,
+) -> Result<ResolvedInternalConnection> {
+    let requested = name.trim();
+    if requested.is_empty() {
+        return Err(anyhow!("A2A connection name is required"));
+    }
+    let Some(a2a) = spec.a2a.as_ref() else {
+        return Err(anyhow!(
+            "agent has no A2A connections; cannot delegate to '{}'",
+            requested
+        ));
+    };
+    let Some(connection) = a2a
+        .connections
+        .iter()
+        .find(|connection| connection.name == requested)
+    else {
+        let valid = internal_connection_names(spec);
+        if valid.is_empty() {
+            return Err(anyhow!(
+                "A2A connection '{}' is not declared; no internal A2A connections are available",
+                requested
+            ));
+        }
+        return Err(anyhow!(
+            "A2A connection '{}' is not declared as an internal delegation target; valid connections: {}",
+            requested,
+            valid.join(", ")
+        ));
+    };
+    let Some(target) = connection.target.as_ref() else {
+        return Err(anyhow!("A2A connection '{}' has no target", requested));
+    };
+    if target.external.is_some() {
+        return Err(anyhow!(
+            "external A2A connection '{}' is not supported by delegate_task yet",
+            requested
+        ));
+    }
+    let Some(internal) = target.internal.as_ref() else {
+        return Err(anyhow!(
+            "A2A connection '{}' is not an internal delegation target",
+            requested
+        ));
+    };
+    Ok(ResolvedInternalConnection {
+        connection_name: connection.name.clone(),
+        target_namespace: internal.namespace.clone(),
+        target_agent: internal.agent.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn connection(name: &str, target: manifests::ConnectionRef) -> manifests::Connection {
+        manifests::Connection {
+            name: name.to_string(),
+            target: Some(target),
+            ..Default::default()
+        }
+    }
+
+    fn internal(namespace: &str, agent: &str) -> manifests::ConnectionRef {
+        manifests::ConnectionRef {
+            internal: Some(manifests::InternalConnectionRef {
+                namespace: namespace.to_string(),
+                agent: agent.to_string(),
+            }),
+            external: None,
+        }
+    }
+
+    fn external(url: &str) -> manifests::ConnectionRef {
+        manifests::ConnectionRef {
+            internal: None,
+            external: Some(manifests::ExternalConnectionRef {
+                agent_card_url: url.to_string(),
+            }),
+        }
+    }
+
+    #[test]
+    fn lists_only_internal_connection_names() {
+        let spec = manifests::AgentSpec {
+            a2a: Some(manifests::A2a {
+                connections: vec![
+                    connection("worker", internal("Tenant:acme:Ops", "worker-agent")),
+                    connection("external", external("https://example.com/card.json")),
+                ],
+                agent_card: None,
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(internal_connection_names(&spec), vec!["worker"]);
+    }
+
+    #[test]
+    fn resolves_internal_connection() {
+        let spec = manifests::AgentSpec {
+            a2a: Some(manifests::A2a {
+                connections: vec![connection(
+                    "worker",
+                    internal("Tenant:acme:Ops", "worker-agent"),
+                )],
+                agent_card: None,
+            }),
+            ..Default::default()
+        };
+
+        let resolved = resolve_internal_connection(&spec, "worker").unwrap();
+        assert_eq!(resolved.connection_name, "worker");
+        assert_eq!(resolved.target_namespace, "Tenant:acme:Ops");
+        assert_eq!(resolved.target_agent, "worker-agent");
+    }
+
+    #[test]
+    fn trims_requested_connection_name() {
+        let spec = manifests::AgentSpec {
+            a2a: Some(manifests::A2a {
+                connections: vec![connection(
+                    "worker",
+                    internal("Tenant:acme:Ops", "worker-agent"),
+                )],
+                agent_card: None,
+            }),
+            ..Default::default()
+        };
+
+        let resolved = resolve_internal_connection(&spec, " worker ").unwrap();
+        assert_eq!(resolved.connection_name, "worker");
+    }
+
+    #[test]
+    fn rejects_unknown_connection_with_valid_names() {
+        let spec = manifests::AgentSpec {
+            a2a: Some(manifests::A2a {
+                connections: vec![connection(
+                    "worker",
+                    internal("Tenant:acme:Ops", "worker-agent"),
+                )],
+                agent_card: None,
+            }),
+            ..Default::default()
+        };
+
+        let err = resolve_internal_connection(&spec, "missing").unwrap_err();
+        assert!(err.to_string().contains("valid connections: worker"));
+    }
+
+    #[test]
+    fn rejects_external_connection() {
+        let spec = manifests::AgentSpec {
+            a2a: Some(manifests::A2a {
+                connections: vec![connection(
+                    "remote",
+                    external("https://example.com/card.json"),
+                )],
+                agent_card: None,
+            }),
+            ..Default::default()
+        };
+
+        let err = resolve_internal_connection(&spec, "remote").unwrap_err();
+        assert!(err.to_string().contains("external A2A connection"));
+    }
+}

--- a/src/harness/agents/resolver.rs
+++ b/src/harness/agents/resolver.rs
@@ -115,6 +115,12 @@ fn validate_a2a(a2a: &manifests::A2a) -> Result<()> {
         if name.is_empty() {
             bail!("A2A connection name is required");
         }
+        if connection.name != name {
+            bail!(
+                "A2A connection name {:?} must not contain leading or trailing whitespace",
+                connection.name
+            );
+        }
         if !seen_connections.insert(name.to_string()) {
             bail!("Duplicate A2A connection '{}'", name);
         }
@@ -432,6 +438,24 @@ mod tests {
         });
         let err = validate_agent_spec(&invalid_url).unwrap_err();
         assert!(err.to_string().contains("http(s) URL"));
+
+        let mut padded_name = valid_agent_spec();
+        padded_name.a2a = Some(manifests::A2a {
+            connections: vec![manifests::Connection {
+                name: " policy ".to_string(),
+                target: Some(manifests::ConnectionRef {
+                    internal: Some(manifests::InternalConnectionRef {
+                        namespace: "customers".to_string(),
+                        agent: "policy-agent".to_string(),
+                    }),
+                    external: None,
+                }),
+                ..Default::default()
+            }],
+            agent_card: None,
+        });
+        let err = validate_agent_spec(&padded_name).unwrap_err();
+        assert!(err.to_string().contains("leading or trailing whitespace"));
     }
 
     #[test]

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
+pub mod a2a;
 pub mod acp;
 pub mod agents;
 pub mod connector;

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -12,12 +12,17 @@ use std::time::Duration;
 use crate::control::resource_model::{self, TypedResource};
 use crate::control::resources::ResourceStore;
 use crate::control::scheduling;
-use crate::control::{keys, ControlPlane, ProtoKeyValueStoreExt};
+use crate::control::{delegation, keys, ControlPlane, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{
     data_proto, manifests, protobuf_value::value::Kind as ProtoValueKind, resources_proto,
 };
 use crate::harness::skills::namespace::{self, NamespaceSkill};
 use crate::harness::skills::registry::ToolRegistry;
+
+#[path = "tools/artifacts.rs"]
+mod artifact_tools;
+#[path = "tools/tasks.rs"]
+mod task_tools;
 
 pub const CREATE_SCHEDULE_TOOL: &str = "create_schedule";
 pub const GET_SCHEDULE_TOOL: &str = "get_schedule";
@@ -25,6 +30,7 @@ pub const LIST_SCHEDULES_TOOL: &str = "list_schedules";
 pub const UPDATE_SCHEDULE_TOOL: &str = "update_schedule";
 pub const DELETE_SCHEDULE_TOOL: &str = "delete_schedule";
 pub const CREATE_TASK_TOOL: &str = "create_task";
+pub const DELEGATE_TASK_TOOL: &str = "delegate_task";
 pub const GET_TASK_TOOL: &str = "get_task";
 pub const LIST_TASKS_TOOL: &str = "list_tasks";
 pub const UPDATE_TASK_TOOL: &str = "update_task";
@@ -103,7 +109,7 @@ pub fn register_channel_tools(registry: &mut ToolRegistry) {
 }
 
 pub fn register_tools(registry: &mut ToolRegistry, spec: &manifests::AgentSpec) {
-    register_artifact_tools(registry);
+    artifact_tools::register(registry);
     register_research_tools(registry, spec);
 
     if !has_capability_action(spec, "schedules", "inspect")
@@ -176,36 +182,6 @@ pub fn register_tools(registry: &mut ToolRegistry, spec: &manifests::AgentSpec) 
                 "properties": {
                     "namespace": { "type": "string", "description": "Namespace containing the schedule. Defaults to the current agent namespace if omitted." },
                     "name": { "type": "string", "description": "Schedule name." }
-                },
-                "required": ["name"]
-            }),
-        );
-    }
-
-    if has_capability_action(spec, "tasks", "inspect") {
-        registry.register_builtin(
-            LIST_TASKS_TOOL,
-            "List durable Talon Tasks in a namespace. Use this to rediscover delegated work across sessions.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "namespace": { "type": "string", "description": "Namespace to inspect. Defaults to the current agent namespace if omitted." },
-                    "status_group": { "type": "string", "description": "Optional group: active or terminal." },
-                    "phase": { "type": "string", "description": "Optional phase filter such as RUNNING, NEEDS_REVIEW, SUCCEEDED, FAILED, or CANCELED." },
-                    "requester_name": { "type": "string", "description": "Optional requester agent resource name filter." },
-                    "assignee_name": { "type": "string", "description": "Optional assignee agent resource name filter." },
-                    "limit": { "type": "integer", "description": "Optional maximum number of results to return." }
-                }
-            }),
-        );
-        registry.register_builtin(
-            GET_TASK_TOOL,
-            "Get one durable Talon Task by name.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "namespace": { "type": "string", "description": "Namespace containing the task. Defaults to the current agent namespace if omitted." },
-                    "name": { "type": "string", "description": "Task resource name." }
                 },
                 "required": ["name"]
             }),
@@ -287,45 +263,7 @@ pub fn register_tools(registry: &mut ToolRegistry, spec: &manifests::AgentSpec) 
         );
     }
 
-    if has_capability_action(spec, "tasks", "create") {
-        registry.register_builtin(
-            CREATE_TASK_TOOL,
-            "Create a durable caller-owned Task before delegating work to another agent.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "namespace": { "type": "string", "description": "Namespace that owns the task. Defaults to the current agent namespace if omitted." },
-                    "title": { "type": "string", "description": "Short human-readable task title." },
-                    "description": { "type": "string", "description": "Brief or acceptance criteria for the task." },
-                    "type": { "type": "string", "description": "Optional caller-defined classifier such as agent_delegation or human_review. Talon does not interpret it." },
-                    "assignee_namespace": { "type": "string", "description": "Namespace of the worker agent." },
-                    "assignee_name": { "type": "string", "description": "Worker agent resource name." }
-                },
-                "required": ["title", "description", "assignee_name"]
-            }),
-        );
-    }
-
-    if has_capability_action(spec, "tasks", "update") {
-        registry.register_builtin(
-            UPDATE_TASK_TOOL,
-            "Update Task status after delegation progress, review, completion, or failure.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "namespace": { "type": "string", "description": "Namespace containing the task. Defaults to the current agent namespace if omitted." },
-                    "name": { "type": "string", "description": "Task resource name." },
-                    "phase": { "type": "string", "description": "Optional phase: QUEUED, RUNNING, BLOCKED, NEEDS_REVIEW, SUCCEEDED, FAILED, CANCELED, or EXPIRED." },
-                    "progress_summary": { "type": "string", "description": "Short current state or result summary." },
-                    "execution_namespace": { "type": "string", "description": "Optional execution namespace." },
-                    "execution_name": { "type": "string", "description": "Optional execution agent resource name." },
-                    "execution_session_id": { "type": "string", "description": "Optional child session id." },
-                    "run_id": { "type": "string", "description": "Optional workflow or run id." }
-                },
-                "required": ["name"]
-            }),
-        );
-    }
+    task_tools::register(registry, spec);
 
     if has_capability_action(spec, "goals", "inspect") {
         registry.register_builtin(
@@ -431,65 +369,6 @@ pub fn register_tools(registry: &mut ToolRegistry, spec: &manifests::AgentSpec) 
     }
 }
 
-fn register_artifact_tools(registry: &mut ToolRegistry) {
-    registry.register_builtin(
-        CREATE_ARTIFACT_TOOL,
-        "Create a session-scoped artifact and return an artifact:// URI that can be read or granted to another agent.",
-        json!({
-            "type": "object",
-            "properties": {
-                "title": { "type": "string", "description": "Human-readable artifact title." },
-                "media_type": { "type": "string", "description": "Media type. Defaults to text/markdown." },
-                "content": { "type": "string", "description": "Text content to store." },
-                "content_base64": { "type": "string", "description": "Base64 bytes to store instead of content." },
-                "labels": { "type": "object", "additionalProperties": { "type": "string" } },
-                "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
-            },
-            "required": ["title"]
-        }),
-    );
-    registry.register_builtin(
-        READ_ARTIFACT_TOOL,
-        "Read an artifact by artifact:// URI.",
-        json!({
-            "type": "object",
-            "properties": {
-                "artifact_uri": { "type": "string" }
-            },
-            "required": ["artifact_uri"]
-        }),
-    );
-    registry.register_builtin(
-        GET_ARTIFACT_METADATA_TOOL,
-        "Return artifact metadata for an artifact:// URI without reading bytes.",
-        json!({
-            "type": "object",
-            "properties": {
-                "artifact_uri": { "type": "string" }
-            },
-            "required": ["artifact_uri"]
-        }),
-    );
-    registry.register_builtin(
-        GRANT_ARTIFACT_TOOL,
-        "Grant another agent or session access to an artifact:// URI.",
-        json!({
-            "type": "object",
-            "properties": {
-                "artifact_uri": { "type": "string" },
-                "target_agent": { "type": "string" },
-                "target_session_id": { "type": "string" },
-                "operations": {
-                    "type": "array",
-                    "items": { "type": "string", "enum": ["read", "metadata", "promote"] }
-                },
-                "ttl_seconds": { "type": "integer" }
-            },
-            "required": ["artifact_uri"]
-        }),
-    );
-}
-
 fn register_research_tools(registry: &mut ToolRegistry, spec: &manifests::AgentSpec) {
     if has_capability_action(spec, "research", "fetch_url") {
         registry.register_builtin(
@@ -587,27 +466,33 @@ pub async fn execute_tool_for_session(
     name: &str,
     args: &Value,
 ) -> Result<Option<String>> {
+    if let Some(result) = artifact_tools::execute(
+        cp,
+        current_namespace,
+        current_agent,
+        current_session,
+        name,
+        args,
+    )
+    .await?
+    {
+        return Ok(Some(result));
+    }
+    if let Some(result) = task_tools::execute(
+        cp,
+        current_namespace,
+        current_agent,
+        current_session,
+        spec,
+        name,
+        args,
+    )
+    .await?
+    {
+        return Ok(Some(result));
+    }
+
     match name {
-        CREATE_ARTIFACT_TOOL => {
-            create_artifact(cp, current_namespace, current_agent, current_session, args)
-                .await
-                .map(Some)
-        }
-        READ_ARTIFACT_TOOL => {
-            read_artifact(cp, current_namespace, current_agent, current_session, args)
-                .await
-                .map(Some)
-        }
-        GET_ARTIFACT_METADATA_TOOL => {
-            get_artifact_metadata(cp, current_namespace, current_agent, current_session, args)
-                .await
-                .map(Some)
-        }
-        GRANT_ARTIFACT_TOOL => {
-            grant_artifact(cp, current_namespace, current_agent, current_session, args)
-                .await
-                .map(Some)
-        }
         READ_SESSION_MESSAGES_TOOL => {
             require_capability(spec, "sessions", "read:messages")?;
             read_session_messages(cp, current_namespace, current_agent, args)
@@ -777,72 +662,6 @@ pub async fn execute_tool_for_session(
             Ok(Some(serde_json::to_string_pretty(
                 &json!({ "success": true }),
             )?))
-        }
-        LIST_TASKS_TOOL => {
-            require_capability(spec, "tasks", "inspect")?;
-            let namespace = opt_str(args, "namespace").unwrap_or(current_namespace);
-            let status_group = opt_str(args, "status_group");
-            let phase = opt_str(args, "phase");
-            let requester_name = opt_str(args, "requester_name");
-            let assignee_name = opt_str(args, "assignee_name");
-            let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(100) as usize;
-            let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
-            let mut resources = store.list(namespace, Some("Task")).await?;
-            resources.sort_by(|a, b| task_updated_at(b).cmp(&task_updated_at(a)));
-            let mut tasks = Vec::new();
-            for resource in resources {
-                let Some(task) = task_from_resource(resource) else {
-                    continue;
-                };
-                if !task_matches(&task, status_group, phase, requester_name, assignee_name) {
-                    continue;
-                }
-                tasks.push(task_json(&task));
-                if tasks.len() >= limit {
-                    break;
-                }
-            }
-            Ok(Some(serde_json::to_string_pretty(
-                &json!({ "tasks": tasks }),
-            )?))
-        }
-        GET_TASK_TOOL => {
-            require_capability(spec, "tasks", "inspect")?;
-            let namespace = opt_str(args, "namespace").unwrap_or(current_namespace);
-            let name = req_str(args, "name")?;
-            let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
-            let resource = store
-                .get(namespace, "Task", name)
-                .await?
-                .ok_or_else(|| anyhow!("task '{}' not found", name))?;
-            let task = task_from_resource(resource).ok_or_else(|| anyhow!("invalid Task"))?;
-            Ok(Some(serde_json::to_string_pretty(&json!({
-                "task": task_json(&task)
-            }))?))
-        }
-        CREATE_TASK_TOOL => {
-            require_capability(spec, "tasks", "create")?;
-            let task =
-                create_task(cp, current_namespace, current_agent, current_session, args).await?;
-            Ok(Some(serde_json::to_string_pretty(&json!({
-                "task": task_json(&task)
-            }))?))
-        }
-        UPDATE_TASK_TOOL => {
-            require_capability(spec, "tasks", "update")?;
-            let namespace = opt_str(args, "namespace").unwrap_or(current_namespace);
-            let name = req_str(args, "name")?;
-            let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
-            let mut resource = store
-                .get(namespace, "Task", name)
-                .await?
-                .ok_or_else(|| anyhow!("task '{}' not found", name))?;
-            update_task_resource(&mut resource, args)?;
-            let resource = store.upsert(namespace, resource).await?;
-            let task = task_from_resource(resource).ok_or_else(|| anyhow!("invalid Task"))?;
-            Ok(Some(serde_json::to_string_pretty(&json!({
-                "task": task_json(&task)
-            }))?))
         }
         LIST_GOALS_TOOL => {
             require_capability(spec, "goals", "inspect")?;
@@ -1757,11 +1576,9 @@ fn schedule_json(schedule: &resources_proto::Schedule) -> Value {
     })
 }
 
-async fn create_task(
-    cp: &ControlPlane,
+fn create_task(
     current_namespace: &str,
     current_agent: &str,
-    _current_session: &str,
     args: &Value,
 ) -> Result<resources_proto::Task> {
     let namespace = opt_str(args, "namespace")
@@ -1769,8 +1586,8 @@ async fn create_task(
         .to_string();
     let title = req_str(args, "title")?.to_string();
     let description = req_str(args, "description")?.to_string();
-    let assignee_name = req_str(args, "assignee_name")?.to_string();
-    let assignee_namespace = opt_str(args, "assignee_namespace")
+    let delegate_name = req_str(args, "delegate_name")?.to_string();
+    let delegate_namespace = opt_str(args, "delegate_namespace")
         .unwrap_or(current_namespace)
         .to_string();
     let task_type = opt_str(args, "type")
@@ -1781,28 +1598,28 @@ async fn create_task(
     let name = unique_task_name(&title);
     let labels = HashMap::from([
         (
-            "talon.impalasys.com/requester-name".to_string(),
+            delegation::LABEL_OWNER_NAME.to_string(),
             current_agent.to_string(),
         ),
         (
-            "talon.impalasys.com/assignee-name".to_string(),
-            assignee_name.clone(),
+            delegation::LABEL_DELEGATE_NAME.to_string(),
+            delegate_name.clone(),
         ),
     ]);
-    let task = resource_model::task_resource(
-        namespace.clone(),
+    let resource = resource_model::task_resource(
+        namespace,
         name,
         resources_proto::TaskSpec {
             title,
             description,
             r#type: task_type,
-            requester: Some(resources_proto::ResourceRef {
+            owner: Some(resources_proto::ResourceRef {
                 namespace: current_namespace.to_string(),
                 name: current_agent.to_string(),
             }),
-            assignee: Some(resources_proto::ResourceRef {
-                namespace: assignee_namespace.clone(),
-                name: assignee_name.clone(),
+            delegate: Some(resources_proto::ResourceRef {
+                namespace: delegate_namespace.clone(),
+                name: delegate_name.clone(),
             }),
         },
         resources_proto::TaskStatus {
@@ -1817,43 +1634,76 @@ async fn create_task(
             expires_at: 0,
             execution_ref: Some(resources_proto::TaskExecutionRef {
                 kind: "AGENT_SESSION".to_string(),
-                namespace: assignee_namespace,
-                name: assignee_name,
+                namespace: delegate_namespace,
+                name: delegate_name,
                 session_id: String::new(),
                 run_id: String::new(),
             }),
         },
         labels,
     );
-    let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
-    let resource = store.upsert(&namespace, task).await?;
     task_from_resource(resource).ok_or_else(|| anyhow!("invalid Task after create"))
 }
 
-fn update_task_resource(resource: &mut resources_proto::Resource, args: &Value) -> Result<()> {
+async fn delegate_task(
+    cp: &ControlPlane,
+    current_namespace: &str,
+    current_agent: &str,
+    current_session: &str,
+    args: &Value,
+    spec: &manifests::AgentSpec,
+) -> Result<resources_proto::Task> {
+    let namespace = opt_str(args, "namespace")
+        .unwrap_or(current_namespace)
+        .to_string();
+    let title = req_str(args, "title")?.to_string();
+    let description = req_str(args, "description")?.to_string();
+    if args.get("delegate_name").is_some() || args.get("delegate_namespace").is_some() {
+        return Err(anyhow!(
+            "delegate_task requires a declared A2A connection; delegate_name and delegate_namespace are not accepted"
+        ));
+    }
+    let connection_name = req_str(args, "connection")?;
+    let target = crate::harness::a2a::resolve_internal_connection(spec, connection_name)?;
+    let task_type = opt_str(args, "type")
+        .unwrap_or("agent_delegation")
+        .trim()
+        .to_string();
+    let name = unique_task_name(&title);
+    delegation::create_delegated_task(
+        cp,
+        delegation::TaskDelegationRequest {
+            namespace,
+            name,
+            title,
+            description,
+            task_type,
+            owner_namespace: current_namespace.to_string(),
+            owner_name: current_agent.to_string(),
+            owner_session_id: current_session.to_string(),
+            connection_name: target.connection_name,
+            delegate_namespace: target.target_namespace,
+            delegate_name: target.target_agent,
+        },
+    )
+    .await
+}
+
+fn task_resource_from_task(task: resources_proto::Task) -> resources_proto::Resource {
+    let namespace = task.namespace().to_string();
+    let name = task.name().to_string();
+    let labels = task.labels().clone();
+    resource_model::task_resource(
+        namespace,
+        name,
+        task.spec.unwrap_or_default(),
+        task.status.unwrap_or_default(),
+        labels,
+    )
+}
+
+fn update_task_status(status: &mut resources_proto::TaskStatus, args: &Value) -> Result<()> {
     let now = chrono::Utc::now().timestamp_micros();
-    let status = match resource
-        .status
-        .as_mut()
-        .and_then(|status| status.kind.as_mut())
-    {
-        Some(resources_proto::resource_status::Kind::Task(status)) => status,
-        _ => {
-            resource.status = Some(resources_proto::ResourceStatus {
-                kind: Some(resources_proto::resource_status::Kind::Task(
-                    Default::default(),
-                )),
-            });
-            match resource
-                .status
-                .as_mut()
-                .and_then(|status| status.kind.as_mut())
-            {
-                Some(resources_proto::resource_status::Kind::Task(status)) => status,
-                _ => return Err(anyhow!("failed to initialize Task status")),
-            }
-        }
-    };
     if let Some(namespace) = opt_str(args, "execution_namespace") {
         status
             .execution_ref
@@ -1911,8 +1761,8 @@ fn task_matches(
     task: &resources_proto::Task,
     status_group: Option<&str>,
     phase: Option<&str>,
-    requester_name: Option<&str>,
-    assignee_name: Option<&str>,
+    owner_name: Option<&str>,
+    delegate_name: Option<&str>,
 ) -> bool {
     let spec = task.spec.as_ref();
     let current_phase = task
@@ -1935,16 +1785,16 @@ fn task_matches(
             return false;
         }
     }
-    if requester_name.is_some_and(|name| {
-        spec.and_then(|spec| spec.requester.as_ref())
-            .map(|requester| requester.name.as_str())
+    if owner_name.is_some_and(|name| {
+        spec.and_then(|spec| spec.owner.as_ref())
+            .map(|owner| owner.name.as_str())
             != Some(name)
     }) {
         return false;
     }
-    if assignee_name.is_some_and(|name| {
-        spec.and_then(|spec| spec.assignee.as_ref())
-            .map(|assignee| assignee.name.as_str())
+    if delegate_name.is_some_and(|name| {
+        spec.and_then(|spec| spec.delegate.as_ref())
+            .map(|delegate| delegate.name.as_str())
             != Some(name)
     }) {
         return false;
@@ -1966,8 +1816,8 @@ fn task_updated_at(resource: &resources_proto::Resource) -> i64 {
 fn task_json(task: &resources_proto::Task) -> Value {
     let spec = task.spec.as_ref();
     let status = task.status.as_ref();
-    let requester = spec.and_then(|spec| spec.requester.as_ref());
-    let assignee = spec.and_then(|spec| spec.assignee.as_ref());
+    let owner = spec.and_then(|spec| spec.owner.as_ref());
+    let delegate = spec.and_then(|spec| spec.delegate.as_ref());
     let execution = status.and_then(|status| status.execution_ref.as_ref());
     json!({
         "name": task.name(),
@@ -1975,8 +1825,8 @@ fn task_json(task: &resources_proto::Task) -> Value {
         "title": spec.map(|spec| spec.title.clone()).unwrap_or_default(),
         "description": spec.map(|spec| spec.description.clone()).unwrap_or_default(),
         "type": spec.map(|spec| spec.r#type.clone()).unwrap_or_default(),
-        "requester": resource_ref_json(requester),
-        "assignee": resource_ref_json(assignee),
+        "owner": resource_ref_json(owner),
+        "delegate": resource_ref_json(delegate),
         "executionRef": execution.map(|execution| json!({
             "kind": execution.kind,
             "namespace": execution.namespace,
@@ -1995,11 +1845,25 @@ fn task_json(task: &resources_proto::Task) -> Value {
             }
         }).unwrap_or("UNKNOWN"),
         "progressSummary": status.map(|status| status.progress_summary.clone()).unwrap_or_default(),
+        "resultArtifacts": status.map(|status| {
+            status.result_artifacts.iter().map(file_object_ref_json).collect::<Vec<_>>()
+        }).unwrap_or_default(),
         "createdAt": status.map(|status| status.created_at).unwrap_or_default(),
         "updatedAt": status.map(|status| status.updated_at).unwrap_or_default(),
         "completedAt": status.map(|status| status.completed_at).unwrap_or_default(),
         "expiresAt": status.map(|status| status.expires_at).unwrap_or_default(),
         "labels": task.labels(),
+    })
+}
+
+fn file_object_ref_json(reference: &resources_proto::FileObjectRef) -> Value {
+    json!({
+        "key": reference.key,
+        "mediaType": reference.media_type,
+        "sizeBytes": reference.size_bytes,
+        "sha256": reference.sha256,
+        "filename": reference.filename,
+        "metadata": reference.metadata,
     })
 }
 
@@ -2015,6 +1879,11 @@ fn resource_ref_json(reference: Option<&resources_proto::ResourceRef>) -> Value 
 }
 
 fn unique_task_name(title: &str) -> String {
+    let slug = task_name_slug(title, 48);
+    format!("{slug}-{}", crate::control::uuid::unique_name("tsk"))
+}
+
+fn task_name_slug(title: &str, max_chars: usize) -> String {
     let mut slug = title
         .chars()
         .map(|ch| {
@@ -2030,12 +1899,8 @@ fn unique_task_name(title: &str) -> String {
     }
     let slug = slug.trim_matches('-');
     let slug = if slug.is_empty() { "task" } else { slug };
-    let trimmed = slug.chars().take(48).collect::<String>();
-    format!(
-        "{}-{}",
-        trimmed.trim_matches('-'),
-        crate::control::uuid::unique_name("tsk")
-    )
+    let trimmed = slug.chars().take(max_chars).collect::<String>();
+    trimmed.trim_matches('-').to_string()
 }
 
 fn parse_task_phase(value: &str) -> Result<i32> {
@@ -2933,6 +2798,51 @@ mod tests {
         }
     }
 
+    fn task_spec_with_internal_connection(
+        capabilities: &[&str],
+        connection: &str,
+        namespace: &str,
+        agent: &str,
+    ) -> manifests::AgentSpec {
+        let mut spec = task_spec(capabilities);
+        spec.a2a = Some(manifests::A2a {
+            connections: vec![manifests::Connection {
+                name: connection.to_string(),
+                target: Some(manifests::ConnectionRef {
+                    internal: Some(manifests::InternalConnectionRef {
+                        namespace: namespace.to_string(),
+                        agent: agent.to_string(),
+                    }),
+                    external: None,
+                }),
+                ..Default::default()
+            }],
+            agent_card: None,
+        });
+        spec
+    }
+
+    fn task_spec_with_external_connection(
+        capabilities: &[&str],
+        connection: &str,
+    ) -> manifests::AgentSpec {
+        let mut spec = task_spec(capabilities);
+        spec.a2a = Some(manifests::A2a {
+            connections: vec![manifests::Connection {
+                name: connection.to_string(),
+                target: Some(manifests::ConnectionRef {
+                    internal: None,
+                    external: Some(manifests::ExternalConnectionRef {
+                        agent_card_url: "https://example.com/agent-card.json".to_string(),
+                    }),
+                }),
+                ..Default::default()
+            }],
+            agent_card: None,
+        });
+        spec
+    }
+
     fn goal_spec(capabilities: &[&str]) -> manifests::AgentSpec {
         manifests::AgentSpec {
             capabilities: HashMap::from([(
@@ -2963,6 +2873,61 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    async fn seed_session(kv: &MockKvStore, ns: &str, agent: &str, session_id: &str) {
+        let now = chrono::Utc::now().timestamp_micros();
+        kv.set_msg(
+            &keys::session(ns, agent, session_id),
+            &data_proto::Session {
+                id: session_id.to_string(),
+                agent: agent.to_string(),
+                ns: ns.to_string(),
+                status: "IDLE".to_string(),
+                created_at: now,
+                last_active: now,
+                metadata: HashMap::new(),
+                labels: HashMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn set_session_status(
+        kv: &MockKvStore,
+        ns: &str,
+        agent: &str,
+        session_id: &str,
+        status: &str,
+    ) {
+        let key = keys::session(ns, agent, session_id);
+        let mut session = kv
+            .get_msg::<data_proto::Session>(&key)
+            .await
+            .unwrap()
+            .unwrap();
+        session.status = status.to_string();
+        kv.set_msg(&key, &session).await.unwrap();
+    }
+
+    async fn session_text_messages(
+        kv: &MockKvStore,
+        ns: &str,
+        agent: &str,
+        session_id: &str,
+    ) -> Vec<String> {
+        let entries = kv
+            .list_entries(&keys::session_message_prefix(ns, agent, session_id))
+            .await
+            .unwrap();
+        entries
+            .into_iter()
+            .filter_map(|(_, bytes)| data_proto::SessionMessage::decode(bytes.as_slice()).ok())
+            .flat_map(|message| message.parts.into_iter())
+            .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+            .map(|part| part.content)
+            .collect()
     }
 
     fn skill(ns: &str, name: &str, description: &str, instructions: &str) -> NamespaceSkill {
@@ -3002,6 +2967,54 @@ mod tests {
 
         assert!(registry.get_tool(FETCH_URL_TOOL).is_some());
         assert!(registry.get_tool(WEB_SEARCH_TOOL).is_none());
+    }
+
+    #[test]
+    fn delegate_task_schema_uses_internal_a2a_connection_enum() {
+        let mut registry = ToolRegistry::new();
+        register_tools(
+            &mut registry,
+            &task_spec_with_internal_connection(
+                &["create"],
+                "worker",
+                "Tenant:acme:Operations",
+                "support-agent",
+            ),
+        );
+
+        let tool = registry
+            .get_tool(DELEGATE_TASK_TOOL)
+            .expect("delegate_task should be registered");
+        assert_eq!(
+            tool.input_schema["properties"]["connection"]["enum"],
+            json!(["worker"])
+        );
+        assert!(tool.input_schema["properties"]
+            .as_object()
+            .unwrap()
+            .get("delegate_name")
+            .is_none());
+        assert!(tool.input_schema["properties"]
+            .as_object()
+            .unwrap()
+            .get("delegate_namespace")
+            .is_none());
+    }
+
+    #[test]
+    fn delegate_task_not_registered_without_internal_a2a_connection() {
+        let mut no_connection_registry = ToolRegistry::new();
+        register_tools(&mut no_connection_registry, &task_spec(&["create"]));
+        assert!(no_connection_registry
+            .get_tool(DELEGATE_TASK_TOOL)
+            .is_none());
+
+        let mut external_registry = ToolRegistry::new();
+        register_tools(
+            &mut external_registry,
+            &task_spec_with_external_connection(&["create"], "remote"),
+        );
+        assert!(external_registry.get_tool(DELEGATE_TASK_TOOL).is_none());
     }
 
     #[test]
@@ -3504,8 +3517,8 @@ mod tests {
                 "title": "Prepare customer onboarding checklist",
                 "description": "Create a reviewed onboarding checklist.",
                 "type": "OPERATIONS",
-                "assignee_namespace": "Tenant:acme:Operations",
-                "assignee_name": "support-agent"
+                "delegate_namespace": "Tenant:acme:Operations",
+                "delegate_name": "support-agent"
             }),
         )
         .await
@@ -3515,8 +3528,8 @@ mod tests {
         let name = created["task"]["name"].as_str().unwrap();
         assert_eq!(created["task"]["phase"], "QUEUED");
         assert_eq!(created["task"]["statusGroup"], "ACTIVE");
-        assert_eq!(created["task"]["requester"]["name"], "ops-lead");
-        assert_eq!(created["task"]["assignee"]["name"], "support-agent");
+        assert_eq!(created["task"]["owner"]["name"], "ops-lead");
+        assert_eq!(created["task"]["delegate"]["name"], "support-agent");
 
         let updated = execute_tool_for_session(
             &cp,
@@ -3554,7 +3567,7 @@ mod tests {
             LIST_TASKS_TOOL,
             &json!({
                 "status_group": "active",
-                "requester_name": "ops-lead"
+                "owner_name": "ops-lead"
             }),
         )
         .await
@@ -3563,6 +3576,446 @@ mod tests {
         let listed: Value = serde_json::from_str(&listed).unwrap();
         assert_eq!(listed["tasks"].as_array().unwrap().len(), 1);
         assert_eq!(listed["tasks"][0]["name"], name);
+    }
+
+    #[tokio::test]
+    async fn task_tools_reject_cross_namespace_overrides() {
+        let kv = Arc::new(MockKvStore::default());
+        let scheduler = Arc::new(MockScheduler::default());
+        let cp = control_plane(kv, scheduler);
+        let spec = task_spec_with_internal_connection(
+            &["inspect", "create"],
+            "support",
+            "Tenant:acme:Operations",
+            "support-agent",
+        );
+
+        let create_err = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            &spec,
+            CREATE_TASK_TOOL,
+            &json!({
+                "namespace": "Tenant:other:Workspace:main",
+                "title": "Prepare checklist",
+                "description": "Create a reviewed checklist."
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(create_err.to_string().contains("cannot target namespace"));
+
+        let delegate_err = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            &spec,
+            DELEGATE_TASK_TOOL,
+            &json!({
+                "namespace": "Tenant:other:Workspace:main",
+                "title": "Prepare checklist",
+                "description": "Create a reviewed checklist.",
+                "connection": "support"
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(delegate_err.to_string().contains("cannot target namespace"));
+    }
+
+    #[tokio::test]
+    async fn delegate_task_starts_delegate_session() {
+        let kv = Arc::new(MockKvStore::default());
+        let scheduler = Arc::new(MockScheduler::default());
+        seed_agent(kv.as_ref(), "Tenant:acme:Operations", "support-agent").await;
+        let cp = control_plane(kv.clone(), scheduler);
+        let spec = task_spec_with_internal_connection(
+            &["inspect", "create"],
+            "support",
+            "Tenant:acme:Operations",
+            "support-agent",
+        );
+
+        let created = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            &spec,
+            DELEGATE_TASK_TOOL,
+            &json!({
+                "title": "Prepare customer onboarding checklist",
+                "description": "Create a reviewed onboarding checklist.",
+                "type": "OPERATIONS",
+                "connection": "support"
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let created: Value = serde_json::from_str(&created).unwrap();
+        let task = &created["task"];
+        let task_name = task["name"].as_str().unwrap();
+        let child_session_id = task["executionRef"]["sessionId"].as_str().unwrap();
+        assert_eq!(task["phase"], "RUNNING");
+        assert_eq!(task["executionRef"]["namespace"], "Tenant:acme:Operations");
+        assert_eq!(task["executionRef"]["name"], "support-agent");
+        assert!(!child_session_id.is_empty());
+        assert!(!task["executionRef"]["runId"].as_str().unwrap().is_empty());
+
+        let child_session = kv
+            .get_msg::<data_proto::Session>(&keys::session(
+                "Tenant:acme:Operations",
+                "support-agent",
+                child_session_id,
+            ))
+            .await
+            .unwrap()
+            .expect("child session should exist");
+        assert_eq!(
+            child_session.labels.get(delegation::LABEL_TASK_NAME),
+            Some(&task_name.to_string())
+        );
+        assert_eq!(
+            child_session.labels.get(delegation::LABEL_OWNER_NAMESPACE),
+            Some(&"Tenant:acme:Workspace:main".to_string())
+        );
+        assert_eq!(
+            child_session.labels.get(delegation::LABEL_OWNER_SESSION_ID),
+            Some(&"session-1".to_string())
+        );
+        assert_eq!(
+            child_session.labels.get(delegation::LABEL_A2A_CONNECTION),
+            Some(&"support".to_string())
+        );
+
+        let store = ResourceStore::new(kv.clone(), Arc::new(EmptyPubSub));
+        let task_resource = store
+            .get("Tenant:acme:Workspace:main", "Task", task_name)
+            .await
+            .unwrap()
+            .expect("delegated task resource should exist");
+        assert_eq!(
+            task_resource
+                .metadata
+                .as_ref()
+                .unwrap()
+                .labels
+                .get(delegation::LABEL_A2A_CONNECTION),
+            Some(&"support".to_string())
+        );
+        assert_eq!(
+            task_resource.metadata.as_ref().unwrap().generation,
+            1,
+            "delegated status updates must not bump resource generation"
+        );
+
+        let entries = kv
+            .list_entries(&keys::session_message_prefix(
+                "Tenant:acme:Operations",
+                "support-agent",
+                child_session_id,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        let message = data_proto::SessionMessage::decode(entries[0].1.as_slice()).unwrap();
+        assert_eq!(
+            message.labels.get(delegation::LABEL_TASK_NAME),
+            Some(&task_name.to_string())
+        );
+        assert_eq!(
+            message.labels.get(delegation::LABEL_A2A_CONNECTION),
+            Some(&"support".to_string())
+        );
+        assert!(message
+            .parts
+            .first()
+            .unwrap()
+            .content
+            .contains("Create a reviewed onboarding checklist."));
+
+        let listed = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            &spec,
+            LIST_TASKS_TOOL,
+            &json!({
+                "status_group": "active",
+                "owner_name": "ops-lead"
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let listed: Value = serde_json::from_str(&listed).unwrap();
+        assert_eq!(listed["tasks"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn delegate_task_completion_ignores_stale_child_sessions() {
+        let kv = Arc::new(MockKvStore::default());
+        let scheduler = Arc::new(MockScheduler::default());
+        seed_agent(kv.as_ref(), "Tenant:acme:Operations", "support-agent").await;
+        seed_session(
+            kv.as_ref(),
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+        )
+        .await;
+        let cp = control_plane(kv.clone(), scheduler);
+        let spec = task_spec_with_internal_connection(
+            &["create"],
+            "support",
+            "Tenant:acme:Operations",
+            "support-agent",
+        );
+
+        let created = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            &spec,
+            DELEGATE_TASK_TOOL,
+            &json!({
+                "title": "Prepare checklist",
+                "description": "Create a reviewed checklist.",
+                "connection": "support"
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let created: Value = serde_json::from_str(&created).unwrap();
+        let task_name = created["task"]["name"].as_str().unwrap();
+        let child_session_id = created["task"]["executionRef"]["sessionId"]
+            .as_str()
+            .unwrap();
+        let mut stale_session = kv
+            .get_msg::<data_proto::Session>(&keys::session(
+                "Tenant:acme:Operations",
+                "support-agent",
+                child_session_id,
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        stale_session.id = "stale-session".to_string();
+
+        delegation::complete_delegated_task_from_session(
+            &cp,
+            &stale_session,
+            delegation::DelegatedSessionCompletion::Completed,
+        )
+        .await
+        .unwrap();
+
+        let store = ResourceStore::new(kv.clone(), Arc::new(EmptyPubSub));
+        let task_resource = store
+            .get("Tenant:acme:Workspace:main", "Task", task_name)
+            .await
+            .unwrap()
+            .unwrap();
+        let phase = match task_resource.status.unwrap().kind.unwrap() {
+            resources_proto::resource_status::Kind::Task(status) => status.phase,
+            _ => panic!("expected Task status"),
+        };
+        assert_eq!(phase, resources_proto::TaskPhase::Running as i32);
+        assert!(session_text_messages(
+            kv.as_ref(),
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+        )
+        .await
+        .is_empty());
+    }
+
+    #[tokio::test]
+    async fn delegate_task_failure_wakes_owner_session() {
+        let kv = Arc::new(MockKvStore::default());
+        let scheduler = Arc::new(MockScheduler::default());
+        seed_agent(kv.as_ref(), "Tenant:acme:Operations", "support-agent").await;
+        seed_session(
+            kv.as_ref(),
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+        )
+        .await;
+        let cp = control_plane(kv.clone(), scheduler);
+        let spec = task_spec_with_internal_connection(
+            &["create"],
+            "support",
+            "Tenant:acme:Operations",
+            "support-agent",
+        );
+
+        let created = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            &spec,
+            DELEGATE_TASK_TOOL,
+            &json!({
+                "title": "Prepare checklist",
+                "description": "Create a reviewed checklist.",
+                "connection": "support"
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let created: Value = serde_json::from_str(&created).unwrap();
+        let task_name = created["task"]["name"].as_str().unwrap();
+        let child_session_id = created["task"]["executionRef"]["sessionId"]
+            .as_str()
+            .unwrap();
+        let child_session = kv
+            .get_msg::<data_proto::Session>(&keys::session(
+                "Tenant:acme:Operations",
+                "support-agent",
+                child_session_id,
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+
+        set_session_status(
+            kv.as_ref(),
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            "PROCESSING",
+        )
+        .await;
+        let task = delegation::complete_delegated_task_from_session(
+            &cp,
+            &child_session,
+            delegation::DelegatedSessionCompletion::Failed,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            task.status.as_ref().unwrap().phase,
+            resources_proto::TaskPhase::Failed as i32
+        );
+        assert_eq!(task.name(), task_name);
+        assert!(session_text_messages(
+            kv.as_ref(),
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+        )
+        .await
+        .is_empty());
+
+        set_session_status(
+            kv.as_ref(),
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            "IDLE",
+        )
+        .await;
+        let owner_session = kv
+            .get_msg::<data_proto::Session>(&keys::session(
+                "Tenant:acme:Workspace:main",
+                "ops-lead",
+                "session-1",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        delegation::retry_owner_wakes_for_session(&cp, &owner_session)
+            .await
+            .unwrap();
+
+        let owner_messages = session_text_messages(
+            kv.as_ref(),
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+        )
+        .await;
+        assert!(owner_messages
+            .iter()
+            .any(|message| message.contains("Delegated Task failed.")));
+    }
+
+    #[tokio::test]
+    async fn delegate_task_rejects_unknown_external_and_raw_delegate_targets() {
+        let kv = Arc::new(MockKvStore::default());
+        let scheduler = Arc::new(MockScheduler::default());
+        let cp = control_plane(kv, scheduler);
+        let spec = task_spec_with_internal_connection(
+            &["create"],
+            "support",
+            "Tenant:acme:Operations",
+            "support-agent",
+        );
+
+        let unknown = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            &spec,
+            DELEGATE_TASK_TOOL,
+            &json!({
+                "connection": "missing",
+                "title": "Prepare checklist",
+                "description": "Create a reviewed checklist."
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(unknown.to_string().contains("valid connections: support"));
+
+        let raw = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            &spec,
+            DELEGATE_TASK_TOOL,
+            &json!({
+                "connection": "support",
+                "title": "Prepare checklist",
+                "description": "Create a reviewed checklist.",
+                "delegate_name": "support-agent"
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(raw.to_string().contains("delegate_name"));
+
+        let external_spec = task_spec_with_external_connection(&["create"], "remote");
+        let external = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "ops-lead",
+            "session-1",
+            &external_spec,
+            DELEGATE_TASK_TOOL,
+            &json!({
+                "connection": "remote",
+                "title": "Prepare checklist",
+                "description": "Create a reviewed checklist."
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(external.to_string().contains("external A2A connection"));
     }
 
     #[tokio::test]

--- a/src/harness/tools/artifacts.rs
+++ b/src/harness/tools/artifacts.rs
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use anyhow::Result;
+use serde_json::{json, Value};
+
+use crate::control::ControlPlane;
+use crate::harness::skills::registry::ToolRegistry;
+
+pub(super) fn register(registry: &mut ToolRegistry) {
+    registry.register_builtin(
+        super::CREATE_ARTIFACT_TOOL,
+        "Create a session-scoped artifact and return an artifact:// URI that can be read or granted to another agent.",
+        json!({
+            "type": "object",
+            "properties": {
+                "title": { "type": "string", "description": "Human-readable artifact title." },
+                "media_type": { "type": "string", "description": "Media type. Defaults to text/markdown." },
+                "content": { "type": "string", "description": "Text content to store." },
+                "content_base64": { "type": "string", "description": "Base64 bytes to store instead of content." },
+                "labels": { "type": "object", "additionalProperties": { "type": "string" } },
+                "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
+            },
+            "required": ["title"]
+        }),
+    );
+    registry.register_builtin(
+        super::READ_ARTIFACT_TOOL,
+        "Read an artifact by artifact:// URI.",
+        json!({
+            "type": "object",
+            "properties": {
+                "artifact_uri": { "type": "string" }
+            },
+            "required": ["artifact_uri"]
+        }),
+    );
+    registry.register_builtin(
+        super::GET_ARTIFACT_METADATA_TOOL,
+        "Return artifact metadata for an artifact:// URI without reading bytes.",
+        json!({
+            "type": "object",
+            "properties": {
+                "artifact_uri": { "type": "string" }
+            },
+            "required": ["artifact_uri"]
+        }),
+    );
+    registry.register_builtin(
+        super::GRANT_ARTIFACT_TOOL,
+        "Grant another agent or session access to an artifact:// URI.",
+        json!({
+            "type": "object",
+            "properties": {
+                "artifact_uri": { "type": "string" },
+                "target_agent": { "type": "string" },
+                "target_session_id": { "type": "string" },
+                "operations": {
+                    "type": "array",
+                    "items": { "type": "string", "enum": ["read", "metadata", "promote"] }
+                },
+                "ttl_seconds": { "type": "integer" }
+            },
+            "required": ["artifact_uri"]
+        }),
+    );
+}
+
+pub(super) async fn execute(
+    cp: &ControlPlane,
+    current_namespace: &str,
+    current_agent: &str,
+    current_session: &str,
+    name: &str,
+    args: &Value,
+) -> Result<Option<String>> {
+    match name {
+        super::CREATE_ARTIFACT_TOOL => {
+            super::create_artifact(cp, current_namespace, current_agent, current_session, args)
+                .await
+                .map(Some)
+        }
+        super::READ_ARTIFACT_TOOL => {
+            super::read_artifact(cp, current_namespace, current_agent, current_session, args)
+                .await
+                .map(Some)
+        }
+        super::GET_ARTIFACT_METADATA_TOOL => super::get_artifact_metadata(
+            cp,
+            current_namespace,
+            current_agent,
+            current_session,
+            args,
+        )
+        .await
+        .map(Some),
+        super::GRANT_ARTIFACT_TOOL => {
+            super::grant_artifact(cp, current_namespace, current_agent, current_session, args)
+                .await
+                .map(Some)
+        }
+        _ => Ok(None),
+    }
+}

--- a/src/harness/tools/tasks.rs
+++ b/src/harness/tools/tasks.rs
@@ -1,0 +1,228 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+
+use crate::control::resource_model::TypedResource;
+use crate::control::resources::ResourceStore;
+use crate::control::ControlPlane;
+use crate::gateway::rpc::{manifests, resources_proto};
+use crate::harness::skills::registry::ToolRegistry;
+
+fn task_namespace<'a>(args: &'a Value, current_namespace: &'a str) -> Result<&'a str> {
+    let namespace = super::opt_str(args, "namespace").unwrap_or(current_namespace);
+    if namespace != current_namespace {
+        return Err(anyhow!(
+            "task tools cannot target namespace '{}' from agent namespace '{}'",
+            namespace,
+            current_namespace
+        ));
+    }
+    Ok(namespace)
+}
+
+pub(super) fn register(registry: &mut ToolRegistry, spec: &manifests::AgentSpec) {
+    if super::has_capability_action(spec, "tasks", "inspect") {
+        registry.register_builtin(
+            super::LIST_TASKS_TOOL,
+            "List durable Talon Tasks in a namespace. Use this to rediscover delegated work across sessions.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "namespace": { "type": "string", "description": "Namespace to inspect. Defaults to the current agent namespace if omitted." },
+                    "status_group": { "type": "string", "description": "Optional group: active or terminal." },
+                    "phase": { "type": "string", "description": "Optional phase filter such as RUNNING, NEEDS_REVIEW, SUCCEEDED, FAILED, or CANCELED." },
+                    "owner_name": { "type": "string", "description": "Optional owner agent resource name filter." },
+                    "delegate_name": { "type": "string", "description": "Optional delegate agent resource name filter." },
+                    "limit": { "type": "integer", "description": "Optional maximum number of results to return." }
+                }
+            }),
+        );
+        registry.register_builtin(
+            super::GET_TASK_TOOL,
+            "Get one durable Talon Task by name.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "namespace": { "type": "string", "description": "Namespace containing the task. Defaults to the current agent namespace if omitted." },
+                    "name": { "type": "string", "description": "Task resource name." }
+                },
+                "required": ["name"]
+            }),
+        );
+    }
+
+    if super::has_capability_action(spec, "tasks", "create") {
+        registry.register_builtin(
+            super::CREATE_TASK_TOOL,
+            "Create a durable caller-owned Task record without starting delegate execution.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "namespace": { "type": "string", "description": "Namespace that owns the task. Defaults to the current agent namespace if omitted." },
+                    "title": { "type": "string", "description": "Short human-readable task title." },
+                    "description": { "type": "string", "description": "Brief or acceptance criteria for the task." },
+                    "type": { "type": "string", "description": "Optional caller-defined classifier such as agent_delegation or human_review. Talon does not interpret it." },
+                    "delegate_namespace": { "type": "string", "description": "Namespace of the worker agent." },
+                    "delegate_name": { "type": "string", "description": "Worker agent resource name." }
+                },
+                "required": ["title", "description", "delegate_name"]
+            }),
+        );
+    }
+
+    let internal_connections = crate::harness::a2a::internal_connection_names(spec);
+    if super::has_capability_action(spec, "tasks", "create") && !internal_connections.is_empty() {
+        registry.register_builtin(
+            super::DELEGATE_TASK_TOOL,
+            "Create a durable Task and start a declared A2A internal connection in a linked child session.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "namespace": { "type": "string", "description": "Namespace that owns the task. Defaults to the current agent namespace if omitted." },
+                    "connection": {
+                        "type": "string",
+                        "description": "Declared A2A connection name to delegate through.",
+                        "enum": internal_connections
+                    },
+                    "title": { "type": "string", "description": "Short human-readable task title." },
+                    "description": { "type": "string", "description": "Full task brief, success criteria, and context for the delegate." },
+                    "type": { "type": "string", "description": "Optional caller-defined classifier. Defaults to agent_delegation." }
+                },
+                "required": ["connection", "title", "description"]
+            }),
+        );
+    }
+
+    if super::has_capability_action(spec, "tasks", "update") {
+        registry.register_builtin(
+            super::UPDATE_TASK_TOOL,
+            "Update Task status after delegation progress, review, completion, or failure.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "namespace": { "type": "string", "description": "Namespace containing the task. Defaults to the current agent namespace if omitted." },
+                    "name": { "type": "string", "description": "Task resource name." },
+                    "phase": { "type": "string", "description": "Optional phase: QUEUED, RUNNING, BLOCKED, NEEDS_REVIEW, SUCCEEDED, FAILED, CANCELED, or EXPIRED." },
+                    "progress_summary": { "type": "string", "description": "Short current state or result summary." },
+                    "execution_namespace": { "type": "string", "description": "Optional execution namespace." },
+                    "execution_name": { "type": "string", "description": "Optional execution agent resource name." },
+                    "execution_session_id": { "type": "string", "description": "Optional child session id." },
+                    "run_id": { "type": "string", "description": "Optional workflow or run id." }
+                },
+                "required": ["name"]
+            }),
+        );
+    }
+}
+
+pub(super) async fn execute(
+    cp: &ControlPlane,
+    current_namespace: &str,
+    current_agent: &str,
+    current_session: &str,
+    spec: &manifests::AgentSpec,
+    name: &str,
+    args: &Value,
+) -> Result<Option<String>> {
+    match name {
+        super::LIST_TASKS_TOOL => {
+            super::require_capability(spec, "tasks", "inspect")?;
+            let namespace = task_namespace(args, current_namespace)?;
+            let status_group = super::opt_str(args, "status_group");
+            let phase = super::opt_str(args, "phase");
+            let owner_name = super::opt_str(args, "owner_name");
+            let delegate_name = super::opt_str(args, "delegate_name");
+            let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(100) as usize;
+            let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+            let mut resources = store.list(namespace, Some("Task")).await?;
+            resources.sort_by(|a, b| super::task_updated_at(b).cmp(&super::task_updated_at(a)));
+            let mut tasks = Vec::new();
+            for resource in resources {
+                let Some(task) = super::task_from_resource(resource) else {
+                    continue;
+                };
+                if !super::task_matches(&task, status_group, phase, owner_name, delegate_name) {
+                    continue;
+                }
+                tasks.push(super::task_json(&task));
+                if tasks.len() >= limit {
+                    break;
+                }
+            }
+            Ok(Some(serde_json::to_string_pretty(
+                &json!({ "tasks": tasks }),
+            )?))
+        }
+        super::GET_TASK_TOOL => {
+            super::require_capability(spec, "tasks", "inspect")?;
+            let namespace = task_namespace(args, current_namespace)?;
+            let name = super::req_str(args, "name")?;
+            let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+            let resource = store
+                .get(namespace, "Task", name)
+                .await?
+                .ok_or_else(|| anyhow!("task '{}' not found", name))?;
+            let task =
+                super::task_from_resource(resource).ok_or_else(|| anyhow!("invalid Task"))?;
+            Ok(Some(serde_json::to_string_pretty(&json!({
+                "task": super::task_json(&task)
+            }))?))
+        }
+        super::CREATE_TASK_TOOL => {
+            super::require_capability(spec, "tasks", "create")?;
+            task_namespace(args, current_namespace)?;
+            let task = super::create_task(current_namespace, current_agent, args)?;
+            let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+            let namespace = task.namespace().to_string();
+            let resource = store
+                .upsert(&namespace, super::task_resource_from_task(task))
+                .await?;
+            let task =
+                super::task_from_resource(resource).ok_or_else(|| anyhow!("invalid Task"))?;
+            Ok(Some(serde_json::to_string_pretty(&json!({
+                "task": super::task_json(&task)
+            }))?))
+        }
+        super::DELEGATE_TASK_TOOL => {
+            super::require_capability(spec, "tasks", "create")?;
+            task_namespace(args, current_namespace)?;
+            let task = super::delegate_task(
+                cp,
+                current_namespace,
+                current_agent,
+                current_session,
+                args,
+                spec,
+            )
+            .await?;
+            Ok(Some(serde_json::to_string_pretty(&json!({
+                "task": super::task_json(&task)
+            }))?))
+        }
+        super::UPDATE_TASK_TOOL => {
+            super::require_capability(spec, "tasks", "update")?;
+            let namespace = task_namespace(args, current_namespace)?;
+            let name = super::req_str(args, "name")?;
+            let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+            let resource = store
+                .patch_status_with(namespace, "Task", name, None, |_, status| {
+                    let mut task_status = match status.kind.take() {
+                        Some(resources_proto::resource_status::Kind::Task(status)) => status,
+                        _ => resources_proto::TaskStatus::default(),
+                    };
+                    super::update_task_status(&mut task_status, args)?;
+                    status.kind = Some(resources_proto::resource_status::Kind::Task(task_status));
+                    Ok(())
+                })
+                .await?;
+            let task =
+                super::task_from_resource(resource).ok_or_else(|| anyhow!("invalid Task"))?;
+            Ok(Some(serde_json::to_string_pretty(&json!({
+                "task": super::task_json(&task)
+            }))?))
+        }
+        _ => Ok(None),
+    }
+}

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -311,6 +311,7 @@ fn builtin_tool_names() -> &'static [&'static str] {
         crate::harness::native_tools::UPDATE_SCHEDULE_TOOL,
         crate::harness::native_tools::DELETE_SCHEDULE_TOOL,
         crate::harness::native_tools::CREATE_GOAL_TOOL,
+        crate::harness::native_tools::DELEGATE_TASK_TOOL,
         crate::harness::native_tools::GET_GOAL_TOOL,
         crate::harness::native_tools::LIST_GOALS_TOOL,
         crate::harness::native_tools::UPDATE_GOAL_TOOL,
@@ -707,6 +708,7 @@ mod tests {
         assert!(names.contains(&crate::harness::native_tools::CREATE_GOAL_TOOL));
         assert!(names.contains(&crate::harness::native_tools::LIST_GOALS_TOOL));
         assert!(names.contains(&crate::harness::native_tools::CREATE_ARTIFACT_TOOL));
+        assert!(names.contains(&crate::harness::native_tools::DELEGATE_TASK_TOOL));
         assert!(names.contains(&crate::harness::native_tools::READ_SESSION_MESSAGES_TOOL));
         assert!(names.contains(&crate::harness::native_tools::SEARCH_MEMORY_TOOL));
         assert!(names.contains(&crate::harness::native_tools::READ_MEMORY_TOOL));

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -1057,6 +1057,42 @@ impl WorkerEventHandler {
                 "failed to dispatch workflow from completed child session"
             );
         }
+        let delegated_completion = match completion_status {
+            SessionCompletionStatus::Completed => {
+                crate::control::delegation::DelegatedSessionCompletion::Completed
+            }
+            SessionCompletionStatus::Errored | SessionCompletionStatus::Panicked => {
+                crate::control::delegation::DelegatedSessionCompletion::Failed
+            }
+        };
+        if let Err(err) = crate::control::delegation::complete_delegated_task_from_session(
+            &self.cp,
+            &session,
+            delegated_completion,
+        )
+        .await
+        {
+            tracing::warn!(
+                namespace = %ns,
+                agent = %agent_id,
+                session = %session_id,
+                error = %err,
+                "failed to update delegated Task from completed child session"
+            );
+        }
+        // Stopgap for the missing durable session inbox: a busy owner may
+        // have rejected a delegation wake, so retry pending wakes on release.
+        if let Err(err) =
+            crate::control::delegation::retry_owner_wakes_for_session(&self.cp, &session).await
+        {
+            tracing::warn!(
+                namespace = %ns,
+                agent = %agent_id,
+                session = %session_id,
+                error = %err,
+                "failed to retry delegated Task owner wakeups after session release"
+            );
+        }
     }
 }
 

--- a/tests/fixtures/mock_llm_scenarios/legal_document_refinement.json
+++ b/tests/fixtures/mock_llm_scenarios/legal_document_refinement.json
@@ -1,0 +1,82 @@
+{
+  "rules": [
+    {
+      "id": "legal_coordinator_delegates_refinement",
+      "system_contains": "legal coordinator",
+      "last_message_contains": "delegate legal document refinement task",
+      "tool_name": "delegate_task",
+      "response": {
+        "type": "tool_call",
+        "tool_call_id": "call_delegate_legal_refinement_1",
+        "tool_name": "delegate_task",
+        "content": "Let me assign the legal review. ",
+        "arguments": {
+          "title": "Refine mutual NDA fallback clause",
+          "description": "Review the mutual NDA fallback clause, tighten the obligation language, and return a markdown redline artifact with a short rationale.",
+          "type": "legal_document_refinement",
+          "connection": "legal-reviewer"
+        }
+      }
+    },
+    {
+      "id": "legal_reviewer_creates_redline_artifact",
+      "system_contains": "legal reviewer",
+      "last_message_contains": "you have been assigned a talon task",
+      "tool_name": "create_artifact",
+      "response": {
+        "type": "tool_call",
+        "tool_call_id": "call_create_legal_redline_artifact_1",
+        "tool_name": "create_artifact",
+        "content": "I will prepare the redline artifact. ",
+        "arguments": {
+          "title": "Mutual NDA fallback clause redline",
+          "content": "## Mutual NDA fallback clause redline\n\nOriginal: The Receiving Party will try to protect Confidential Information using reasonable efforts.\n\nRevised: The Receiving Party must protect Confidential Information using at least the same degree of care it uses for its own similar confidential information, and never less than reasonable care.\n\nRationale: The revision replaces aspirational language with a concrete obligation and adds a fallback standard if internal practices are weak.",
+          "media_type": "text/markdown",
+          "metadata": {
+            "source": "legal-reviewer",
+            "content_type": "legal_redline"
+          }
+        }
+      }
+    },
+    {
+      "id": "coordinator_reads_granted_redline",
+      "system_contains": "legal coordinator",
+      "last_message_contains": "read this delegated artifact",
+      "tool_name": "read_artifact",
+      "response": {
+        "type": "tool_call",
+        "tool_call_id": "call_read_legal_redline_artifact_1",
+        "tool_name": "read_artifact",
+        "content": "I will inspect the delegated redline. ",
+        "arguments": {
+          "artifact_uri": "{{artifact_uri}}"
+        }
+      }
+    },
+    {
+      "id": "legal_delegate_followup",
+      "tool_call_id": "call_delegate_legal_refinement_1",
+      "response": {
+        "type": "text",
+        "content": "I delegated the legal document refinement task."
+      }
+    },
+    {
+      "id": "legal_artifact_followup",
+      "tool_call_id": "call_create_legal_redline_artifact_1",
+      "response": {
+        "type": "text",
+        "content": "I created the legal redline artifact."
+      }
+    },
+    {
+      "id": "legal_read_followup",
+      "tool_call_id": "call_read_legal_redline_artifact_1",
+      "response": {
+        "type": "text",
+        "content": "I read the delegated legal redline artifact."
+      }
+    }
+  ]
+}

--- a/tests/mock_llm.py
+++ b/tests/mock_llm.py
@@ -4,12 +4,22 @@ import uuid
 import time
 import json
 import asyncio
+from pathlib import Path
+import re
 
 app = FastAPI()
 
 TOOL_TRIGGER = "lookup docs.example.com"
 TOOL_CALL_ID = "call_knowledge_search_1"
 TOOL_NAME = "knowledge_search"
+DELEGATE_TASK_TRIGGER = "delegate onboarding task"
+DELEGATE_TASK_CALL_ID = "call_delegate_task_1"
+DELEGATE_TASK_NAME = "delegate_task"
+CREATE_ARTIFACT_CALL_ID = "call_create_artifact_1"
+CREATE_ARTIFACT_NAME = "create_artifact"
+READ_ARTIFACT_CALL_ID = "call_read_artifact_1"
+READ_ARTIFACT_NAME = "read_artifact"
+SCENARIO_DIR = Path(__file__).resolve().parent / "fixtures" / "mock_llm_scenarios"
 BLOCKING_TOOL_TRIGGER = "blocking lookup docs.example.com"
 BLOCKING_TOOL_CALL_ID = "call_blocking_lookup_1"
 BLOCKING_TOOL_NAME = "mcp_durable_slow_blocking_lookup"
@@ -48,6 +58,21 @@ CONTROL_STATE = {
 }
 
 
+def load_mock_scenarios():
+    scenarios = []
+    if not SCENARIO_DIR.exists():
+        return scenarios
+    for path in sorted(SCENARIO_DIR.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for rule in data.get("rules", []):
+            rule["_source"] = path.name
+            scenarios.append(rule)
+    return scenarios
+
+
+MOCK_SCENARIO_RULES = load_mock_scenarios()
+
+
 def reset_control_state():
     CONTROL_STATE.update(
         {
@@ -75,8 +100,126 @@ def last_message_text(messages):
     return content if isinstance(content, str) else ""
 
 
+def system_message_text(messages):
+    return "\n".join(
+        message.get("content", "")
+        for message in messages
+        if message.get("role") == "system" and isinstance(message.get("content"), str)
+    )
+
+
+def available_tool_names(tools):
+    return {
+        tool.get("function", {}).get("name")
+        for tool in tools
+        if isinstance(tool, dict)
+    }
+
+
 def should_emit_tool_call(messages, tools):
     return bool(tools) and TOOL_TRIGGER in last_message_text(messages).lower()
+
+
+def collect_scenario_vars(rule, messages):
+    text = last_message_text(messages)
+    values = {"artifact_uri": artifact_uri_from_text(text)}
+    for capture in rule.get("captures", []):
+        match = re.search(capture["pattern"], text, re.IGNORECASE)
+        if match:
+            values[capture["name"]] = match.group(1)
+    return values
+
+
+def render_scenario_value(value, variables):
+    if isinstance(value, str):
+        rendered = value
+        for key, replacement in variables.items():
+            rendered = rendered.replace(f"{{{{{key}}}}}", replacement)
+        return rendered
+    if isinstance(value, list):
+        return [render_scenario_value(item, variables) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: render_scenario_value(item, variables)
+            for key, item in value.items()
+        }
+    return value
+
+
+def scenario_response_for(messages, tools):
+    system_text = system_message_text(messages).lower()
+    last_text = last_message_text(messages).lower()
+    tool_names = available_tool_names(tools)
+    last = last_message(messages)
+    for rule in MOCK_SCENARIO_RULES:
+        expected_tool_call_id = rule.get("tool_call_id")
+        if expected_tool_call_id:
+            if last.get("role") != "tool" or last.get("tool_call_id") != expected_tool_call_id:
+                continue
+        elif last.get("role") == "tool":
+            continue
+
+        system_contains = rule.get("system_contains")
+        if system_contains and system_contains.lower() not in system_text:
+            continue
+        last_contains = rule.get("last_message_contains")
+        if last_contains and last_contains.lower() not in last_text:
+            continue
+        tool_name = rule.get("tool_name")
+        if tool_name and tool_name not in tool_names:
+            continue
+
+        response = dict(rule["response"])
+        variables = collect_scenario_vars(rule, messages)
+        response["arguments"] = render_scenario_value(
+            response.get("arguments", {}),
+            variables,
+        )
+        return response
+    return None
+
+
+def should_emit_delegate_task_call(messages, tools):
+    tool_names = {
+        tool.get("function", {}).get("name")
+        for tool in tools
+        if isinstance(tool, dict)
+    }
+    return (
+        DELEGATE_TASK_NAME in tool_names
+        and DELEGATE_TASK_TRIGGER in last_message_text(messages).lower()
+    )
+
+
+def should_emit_delegated_artifact_call(messages, tools):
+    tool_names = {
+        tool.get("function", {}).get("name")
+        for tool in tools
+        if isinstance(tool, dict)
+    }
+    return (
+        CREATE_ARTIFACT_NAME in tool_names
+        and "you have been assigned a talon task" in last_message_text(messages).lower()
+    )
+
+
+def artifact_uri_from_text(text):
+    match = re.search(r"artifact://[^\s'\")]+", text)
+    return match.group(0).strip(".,;)") if match else ""
+
+
+def should_emit_read_artifact_call(messages, tools):
+    tool_names = {
+        tool.get("function", {}).get("name")
+        for tool in tools
+        if isinstance(tool, dict)
+    }
+    text = last_message_text(messages).lower()
+    return (
+        READ_ARTIFACT_NAME in tool_names
+        and ("read this" in text or "read artifact" in text)
+        and artifact_uri_from_text(text)
+    )
 
 
 def should_emit_blocking_tool_call(messages, tools):
@@ -96,10 +239,20 @@ def is_tool_followup(messages):
     return message.get("role") == "tool" and message.get("tool_call_id") in {
         TOOL_CALL_ID,
         BLOCKING_TOOL_CALL_ID,
+        DELEGATE_TASK_CALL_ID,
+        CREATE_ARTIFACT_CALL_ID,
+        READ_ARTIFACT_CALL_ID,
     }
 
 
-def tool_call_response_payload(model, *, tool_call_id, tool_name, arguments):
+def tool_call_response_payload(
+    model,
+    *,
+    tool_call_id,
+    tool_name,
+    arguments,
+    content=TOOL_PREFACE,
+):
     return {
         "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
         "object": "chat.completion",
@@ -110,7 +263,7 @@ def tool_call_response_payload(model, *, tool_call_id, tool_name, arguments):
                 "index": 0,
                 "message": {
                     "role": "assistant",
-                    "content": TOOL_PREFACE,
+                    "content": content,
                     "tool_calls": [
                         {
                             "id": tool_call_id,
@@ -133,6 +286,16 @@ def tool_call_response_payload(model, *, tool_call_id, tool_name, arguments):
     }
 
 
+def scenario_tool_call_payload(model, response):
+    return tool_call_response_payload(
+        model,
+        tool_call_id=response["tool_call_id"],
+        tool_name=response["tool_name"],
+        arguments=response.get("arguments", {}),
+        content=response.get("content", TOOL_PREFACE),
+    )
+
+
 def build_tool_call_response(model):
     return tool_call_response_payload(
         model,
@@ -142,17 +305,67 @@ def build_tool_call_response(model):
     )
 
 
-def build_blocking_tool_call_response(model):
+def build_blocking_tool_call_response(model, query="docs.example.com"):
     return tool_call_response_payload(
         model,
         tool_call_id=BLOCKING_TOOL_CALL_ID,
         tool_name=BLOCKING_TOOL_NAME,
-        arguments={"query": "docs.example.com"},
+        arguments={"query": query},
+    )
+
+
+def delegate_task_arguments(text):
+    return {
+        "title": "Prepare customer onboarding checklist",
+        "description": "Create a reviewed onboarding checklist.",
+        "type": "OPERATIONS",
+        "connection": "worker",
+    }
+
+
+def build_delegate_task_call_response(model, messages):
+    return tool_call_response_payload(
+        model,
+        tool_call_id=DELEGATE_TASK_CALL_ID,
+        tool_name=DELEGATE_TASK_NAME,
+        arguments=delegate_task_arguments(last_message_text(messages)),
+    )
+
+
+def artifact_arguments_for_task(text):
+    return {
+        "title": "Onboarding checklist artifact",
+        "content": "# Onboarding checklist\n\n- Confirm kickoff owner\n- Prepare success plan",
+        "media_type": "text/markdown",
+        "metadata": {"source": "delegated-worker"},
+    }
+
+
+def build_create_artifact_call_response(model, messages):
+    return tool_call_response_payload(
+        model,
+        tool_call_id=CREATE_ARTIFACT_CALL_ID,
+        tool_name=CREATE_ARTIFACT_NAME,
+        arguments=artifact_arguments_for_task(last_message_text(messages)),
+    )
+
+
+def build_read_artifact_call_response(model, artifact_uri):
+    return tool_call_response_payload(
+        model,
+        tool_call_id=READ_ARTIFACT_CALL_ID,
+        tool_name=READ_ARTIFACT_NAME,
+        arguments={"artifact_uri": artifact_uri},
     )
 
 
 async def stream_tool_call_response(
-    model, *, tool_call_id=TOOL_CALL_ID, tool_name=TOOL_NAME, arguments=None
+    model,
+    *,
+    tool_call_id=TOOL_CALL_ID,
+    tool_name=TOOL_NAME,
+    arguments=None,
+    content=TOOL_PREFACE,
 ):
     arguments = arguments or {"query": "docs.example.com"}
     preface_chunk = {
@@ -163,7 +376,7 @@ async def stream_tool_call_response(
         "choices": [
             {
                 "index": 0,
-                "delta": {"content": TOOL_PREFACE},
+                "delta": {"content": content},
                 "finish_reason": None,
             }
         ],
@@ -220,6 +433,22 @@ async def stream_tool_call_response(
     }
     yield f"data: {json.dumps(final_chunk)}\n\n"
     yield "data: [DONE]\n\n"
+
+
+async def stream_scenario_response(model, response):
+    if response.get("type") == "tool_call":
+        async for chunk in stream_tool_call_response(
+            model,
+            tool_call_id=response["tool_call_id"],
+            tool_name=response["tool_name"],
+            arguments=response.get("arguments", {}),
+            content=response.get("content", TOOL_PREFACE),
+        ):
+            yield chunk
+        return
+
+    async for chunk in stream_text_response(model, response.get("content", "")):
+        yield chunk
 
 
 async def stream_text_response(model, reply):
@@ -311,34 +540,53 @@ async def chat_completions(request: Request):
             ],
         }
     )
-    last_message = last_message_text(messages)
+    last_text = last_message_text(messages)
     model = data.get("model", "minimax-m2.7")
+    scenario_response = scenario_response_for(messages, tools)
 
     # Generate a deterministic reply based on input or just static
-    if should_emit_blocking_tool_call(messages, tools):
+    if scenario_response is not None:
+        reply = None
+    elif should_emit_blocking_tool_call(messages, tools):
+        reply = None
+    elif should_emit_delegate_task_call(messages, tools):
+        reply = None
+    elif should_emit_delegated_artifact_call(messages, tools):
+        reply = None
+    elif should_emit_read_artifact_call(messages, tools):
         reply = None
     elif should_emit_tool_call(messages, tools):
         reply = None
     elif is_tool_followup(messages):
-        if any(
-            message.get("tool_call_id") == BLOCKING_TOOL_CALL_ID for message in messages
-        ):
+        tool_call_id = last_message(messages).get("tool_call_id")
+        if tool_call_id == DELEGATE_TASK_CALL_ID:
+            reply = "I delegated the onboarding task."
+        elif tool_call_id == CREATE_ARTIFACT_CALL_ID:
+            reply = "I created the onboarding checklist artifact."
+        elif tool_call_id == READ_ARTIFACT_CALL_ID:
+            reply = "I read the delegated artifact."
+        elif tool_call_id == BLOCKING_TOOL_CALL_ID:
             reply = "I checked blocking_lookup for docs.example.com."
         else:
             reply = "I checked knowledge_search for docs.example.com."
-    elif "square root of 144" in last_message.lower():
+    elif "square root of 144" in last_text.lower():
         reply = "The square root of 144 is 12."
-    elif "hello" in last_message.lower():
+    elif "hello" in last_text.lower():
         reply = "Hello! I am a mock LLM. How can I assist you today?"
     else:
-        reply = "I received your message: " + last_message
+        reply = "I received your message: " + last_text
 
     if data.get("stream", False):
         async def stream_generator():
+            if scenario_response is not None:
+                async for chunk in stream_scenario_response(model, scenario_response):
+                    yield chunk
+                return
+
             if should_emit_blocking_tool_call(messages, tools):
                 query = (
                     "super-large-docs.example.com"
-                    if "super large" in last_message.lower()
+                    if "super large" in last_text.lower()
                     else "docs.example.com"
                 )
                 async for chunk in stream_tool_call_response(
@@ -346,6 +594,38 @@ async def chat_completions(request: Request):
                     tool_call_id=BLOCKING_TOOL_CALL_ID,
                     tool_name=BLOCKING_TOOL_NAME,
                     arguments={"query": query},
+                ):
+                    yield chunk
+                return
+
+            if should_emit_delegate_task_call(messages, tools):
+                async for chunk in stream_tool_call_response(
+                    model,
+                    tool_call_id=DELEGATE_TASK_CALL_ID,
+                    tool_name=DELEGATE_TASK_NAME,
+                    arguments=delegate_task_arguments(last_message_text(messages)),
+                ):
+                    yield chunk
+                return
+
+            if should_emit_delegated_artifact_call(messages, tools):
+                async for chunk in stream_tool_call_response(
+                    model,
+                    tool_call_id=CREATE_ARTIFACT_CALL_ID,
+                    tool_name=CREATE_ARTIFACT_NAME,
+                    arguments=artifact_arguments_for_task(last_message_text(messages)),
+                ):
+                    yield chunk
+                return
+
+            if should_emit_read_artifact_call(messages, tools):
+                async for chunk in stream_tool_call_response(
+                    model,
+                    tool_call_id=READ_ARTIFACT_CALL_ID,
+                    tool_name=READ_ARTIFACT_NAME,
+                    arguments={
+                        "artifact_uri": artifact_uri_from_text(last_text),
+                    },
                 ):
                     yield chunk
                 return
@@ -360,8 +640,54 @@ async def chat_completions(request: Request):
             
         return StreamingResponse(stream_generator(), media_type="text/event-stream")
 
+    if scenario_response is not None:
+        if scenario_response.get("type") == "tool_call":
+            return JSONResponse(content=scenario_tool_call_payload(model, scenario_response))
+        response_json = {
+            "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": scenario_response.get("content", ""),
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 10,
+                "reasoning_tokens": 6,
+                "total_tokens": 26,
+            },
+        }
+        return JSONResponse(content=response_json)
+
     if should_emit_blocking_tool_call(messages, tools):
-        return JSONResponse(content=build_blocking_tool_call_response(model))
+        query = (
+            "super-large-docs.example.com"
+            if "super large" in last_text.lower()
+            else "docs.example.com"
+        )
+        return JSONResponse(content=build_blocking_tool_call_response(model, query))
+
+    if should_emit_delegate_task_call(messages, tools):
+        return JSONResponse(content=build_delegate_task_call_response(model, messages))
+
+    if should_emit_delegated_artifact_call(messages, tools):
+        return JSONResponse(content=build_create_artifact_call_response(model, messages))
+
+    if should_emit_read_artifact_call(messages, tools):
+        return JSONResponse(
+            content=build_read_artifact_call_response(
+                model,
+                artifact_uri_from_text(last_text),
+            )
+        )
 
     if should_emit_tool_call(messages, tools):
         return JSONResponse(content=build_tool_call_response(model))

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -10,6 +10,7 @@ import boto3
 import grpc
 import requests
 import zstandard
+from google.protobuf.struct_pb2 import ListValue, Value
 
 from e2e.blackbox import (
     create_agent_resource,
@@ -22,12 +23,16 @@ from e2e.stack import E2EStack, MOCK_LLM_PORT
 from talon_client import (
     CreateSessionRequest,
     GetCasObjectRequest,
+    GetResourceRequest,
     GetSessionRequest,
+    ListResourcesRequest,
+    ListSessionsRequest,
     SendMessageRequest,
     StreamSessionPartsRequest,
     TalonClient,
 )
 from talon_client.resources import AgentSpec, McpServerSpec, Model, ResourceSpec
+from talon_client.resources import A2A, Connection, ConnectionRef, InternalConnectionRef
 
 
 PART_TYPE_TEXT = 1
@@ -38,6 +43,23 @@ STREAM_TIMEOUT_SECONDS = 30
 
 
 logger = logging.getLogger(__name__)
+
+
+def _capability_values(*values: str) -> ListValue:
+    return ListValue(values=[Value(string_value=value) for value in values])
+
+
+def _internal_a2a(connection: str, namespace: str, agent: str) -> A2A:
+    return A2A(
+        connections=[
+            Connection(
+                name=connection,
+                target=ConnectionRef(
+                    internal=InternalConnectionRef(namespace=namespace, agent=agent)
+                ),
+            )
+        ]
+    )
 
 
 def _cas_response_bytes(response) -> bytes:
@@ -128,6 +150,482 @@ def test_single_turn_chat(
     assert agent_message is not None
     assert agent_message.role == 2
     assert "12" in message_text(agent_message)
+
+
+def test_delegate_task_creates_durable_child_session(
+    stack: E2EStack,
+    client: TalonClient,
+) -> None:
+    namespace_suffix = f"{stack.name}-{uuid.uuid4().hex[:8]}"
+    owner_namespace = f"talon-delegate-owner-{namespace_suffix}"
+    worker_namespace = f"talon-delegate-worker-{namespace_suffix}"
+    ensure_namespace(client, owner_namespace)
+    ensure_namespace(client, worker_namespace)
+    create_agent_resource(
+        client,
+        worker_namespace,
+        "worker-agent",
+        AgentSpec(
+            model_policy={
+                "profiles": [
+                    {
+                        "name": "default",
+                        "model": Model(
+                            provider="mock",
+                            name="minimax-m2.7",
+                            temperature=0.7,
+                        ),
+                    }
+                ]
+            },
+            system_prompt="You complete assigned tasks and reply concisely.",
+        ),
+    )
+    create_agent_resource(
+        client,
+        owner_namespace,
+        "owner-agent",
+        AgentSpec(
+            capabilities={
+                "tasks": _capability_values("create", "inspect"),
+                "sessions": _capability_values("read:messages"),
+            },
+            a2a=_internal_a2a("worker", worker_namespace, "worker-agent"),
+            model_policy={
+                "profiles": [
+                    {
+                        "name": "default",
+                        "model": Model(
+                            provider="mock",
+                            name="minimax-m2.7",
+                            temperature=0.7,
+                        ),
+                    }
+                ]
+            },
+            system_prompt="Delegate suitable work with the delegate_task tool.",
+        ),
+    )
+
+    owner_session_id = client.sessions.Create(
+        CreateSessionRequest(agent="owner-agent", ns=owner_namespace)
+    ).session_id
+    client.sessions.SendMessage(
+        SendMessageRequest(
+            agent="owner-agent",
+            session_id=owner_session_id,
+            ns=owner_namespace,
+            message=(
+                "Please delegate onboarding task to the worker connection."
+            ),
+        )
+    )
+
+    owner_done = False
+    task_name = ""
+    owner_messages = []
+    for _ in range(45):
+        time.sleep(1)
+        owner = client.sessions.Get(
+            GetSessionRequest(
+                agent="owner-agent",
+                session_id=owner_session_id,
+                ns=owner_namespace,
+            )
+        )
+        owner_messages = owner.messages
+        owner_text = "\n".join(message_text(message) for message in owner_messages)
+        if (
+            owner.state == "IDLE"
+            and "delegated the onboarding task" in owner_text.lower()
+        ):
+            owner_done = True
+            break
+
+    assert owner_done, "owner did not call delegate_task and finish"
+    task_resources = list(
+        client.resources.List(
+            ListResourcesRequest(ns=owner_namespace, kind="Task")
+        ).resources
+    )
+    assert len(task_resources) == 1
+    task_name = task_resources[0].metadata.name
+
+    task = client.resources.Get(
+        GetResourceRequest(ns=owner_namespace, kind="Task", name=task_name)
+    ).resource
+    assert task.status.task.phase in (2, 4)  # RUNNING or already NEEDS_REVIEW.
+    child_session_id = task.status.task.execution_ref.session_id
+    assert child_session_id
+    assert task.status.task.execution_ref.name == "worker-agent"
+    assert task.spec.task.owner.namespace == owner_namespace
+    assert task.spec.task.delegate.namespace == worker_namespace
+    assert (
+        task_resources[0].metadata.labels.get("talon.impalasys.com/a2a-connection")
+        == "worker"
+    )
+
+    worker_sessions = client.sessions.List(
+        ListSessionsRequest(ns=worker_namespace, agent="worker-agent")
+    )
+    assert child_session_id in worker_sessions.session_ids
+
+    worker_done = False
+    worker_messages = []
+    for _ in range(45):
+        time.sleep(1)
+        worker = client.sessions.Get(
+            GetSessionRequest(
+                agent="worker-agent",
+                session_id=child_session_id,
+                ns=worker_namespace,
+            )
+        )
+        worker_messages = worker.messages
+        if worker.state == "IDLE" and last_assistant_message(worker_messages) is not None:
+            worker_done = True
+            break
+
+    assert worker_done, "delegated worker session did not finish"
+    first_worker_message = worker_messages[0]
+    assert (
+        first_worker_message.labels["talon.impalasys.com/task-name"] == task_name
+    )
+    assert (
+        first_worker_message.labels["talon.impalasys.com/owner-namespace"]
+        == owner_namespace
+    )
+    assert "Create a reviewed onboarding checklist." in message_text(first_worker_message)
+
+    reviewed_task = None
+    for _ in range(15):
+        reviewed_task = client.resources.Get(
+            GetResourceRequest(ns=owner_namespace, kind="Task", name=task_name)
+        ).resource
+        if reviewed_task.status.task.phase == 4:  # TASK_PHASE_NEEDS_REVIEW
+            break
+        time.sleep(1)
+
+    assert reviewed_task is not None
+    assert reviewed_task.status.task.phase == 4
+    assert "onboarding" in reviewed_task.status.task.progress_summary.lower()
+    assert "artifact" in reviewed_task.status.task.progress_summary.lower()
+    assert reviewed_task.status.task.result_artifacts
+    artifact_uri = (
+        reviewed_task.status.task.result_artifacts[0].metadata.get("artifact_uri", "")
+    )
+    assert artifact_uri.startswith(f"artifact://{worker_namespace}/worker-agent/")
+
+    worker_tool_results = [
+        part
+        for message in worker_messages
+        for part in message.parts
+        if part.part_type == PART_TYPE_TOOL_RESULT
+    ]
+    assert worker_tool_results, "worker should create an artifact"
+    worker_artifact_uri = ""
+    for part in worker_tool_results:
+        payload = json.loads(part.payload_json or "{}")
+        output = payload.get("output", "")
+        if output:
+            output_json = json.loads(output)
+            worker_artifact_uri = output_json.get("artifactUri", "")
+            if worker_artifact_uri:
+                break
+    assert worker_artifact_uri == artifact_uri
+
+    owner_woke = False
+    for _ in range(45):
+        time.sleep(1)
+        owner = client.sessions.Get(
+            GetSessionRequest(
+                agent="owner-agent",
+                session_id=owner_session_id,
+                ns=owner_namespace,
+            )
+        )
+        owner_text = "\n".join(message_text(message) for message in owner.messages)
+        if (
+            owner.state == "IDLE"
+            and "Delegated Task is ready for review." in owner_text
+            and artifact_uri in owner_text
+        ):
+            owner_woke = True
+            break
+
+    assert owner_woke, "owner was not woken when delegated Task became ready"
+
+    client.sessions.SendMessage(
+        SendMessageRequest(
+            agent="owner-agent",
+            session_id=owner_session_id,
+            ns=owner_namespace,
+            message=f"Please read this delegated artifact {artifact_uri}",
+        )
+    )
+    owner_read_messages = []
+    for _ in range(45):
+        time.sleep(1)
+        owner = client.sessions.Get(
+            GetSessionRequest(
+                agent="owner-agent",
+                session_id=owner_session_id,
+                ns=owner_namespace,
+            )
+        )
+        owner_read_messages = owner.messages
+        owner_tool_results = [
+            part
+            for message in owner_read_messages
+            for part in message.parts
+            if part.part_type == PART_TYPE_TOOL_RESULT
+        ]
+        read_outputs = []
+        for part in owner_tool_results:
+            payload = json.loads(part.payload_json or "{}")
+            output = payload.get("output", "")
+            if output:
+                read_outputs.append(json.loads(output))
+        if owner.state == "IDLE" and any(
+            "Onboarding checklist" in output.get("content", "")
+            for output in read_outputs
+        ):
+            break
+
+    assert owner_read_messages, "owner did not process artifact read"
+    owner_tool_results = [
+        part
+        for message in owner_read_messages
+        for part in message.parts
+        if part.part_type == PART_TYPE_TOOL_RESULT
+    ]
+    read_outputs = [
+        json.loads(json.loads(part.payload_json or "{}").get("output", "{}"))
+        for part in owner_tool_results
+        if json.loads(part.payload_json or "{}").get("output")
+    ]
+    assert any(
+        "Onboarding checklist" in output.get("content", "")
+        for output in read_outputs
+    ), "owner could not read child artifact"
+
+
+def test_legal_document_refinement_delegation_returns_redline_artifact(
+    stack: E2EStack,
+    client: TalonClient,
+) -> None:
+    namespace_suffix = f"{stack.name}-{uuid.uuid4().hex[:8]}"
+    coordinator_namespace = f"talon-legal-coordinator-{namespace_suffix}"
+    reviewer_namespace = f"talon-legal-reviewer-{namespace_suffix}"
+    ensure_namespace(client, coordinator_namespace)
+    ensure_namespace(client, reviewer_namespace)
+    create_agent_resource(
+        client,
+        reviewer_namespace,
+        "legal-reviewer-agent",
+        AgentSpec(
+            model_policy={
+                "profiles": [
+                    {
+                        "name": "default",
+                        "model": Model(
+                            provider="mock",
+                            name="minimax-m2.7",
+                            temperature=0.7,
+                        ),
+                    }
+                ]
+            },
+            system_prompt=(
+                "You are a legal reviewer. Produce redline artifacts when "
+                "assigned a Talon Task."
+            ),
+        ),
+    )
+    create_agent_resource(
+        client,
+        coordinator_namespace,
+        "legal-coordinator-agent",
+        AgentSpec(
+            capabilities={
+                "tasks": _capability_values("create", "inspect"),
+                "sessions": _capability_values("read:messages"),
+            },
+            a2a=_internal_a2a(
+                "legal-reviewer",
+                reviewer_namespace,
+                "legal-reviewer-agent",
+            ),
+            model_policy={
+                "profiles": [
+                    {
+                        "name": "default",
+                        "model": Model(
+                            provider="mock",
+                            name="minimax-m2.7",
+                            temperature=0.7,
+                        ),
+                    }
+                ]
+            },
+            system_prompt=(
+                "You are a legal coordinator. Delegate legal refinement work "
+                "with delegate_task, then review delegated artifacts."
+            ),
+        ),
+    )
+
+    coordinator_session_id = client.sessions.Create(
+        CreateSessionRequest(agent="legal-coordinator-agent", ns=coordinator_namespace)
+    ).session_id
+    client.sessions.SendMessage(
+        SendMessageRequest(
+            agent="legal-coordinator-agent",
+            session_id=coordinator_session_id,
+            ns=coordinator_namespace,
+            message=(
+                "Please delegate legal document refinement task to the "
+                "legal-reviewer connection."
+            ),
+        )
+    )
+
+    task_name = ""
+    for _ in range(45):
+        time.sleep(1)
+        coordinator = client.sessions.Get(
+            GetSessionRequest(
+                agent="legal-coordinator-agent",
+                session_id=coordinator_session_id,
+                ns=coordinator_namespace,
+            )
+        )
+        coordinator_text = "\n".join(
+            message_text(message) for message in coordinator.messages
+        )
+        if (
+            coordinator.state == "IDLE"
+            and "delegated the legal document refinement task"
+            in coordinator_text.lower()
+        ):
+            break
+    else:
+        raise AssertionError("legal coordinator did not delegate refinement work")
+
+    task_resources = list(
+        client.resources.List(
+            ListResourcesRequest(ns=coordinator_namespace, kind="Task")
+        ).resources
+    )
+    assert len(task_resources) == 1
+    task_name = task_resources[0].metadata.name
+    task = client.resources.Get(
+        GetResourceRequest(ns=coordinator_namespace, kind="Task", name=task_name)
+    ).resource
+    assert task.spec.task.owner.namespace == coordinator_namespace
+    assert task.spec.task.delegate.namespace == reviewer_namespace
+    assert task.spec.task.delegate.name == "legal-reviewer-agent"
+    child_session_id = task.status.task.execution_ref.session_id
+    assert child_session_id
+
+    for _ in range(45):
+        time.sleep(1)
+        reviewer = client.sessions.Get(
+            GetSessionRequest(
+                agent="legal-reviewer-agent",
+                session_id=child_session_id,
+                ns=reviewer_namespace,
+            )
+        )
+        if reviewer.state == "IDLE" and last_assistant_message(reviewer.messages):
+            break
+    else:
+        raise AssertionError("legal reviewer child session did not finish")
+
+    reviewed_task = None
+    for _ in range(20):
+        reviewed_task = client.resources.Get(
+            GetResourceRequest(ns=coordinator_namespace, kind="Task", name=task_name)
+        ).resource
+        if reviewed_task.status.task.phase == 4:  # TASK_PHASE_NEEDS_REVIEW
+            break
+        time.sleep(1)
+
+    assert reviewed_task is not None
+    assert reviewed_task.status.task.phase == 4
+    assert reviewed_task.status.task.result_artifacts
+    artifact_uri = reviewed_task.status.task.result_artifacts[0].metadata.get(
+        "artifact_uri",
+        "",
+    )
+    assert artifact_uri.startswith(
+        f"artifact://{reviewer_namespace}/legal-reviewer-agent/"
+    )
+    assert (
+        reviewed_task.status.task.result_artifacts[0].metadata.get("content_type")
+        == "legal_redline"
+    )
+
+    for _ in range(45):
+        time.sleep(1)
+        coordinator = client.sessions.Get(
+            GetSessionRequest(
+                agent="legal-coordinator-agent",
+                session_id=coordinator_session_id,
+                ns=coordinator_namespace,
+            )
+        )
+        coordinator_text = "\n".join(
+            message_text(message) for message in coordinator.messages
+        )
+        if (
+            coordinator.state == "IDLE"
+            and "Delegated Task is ready for review." in coordinator_text
+            and artifact_uri in coordinator_text
+        ):
+            break
+    else:
+        raise AssertionError("coordinator was not woken with the redline artifact")
+
+    client.sessions.SendMessage(
+        SendMessageRequest(
+            agent="legal-coordinator-agent",
+            session_id=coordinator_session_id,
+            ns=coordinator_namespace,
+            message=f"Please read this delegated artifact {artifact_uri}",
+        )
+    )
+
+    read_outputs = []
+    for _ in range(45):
+        time.sleep(1)
+        coordinator = client.sessions.Get(
+            GetSessionRequest(
+                agent="legal-coordinator-agent",
+                session_id=coordinator_session_id,
+                ns=coordinator_namespace,
+            )
+        )
+        read_outputs = []
+        for message in coordinator.messages:
+            for part in message.parts:
+                if part.part_type != PART_TYPE_TOOL_RESULT:
+                    continue
+                payload = json.loads(part.payload_json or "{}")
+                output = payload.get("output", "")
+                if output:
+                    read_outputs.append(json.loads(output))
+        if coordinator.state == "IDLE" and any(
+            "Mutual NDA fallback clause redline" in output.get("content", "")
+            for output in read_outputs
+        ):
+            break
+
+    assert any(
+        "same degree of care" in output.get("content", "")
+        and "reasonable care" in output.get("content", "")
+        for output in read_outputs
+    ), "coordinator could not read the delegated legal redline artifact"
 
 
 def test_streaming_chat(

--- a/tests/test_cli_sqlite.py
+++ b/tests/test_cli_sqlite.py
@@ -371,10 +371,10 @@ spec:
   title: Launch copy
   description: Draft launch copy.
   type: agent_delegation
-  requester:
+  owner:
     namespace: {namespace}
     name: cmo
-  assignee:
+  delegate:
     namespace: {namespace}
     name: writer
 """

--- a/tests/test_mock_llm.py
+++ b/tests/test_mock_llm.py
@@ -34,6 +34,64 @@ def test_mock_llm_helper_functions_cover_message_and_tool_detection() -> None:
     assert json.loads(tool_call["function"]["arguments"]) == {"query": "docs.example.com"}
 
 
+def test_mock_llm_json_scenario_rules_emit_legal_delegate_tool_call() -> None:
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a legal coordinator.",
+        },
+        {
+            "role": "user",
+            "content": (
+                "Please delegate legal document refinement task to the legal "
+                "reviewer connection."
+            ),
+        },
+    ]
+    response = mock_llm.scenario_response_for(
+        messages,
+        [{"type": "function", "function": {"name": "delegate_task"}}],
+    )
+
+    assert response is not None
+    assert response["type"] == "tool_call"
+    assert response["tool_name"] == "delegate_task"
+    assert response["arguments"]["connection"] == "legal-reviewer"
+    assert response["arguments"]["type"] == "legal_document_refinement"
+
+    payload = mock_llm.scenario_tool_call_payload("mock-model", response)
+    assert payload["choices"][0]["message"]["content"] == "Let me assign the legal review. "
+
+
+@pytest.mark.anyio
+async def test_mock_llm_non_streaming_blocking_lookup_honors_super_large_query() -> None:
+    transport = httpx.ASGITransport(app=mock_llm.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/chat/completions",
+            json={
+                "model": "mock-model",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "blocking lookup docs.example.com with super large result",
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": mock_llm.BLOCKING_TOOL_NAME},
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    tool_call = response.json()["choices"][0]["message"]["tool_calls"][0]
+    arguments = json.loads(tool_call["function"]["arguments"])
+    assert arguments == {"query": "super-large-docs.example.com"}
+
+
 @pytest.mark.anyio
 async def test_mock_llm_stream_helpers_cover_text_and_tool_chunks() -> None:
     # Verify the mock LLM stream helpers produce the expected chunk structure for


### PR DESCRIPTION
## Summary

- add durable Task delegation handling that starts assignee sessions and marks delegated work ready for requester review
- make `delegate_task` resolve declared internal `spec.a2a.connections` instead of accepting raw assignee namespace/agent names
- split new native artifact/task tool implementations into `src/harness/tools/` so `native_tools.rs` is mostly registration/shared plumbing
- add a JSON-driven mock LLM scenario framework plus a non-proprietary legal document refinement E2E case
- verify child-created artifacts are granted back to the requester and can be read by the parent agent
- add `docs/contributing/runtime-state.md` to document where replay idempotency belongs and when hidden KV state is acceptable

## Why

The production issue exposed that delegation needs to be durable and observable without synchronous wakeup hacks. This PR models delegation through Task state and session labels, then wakes the requester when the assigned session completes and produces artifacts. The new E2E uses a mock legal-review workflow instead of proprietary Conic content-generation prompts, so the behavior is testable in OSS with no real model calls.

Delegation is now authorized by the caller agent manifest’s A2A graph: the model can only call `delegate_task` with a declared internal connection alias from `spec.a2a.connections`. Talon resolves that alias to the target namespace/agent. Raw `assignee_namespace` and `assignee_name` are rejected by `delegate_task`, so the model cannot invent or guess an arbitrary target agent.

Delegated Tasks use normal readable, time-sortable resource names. This PR intentionally does not add a hidden delegation-key KV index or deterministic hash-only Task names. Direct native tool execution remains side-effecting; replay protection belongs to the session submission/journal layer, where completed tool results are already stored and recovered by `tool_call_id` without executing the tool again.

## Audit cleanup

A scope audit after removing the delegated-task idempotency design found stale executor/native-tool plumbing that passed `tool_call_id` into native tools. That was removed because no native tool should need tool-call identity for replay safety. The PR diff does not touch `src/harness/executor/runtime.rs`.

The only KV write used for child-to-parent artifact handoff is the existing ArtifactAccess record. It is not a delegation index; it is the ACL that lets the requester read artifacts produced by the assignee session.

The new runtime-state contributing doc captures the review rule this PR tripped over: do not add bespoke idempotency stores, claim records, or deterministic resource names when the session journal is the correct replay boundary.

## Testing

- `cargo fmt --check`
- `cargo check --bins`
- `cargo test -p talon a2a::tests`
- `cargo test -p talon delegate_task_`
- `cargo test -p talon redelivery_with_committed_journal_repairs_submission_without_duplicate_execution`
- `python -m py_compile tests/mock_llm.py tests/test_chat.py tests/test_mock_llm.py`
- `.venv-e2e/bin/python -m pytest tests/test_mock_llm.py -q`
- `TALON_E2E_STACKS=postgres_pubsub .venv-e2e/bin/python -m pytest tests/test_chat.py -k 'delegate_task_creates_durable_child_session or legal_document_refinement_delegation_returns_redline_artifact' -q`
- `git diff --check`
- `rg -n 'execute_tool_for_session_with_call|delegation_key|LABEL_DELEGATION_KEY|create_if_absent|delegated_task_name|idempotency_key|DelegationClaim|DELEGATE_AGENT_ASYNC|DELEGATE_AGENT_TOOL|DELEGATE_AGENT_ASYNC_TOOL' src tests proto docs || true`

## Notes

- `agy` was used for review attempts. A narrow prior review found mock-response bugs that are fixed here; the final bounded review attempt hung on workspace searches and was stopped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable task delegation between owner and delegate agents, including task tracking, completion updates, review notifications, and artifact access.
  * Added task and artifact tools for creating, viewing, updating, delegating, and sharing results.
  * Added support for internal A2A connection discovery and validation.
  * Renamed task roles from requester/assignee to owner/delegate across APIs and manifests.
* **Bug Fixes**
  * Added validation to reject A2A connection names with leading or trailing whitespace.
* **Documentation**
  * Added guidance for runtime state persistence, task delegation, cleanup, and resource naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->