### PR TITLE
Fix Sightline expired JWT refresh

### DIFF
--- a/ui/e2e/sightlineRefresh.spec.ts
+++ b/ui/e2e/sightlineRefresh.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+import { e2eGatewayUrl, readE2EAuth } from './talonAuth';
+
+const SIGHTLINE_REFRESH_URL_COOKIE_NAME = 'sightline_refresh_url';
+const RUNTIME_AUTH_TOKEN_STORAGE_KEY = 'talon_auth_token';
+
+function grpcWebTrailers(headers: Record<string, string>) {
+  const trailerBlock = `${Object.entries(headers)
+    .map(([name, value]) => `${name}: ${value}`)
+    .join('\r\n')}\r\n`;
+  const trailerBytes = Buffer.from(trailerBlock, 'utf8');
+  const frame = Buffer.alloc(5 + trailerBytes.length);
+  frame[0] = 0x80;
+  frame.writeUInt32BE(trailerBytes.length, 1);
+  trailerBytes.copy(frame, 5);
+  return frame;
+}
+
+test.describe('Sightline auth refresh', () => {
+  test('refreshes from the Osprey cookie and retries when the gateway rejects an expired JWT', async ({ page }) => {
+    const auth = readE2EAuth();
+    expect(auth?.accessToken, 'E2E stack must provide a valid replacement access token').toBeTruthy();
+
+    const gatewayUrl = e2eGatewayUrl();
+    const webPort = process.env.WEB_PORT || '3000';
+    const appOrigin = `http://localhost:${webPort}`;
+    const refreshUrl = `${appOrigin}/internal/v1/sightline/refresh`;
+    const expiredToken = 'expired-platform-jwt';
+    let refreshCalls = 0;
+    let namespaceListCalls = 0;
+    let firstAuthorizationHeader: string | undefined;
+    let retryAuthorizationHeader: string | undefined;
+
+    await page.addInitScript(
+      ({ gatewayUrl: initGatewayUrl, token }) => {
+        localStorage.setItem('talon_gateway_url', initGatewayUrl);
+        localStorage.setItem('talon_auth_token', token);
+      },
+      { gatewayUrl, token: expiredToken },
+    );
+    await page.context().addCookies([
+      {
+        name: SIGHTLINE_REFRESH_URL_COOKIE_NAME,
+        value: encodeURIComponent(refreshUrl),
+        url: appOrigin,
+        sameSite: 'Lax',
+      },
+    ]);
+
+    await page.route('**/internal/v1/sightline/refresh', async (route) => {
+      refreshCalls += 1;
+      expect(route.request().method()).toBe('POST');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ accessToken: auth?.accessToken }),
+      });
+    });
+
+    await page.route('**/talon.v1.NamespaceService/List', async (route) => {
+      namespaceListCalls += 1;
+      const authorization = route.request().headers().authorization;
+      if (namespaceListCalls === 1) {
+        firstAuthorizationHeader = authorization;
+        await route.fulfill({
+          status: 200,
+          headers: { 'content-type': 'application/grpc-web+proto' },
+          body: grpcWebTrailers({
+            'grpc-status': '16',
+            'grpc-message': encodeURIComponent('Invalid token: invalid platform JWT: ExpiredSignature'),
+          }),
+        });
+        return;
+      }
+
+      retryAuthorizationHeader = authorization;
+      await route.continue();
+    });
+
+    await page.goto('/?connected=true');
+
+    await expect(page.locator('text=Connected')).toBeVisible({ timeout: 45000 });
+    await expect.poll(() => refreshCalls).toBe(1);
+    await expect.poll(() => namespaceListCalls).toBeGreaterThanOrEqual(2);
+    expect(firstAuthorizationHeader).toBe(`Bearer ${expiredToken}`);
+    expect(retryAuthorizationHeader).toBe(`Bearer ${auth?.accessToken}`);
+    await expect.poll(
+      () => page.evaluate((key) => localStorage.getItem(key), RUNTIME_AUTH_TOKEN_STORAGE_KEY),
+    ).toBe(auth?.accessToken);
+  });
+});

