### PR TITLE
Add minimal artifact update tool

### DIFF
--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -45,6 +45,7 @@ pub const CHANNEL_PUBLISH_TOOL: &str = "channel_publish";
 pub const CHANNEL_SKIP_REPLY_TOOL: &str = "channel_skip_reply";
 pub const ACTIVATE_SKILL_TOOL: &str = "activate_skill";
 pub const CREATE_ARTIFACT_TOOL: &str = "create_artifact";
+pub const UPDATE_ARTIFACT_TOOL: &str = "update_artifact";
 pub const READ_ARTIFACT_TOOL: &str = "read_artifact";
 pub const GET_ARTIFACT_METADATA_TOOL: &str = "get_artifact_metadata";
 pub const GRANT_ARTIFACT_TOOL: &str = "grant_artifact";
@@ -1264,6 +1265,83 @@ async fn read_artifact(
     }))?)
 }
 
+async fn update_artifact(
+    cp: &ControlPlane,
+    _current_namespace: &str,
+    current_agent: &str,
+    current_session: &str,
+    args: &Value,
+) -> Result<String> {
+    let artifact_uri = req_str(args, "artifact_uri")?;
+    let uri = parse_artifact_uri(artifact_uri)?;
+    if current_agent != uri.agent || current_session != uri.session_id {
+        return Err(anyhow!(
+            "only the owning artifact agent/session may update '{artifact_uri}'"
+        ));
+    }
+    let mut artifact = cp
+        .kv
+        .get_msg::<crate::gateway::rpc::data_proto::Artifact>(&keys::artifact(
+            &uri.namespace,
+            &uri.agent,
+            &uri.session_id,
+            &uri.artifact_id,
+        ))
+        .await?
+        .ok_or_else(|| anyhow!("Artifact '{}' not found", uri.artifact_id))?;
+    let previous_object_key = artifact
+        .object_ref
+        .as_ref()
+        .map(|object_ref| object_ref.key.clone());
+    let media_type = opt_str(args, "media_type").unwrap_or(&artifact.media_type);
+    if args.get("content").and_then(Value::as_str).is_none()
+        && opt_str(args, "content_base64").is_none()
+    {
+        return Err(anyhow!(
+            "update_artifact requires content or content_base64"
+        ));
+    }
+    let content = artifact_content_bytes(args)?;
+    let cas = crate::control::cas::CasStore::new(cp.objects.clone());
+    let object_ref = cas
+        .put_artifact(
+            &uri.namespace,
+            &uri.agent,
+            &uri.session_id,
+            &uri.artifact_id,
+            &content,
+            media_type,
+            artifact.metadata.clone(),
+        )
+        .await?;
+    artifact.media_type = media_type.to_string();
+    artifact.object_ref = Some(object_ref);
+    cp.kv
+        .set_msg(
+            &keys::artifact(
+                &uri.namespace,
+                &uri.agent,
+                &uri.session_id,
+                &uri.artifact_id,
+            ),
+            &artifact,
+        )
+        .await?;
+    if let Some(previous_object_key) = previous_object_key {
+        if artifact
+            .object_ref
+            .as_ref()
+            .is_none_or(|object_ref| object_ref.key != previous_object_key)
+        {
+            cas.delete_object(&previous_object_key).await?;
+        }
+    }
+    Ok(serde_json::to_string_pretty(&json!({
+        "artifact": artifact_json(&artifact),
+        "artifactUri": uri.encode()
+    }))?)
+}
+
 async fn get_artifact_metadata(
     cp: &ControlPlane,
     _current_namespace: &str,
@@ -2270,7 +2348,12 @@ fn artifact_content_bytes(args: &Value) -> Result<Vec<u8>> {
             .decode(encoded)
             .map_err(|err| anyhow!("content_base64 is invalid: {err}"));
     }
-    Ok(opt_str(args, "content").unwrap_or("").as_bytes().to_vec())
+    Ok(args
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .as_bytes()
+        .to_vec())
 }
 
 #[derive(Debug, Clone)]
