### PR TITLE
Add ordered KV list operations

### DIFF
--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -1793,7 +1793,10 @@ mod tests {
             .await
             .unwrap());
 
-        let keys = kv.list_keys(&list).await.unwrap();
+        let keys = kv
+            .list_keys(&list, talon::control::Order::Asc)
+            .await
+            .unwrap();
         assert_eq!(keys, vec![a.clone(), b.clone(), new.clone()]);
 
         kv.delete(&b).await.unwrap();

--- a/src/control/delegation.rs
+++ b/src/control/delegation.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use crate::control::resource_model::{self, TypedResource};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, scheduling, ControlPlane, ProtoKeyValueStoreExt};
+use crate::control::{keys, scheduling, ControlPlane, Order, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{data_proto, resources_proto};
 
 // Task resource label: marks a Task as created through agent delegation.
@@ -532,30 +532,36 @@ async fn latest_assistant_text(
     agent: &str,
     session_id: &str,
 ) -> Result<Option<String>> {
-    let mut entries = cp
-        .kv
-        .list_entries(&keys::session_message_prefix(ns, agent, session_id))
-        .await?;
-    entries.sort_by(|left, right| right.0.name.cmp(&left.0.name));
-    for (_, bytes) in entries {
-        let message = data_proto::SessionMessage::decode(bytes.as_slice())?;
-        if message.role != data_proto::MessageRole::RoleAssistant as i32 {
-            continue;
+    let prefix = keys::session_message_prefix(ns, agent, session_id);
+    let mut before_name = None;
+    loop {
+        let entries = cp
+            .kv
+            .list_entries_page(&prefix, before_name.as_deref(), 64)
+            .await?;
+        if entries.is_empty() {
+            return Ok(None);
         }
-        let text = message
-            .parts
-            .iter()
-            .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
-            .map(|part| part.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n")
-            .trim()
-            .to_string();
-        if !text.is_empty() {
-            return Ok(Some(text));
+        before_name = entries.last().map(|(key, _)| key.name.clone());
+        for (_, bytes) in entries {
+            let message = data_proto::SessionMessage::decode(bytes.as_slice())?;
+            if message.role != data_proto::MessageRole::RoleAssistant as i32 {
+                continue;
+            }
+            let text = message
+                .parts
+                .iter()
+                .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
+                .map(|part| part.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n")
+                .trim()
+                .to_string();
+            if !text.is_empty() {
+                return Ok(Some(text));
+            }
         }
     }
-    Ok(None)
 }
 
 async fn grant_child_artifacts_to_owner(
@@ -582,11 +588,10 @@ async fn grant_child_artifacts_to_owner(
 
     let entries = cp
         .kv
-        .list_entries(&keys::artifact_prefix(
-            &session.ns,
-            &session.agent,
-            &session.id,
-        ))
+        .list_entries(
+            &keys::artifact_prefix(&session.ns, &session.agent, &session.id),
+            Order::Asc,
+        )
         .await?;
     let mut result_artifacts = Vec::new();
     let now = chrono::Utc::now().timestamp_micros();

--- a/src/control/kv/dynamodb.rs
+++ b/src/control/kv/dynamodb.rs
@@ -3,7 +3,7 @@
 
 use crate::control::{
     keys::{ResourceKey, ResourceList},
-    KeyValueStore,
+    KeyValueStore, Order,
 };
 use anyhow::{anyhow, Result};
 use aws_config::meta::region::RegionProviderChain;
@@ -68,6 +68,7 @@ impl DynamoDbKvStore {
         list: &ResourceList,
         before_name: Option<&str>,
         limit: Option<usize>,
+        order: Order,
         include_values: bool,
     ) -> Result<Vec<(ResourceKey, Option<Vec<u8>>)>> {
         if limit == Some(0) {
@@ -86,8 +87,6 @@ impl DynamoDbKvStore {
             );
             key_condition = "#pk = :pk AND begins_with(#sk, :sk_prefix)".to_string();
         }
-        let descending_page = before_name.is_some() || limit.is_some();
-
         if let (Some(kind), Some(before_name)) = (list.kind.as_deref(), before_name) {
             key_condition = "#pk = :pk AND #sk BETWEEN :sk_prefix AND :before_sk".to_string();
             values.insert(
@@ -120,7 +119,7 @@ impl DynamoDbKvStore {
                 .query()
                 .table_name(&self.table)
                 .consistent_read(true)
-                .scan_index_forward(!descending_page)
+                .scan_index_forward(order != Order::Desc)
                 .key_condition_expression(key_condition.clone())
                 .set_expression_attribute_names(Some(names.clone()))
                 .set_expression_attribute_values(Some(values.clone()))
@@ -234,18 +233,24 @@ impl KeyValueStore for DynamoDbKvStore {
         Ok(())
     }
 
-    async fn list_keys(&self, list: &ResourceList) -> Result<Vec<ResourceKey>> {
-        self.query_list(list, None, None, false)
+    async fn list_keys(&self, list: &ResourceList, order: Order) -> Result<Vec<ResourceKey>> {
+        self.query_list(list, None, None, order, false)
             .await
             .map(|rows| rows.into_iter().map(|(key, _)| key).collect())
     }
 
-    async fn list_entries(&self, list: &ResourceList) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        self.query_list(list, None, None, true).await.map(|rows| {
-            rows.into_iter()
-                .filter_map(|(key, value)| value.map(|value| (key, value)))
-                .collect()
-        })
+    async fn list_entries(
+        &self,
+        list: &ResourceList,
+        order: Order,
+    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        self.query_list(list, None, None, order, true)
+            .await
+            .map(|rows| {
+                rows.into_iter()
+                    .filter_map(|(key, value)| value.map(|value| (key, value)))
+                    .collect()
+            })
     }
 
     async fn list_keys_page(
@@ -258,7 +263,7 @@ impl KeyValueStore for DynamoDbKvStore {
             .kind
             .as_ref()
             .ok_or_else(|| anyhow!("dynamodb list_keys_page requires a resource kind"))?;
-        self.query_list(list, before_name, Some(limit), false)
+        self.query_list(list, before_name, Some(limit), Order::Desc, false)
             .await
             .map(|rows| rows.into_iter().map(|(key, _)| key).collect())
     }
@@ -273,7 +278,7 @@ impl KeyValueStore for DynamoDbKvStore {
             .kind
             .as_ref()
             .ok_or_else(|| anyhow!("dynamodb list_entries_page requires a resource kind"))?;
-        self.query_list(list, before_name, Some(limit), true)
+        self.query_list(list, before_name, Some(limit), Order::Desc, true)
             .await
             .map(|rows| {
                 rows.into_iter()

--- a/src/control/kv/postgres.rs
+++ b/src/control/kv/postgres.rs
@@ -3,7 +3,7 @@
 
 use crate::control::{
     keys::{ResourceKey, ResourceList},
-    KeyValueStore,
+    KeyValueStore, Order,
 };
 use anyhow::{bail, Result};
 use sqlx::{pool::PoolConnection, postgres::PgPoolOptions, PgConnection, PgPool, Postgres, Row};
@@ -72,22 +72,32 @@ fn delete_query(table: &str) -> String {
     )
 }
 
-fn list_keys_query(table: &str, has_kind: bool) -> String {
+fn list_order_sql(order: Order) -> &'static str {
+    if order == Order::Desc {
+        "DESC"
+    } else {
+        "ASC"
+    }
+}
+
+fn list_keys_query(table: &str, has_kind: bool, order: Order) -> String {
     let kind_clause = if has_kind { "AND kind = $3" } else { "" };
+    let direction = list_order_sql(order);
     format!(
         "SELECT namespace, parent_path, kind, name FROM {}
          WHERE namespace = $1 AND parent_path = $2 {kind_clause}
-         ORDER BY kind ASC, name ASC",
+         ORDER BY kind {direction}, name {direction}",
         quoted_identifier(table)
     )
 }
 
-fn list_entries_query(table: &str, has_kind: bool) -> String {
+fn list_entries_query(table: &str, has_kind: bool, order: Order) -> String {
     let kind_clause = if has_kind { "AND kind = $3" } else { "" };
+    let direction = list_order_sql(order);
     format!(
         "SELECT namespace, parent_path, kind, name, value FROM {}
          WHERE namespace = $1 AND parent_path = $2 {kind_clause}
-         ORDER BY kind ASC, name ASC",
+         ORDER BY kind {direction}, name {direction}",
         quoted_identifier(table)
     )
 }
@@ -539,8 +549,8 @@ impl KeyValueStore for PostgresKvStore {
         Ok(())
     }
 
-    async fn list_keys(&self, list: &ResourceList) -> Result<Vec<ResourceKey>> {
-        let query = list_keys_query(&self.table, list.kind.is_some());
+    async fn list_keys(&self, list: &ResourceList, order: Order) -> Result<Vec<ResourceKey>> {
+        let query = list_keys_query(&self.table, list.kind.is_some(), order);
         let span = tracing::debug_span!(
             "PostgresKvStore.list_keys",
             "db.system" = "postgresql",
@@ -585,8 +595,12 @@ impl KeyValueStore for PostgresKvStore {
         Ok(keys)
     }
 
-    async fn list_entries(&self, list: &ResourceList) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        let query = list_entries_query(&self.table, list.kind.is_some());
+    async fn list_entries(
+        &self,
+        list: &ResourceList,
+        order: Order,
+    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let query = list_entries_query(&self.table, list.kind.is_some(), order);
         let span = tracing::debug_span!(
             "PostgresKvStore.list_entries",
             "db.system" = "postgresql",
@@ -769,7 +783,7 @@ mod tests {
         list_entries_page_query, list_entries_query, list_keys_page_query, list_keys_query,
         rename_migration_index_statement, set_query, PostgresKvStore,
     };
-    use crate::control::{keys, KeyValueStore};
+    use crate::control::{keys, KeyValueStore, Order};
     use crate::test_support::{docker_test_guard, PostgresContainer};
     use std::time::Duration;
 
@@ -784,11 +798,14 @@ mod tests {
         assert!(compare_and_swap_query("talon_kv", true).contains("AND value = $6"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
         assert!(delete_query("talon_kv").contains("WHERE namespace = $1"));
-        assert!(list_keys_query("talon_kv", true).contains("AND kind = $3"));
+        assert!(list_keys_query("talon_kv", true, Order::Asc).contains("AND kind = $3"));
+        assert!(list_keys_query("talon_kv", true, Order::Desc)
+            .contains("ORDER BY kind DESC, name DESC"));
         assert!(list_keys_page_query("talon_kv").contains("ORDER BY name DESC"));
         assert!(list_entries_page_query("talon_kv")
             .contains("SELECT namespace, parent_path, kind, name, value"));
-        assert!(list_entries_query("talon_kv", false).contains("ORDER BY kind ASC, name ASC"));
+        assert!(list_entries_query("talon_kv", false, Order::Asc)
+            .contains("ORDER BY kind ASC, name ASC"));
         assert_eq!(
             rename_migration_index_statement("talon_kv", "talon_kv_structured_key_migration"),
             "ALTER INDEX IF EXISTS \"talon_kv_structured_key_migration_pkey\" RENAME TO \"talon_kv_pkey\""
@@ -848,9 +865,12 @@ mod tests {
         store.set(&other, b"three").await.unwrap();
         assert_eq!(store.get(&a).await.unwrap(), Some(b"one".to_vec()));
 
-        let mut listed = store.list_keys(&list).await.unwrap();
-        listed.sort_by(|left, right| left.name.cmp(&right.name));
+        let listed = store.list_keys(&list, Order::Asc).await.unwrap();
         assert_eq!(listed, vec![a.clone(), b.clone()]);
+        assert_eq!(
+            store.list_keys(&list, Order::Desc).await.unwrap(),
+            vec![b.clone(), a.clone()]
+        );
 
         assert_eq!(
             store.list_keys_page(&list, None, 10).await.unwrap(),
@@ -865,10 +885,13 @@ mod tests {
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 
-        let mut entries = store.list_entries(&list).await.unwrap();
-        entries.sort_by(|left, right| left.0.name.cmp(&right.0.name));
+        let entries = store.list_entries(&list, Order::Asc).await.unwrap();
         assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
         assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
+        assert_eq!(
+            store.list_entries(&list, Order::Desc).await.unwrap(),
+            vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
+        );
 
         assert!(store
             .compare_and_swap(&a, Some(b"one"), b"updated")

--- a/src/control/kv/rocksdb.rs
+++ b/src/control/kv/rocksdb.rs
@@ -3,7 +3,7 @@
 
 use crate::control::{
     keys::{ResourceKey, ResourceList},
-    KeyValueStore,
+    KeyValueStore, Order,
 };
 use anyhow::{anyhow, bail, Result};
 use rocksdb::{
@@ -39,6 +39,12 @@ fn page_seek_bytes(prefix: &[u8], cursor: Option<&[u8]>) -> Vec<u8> {
             seek
         }
     }
+}
+
+fn reverse_seek_bytes(prefix: &[u8]) -> Vec<u8> {
+    let mut seek = prefix.to_vec();
+    seek.push(0xff);
+    seek
 }
 
 fn parse_key(bytes: &[u8]) -> Result<ResourceKey> {
@@ -313,8 +319,9 @@ impl KeyValueStore for RocksDbKvStore {
         .await
     }
 
-    async fn list_keys(&self, list: &ResourceList) -> Result<Vec<ResourceKey>> {
+    async fn list_keys(&self, list: &ResourceList, order: Order) -> Result<Vec<ResourceKey>> {
         let prefix = prefix_bytes(list);
+        let seek_key = (order == Order::Desc).then(|| reverse_seek_bytes(&prefix));
         let span = tracing::debug_span!(
             "RocksDbKvStore.list_keys",
             "db.system" = "rocksdb",
@@ -330,14 +337,26 @@ impl KeyValueStore for RocksDbKvStore {
             let mut keys = self
                 .spawn_blocking("list_keys", move |db| {
                     let mut keys = Vec::new();
-                    for item in
-                        db.iterator(IteratorMode::From(&prefix, rocksdb::Direction::Forward))
-                    {
-                        let (raw_key, _) = item?;
-                        if !raw_key.starts_with(&prefix) {
-                            break;
+                    if let Some(seek_key) = seek_key {
+                        for item in
+                            db.iterator(IteratorMode::From(&seek_key, rocksdb::Direction::Reverse))
+                        {
+                            let (raw_key, _) = item?;
+                            if !raw_key.starts_with(&prefix) {
+                                break;
+                            }
+                            keys.push(parse_key(&raw_key)?);
                         }
-                        keys.push(parse_key(&raw_key)?);
+                    } else {
+                        for item in
+                            db.iterator(IteratorMode::From(&prefix, rocksdb::Direction::Forward))
+                        {
+                            let (raw_key, _) = item?;
+                            if !raw_key.starts_with(&prefix) {
+                                break;
+                            }
+                            keys.push(parse_key(&raw_key)?);
+                        }
                     }
                     Ok(keys)
                 })
@@ -350,8 +369,13 @@ impl KeyValueStore for RocksDbKvStore {
         .await
     }
 
-    async fn list_entries(&self, list: &ResourceList) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+    async fn list_entries(
+        &self,
+        list: &ResourceList,
+        order: Order,
+    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
         let prefix = prefix_bytes(list);
+        let seek_key = (order == Order::Desc).then(|| reverse_seek_bytes(&prefix));
         let span = tracing::debug_span!(
             "RocksDbKvStore.list_entries",
             "db.system" = "rocksdb",
@@ -369,15 +393,28 @@ impl KeyValueStore for RocksDbKvStore {
                 .spawn_blocking("list_entries", move |db| {
                     let mut entries = Vec::new();
                     let mut value_bytes = 0usize;
-                    for item in
-                        db.iterator(IteratorMode::From(&prefix, rocksdb::Direction::Forward))
-                    {
-                        let (raw_key, value) = item?;
-                        if !raw_key.starts_with(&prefix) {
-                            break;
+                    if let Some(seek_key) = seek_key {
+                        for item in
+                            db.iterator(IteratorMode::From(&seek_key, rocksdb::Direction::Reverse))
+                        {
+                            let (raw_key, value) = item?;
+                            if !raw_key.starts_with(&prefix) {
+                                break;
+                            }
+                            value_bytes += value.len();
+                            entries.push((parse_key(&raw_key)?, value.to_vec()));
                         }
-                        value_bytes += value.len();
-                        entries.push((parse_key(&raw_key)?, value.to_vec()));
+                    } else {
+                        for item in
+                            db.iterator(IteratorMode::From(&prefix, rocksdb::Direction::Forward))
+                        {
+                            let (raw_key, value) = item?;
+                            if !raw_key.starts_with(&prefix) {
+                                break;
+                            }
+                            value_bytes += value.len();
+                            entries.push((parse_key(&raw_key)?, value.to_vec()));
+                        }
                     }
                     Ok((entries, value_bytes))
                 })
@@ -518,7 +555,7 @@ impl KeyValueStore for RocksDbKvStore {
 #[cfg(test)]
 mod tests {
     use super::RocksDbKvStore;
-    use crate::control::{keys, KeyValueStore};
+    use crate::control::{keys, KeyValueStore, Order};
     use tempfile::{tempdir, TempDir};
 
     async fn test_store() -> (TempDir, RocksDbKvStore) {
@@ -572,10 +609,26 @@ mod tests {
         store.set(&other, b"o").await.unwrap();
 
         let list = keys::session_prefix("default", "agent-a");
-        let keys = store.list_keys(&list).await.unwrap();
+        let keys = store.list_keys(&list, Order::Asc).await.unwrap();
         assert_eq!(
             keys.iter().map(|key| key.name.as_str()).collect::<Vec<_>>(),
             vec!["alpha", "beta", "gamma"]
+        );
+        let desc_keys = store.list_keys(&list, Order::Desc).await.unwrap();
+        assert_eq!(
+            desc_keys
+                .iter()
+                .map(|key| key.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gamma", "beta", "alpha"]
+        );
+        let desc_entries = store.list_entries(&list, Order::Desc).await.unwrap();
+        assert_eq!(
+            desc_entries
+                .iter()
+                .map(|(key, _)| key.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gamma", "beta", "alpha"]
         );
 
         let page = store.list_keys_page(&list, None, 2).await.unwrap();

--- a/src/control/kv/sqlite.rs
+++ b/src/control/kv/sqlite.rs
@@ -3,7 +3,7 @@
 
 use crate::control::{
     keys::{ResourceKey, ResourceList},
-    KeyValueStore,
+    KeyValueStore, Order,
 };
 use anyhow::{bail, Result};
 use sqlx::{
@@ -425,8 +425,8 @@ impl KeyValueStore for SqliteKvStore {
         Ok(())
     }
 
-    async fn list_keys(&self, list: &ResourceList) -> Result<Vec<ResourceKey>> {
-        let query = list_keys_query(&self.table, list.kind.is_some());
+    async fn list_keys(&self, list: &ResourceList, order: Order) -> Result<Vec<ResourceKey>> {
+        let query = list_keys_query(&self.table, list.kind.is_some(), order);
         let span = tracing::debug_span!(
             "SqliteKvStore.list_keys",
             "db.system" = "sqlite",
@@ -472,8 +472,12 @@ impl KeyValueStore for SqliteKvStore {
         Ok(keys)
     }
 
-    async fn list_entries(&self, list: &ResourceList) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        let query = list_entries_query(&self.table, list.kind.is_some());
+    async fn list_entries(
+        &self,
+        list: &ResourceList,
+        order: Order,
+    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let query = list_entries_query(&self.table, list.kind.is_some(), order);
         let span = tracing::debug_span!(
             "SqliteKvStore.list_entries",
             "db.system" = "sqlite",
@@ -660,7 +664,7 @@ mod tests {
         set_query, sqlite_pool, SqliteKvStore,
     };
     use crate::control::kv::sqlite_url_for_path;
-    use crate::control::{keys, KeyValueStore};
+    use crate::control::{keys, KeyValueStore, Order};
     use tempfile::tempdir;
 
     #[test]
@@ -675,11 +679,14 @@ mod tests {
         assert!(compare_and_swap_query("talon_kv", true).contains("AND value = ?6"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
         assert!(delete_query("talon_kv").contains("WHERE namespace = ?1"));
-        assert!(list_keys_query("talon_kv", true).contains("AND kind = ?3"));
+        assert!(list_keys_query("talon_kv", true, Order::Asc).contains("AND kind = ?3"));
+        assert!(list_keys_query("talon_kv", true, Order::Desc)
+            .contains("ORDER BY kind DESC, name DESC"));
         assert!(list_keys_page_query("talon_kv").contains("ORDER BY name DESC"));
         assert!(list_entries_page_query("talon_kv")
             .contains("SELECT namespace, parent_path, kind, name, value"));
-        assert!(list_entries_query("talon_kv", false).contains("ORDER BY kind ASC, name ASC"));
+        assert!(list_entries_query("talon_kv", false, Order::Asc)
+            .contains("ORDER BY kind ASC, name ASC"));
     }
 
     #[test]
@@ -781,9 +788,12 @@ mod tests {
         store.set(&other, b"three").await.unwrap();
         assert_eq!(store.get(&a).await.unwrap(), Some(b"one".to_vec()));
 
-        let mut listed = store.list_keys(&list).await.unwrap();
-        listed.sort_by(|left, right| left.name.cmp(&right.name));
+        let listed = store.list_keys(&list, Order::Asc).await.unwrap();
         assert_eq!(listed, vec![a.clone(), b.clone()]);
+        assert_eq!(
+            store.list_keys(&list, Order::Desc).await.unwrap(),
+            vec![b.clone(), a.clone()]
+        );
 
         assert_eq!(
             store.list_keys_page(&list, None, 10).await.unwrap(),
@@ -798,10 +808,13 @@ mod tests {
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 
-        let mut entries = store.list_entries(&list).await.unwrap();
-        entries.sort_by(|left, right| left.0.name.cmp(&right.0.name));
+        let entries = store.list_entries(&list, Order::Asc).await.unwrap();
         assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
         assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
+        assert_eq!(
+            store.list_entries(&list, Order::Desc).await.unwrap(),
+            vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
+        );
 
         assert!(store
             .compare_and_swap(&a, Some(b"one"), b"updated")

--- a/src/control/kv/sqlite_sql.rs
+++ b/src/control/kv/sqlite_sql.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use super::shared::quoted_identifier;
+use crate::control::Order;
 
 pub(crate) fn create_table_statement(table: &str) -> String {
     let table = quoted_identifier(table);
@@ -63,22 +64,32 @@ pub(crate) fn delete_query(table: &str) -> String {
     )
 }
 
-pub(crate) fn list_keys_query(table: &str, has_kind: bool) -> String {
+fn list_order_sql(order: Order) -> &'static str {
+    if order == Order::Desc {
+        "DESC"
+    } else {
+        "ASC"
+    }
+}
+
+pub(crate) fn list_keys_query(table: &str, has_kind: bool, order: Order) -> String {
     let kind_clause = if has_kind { "AND kind = ?3" } else { "" };
+    let direction = list_order_sql(order);
     format!(
         "SELECT namespace, parent_path, kind, name FROM {}
          WHERE namespace = ?1 AND parent_path = ?2 {kind_clause}
-         ORDER BY kind ASC, name ASC",
+         ORDER BY kind {direction}, name {direction}",
         quoted_identifier(table)
     )
 }
 
-pub(crate) fn list_entries_query(table: &str, has_kind: bool) -> String {
+pub(crate) fn list_entries_query(table: &str, has_kind: bool, order: Order) -> String {
     let kind_clause = if has_kind { "AND kind = ?3" } else { "" };
+    let direction = list_order_sql(order);
     format!(
         "SELECT namespace, parent_path, kind, name, value FROM {}
          WHERE namespace = ?1 AND parent_path = ?2 {kind_clause}
-         ORDER BY kind ASC, name ASC",
+         ORDER BY kind {direction}, name {direction}",
         quoted_identifier(table)
     )
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -28,6 +28,12 @@ use std::path::PathBuf;
 
 use keys::{ResourceKey, ResourceList};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Order {
+    Asc,
+    Desc,
+}
+
 pub fn page_keys_desc(
     mut keys: Vec<ResourceKey>,
     before_name: Option<&str>,
@@ -78,44 +84,53 @@ pub trait KeyValueStore: Send + Sync {
     async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()>;
 
     /// List direct children matching a resource parent and optional kind.
-    async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>>;
+    async fn list_keys(
+        &self,
+        list: &ResourceList,
+        order: Order,
+    ) -> anyhow::Result<Vec<ResourceKey>>;
 
     /// List direct children, ordered by resource name descending.
     ///
     /// `before_name` is an exclusive resource-name cursor. Production backends
-    /// should override this with a storage-level page read. The default
-    /// implementation fails rather than silently materializing an unbounded list.
+    /// should override this with a storage-level page read.
     async fn list_keys_page(
         &self,
         list: &ResourceList,
         before_name: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<ResourceKey>> {
-        let _ = (list, before_name, limit);
-        anyhow::bail!("list_keys_page is not implemented for this KeyValueStore")
+        Ok(page_keys_desc(
+            self.list_keys(list, Order::Asc).await?,
+            before_name,
+            limit,
+        ))
     }
 
     /// List direct child key/value pairs, ordered by resource name descending.
     ///
     /// `before_name` is an exclusive resource-name cursor. Production backends
-    /// should override this with a storage-level page read. The default
-    /// implementation fails rather than silently materializing an unbounded list.
+    /// should override this with a storage-level page read.
     async fn list_entries_page(
         &self,
         list: &ResourceList,
         before_name: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
-        let _ = (list, before_name, limit);
-        anyhow::bail!("list_entries_page is not implemented for this KeyValueStore")
+        Ok(page_entries_desc(
+            self.list_entries(list, Order::Asc).await?,
+            before_name,
+            limit,
+        ))
     }
 
     /// List all matching direct child key/value pairs.
     async fn list_entries(
         &self,
         list: &ResourceList,
+        order: Order,
     ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
-        let keys = self.list_keys(list).await?;
+        let keys = self.list_keys(list, order).await?;
         let mut entries = Vec::with_capacity(keys.len());
         for key in keys {
             if let Some(value) = self.get(&key).await? {
@@ -288,7 +303,11 @@ impl KeyValueStore for NoopKeyValueStore {
         Ok(())
     }
 
-    async fn list_keys(&self, _list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+    async fn list_keys(
+        &self,
+        _list: &ResourceList,
+        _order: Order,
+    ) -> anyhow::Result<Vec<ResourceKey>> {
         Ok(Vec::new())
     }
 
@@ -806,7 +825,7 @@ mod tests {
     use super::{
         build_control_plane, configured_scheduler, configured_scheduler_callback_auth_from_env,
         ensure_builtin_namespaces, message_broker_config, sqlite_database_url, KeyValueStore,
-        ProtoKeyValueStoreExt,
+        Order, ProtoKeyValueStoreExt,
     };
     use crate::control::config::proto;
     use crate::control::config::proto::{scheduler_callback_auth_config, scheduler_config, secret};
@@ -1035,11 +1054,14 @@ mod tests {
         kv.set(&b, b"two").await.unwrap();
         kv.set(&other, b"three").await.unwrap();
 
-        let mut entries = kv.list_entries(&list).await.unwrap();
-        entries.sort_by(|a, b| a.0.name.cmp(&b.0.name));
+        let entries = kv.list_entries(&list, Order::Asc).await.unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
         assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
+        assert_eq!(
+            kv.list_entries(&list, Order::Desc).await.unwrap(),
+            vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
+        );
 
         kv.delete(&a).await.unwrap();
         kv.delete(&b).await.unwrap();

--- a/src/control/resources.rs
+++ b/src/control/resources.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use crate::control::events;
-use crate::control::{keys, topics, KeyValueStore, MessagePublisher};
+use crate::control::{keys, topics, KeyValueStore, MessagePublisher, Order};
 use crate::gateway::rpc::resources_proto;
 use anyhow::{anyhow, Context, Result};
 use prost::Message;
@@ -423,7 +423,10 @@ impl ResourceStore {
     ) -> Result<Vec<resources_proto::Resource>> {
         let entries = self
             .kv
-            .list_entries(&keys::ResourceParent::root(namespace).list(kind))
+            .list_entries(
+                &keys::ResourceParent::root(namespace).list(kind),
+                Order::Asc,
+            )
             .await?;
         let mut status_fetches = Vec::with_capacity(entries.len());
         for (key, value) in entries {

--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -1140,7 +1140,11 @@ mod tests {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            _order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             let map = self.store.lock().await;
             Ok(map
                 .keys()

--- a/src/control/usage.rs
+++ b/src/control/usage.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::control::{keys, KeyValueStore};
+use crate::control::{keys, KeyValueStore, Order};
 use crate::gateway::rpc::{harness_proto, resources_proto};
 use anyhow::{anyhow, bail, Context, Result};
 use prost::Message;
@@ -336,7 +336,7 @@ async fn usage_status_used(
             let prefix = format!("{rule_id}:subject=");
             let suffix = format!(":{window_start}");
             let mut max_used = 0;
-            for (key, value) in kv.list_entries(&parent).await? {
+            for (key, value) in kv.list_entries(&parent, Order::Asc).await? {
                 if key.name.starts_with(&prefix) && key.name.ends_with(&suffix) {
                     max_used = max_used.max(
                         decode_counter(&value)
@@ -515,7 +515,7 @@ async fn matched_limits(
         .into_iter()
         .map(|namespace| {
             let list_key = keys::ResourceParent::root(&namespace).list(Some("UsagePolicy"));
-            async move { kv.list_entries(&list_key).await }
+            async move { kv.list_entries(&list_key, Order::Asc).await }
         });
     for entries in futures::future::try_join_all(ancestor_fetches).await? {
         for (key, value) in entries {

--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -19,7 +19,7 @@ use crate::control::scheduling;
 use crate::control::{
     events::SessionMessagePartEventKind,
     keys::{self},
-    ProtoKeyValueStoreExt,
+    Order, ProtoKeyValueStoreExt,
 };
 use crate::gateway::auth::{self, AuthConfig};
 use crate::gateway::rpc::data_proto;
@@ -435,7 +435,7 @@ pub async fn list_tasks(
         Err(response) => return response,
     };
     let prefix = keys::session_prefix(&route.ns, &route.agent);
-    let session_keys = match gateway.kv.list_keys(&prefix).await {
+    let session_keys = match gateway.kv.list_keys(&prefix, Order::Asc).await {
         Ok(keys) => keys,
         Err(err) => {
             tracing::error!(%err, "Failed to list A2A sessions");

--- a/src/gateway/rest/a2a/tasks.rs
+++ b/src/gateway/rest/a2a/tasks.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use crate::control::{
     events,
     keys::{self, ResourceKey},
-    topics, ProtoKeyValueStoreExt,
+    topics, Order, ProtoKeyValueStoreExt,
 };
 use crate::gateway::server::Gateway;
 
@@ -300,13 +300,12 @@ pub(super) async fn list_a2a_session_task_ids(
     session_id: &str,
     session: &crate::gateway::rpc::data_proto::Session,
 ) -> Result<Vec<String>, Response> {
-    let mut message_keys = gateway
+    let message_keys = gateway
         .kv
-        .list_keys(&keys::session_message_prefix(
-            &route.ns,
-            &route.agent,
-            session_id,
-        ))
+        .list_keys(
+            &keys::session_message_prefix(&route.ns, &route.agent, session_id),
+            Order::Asc,
+        )
         .await
         .map_err(|err| {
             tracing::error!(%err, "Failed to list A2A task messages");
@@ -315,7 +314,6 @@ pub(super) async fn list_a2a_session_task_ids(
                 "failed to load task messages",
             )
         })?;
-    message_keys.sort();
 
     let mut task_ids = Vec::new();
     for key in message_keys {
@@ -404,10 +402,14 @@ pub(super) async fn find_a2a_task_session(
     }
 
     let prefix = keys::session_prefix(&route.ns, &route.agent);
-    let session_keys = gateway.kv.list_keys(&prefix).await.map_err(|err| {
-        tracing::error!(%err, "Failed to list A2A sessions");
-        a2a_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to load task")
-    })?;
+    let session_keys = gateway
+        .kv
+        .list_keys(&prefix, Order::Asc)
+        .await
+        .map_err(|err| {
+            tracing::error!(%err, "Failed to list A2A sessions");
+            a2a_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to load task")
+        })?;
 
     let mut fallback = None;
     for key in session_keys {
@@ -464,11 +466,10 @@ async fn session_contains_a2a_task_message(
 ) -> Result<bool, Response> {
     let message_keys = gateway
         .kv
-        .list_keys(&keys::session_message_prefix(
-            &route.ns,
-            &route.agent,
-            session_id,
-        ))
+        .list_keys(
+            &keys::session_message_prefix(&route.ns, &route.agent, session_id),
+            Order::Asc,
+        )
         .await
         .map_err(|err| {
             tracing::error!(%err, "Failed to list A2A task messages");
@@ -545,13 +546,12 @@ pub(super) async fn load_a2a_task_from_session(
     task_id: &str,
 ) -> Result<A2aTaskJson, Response> {
     let session = &task_ref.session;
-    let mut message_keys = gateway
+    let message_keys = gateway
         .kv
-        .list_keys(&keys::session_message_prefix(
-            &route.ns,
-            &route.agent,
-            &task_ref.session_id,
-        ))
+        .list_keys(
+            &keys::session_message_prefix(&route.ns, &route.agent, &task_ref.session_id),
+            Order::Asc,
+        )
         .await
         .map_err(|err| {
             tracing::error!(%err, "Failed to list A2A task messages");
@@ -560,7 +560,6 @@ pub(super) async fn load_a2a_task_from_session(
                 "failed to load task messages",
             )
         })?;
-    message_keys.sort();
 
     let mut messages = Vec::new();
     for key in message_keys {

--- a/src/gateway/rpc/auth.rs
+++ b/src/gateway/rpc/auth.rs
@@ -4,7 +4,7 @@
 use super::{data_proto, proto, GrpcGatewayHandler};
 use crate::control::config::proto as config_proto;
 use crate::control::security::platform_jwt;
-use crate::control::{keys, ns};
+use crate::control::{keys, ns, Order};
 use crate::gateway::auth::{
     self as gateway_auth, AuthConfig, AuthMode, AuthzOperation, Claims, TalonGrantClaim,
 };
@@ -221,7 +221,7 @@ impl GrpcGatewayHandler {
         let entries = self
             .gateway
             .kv
-            .list_entries(&api_key_list())
+            .list_entries(&api_key_list(), Order::Asc)
             .await
             .map_err(|err| tonic::Status::internal(format!("failed to list API keys: {err}")))?;
         let mut api_keys = Vec::with_capacity(entries.len());

--- a/src/gateway/rpc/channels.rs
+++ b/src/gateway/rpc/channels.rs
@@ -7,7 +7,7 @@ use crate::control::resource_model::{
 };
 use crate::control::scheduling;
 use crate::control::topics;
-use crate::control::{events, keys, ControlPlane, KeyValueStore};
+use crate::control::{events, keys, ControlPlane, KeyValueStore, Order};
 use crate::control::{MessagePublisher, ProtoKeyValueStoreExt};
 use anyhow::Context;
 use futures::StreamExt;
@@ -733,10 +733,10 @@ async fn matching_subscriptions(
     let manual: HashSet<&str> = manual_subscriptions.iter().map(String::as_str).collect();
     let entries = cp
         .kv
-        .list_entries(&keys::channel_subscription_prefix(
-            &message.ns,
-            &message.channel,
-        ))
+        .list_entries(
+            &keys::channel_subscription_prefix(&message.ns, &message.channel),
+            Order::Asc,
+        )
         .await?;
     let mut subscriptions = Vec::new();
     for (_, value) in entries {
@@ -1012,7 +1012,7 @@ async fn delete_routed_session(
     let mut stack = vec![keys::session_parent(ns, agent, session_id)];
     while let Some(parent) = stack.pop() {
         let list = parent.list(None);
-        let children = kv.list_keys(&list).await?;
+        let children = kv.list_keys(&list, Order::Asc).await?;
         for child in children {
             stack.push(child.as_parent());
             kv.delete(&child).await?;

--- a/src/gateway/rpc/knowledge.rs
+++ b/src/gateway/rpc/knowledge.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use super::{data_proto, proto, GrpcGatewayHandler};
-use crate::control::keys;
 use crate::control::ns;
 use crate::control::resources::ResourceStore;
 use crate::control::search::{DOCUMENT_KIND_CONTENT, KIND_KNOWLEDGE};
+use crate::control::{keys, Order};
 use crate::gateway::rpc::resources_proto;
 use crate::harness::knowledge::KnowledgeEntry;
 use std::collections::HashMap;
@@ -64,7 +64,7 @@ async fn list_namespace_knowledge(
         }
 
         let prefix = keys::knowledge_prefix(&candidate_ns);
-        let keys = kv.list_keys(&prefix).await.map_err(|e| {
+        let keys = kv.list_keys(&prefix, Order::Asc).await.map_err(|e| {
             tonic::Status::internal(format!("Failed to list knowledge artifacts: {}", e))
         })?;
 
@@ -356,7 +356,11 @@ mod tests {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            _order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()

--- a/src/gateway/rpc/namespaces.rs
+++ b/src/gateway/rpc/namespaces.rs
@@ -3,7 +3,7 @@
 
 use crate::control::resource_model::{self, NamespaceResourceExt, TypedResource};
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{events, keys, topics};
+use crate::control::{events, keys, topics, Order};
 use crate::gateway::rpc::{proto, resources_proto, GrpcGatewayHandler};
 use prost::Message;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -305,9 +305,14 @@ impl GrpcGatewayHandler {
         let edge_prefix =
             keys::namespace_ref_prefix((!parent.is_empty()).then_some(parent.as_str()));
 
-        let keys = self.gateway.kv.list_keys(&edge_prefix).await.map_err(|e| {
-            tonic::Status::internal(format!("Failed to list namespace references: {}", e))
-        })?;
+        let keys = self
+            .gateway
+            .kv
+            .list_keys(&edge_prefix, Order::Asc)
+            .await
+            .map_err(|e| {
+                tonic::Status::internal(format!("Failed to list namespace references: {}", e))
+            })?;
 
         for k in keys {
             if let Ok(Some(bytes)) = self.gateway.kv.get(&k).await {
@@ -457,7 +462,11 @@ mod tests {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            _order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             let map = self.store.lock().await;
             let mut results = Vec::new();
             for k in map.keys() {

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -6,7 +6,7 @@ use crate::control::cas::{session_object_key_prefix, SessionCasScope, METADATA_A
 use crate::control::scheduling;
 use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{events, keys, keys::ResourceParent, KeyValueStore};
+use crate::control::{events, keys, keys::ResourceParent, KeyValueStore, Order};
 use prost::Message;
 use serde_json::{json, Value};
 use std::collections::HashSet;
@@ -169,7 +169,7 @@ async fn delete_descendants(kv: &dyn KeyValueStore, parent: ResourceParent) -> a
     let mut stack = vec![parent];
     while let Some(parent) = stack.pop() {
         let list = parent.list(None);
-        let children = kv.list_keys(&list).await?;
+        let children = kv.list_keys(&list, Order::Asc).await?;
         for child in children {
             stack.push(child.as_parent());
             kv.delete(&child).await?;
@@ -187,7 +187,10 @@ async fn collect_session_tool_result_object_keys(
     let expected_prefix = session_object_key_prefix(&SessionCasScope::new(ns, agent, session_id));
     let mut keys_to_delete = HashSet::new();
     for key in kv
-        .list_keys(&keys::session_message_prefix(ns, agent, session_id))
+        .list_keys(
+            &keys::session_message_prefix(ns, agent, session_id),
+            Order::Asc,
+        )
         .await?
     {
         let message = match kv.get_msg::<data_proto::SessionMessage>(&key).await {
@@ -218,16 +221,17 @@ async fn collect_session_tool_result_object_keys(
     }
 
     for submission_key in kv
-        .list_keys(&keys::session_submission_prefix(ns, agent, session_id))
+        .list_keys(
+            &keys::session_submission_prefix(ns, agent, session_id),
+            Order::Asc,
+        )
         .await?
     {
         for (_, bytes) in kv
-            .list_entries(&keys::session_journal_entry_prefix(
-                ns,
-                agent,
-                session_id,
-                &submission_key.name,
-            ))
+            .list_entries(
+                &keys::session_journal_entry_prefix(ns, agent, session_id, &submission_key.name),
+                Order::Asc,
+            )
             .await?
         {
             let entry = match data_proto::SessionJournalEntry::decode(bytes.as_slice()) {
@@ -383,10 +387,9 @@ async fn find_request_permission_message_id(
     request_id: &str,
 ) -> std::result::Result<Option<String>, tonic::Status> {
     let prefix = keys::session_message_prefix(ns, agent, session_id);
-    let mut message_keys = kv.list_keys(&prefix).await.map_err(|err| {
+    let message_keys = kv.list_keys(&prefix, Order::Asc).await.map_err(|err| {
         tonic::Status::internal(format!("Failed to list session messages: {err}"))
     })?;
-    message_keys.sort();
     for key in message_keys {
         let Some(bytes) = kv.get(&key).await.map_err(|err| {
             tonic::Status::internal(format!("Failed to fetch session message: {err}"))
@@ -720,18 +723,22 @@ impl GrpcGatewayHandler {
                 keys.sort();
                 keys
             } else {
-                let mut keys = self.gateway.kv.list_keys(&msg_prefix).await.map_err(|e| {
-                    tracing::error!(
-                        ns = %req.ns,
-                        agent = %req.agent,
-                        session_id = %req.session_id,
-                        prefix = %msg_prefix,
-                        error = %e,
-                        "failed to list session messages"
-                    );
-                    tonic::Status::internal(format!("Failed to list session messages: {}", e))
-                })?;
-                keys.sort();
+                let keys = self
+                    .gateway
+                    .kv
+                    .list_keys(&msg_prefix, Order::Asc)
+                    .await
+                    .map_err(|e| {
+                        tracing::error!(
+                            ns = %req.ns,
+                            agent = %req.agent,
+                            session_id = %req.session_id,
+                            prefix = %msg_prefix,
+                            error = %e,
+                            "failed to list session messages"
+                        );
+                        tonic::Status::internal(format!("Failed to list session messages: {}", e))
+                    })?;
                 keys
             };
             tracing::info!(
@@ -954,7 +961,7 @@ impl GrpcGatewayHandler {
         let keys = self
             .gateway
             .kv
-            .list_keys(&session_prefix)
+            .list_keys(&session_prefix, Order::Asc)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to list sessions: {}", e)))?;
 
@@ -2832,7 +2839,7 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::Internal);
 
         let session_keys = kv
-            .list_keys(&keys::session_prefix(ns, "assistant"))
+            .list_keys(&keys::session_prefix(ns, "assistant"), Order::Asc)
             .await
             .unwrap();
         assert!(session_keys.is_empty());

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -4,7 +4,7 @@
 use crate::control::scheduling;
 use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{events, keys, KeyValueStore, MessagePublisher};
+use crate::control::{events, keys, KeyValueStore, MessagePublisher, Order};
 use crate::gateway::rpc::{data_proto, resources_proto, worker_proto};
 use crate::gateway::worker_conn::WorkerConnectionPool;
 use futures::{stream::SelectAll, Stream, StreamExt};
@@ -676,7 +676,7 @@ async fn latest_nonterminal_submission(
 ) -> std::result::Result<Option<data_proto::SessionSubmission>, tonic::Status> {
     let prefix = keys::session_submission_prefix(&target.ns, &target.agent, &target.session_id);
     let entries = kv
-        .list_entries(&prefix)
+        .list_entries(&prefix, Order::Asc)
         .await
         .map_err(|err| tonic::Status::internal(format!("Failed to list submissions: {err}")))?;
     let mut submissions = Vec::new();
@@ -700,7 +700,7 @@ async fn latest_submission(
 ) -> std::result::Result<Option<data_proto::SessionSubmission>, tonic::Status> {
     let prefix = keys::session_submission_prefix(&target.ns, &target.agent, &target.session_id);
     let entries = kv
-        .list_entries(&prefix)
+        .list_entries(&prefix, Order::Asc)
         .await
         .map_err(|err| tonic::Status::internal(format!("Failed to list submissions: {err}")))?;
     let mut submissions = Vec::new();

--- a/src/gateway/rpc/workflows.rs
+++ b/src/gateway/rpc/workflows.rs
@@ -3,7 +3,7 @@
 
 use super::{data_proto, proto, resources_proto, worker_proto, GrpcGatewayHandler};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, KeyValueStore, ProtoKeyValueStoreExt};
+use crate::control::{keys, KeyValueStore, Order, ProtoKeyValueStoreExt};
 use crate::gateway::worker_conn::WorkerConnectionPool;
 use crate::worker::workflows;
 use futures::StreamExt;
@@ -455,11 +455,13 @@ async fn load_sorted_workflow_run_events(
     workflow: &str,
     run_id: &str,
 ) -> Result<Vec<data_proto::WorkflowRunEvent>, tonic::Status> {
-    let mut entries = kv
-        .list_entries(&keys::workflow_run_event_prefix(ns, workflow, run_id))
+    let entries = kv
+        .list_entries(
+            &keys::workflow_run_event_prefix(ns, workflow, run_id),
+            Order::Asc,
+        )
         .await
         .map_err(|err| tonic::Status::internal(err.to_string()))?;
-    entries.sort_by(|left, right| left.0.cmp(&right.0));
 
     let mut events = Vec::new();
     for (key, bytes) in entries {

--- a/src/harness/knowledge/mod.rs
+++ b/src/harness/knowledge/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::control::resources::ResourceStore;
 use crate::control::search::{DocumentStore, DOCUMENT_KIND_CONTENT, KIND_KNOWLEDGE};
-use crate::control::MessagePublisher;
+use crate::control::{MessagePublisher, Order};
 use crate::gateway::rpc::{proto, resources_proto};
 
 #[derive(Default, serde::Serialize, serde::Deserialize)]
@@ -263,7 +263,7 @@ impl KvKnowledgeBook {
         let path_lower = path.to_lowercase();
         let matches = self
             .kv
-            .list_keys(&prefix)
+            .list_keys(&prefix, Order::Asc)
             .await?
             .into_iter()
             .filter(|candidate| {
@@ -467,7 +467,7 @@ impl KnowledgeBook for KvKnowledgeBook {
 
         for (depth, candidate_ns) in crate::control::ns::ancestry(ns).into_iter().enumerate() {
             let prefix = crate::control::keys::knowledge_prefix(&candidate_ns);
-            let keys = self.kv.list_keys(&prefix).await?;
+            let keys = self.kv.list_keys(&prefix, Order::Asc).await?;
 
             for key in keys {
                 if let Some(bytes) = self.kv.get(&key).await.unwrap_or(None) {
@@ -556,8 +556,7 @@ impl KnowledgeBook for KvKnowledgeBook {
 
         for candidate_ns in namespaces {
             let prefix = crate::control::keys::knowledge_prefix(&candidate_ns);
-            let mut keys = self.kv.list_keys(&prefix).await?;
-            keys.sort();
+            let keys = self.kv.list_keys(&prefix, Order::Asc).await?;
 
             for key in keys {
                 let artifact_path =
@@ -774,13 +773,22 @@ mod tests {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             let map = self.store.lock().await;
             let mut results = Vec::new();
             for key in map.keys() {
                 if list.matches(key) {
                     results.push(key.clone());
                 }
+            }
+            if order == crate::control::Order::Desc {
+                results.sort_by(|left, right| right.cmp(left));
+            } else {
+                results.sort();
             }
             Ok(results)
         }

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use crate::control::resource_model::{self, TypedResource};
 use crate::control::resources::ResourceStore;
 use crate::control::scheduling;
-use crate::control::{delegation, keys, ControlPlane, ProtoKeyValueStoreExt};
+use crate::control::{delegation, keys, ControlPlane, Order, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{
     data_proto, manifests, protobuf_value::value::Kind as ProtoValueKind, resources_proto,
 };
@@ -573,11 +573,10 @@ pub async fn execute_tool_for_session(
             let agent = opt_str(args, "agent");
             let enabled = args.get("enabled").and_then(Value::as_bool);
             let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(100) as usize;
-            let mut entries = cp
+            let entries = cp
                 .kv
-                .list_entries(&keys::schedule_prefix(namespace))
+                .list_entries(&keys::schedule_prefix(namespace), Order::Asc)
                 .await?;
-            entries.sort_by(|a, b| a.0.cmp(&b.0));
             let mut schedules = Vec::new();
             for (_key, value) in entries {
                 let schedule = resources_proto::Schedule::decode(value.as_slice())?;
@@ -758,11 +757,15 @@ async fn read_session_messages(
     let limit = opt_usize(args, "limit").unwrap_or(20).clamp(1, 100);
     let mut entries = cp
         .kv
-        .list_entries(&keys::session_message_prefix(namespace, agent, session_id))
+        .list_entries_page(
+            &keys::session_message_prefix(namespace, agent, session_id),
+            None,
+            limit,
+        )
         .await?;
-    entries.sort_by(|left, right| left.0.name.cmp(&right.0.name));
     let mut messages = Vec::new();
-    for (_, bytes) in entries.into_iter().rev().take(limit).rev() {
+    entries.reverse();
+    for (_, bytes) in entries {
         let message = data_proto::SessionMessage::decode(bytes.as_slice())?;
         let role = data_proto::MessageRole::try_from(message.role)
             .map(|role| format!("{role:?}"))
@@ -2051,7 +2054,7 @@ async fn list_session_goals(
 ) -> Result<Vec<data_proto::Goal>> {
     let mut goals = cp
         .kv
-        .list_entries(&keys::goal_prefix(namespace, agent, session_id))
+        .list_entries(&keys::goal_prefix(namespace, agent, session_id), Order::Asc)
         .await?
         .into_iter()
         .filter_map(|(_, value)| data_proto::Goal::decode(value.as_slice()).ok())
@@ -2918,7 +2921,10 @@ mod tests {
         session_id: &str,
     ) -> Vec<String> {
         let entries = kv
-            .list_entries(&keys::session_message_prefix(ns, agent, session_id))
+            .list_entries(
+                &keys::session_message_prefix(ns, agent, session_id),
+                Order::Asc,
+            )
             .await
             .unwrap();
         entries
@@ -3714,11 +3720,14 @@ mod tests {
         );
 
         let entries = kv
-            .list_entries(&keys::session_message_prefix(
-                "Tenant:acme:Operations",
-                "support-agent",
-                child_session_id,
-            ))
+            .list_entries(
+                &keys::session_message_prefix(
+                    "Tenant:acme:Operations",
+                    "support-agent",
+                    child_session_id,
+                ),
+                Order::Asc,
+            )
             .await
             .unwrap();
         assert_eq!(entries.len(), 1);

--- a/src/harness/sessions/journal.rs
+++ b/src/harness/sessions/journal.rs
@@ -7,7 +7,7 @@ use prost::Message;
 use super::submission::{ensure_submission_attempt_current, update_submission_from_entry};
 use super::SessionJournalEntry;
 use crate::control::cas::CasStore;
-use crate::control::{keys, KeyValueStore};
+use crate::control::{keys, KeyValueStore, Order};
 use crate::gateway::rpc::data_proto::{
     session_journal_entry_payload, SessionExecutionPhase, SessionJournalEntryPayload,
     SessionJournalEntryPayloadCommit, SessionJournalEntryPayloadLlmResponse,
@@ -213,13 +213,12 @@ pub async fn list_journal_entries(
     submission_id: &str,
 ) -> Result<Vec<SessionJournalEntry>> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
-    let mut entries = kv
-        .list_entries(&prefix)
+    let entries = kv
+        .list_entries(&prefix, Order::Asc)
         .await?
         .into_iter()
         .map(|(_, bytes)| SessionJournalEntry::decode(bytes.as_slice()).map_err(Into::into))
         .collect::<Result<Vec<_>>>()?;
-    entries.sort_by_key(|entry| entry.journal_entry_id.parse::<u64>().unwrap_or(0));
     Ok(entries)
 }
 
@@ -316,11 +315,11 @@ async fn next_journal_entry_id(
 ) -> Result<String> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
     let max_id = kv
-        .list_keys(&prefix)
+        .list_keys_page(&prefix, None, 1)
         .await?
         .into_iter()
-        .filter_map(|key| key.name.parse::<u64>().ok())
-        .max()
+        .next()
+        .and_then(|key| key.name.parse::<u64>().ok())
         .unwrap_or(0);
     Ok(format!("{:06}", max_id.saturating_add(1)))
 }
@@ -334,10 +333,10 @@ async fn latest_journal_entry(
 ) -> Result<Option<SessionJournalEntry>> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
     let Some(key) = kv
-        .list_keys(&prefix)
+        .list_keys_page(&prefix, None, 1)
         .await?
         .into_iter()
-        .max_by_key(|key| key.name.parse::<u64>().unwrap_or(0))
+        .next()
     else {
         return Ok(None);
     };
@@ -357,7 +356,7 @@ async fn committed_journal_entry(
 ) -> Result<Option<SessionJournalEntry>> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
     let mut found: Option<SessionJournalEntry> = None;
-    for (_, bytes) in kv.list_entries(&prefix).await? {
+    for (_, bytes) in kv.list_entries(&prefix, Order::Asc).await? {
         let entry = SessionJournalEntry::decode(bytes.as_slice())?;
         if entry.phase == SessionExecutionPhase::Committed as i32
             && entry.committed_message_id.as_deref() == Some(committed_message_id)

--- a/src/harness/skills/namespace.rs
+++ b/src/harness/skills/namespace.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::control::keys;
+use crate::control::{keys, Order};
 use crate::gateway::rpc::resources_proto;
 use anyhow::Result;
 use prost::Message;
@@ -25,8 +25,7 @@ pub async fn load_effective_skills(
 
     for candidate_ns in crate::control::ns::ancestry(namespace) {
         let prefix = keys::skill_prefix(&candidate_ns);
-        let mut skill_keys = kv.list_keys(&prefix).await?;
-        skill_keys.sort();
+        let skill_keys = kv.list_keys(&prefix, Order::Asc).await?;
 
         for key in skill_keys {
             let name = key.name.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod test_support {
     use crate::control::keys::{ResourceKey, ResourceList};
     #[cfg(test)]
     use crate::control::security::platform_jwt;
-    use crate::control::{KeyValueStore, MessagePublisher};
+    use crate::control::{KeyValueStore, MessagePublisher, Order};
     use futures::stream;
     use std::collections::HashMap;
     #[cfg(test)]
@@ -182,7 +182,11 @@ pub mod test_support {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            order: Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
@@ -190,7 +194,11 @@ pub mod test_support {
                 .keys()
                 .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
-            keys.sort();
+            if order == Order::Desc {
+                keys.sort_by(|left, right| right.cmp(left));
+            } else {
+                keys.sort();
+            }
             Ok(keys)
         }
 
@@ -201,7 +209,7 @@ pub mod test_support {
             limit: usize,
         ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(crate::control::page_keys_desc(
-                self.list_keys(list).await?,
+                self.list_keys(list, Order::Asc).await?,
                 before_name,
                 limit,
             ))
@@ -214,7 +222,7 @@ pub mod test_support {
             limit: usize,
         ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
             Ok(crate::control::page_entries_desc(
-                self.list_entries(list).await?,
+                self.list_entries(list, Order::Asc).await?,
                 before_name,
                 limit,
             ))

--- a/src/worker/controllers/connectors.rs
+++ b/src/worker/controllers/connectors.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::control::resources::ResourceStore;
 use crate::control::security::platform_jwt;
-use crate::control::{keys, ControlPlane, KeyValueStore, ProtoKeyValueStoreExt};
+use crate::control::{keys, ControlPlane, KeyValueStore, Order, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{data_proto, external_proto, resources_proto};
 
 const CONNECTOR_INDEX_FIELD_SEP: &str = "\x1f";
@@ -73,7 +73,11 @@ impl ConnectorController {
             )
             .await?;
         // Reconcile Connectors that may have been waiting for this class.
-        for namespace_key in cp.kv.list_keys(&keys::namespace_metadata_prefix()).await? {
+        for namespace_key in cp
+            .kv
+            .list_keys(&keys::namespace_metadata_prefix(), Order::Asc)
+            .await?
+        {
             let namespace = namespace_key.name;
             for connector in self.store.list(&namespace, Some("Connector")).await? {
                 if connector_references_class(&connector, &meta.namespace, &meta.name) {
@@ -342,7 +346,10 @@ pub async fn delete_route_entries_for_uid(
         return Ok(());
     }
     for (key, bytes) in kv
-        .list_entries(&keys::connector_route_prefix(class_namespace, class_name))
+        .list_entries(
+            &keys::connector_route_prefix(class_namespace, class_name),
+            Order::Asc,
+        )
         .await?
     {
         let Ok(route) = data_proto::Route::decode(bytes.as_slice()) else {
@@ -395,7 +402,7 @@ pub async fn delete_connector_class_entries(
 }
 
 async fn delete_entries(kv: &dyn KeyValueStore, prefix: &keys::ResourceList) -> Result<()> {
-    for key in kv.list_keys(prefix).await? {
+    for key in kv.list_keys(prefix, Order::Asc).await? {
         kv.delete(&key).await?;
     }
     Ok(())

--- a/src/worker/controllers/controller.rs
+++ b/src/worker/controllers/controller.rs
@@ -9,7 +9,7 @@ use crate::control::config::Config;
 use crate::control::events::ResourceChangedEvent;
 use crate::control::resource_model::{NamespaceResourceExt, TypedResource};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, ControlPlane, ProtoKeyValueStoreExt};
+use crate::control::{keys, ControlPlane, Order, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::resources_proto;
 
 #[derive(Clone)]
@@ -140,7 +140,10 @@ impl ControllerHost {
                             for namespace_key in self
                                 .cp
                                 .kv
-                                .list_keys(&crate::control::keys::namespace_metadata_prefix())
+                                .list_keys(
+                                    &crate::control::keys::namespace_metadata_prefix(),
+                                    Order::Asc,
+                                )
                                 .await?
                             {
                                 for class in store

--- a/src/worker/controllers/deployment.rs
+++ b/src/worker/controllers/deployment.rs
@@ -3,7 +3,7 @@
 
 use crate::control::resource_model::{NamespaceResourceExt, TypedResource};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, ControlPlane, ProtoKeyValueStoreExt};
+use crate::control::{keys, ControlPlane, Order, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::resources_proto;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
@@ -374,7 +374,10 @@ impl DeploymentController {
     ) -> Result<Vec<resources_proto::Namespace>> {
         let refs = cp
             .kv
-            .list_entries(&keys::namespace_ref_prefix(Some(&selector.parent)))
+            .list_entries(
+                &keys::namespace_ref_prefix(Some(&selector.parent)),
+                Order::Asc,
+            )
             .await?;
         let mut namespaces = Vec::new();
         for (_, value) in refs {

--- a/src/worker/mcp_registry.rs
+++ b/src/worker/mcp_registry.rs
@@ -176,7 +176,11 @@ mod tests {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            _order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -476,7 +476,11 @@ mod tests {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            _order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
@@ -871,11 +875,14 @@ mod tests {
         assert_eq!(session.status, "PROCESSING");
 
         let message_keys = kv
-            .list_keys(&crate::control::keys::session_message_prefix(
-                "conic:test",
-                "assistant",
-                "session-1",
-            ))
+            .list_keys(
+                &crate::control::keys::session_message_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                ),
+                crate::control::Order::Asc,
+            )
             .await
             .unwrap();
         assert_eq!(message_keys.len(), 1);
@@ -982,11 +989,14 @@ mod tests {
             .any(|event| event.phase == "dispatch" && event.outcome == "success"));
 
         let message_keys = kv
-            .list_keys(&crate::control::keys::session_message_prefix(
-                "conic:test",
-                "assistant",
-                "session-1",
-            ))
+            .list_keys(
+                &crate::control::keys::session_message_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                ),
+                crate::control::Order::Asc,
+            )
             .await
             .unwrap();
         assert_eq!(message_keys.len(), 1);

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use super::mcp_registry::McpRegistry;
 use crate::control::config::Config;
-use crate::control::ControlPlane;
 use crate::control::ProtoKeyValueStoreExt;
+use crate::control::{ControlPlane, Order};
 use crate::gateway::rpc::data_proto;
 use crate::gateway::rpc::resources_proto;
 use crate::gateway::rpc::{manifests, protobuf_value::value::Kind as ProtoValueKind};
@@ -82,8 +82,7 @@ impl AgentRuntime {
 
         // 2. Load session history from KV
         let msg_prefix = crate::control::keys::session_message_prefix(ns, agent_id, session_id);
-        let mut msg_entries = cp.kv.list_entries(&msg_prefix).await?;
-        msg_entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+        let msg_entries = cp.kv.list_entries(&msg_prefix, Order::Asc).await?;
 
         let mut history = Vec::new();
         for (_, value) in msg_entries {
@@ -439,7 +438,11 @@ mod tests {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            _order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -1591,7 +1591,11 @@ mod tests {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            _order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data
                 .lock()
@@ -1965,11 +1969,14 @@ mod tests {
         assert_eq!(session.status, "ERROR");
 
         let message_keys = kv
-            .list_keys(&crate::control::keys::session_message_prefix(
-                "conic:test",
-                "assistant",
-                "session-1",
-            ))
+            .list_keys(
+                &crate::control::keys::session_message_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                ),
+                crate::control::Order::Asc,
+            )
             .await
             .unwrap();
         let mut user_message = None;
@@ -2941,11 +2948,14 @@ mod tests {
             .unwrap();
         assert_eq!(session.status, "ERROR");
         let message_keys = kv
-            .list_keys(&crate::control::keys::session_message_prefix(
-                "conic:test",
-                "assistant",
-                "session-1",
-            ))
+            .list_keys(
+                &crate::control::keys::session_message_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                ),
+                crate::control::Order::Asc,
+            )
             .await
             .unwrap();
         let error_message_id = message_keys
@@ -3065,11 +3075,14 @@ mod tests {
             .is_none());
 
         let message_keys = kv
-            .list_keys(&crate::control::keys::session_message_prefix(
-                "conic:test",
-                "assistant",
-                "session-1",
-            ))
+            .list_keys(
+                &crate::control::keys::session_message_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                ),
+                crate::control::Order::Asc,
+            )
             .await
             .unwrap();
         let prefix =
@@ -3152,11 +3165,14 @@ mod tests {
         );
 
         let before_duplicate_keys = kv
-            .list_keys(&crate::control::keys::session_message_prefix(
-                "conic:test",
-                "assistant",
-                "session-1",
-            ))
+            .list_keys(
+                &crate::control::keys::session_message_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                ),
+                crate::control::Order::Asc,
+            )
             .await
             .unwrap();
         handler
@@ -3173,11 +3189,14 @@ mod tests {
             .await
             .unwrap();
         let after_duplicate_keys = kv
-            .list_keys(&crate::control::keys::session_message_prefix(
-                "conic:test",
-                "assistant",
-                "session-1",
-            ))
+            .list_keys(
+                &crate::control::keys::session_message_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                ),
+                crate::control::Order::Asc,
+            )
             .await
             .unwrap();
         assert_eq!(after_duplicate_keys.len(), before_duplicate_keys.len());
@@ -3406,11 +3425,14 @@ mod tests {
             .unwrap();
 
         let messages = kv
-            .list_keys(&crate::control::keys::session_message_prefix(
-                "conic:test",
-                "assistant",
-                "session-1",
-            ))
+            .list_keys(
+                &crate::control::keys::session_message_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                ),
+                crate::control::Order::Asc,
+            )
             .await
             .unwrap();
         assert_eq!(messages.len(), 1);

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1449,7 +1449,11 @@ mod tests {
         async fn delete(&self, _k: &ResourceKey) -> anyhow::Result<()> {
             Ok(())
         }
-        async fn list_keys(&self, _list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            _list: &ResourceList,
+            _order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(vec![])
         }
         async fn list_keys_page(
@@ -2320,12 +2324,10 @@ mod tests {
         sink.on_done().await;
 
         let entry_keys = kv
-            .list_keys(&keys::session_journal_entry_prefix(
-                "conic",
-                "infra",
-                "session-1",
-                "submission-1",
-            ))
+            .list_keys(
+                &keys::session_journal_entry_prefix("conic", "infra", "session-1", "submission-1"),
+                crate::control::Order::Asc,
+            )
             .await
             .unwrap();
         let mut entries = Vec::new();

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -36,7 +36,7 @@ use crate::{
         resource_model::{self, ChannelResourceExt, NamespaceResourceExt, TypedResource},
         scheduling,
         security::platform_jwt,
-        ProtoKeyValueStoreExt,
+        Order, ProtoKeyValueStoreExt,
     },
     gateway::rpc::{data_proto, manifests, resources_proto},
 };
@@ -178,11 +178,10 @@ impl TalonOpsServer {
     }
 
     async fn list_all_namespaces(&self) -> Result<Vec<resources_proto::Namespace>> {
-        let mut keys = self
+        let keys = self
             .kv()
-            .list_keys(&keys::namespace_metadata_prefix())
+            .list_keys(&keys::namespace_metadata_prefix(), Order::Asc)
             .await?;
-        keys.sort();
         let namespaces = self
             .load_messages::<resources_proto::Namespace>(keys, 32)
             .await?;
@@ -228,11 +227,10 @@ impl TalonOpsServer {
     }
 
     async fn list_channel_models(&self, namespace: &str) -> Result<Vec<resources_proto::Channel>> {
-        let mut keys = self
+        let keys = self
             .kv()
-            .list_keys(&keys::channel_prefix(namespace))
+            .list_keys(&keys::channel_prefix(namespace), Order::Asc)
             .await?;
-        keys.sort();
         self.load_messages::<resources_proto::Channel>(keys, 32)
             .await
     }
@@ -306,8 +304,7 @@ impl TalonOpsServer {
         agent: &str,
     ) -> Result<Vec<data_proto::Session>> {
         let prefix = keys::session_prefix(namespace, agent);
-        let mut keys = self.kv().list_keys(&prefix).await?;
-        keys.sort();
+        let keys = self.kv().list_keys(&prefix, Order::Asc).await?;
         self.load_messages::<data_proto::Session>(keys, 32).await
     }
 
@@ -318,8 +315,7 @@ impl TalonOpsServer {
         session_id: &str,
     ) -> Result<Vec<data_proto::SessionMessage>> {
         let prefix = keys::session_message_prefix(namespace, agent, session_id);
-        let mut keys = self.kv().list_keys(&prefix).await?;
-        keys.sort();
+        let keys = self.kv().list_keys(&prefix, Order::Asc).await?;
         self.load_messages::<data_proto::SessionMessage>(keys, 32)
             .await
     }
@@ -328,11 +324,10 @@ impl TalonOpsServer {
         &self,
         namespace: &str,
     ) -> Result<Vec<resources_proto::Schedule>> {
-        let mut keys = self
+        let keys = self
             .kv()
-            .list_keys(&keys::schedule_prefix(namespace))
+            .list_keys(&keys::schedule_prefix(namespace), Order::Asc)
             .await?;
-        keys.sort();
         self.load_messages::<resources_proto::Schedule>(keys, 32)
             .await
     }
@@ -883,12 +878,11 @@ impl TalonOpsServer {
         let access = talon_ops_access_from_parts(&parts)?;
         require_namespace_access(&access, &args.namespace)?;
         let limit = bounded_limit(&access, args.limit);
-        let mut keys = self
+        let keys = self
             .kv()
-            .list_keys(&keys::mcp_server_prefix(&args.namespace))
+            .list_keys(&keys::mcp_server_prefix(&args.namespace), Order::Asc)
             .await
             .map_err(internal_mcp_error)?;
-        keys.sort();
         let mut servers = Vec::new();
         for key in keys.into_iter().take(limit) {
             if let Some(server) = self
@@ -1599,7 +1593,11 @@ mod tests {
             Ok(())
         }
 
-        async fn list_keys(&self, list: &ResourceList) -> anyhow::Result<Vec<ResourceKey>> {
+        async fn list_keys(
+            &self,
+            list: &ResourceList,
+            _order: crate::control::Order,
+        ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(self
                 .entries
                 .read()
@@ -1617,7 +1615,7 @@ mod tests {
             limit: usize,
         ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
             Ok(crate::control::page_entries_desc(
-                self.list_entries(list).await?,
+                self.list_entries(list, crate::control::Order::Asc).await?,
                 before_name,
                 limit,
             ))

--- a/src/worker/workflows.rs
+++ b/src/worker/workflows.rs
@@ -11,7 +11,8 @@ use std::sync::Arc;
 
 use crate::control::resource_model::TypedResource;
 use crate::control::{
-    events, keys, topics, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
+    events, keys, topics, ControlPlane, KeyValueStore, MessagePublisher, Order,
+    ProtoKeyValueStoreExt,
 };
 use crate::gateway::rpc::{data_proto, resources_proto};
 use crate::harness::knowledge::KvKnowledgeBook;
@@ -1393,11 +1394,10 @@ pub async fn load_step_runs(
 ) -> Result<HashMap<String, data_proto::WorkflowStepRun>> {
     let mut map = HashMap::new();
     for (_, bytes) in kv
-        .list_entries(&keys::workflow_step_run_prefix(
-            &run.ns,
-            &run.workflow,
-            &run.id,
-        ))
+        .list_entries(
+            &keys::workflow_step_run_prefix(&run.ns, &run.workflow, &run.id),
+            Order::Asc,
+        )
         .await?
     {
         let step_run = data_proto::WorkflowStepRun::decode(bytes.as_slice())?;
@@ -2175,25 +2175,33 @@ async fn latest_assistant_text(
     agent: &str,
     session_id: &str,
 ) -> Result<String> {
-    let mut entries = kv
-        .list_entries(&keys::session_message_prefix(ns, agent, session_id))
-        .await?;
-    entries.sort_by(|left, right| right.0.cmp(&left.0));
-    for (_, bytes) in entries {
-        let message = data_proto::SessionMessage::decode(bytes.as_slice())?;
-        if message.role == data_proto::MessageRole::RoleAssistant as i32 {
-            let text = message
-                .parts
-                .iter()
-                .filter(|part| part.part_type == data_proto::SessionMessagePartType::Text as i32)
-                .map(|part| part.content.as_str())
-                .collect::<String>();
-            if !text.is_empty() {
-                return Ok(text);
+    let prefix = keys::session_message_prefix(ns, agent, session_id);
+    let mut before_name = None;
+    loop {
+        let entries = kv
+            .list_entries_page(&prefix, before_name.as_deref(), 64)
+            .await?;
+        if entries.is_empty() {
+            return Ok(String::new());
+        }
+        before_name = entries.last().map(|(key, _)| key.name.clone());
+        for (_, bytes) in entries {
+            let message = data_proto::SessionMessage::decode(bytes.as_slice())?;
+            if message.role == data_proto::MessageRole::RoleAssistant as i32 {
+                let text = message
+                    .parts
+                    .iter()
+                    .filter(|part| {
+                        part.part_type == data_proto::SessionMessagePartType::Text as i32
+                    })
+                    .map(|part| part.content.as_str())
+                    .collect::<String>();
+                if !text.is_empty() {
+                    return Ok(text);
+                }
             }
         }
     }
-    Ok(String::new())
 }
 
 fn parse_json_or(input: &str, default: Value) -> Result<Value> {
@@ -2600,11 +2608,10 @@ mod tests {
         drop(published);
 
         let events = kv
-            .list_entries(&keys::workflow_run_event_prefix(
-                "default",
-                "dispatch-only",
-                &run.id,
-            ))
+            .list_entries(
+                &keys::workflow_run_event_prefix("default", "dispatch-only", &run.id),
+                Order::Asc,
+            )
             .await
             .unwrap();
         assert_eq!(events.len(), 1);
@@ -2669,16 +2676,19 @@ mod tests {
         workflow: &str,
         run_id: &str,
     ) -> Vec<String> {
-        kv.list_entries(&keys::workflow_run_event_prefix(ns, workflow, run_id))
-            .await
-            .expect("events should list")
-            .into_iter()
-            .map(|(_, bytes)| {
-                data_proto::WorkflowRunEvent::decode(bytes.as_slice())
-                    .expect("event should decode")
-                    .r#type
-            })
-            .collect()
+        kv.list_entries(
+            &keys::workflow_run_event_prefix(ns, workflow, run_id),
+            Order::Asc,
+        )
+        .await
+        .expect("events should list")
+        .into_iter()
+        .map(|(_, bytes)| {
+            data_proto::WorkflowRunEvent::decode(bytes.as_slice())
+                .expect("event should decode")
+                .r#type
+        })
+        .collect()
     }
 
     async fn event_type_count(


### PR DESCRIPTION
## Summary

- Add explicit ascending/descending ordering helpers for KV key and entry listings.
- Implement ordered listing in Postgres, SQLite, RocksDB, and DynamoDB backends.
- Optimize callsites that previously listed all KV entries just to sort, reverse, or take the newest items.

## Validation

- `cargo check --locked -p talon`
- `cargo metadata --locked --format-version 1`
- `cargo test --locked -p talon key_value_store_default_helpers_and_proto_round_trip_work`
- `cargo test --locked -p talon sqlite_kv_round_trip_compare_and_swap_and_direct_list_ops`

Note: the Docker-backed Postgres test was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Key and entry listings now support explicit ascending or descending ordering across storage backends.
  * Paginated listing is available for more session and workflow data retrieval scenarios.

* **Bug Fixes**
  * Improved deterministic ordering for sessions, tasks, workflows, schedules, journals, namespaces, and other displayed or processed records.
  * Reduced unnecessary data loading when retrieving recent session messages and journal entries.
  * Improved consistency when identifying the latest assistant responses and workflow events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->