### PR TITLE
Fix README logo asset path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="#logo-attribution">
-    <img src="./docs-site/static/img/talon-title.svg" alt="Talon" width="260">
+    <img src="./docs-site/public/talon-title.svg" alt="Talon" width="260">
   </a>
 </p>
 


### PR DESCRIPTION
## Summary

- Update the README logo image reference to use the new `docs-site/public/talon-title.svg` location.

## Why

The docs asset move in `4b0f568c` relocated `talon-title.svg` out of `docs-site/static/img`, leaving the README image path dangling.

## Validation

- Verified `docs-site/public/talon-title.svg` exists.
- Verified `docs-site/static/img/talon-title.svg` no longer exists.
- Searched README/docs/package paths for stale `docs-site/static/img/talon-title.svg` or `talon-claw` references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README logo reference so the Talon title image displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->