--- a/ui/lib/grpc.test.ts
+++ b/ui/lib/grpc.test.ts
@@ -119,10 +119,14 @@ describe("isExpiredSignatureAuthError", () => {
   it("detects expired signature messages", () => {
     expect(isExpiredSignatureAuthError({ rawMessage: "JWT expired signature" })).toBe(true);
     expect(isExpiredSignatureAuthError({ message: "signature has expired" })).toBe(true);
+    expect(isExpiredSignatureAuthError({ message: "Invalid token: invalid platform JWT: ExpiredSignature" })).toBe(true);
   });
 
   it("detects unauthenticated expired errors", () => {
     expect(isExpiredSignatureAuthError({ codeName: "Unauthenticated", message: "token expired" })).toBe(true);
+    expect(isExpiredSignatureAuthError({
+      message: "[unauthenticated] Invalid token: invalid platform JWT: ExpiredSignature",
+    })).toBe(true);
   });
 
   it("ignores unrelated auth errors", () => {

--- a/ui/lib/grpc.ts
+++ b/ui/lib/grpc.ts
@@ -90,10 +90,13 @@ export function isExpiredSignatureAuthError(error: unknown) {
   };
   const message = `${candidate?.rawMessage || candidate?.message || candidate?.cause?.message || ""}`.toLowerCase();
   const code = `${candidate?.codeName || candidate?.code || ""}`.toLowerCase();
+  const normalizedMessage = message.replace(/[\s_-]+/g, "");
+  const authText = `${message} ${code}`;
   return (
     message.includes("expired signature") ||
     message.includes("signature has expired") ||
-    (code.includes("unauthenticated") && message.includes("expired"))
+    normalizedMessage.includes("expiredsignature") ||
+    (authText.includes("unauthenticated") && message.includes("expired"))
   );
 }
 

--- a/ui/lib/grpc.ts
+++ b/ui/lib/grpc.ts
@@ -93,7 +93,6 @@ export function isExpiredSignatureAuthError(error: unknown) {
   const normalizedMessage = message.replace(/[\s_-]+/g, "");
   const authText = `${message} ${code}`;
   return (
-    message.includes("expired signature") ||
     message.includes("signature has expired") ||
     normalizedMessage.includes("expiredsignature") ||
     (authText.includes("unauthenticated") && message.includes("expired"))


### PR DESCRIPTION
## Summary

Fix Sightline's JWT refresh retry path for production-shaped expired platform JWT errors.

The production gateway error can arrive as `ExpiredSignature` without a space, and `unauthenticated` can appear in the error message rather than only in the structured Connect error code field. That meant Sightline displayed the terminal auth error even when the `sightline_refresh_url` cookie was present.

This PR updates the expired-auth classifier and adds regression coverage for the Osprey refresh-cookie behavior.

## Changes

- Detect collapsed `ExpiredSignature` messages in the Sightline gRPC auth interceptor.
- Treat `unauthenticated` embedded in the error text as auth context for expired-token errors.
- Add unit coverage for the exact production-style error strings.
- Add a Playwright E2E that starts connected with an expired token, sets the refresh URL cookie, mocks the first gateway call as an expired JWT, verifies the refresh endpoint is called, and verifies the retry uses the fresh token against the local Talon stack.

## Validation

- `pnpm --filter @impalasys/talon-client build && pnpm --dir ui exec jest --runTestsByPath lib/grpc.test.ts --coverage=false`
- `PYTHON_BIN=/Users/shukant/Workspace/impalasys/talon-sightline-refresh-e2e/target/e2e-venv/bin/python pnpm --dir ui exec playwright test e2e/sightlineRefresh.spec.ts --project=chromium`