@@ -3221,6 +3304,67 @@ mod tests {
         let read_value: Value = serde_json::from_str(&read_output).unwrap();
         assert_eq!(read_value["content"], "draft body");
 
+        let update_output = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "writer",
+            "session-1",
+            &manifests::AgentSpec::default(),
+            UPDATE_ARTIFACT_TOOL,
+            &json!({
+                "artifact_uri": artifact_uri,
+                "content": "revised body",
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let update_value: Value = serde_json::from_str(&update_output).unwrap();
+        assert_eq!(update_value["artifactUri"], artifact_uri);
+        let updated_object_key = update_value["artifact"]["objectRef"]["key"]
+            .as_str()
+            .unwrap();
+        assert_ne!(updated_object_key, object_key);
+        assert!(crate::control::cas::CasStore::new(cp.objects.clone())
+            .get_object_decoded(object_key)
+            .await
+            .unwrap()
+            .is_none());
+
+        let read_updated_output = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "writer",
+            "session-1",
+            &manifests::AgentSpec::default(),
+            READ_ARTIFACT_TOOL,
+            &json!({
+                "artifact_uri": artifact_uri,
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let read_updated_value: Value = serde_json::from_str(&read_updated_output).unwrap();
+        assert_eq!(read_updated_value["content"], "revised body");
+
+        let empty_update = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "writer",
+            "session-1",
+            &manifests::AgentSpec::default(),
+            UPDATE_ARTIFACT_TOOL,
+            &json!({
+                "artifact_uri": artifact_uri,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(empty_update
+            .to_string()
+            .contains("requires content or content_base64"));
+
         execute_tool_for_session(
             &cp,
             "Tenant:acme:Workspace:main",
@@ -3253,6 +3397,131 @@ mod tests {
         assert_eq!(stored_access.target_agent, "critic");
         assert_eq!(stored_access.target_session_id, "session-2");
         assert_eq!(stored_access.operations, vec!["read", "metadata"]);
+
+        let update_denied = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "critic",
+            "session-2",
+            &manifests::AgentSpec::default(),
+            UPDATE_ARTIFACT_TOOL,
+            &json!({
+                "artifact_uri": artifact_uri,
+                "content": "critic overwrite",
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(update_denied.to_string().contains("only the owning"));
+    }
+
+    #[tokio::test]
+    async fn artifact_tools_accept_large_string_content_arguments() {
+        let kv = Arc::new(MockKvStore::default());
+        let scheduler = Arc::new(MockScheduler::default());
+        let cp = control_plane(kv, scheduler);
+        let large_content = format!("# Large Artifact\n\n{}", "0123456789abcdef ".repeat(700));
+        assert!(
+            large_content.len() > 10_000,
+            "test must exercise a 10k+ string argument"
+        );
+
+        let output = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "writer",
+            "session-1",
+            &manifests::AgentSpec::default(),
+            CREATE_ARTIFACT_TOOL,
+            &json!({
+                "title": "Large draft",
+                "content": large_content,
+                "media_type": "text/markdown"
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let value: Value = serde_json::from_str(&output).unwrap();
+        let artifact_uri = value["artifactUri"].as_str().unwrap();
+
+        let read_output = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "writer",
+            "session-1",
+            &manifests::AgentSpec::default(),
+            READ_ARTIFACT_TOOL,
+            &json!({
+                "artifact_uri": artifact_uri,
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let read_value: Value = serde_json::from_str(&read_output).unwrap();
+        let actual_content = read_value["content"].as_str().unwrap();
+        assert_eq!(
+            actual_content.len(),
+            large_content.len(),
+            "large create content length mismatch; actual_suffix={:?} expected_suffix={:?}",
+            &actual_content[actual_content.len().saturating_sub(64)..],
+            &large_content[large_content.len().saturating_sub(64)..]
+        );
+        assert!(
+            actual_content == large_content,
+            "large create content mismatch; actual_suffix={:?} expected_suffix={:?}",
+            &actual_content[actual_content.len().saturating_sub(64)..],
+            &large_content[large_content.len().saturating_sub(64)..]
+        );
+
+        let large_revision = format!("# Large Revision\n\n{}", "fedcba9876543210 ".repeat(700));
+        assert!(large_revision.len() > 10_000);
+        execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "writer",
+            "session-1",
+            &manifests::AgentSpec::default(),
+            UPDATE_ARTIFACT_TOOL,
+            &json!({
+                "artifact_uri": artifact_uri,
+                "content": large_revision,
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let read_revision = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "writer",
+            "session-1",
+            &manifests::AgentSpec::default(),
+            READ_ARTIFACT_TOOL,
+            &json!({
+                "artifact_uri": artifact_uri,
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let read_revision: Value = serde_json::from_str(&read_revision).unwrap();
+        let actual_revision = read_revision["content"].as_str().unwrap();
+        assert_eq!(
+            actual_revision.len(),
+            large_revision.len(),
+            "large update content length mismatch; actual_suffix={:?} expected_suffix={:?}",
+            &actual_revision[actual_revision.len().saturating_sub(64)..],
+            &large_revision[large_revision.len().saturating_sub(64)..]
+        );
+        assert!(
+            actual_revision == large_revision,
+            "large update content mismatch; actual_suffix={:?} expected_suffix={:?}",
+            &actual_revision[actual_revision.len().saturating_sub(64)..],
+            &large_revision[large_revision.len().saturating_sub(64)..]
+        );
     }
 
     #[tokio::test]

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -1267,16 +1267,19 @@ async fn read_artifact(
 
 async fn update_artifact(
     cp: &ControlPlane,
-    _current_namespace: &str,
+    current_namespace: &str,
     current_agent: &str,
     current_session: &str,
     args: &Value,
 ) -> Result<String> {
     let artifact_uri = req_str(args, "artifact_uri")?;
     let uri = parse_artifact_uri(artifact_uri)?;
-    if current_agent != uri.agent || current_session != uri.session_id {
+    if current_namespace != uri.namespace
+        || current_agent != uri.agent
+        || current_session != uri.session_id
+    {
         return Err(anyhow!(
-            "only the owning artifact agent/session may update '{artifact_uri}'"
+            "only the owning artifact namespace/agent/session may update '{artifact_uri}'"
         ));
     }
     let mut artifact = cp
@@ -3413,6 +3416,24 @@ mod tests {
         .await
         .unwrap_err();
         assert!(update_denied.to_string().contains("only the owning"));
+
+        let cross_namespace_update_denied = execute_tool_for_session(
+            &cp,
+            "Tenant:other:Workspace:main",
+            "writer",
+            "session-1",
+            &manifests::AgentSpec::default(),
+            UPDATE_ARTIFACT_TOOL,
+            &json!({
+                "artifact_uri": artifact_uri,
+                "content": "cross-tenant overwrite",
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(cross_namespace_update_denied
+            .to_string()
+            .contains("only the owning artifact namespace/agent/session"));
     }
 
     #[tokio::test]

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -1319,24 +1319,41 @@ async fn update_artifact(
         .await?;
     artifact.media_type = media_type.to_string();
     artifact.object_ref = Some(object_ref);
-    cp.kv
-        .set_msg(
-            &keys::artifact(
-                &uri.namespace,
-                &uri.agent,
-                &uri.session_id,
-                &uri.artifact_id,
-            ),
-            &artifact,
-        )
-        .await?;
+    let artifact_key = keys::artifact(
+        &uri.namespace,
+        &uri.agent,
+        &uri.session_id,
+        &uri.artifact_id,
+    );
+    if let Err(error) = cp.kv.set_msg(&artifact_key, &artifact).await {
+        if let Some(new_object_key) = artifact
+            .object_ref
+            .as_ref()
+            .map(|object_ref| &object_ref.key)
+        {
+            if let Err(cleanup_error) = cas.delete_object(new_object_key).await {
+                tracing::warn!(
+                    error = %cleanup_error,
+                    object_key = %new_object_key,
+                    "failed to delete uncommitted artifact CAS object after update failure"
+                );
+            }
+        }
+        return Err(error);
+    }
     if let Some(previous_object_key) = previous_object_key {
         if artifact
             .object_ref
             .as_ref()
             .is_none_or(|object_ref| object_ref.key != previous_object_key)
         {
-            cas.delete_object(&previous_object_key).await?;
+            if let Err(error) = cas.delete_object(&previous_object_key).await {
+                tracing::warn!(
+                    error = %error,
+                    object_key = %previous_object_key,
+                    "failed to delete superseded artifact CAS object"
+                );
+            }
         }
     }
     Ok(serde_json::to_string_pretty(&json!({

--- a/src/harness/tools/artifacts.rs
+++ b/src/harness/tools/artifacts.rs
@@ -36,6 +36,20 @@ pub(super) fn register(registry: &mut ToolRegistry) {
         }),
     );
     registry.register_builtin(
+        super::UPDATE_ARTIFACT_TOOL,
+        "Update an artifact owned by the current agent/session. Writes a new immutable object and keeps the same artifact:// URI.",
+        json!({
+            "type": "object",
+            "properties": {
+                "artifact_uri": { "type": "string" },
+                "media_type": { "type": "string", "description": "Media type. Defaults to the artifact's current media type." },
+                "content": { "type": "string", "description": "Text content to store." },
+                "content_base64": { "type": "string", "description": "Base64 bytes to store instead of content." }
+            },
+            "required": ["artifact_uri"]
+        }),
+    );
+    registry.register_builtin(
         super::GET_ARTIFACT_METADATA_TOOL,
         "Return artifact metadata for an artifact:// URI without reading bytes.",
         json!({
@@ -82,6 +96,11 @@ pub(super) async fn execute(
         }
         super::READ_ARTIFACT_TOOL => {
             super::read_artifact(cp, current_namespace, current_agent, current_session, args)
+                .await
+                .map(Some)
+        }
+        super::UPDATE_ARTIFACT_TOOL => {
+            super::update_artifact(cp, current_namespace, current_agent, current_session, args)
                 .await
                 .map(Some)
         }

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -321,6 +321,7 @@ fn builtin_tool_names() -> &'static [&'static str] {
         crate::harness::native_tools::CHANNEL_SKIP_REPLY_TOOL,
         crate::harness::native_tools::READ_SESSION_MESSAGES_TOOL,
         crate::harness::native_tools::CREATE_ARTIFACT_TOOL,
+        crate::harness::native_tools::UPDATE_ARTIFACT_TOOL,
         crate::harness::native_tools::READ_ARTIFACT_TOOL,
         crate::harness::native_tools::GET_ARTIFACT_METADATA_TOOL,
         crate::harness::native_tools::GRANT_ARTIFACT_TOOL,
@@ -708,6 +709,7 @@ mod tests {
         assert!(names.contains(&crate::harness::native_tools::CREATE_GOAL_TOOL));
         assert!(names.contains(&crate::harness::native_tools::LIST_GOALS_TOOL));
         assert!(names.contains(&crate::harness::native_tools::CREATE_ARTIFACT_TOOL));
+        assert!(names.contains(&crate::harness::native_tools::UPDATE_ARTIFACT_TOOL));
         assert!(names.contains(&crate::harness::native_tools::DELEGATE_TASK_TOOL));
         assert!(names.contains(&crate::harness::native_tools::READ_SESSION_MESSAGES_TOOL));
         assert!(names.contains(&crate::harness::native_tools::SEARCH_MEMORY_TOOL));


### PR DESCRIPTION
## Summary

Adds a minimal `update_artifact` native tool for the artifact owner session.

The tool:
- accepts `artifact_uri` plus `content` or `content_base64`
- only allows the owning agent/session to update the artifact
- writes a replacement CAS object using the existing artifact id
- updates the existing Artifact record's `objectRef`
- deletes the previous object immediately

This also fixes artifact content parsing so raw `content` strings are not trimmed. That matters for large Markdown/tool arguments because body whitespace is payload, not argument decoration.

No new resources, KV records, version records, or indexing behavior are added.

## Stack

1. This PR: minimal artifact editing, old-object deletion, raw content parsing
2. #134: Task artifact URI outputs and completion-time access propagation

`gh stack submit` could not be used because GitHub reported stacked PRs are not enabled for this repository, so this was published as equivalent base-branch stacked PRs.

## Why

Copywriter-style agents need to revise an artifact without creating a pile of new artifacts for every edit. For now we explicitly do not retain old versions; version retention can be added later with a deliberate design.

The 10k+ content test caught that the generic string helper trims tool strings. Artifact body content now bypasses that helper and preserves the exact JSON string value.

## Validation

- `cargo test -p talon create_artifact_stores_canonical_session_owned_cas_object --lib`
- `cargo test -p talon artifact_tools_accept_large_string_content_arguments --lib`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating existing artifacts through the built-in artifact tool.
  * Updates can replace artifact content and optionally change its media type.
  * Added validation to prevent unauthorized updates and reject requests without replacement content.
  * Improved handling of large text content during artifact creation, reading, and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->