### PR TITLE
Use shared mock KV store in tests

### DIFF
--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -1086,73 +1086,14 @@ pub fn append_schedule_event(
 mod tests {
     use super::*;
     use crate::control::{
-        keys::{ResourceKey, ResourceList},
-        scheduler::NoopSchedulerBackend,
-        KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
+        scheduler::NoopSchedulerBackend, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::manifests;
+    use crate::test_support::MockKvStore;
     use futures::stream;
     use std::pin::Pin;
     use std::sync::Arc;
     use tokio::sync::Mutex;
-
-    #[derive(Default)]
-    struct MockKvStore {
-        store: Mutex<HashMap<ResourceKey, Vec<u8>>>,
-    }
-
-    #[async_trait::async_trait]
-    impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
-            let map = self.store.lock().await;
-            Ok(map.get(key).cloned())
-        }
-
-        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
-            let mut map = self.store.lock().await;
-            map.insert(key.clone(), value.to_vec());
-            Ok(())
-        }
-
-        async fn compare_and_swap(
-            &self,
-            key: &ResourceKey,
-            expected: Option<&[u8]>,
-            value: &[u8],
-        ) -> anyhow::Result<bool> {
-            let mut map = self.store.lock().await;
-            let current = map.get(key).cloned();
-            let matches = match (current.as_deref(), expected) {
-                (None, None) => true,
-                (Some(current), Some(expected)) => current == expected,
-                _ => false,
-            };
-            if !matches {
-                return Ok(false);
-            }
-            map.insert(key.clone(), value.to_vec());
-            Ok(true)
-        }
-
-        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
-            let mut map = self.store.lock().await;
-            map.remove(key);
-            Ok(())
-        }
-
-        async fn list_keys(
-            &self,
-            list: &ResourceList,
-            _order: crate::control::Order,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            let map = self.store.lock().await;
-            Ok(map
-                .keys()
-                .filter(|key| list.matches(key))
-                .cloned()
-                .collect())
-        }
-    }
 
     #[derive(Default)]
     struct MockPubSub {

--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -1086,7 +1086,7 @@ pub fn append_schedule_event(
 mod tests {
     use super::*;
     use crate::control::{
-        scheduler::NoopSchedulerBackend, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
+        scheduler::NoopSchedulerBackend, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::manifests;
     use crate::test_support::MockKvStore;

--- a/src/gateway/rpc/knowledge.rs
+++ b/src/gateway/rpc/knowledge.rs
@@ -305,73 +305,14 @@ impl GrpcGatewayHandler {
 #[cfg(test)]
 mod tests {
     use super::{decode_entry, list_namespace_knowledge};
-    use crate::control::keys::{self, ResourceKey, ResourceList};
-    use crate::control::KeyValueStore;
+    use crate::control::{keys, KeyValueStore};
     use crate::gateway::rpc::{proto, GrpcGatewayHandler};
     use crate::gateway::server::Gateway;
+    use crate::test_support::MockKvStore;
     use async_trait::async_trait;
     use futures::stream;
-    use std::collections::HashMap;
     use std::pin::Pin;
     use std::sync::Arc;
-    use tokio::sync::Mutex;
-
-    #[derive(Default)]
-    struct MockKvStore {
-        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
-    }
-
-    #[async_trait]
-    impl KeyValueStore for MockKvStore {
-        async fn get(&self, k: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self.data.lock().await.get(k).cloned())
-        }
-
-        async fn set(&self, k: &ResourceKey, v: &[u8]) -> anyhow::Result<()> {
-            self.data.lock().await.insert(k.clone(), v.to_vec());
-            Ok(())
-        }
-
-        async fn compare_and_swap(
-            &self,
-            k: &ResourceKey,
-            expected: Option<&[u8]>,
-            value: &[u8],
-        ) -> anyhow::Result<bool> {
-            let mut data = self.data.lock().await;
-            let current = data.get(k).cloned();
-            let matches = match (current.as_deref(), expected) {
-                (None, None) => true,
-                (Some(current), Some(expected)) => current == expected,
-                _ => false,
-            };
-            if matches {
-                data.insert(k.clone(), value.to_vec());
-            }
-            Ok(matches)
-        }
-
-        async fn delete(&self, k: &ResourceKey) -> anyhow::Result<()> {
-            self.data.lock().await.remove(k);
-            Ok(())
-        }
-
-        async fn list_keys(
-            &self,
-            list: &ResourceList,
-            _order: crate::control::Order,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            let mut keys = self
-                .data
-                .lock()
-                .await
-                .keys()
-                .filter_map(|key| list.matches(key).then(|| key.clone()))
-                .collect::<Vec<_>>();
-            keys.sort();
-            Ok(keys)
-        }
-    }
 
     #[derive(Default)]
     struct MockPubSub;

--- a/src/gateway/rpc/namespaces.rs
+++ b/src/gateway/rpc/namespaces.rs
@@ -400,83 +400,11 @@ impl GrpcGatewayHandler {
 mod tests {
     use super::*;
     use crate::control::security::platform_jwt;
-    use crate::control::{
-        keys::{ResourceKey, ResourceList},
-        ControlPlane, KeyValueStore, MessagePublisher,
-    };
+    use crate::control::{ControlPlane, MessagePublisher};
     use crate::gateway::auth::{AuthConfig, Claims};
     use crate::gateway::server::Gateway;
-    use crate::test_support::{PlatformJwtEnvGuard, TEST_PLATFORM_JWT_ISSUER};
-    use std::collections::HashMap;
+    use crate::test_support::{MockKvStore, PlatformJwtEnvGuard, TEST_PLATFORM_JWT_ISSUER};
     use std::sync::Arc;
-    use tokio::sync::Mutex;
-
-    struct MockKvStore {
-        store: Mutex<HashMap<ResourceKey, Vec<u8>>>,
-    }
-
-    impl MockKvStore {
-        fn new() -> Self {
-            Self {
-                store: Mutex::new(HashMap::new()),
-            }
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
-            let map = self.store.lock().await;
-            Ok(map.get(key).cloned())
-        }
-
-        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
-            let mut map = self.store.lock().await;
-            map.insert(key.clone(), value.to_vec());
-            Ok(())
-        }
-
-        async fn compare_and_swap(
-            &self,
-            key: &ResourceKey,
-            expected: Option<&[u8]>,
-            value: &[u8],
-        ) -> anyhow::Result<bool> {
-            let mut map = self.store.lock().await;
-            let current = map.get(key).cloned();
-            let matches = match (current.as_deref(), expected) {
-                (None, None) => true,
-                (Some(current), Some(expected)) => current == expected,
-                _ => false,
-            };
-            if !matches {
-                return Ok(false);
-            }
-            map.insert(key.clone(), value.to_vec());
-            Ok(true)
-        }
-
-        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
-            let mut map = self.store.lock().await;
-            map.remove(key);
-            Ok(())
-        }
-
-        async fn list_keys(
-            &self,
-            list: &ResourceList,
-            _order: crate::control::Order,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            let map = self.store.lock().await;
-            let mut results = Vec::new();
-            for k in map.keys() {
-                if list.matches(k) {
-                    results.push(k.clone());
-                }
-            }
-            Ok(results)
-        }
-    }
 
     struct MockPubSub;
     #[async_trait::async_trait]
@@ -499,7 +427,7 @@ mod tests {
 
     fn setup_mock_gateway_handler_with_auth(auth_config: Option<AuthConfig>) -> GrpcGatewayHandler {
         let pubsub = Arc::new(MockPubSub);
-        let control_plane = ControlPlane::builder(Arc::new(MockKvStore::new()), pubsub).build();
+        let control_plane = ControlPlane::builder(Arc::new(MockKvStore::default()), pubsub).build();
         let gateway = Arc::new(Gateway::from_control_plane(auth_config, control_plane));
         GrpcGatewayHandler { gateway }
     }

--- a/src/gateway/rpc/namespaces.rs
+++ b/src/gateway/rpc/namespaces.rs
@@ -404,6 +404,7 @@ mod tests {
     use crate::gateway::auth::{AuthConfig, Claims};
     use crate::gateway::server::Gateway;
     use crate::test_support::{MockKvStore, PlatformJwtEnvGuard, TEST_PLATFORM_JWT_ISSUER};
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     struct MockPubSub;

--- a/src/harness/knowledge/mod.rs
+++ b/src/harness/knowledge/mod.rs
@@ -616,23 +616,13 @@ mod tests {
         execute_tool, KnowledgeBook, KnowledgeEntry, KvKnowledgeBook, KNOWLEDGE_GET_TOOL,
         KNOWLEDGE_LIST_TOOL, KNOWLEDGE_SEARCH_TOOL, KNOWLEDGE_WRITE_TOOL,
     };
-    use crate::control::{
-        keys::{ResourceKey, ResourceList},
-        search::{
-            document_ref, document_source, ephemeral_document_store, Document, DocumentRef,
-            DOCUMENT_KIND_CONTENT, KIND_KNOWLEDGE,
-        },
-        KeyValueStore,
+    use crate::control::search::{
+        document_ref, document_source, ephemeral_document_store, Document, DocumentRef,
+        DOCUMENT_KIND_CONTENT, KIND_KNOWLEDGE,
     };
-    use async_trait::async_trait;
+    use crate::test_support::MockKvStore;
     use serde_json::json;
-    use std::collections::HashMap;
     use std::sync::Arc;
-    use tokio::sync::Mutex;
-
-    struct MockKvStore {
-        store: Mutex<HashMap<ResourceKey, Vec<u8>>>,
-    }
 
     fn knowledge_document(
         id: &str,
@@ -666,7 +656,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_inherits_namespace_and_respects_prefix_modes() {
-        let kv = Arc::new(MockKvStore::new());
+        let kv = Arc::new(MockKvStore::default());
         let book = KvKnowledgeBook::new(kv.clone());
 
         for (ns, path, content) in [
@@ -726,77 +716,9 @@ mod tests {
         assert!(!local_only[0].inherited);
     }
 
-    impl MockKvStore {
-        fn new() -> Self {
-            Self {
-                store: Mutex::new(HashMap::new()),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
-            let map = self.store.lock().await;
-            Ok(map.get(key).cloned())
-        }
-
-        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
-            let mut map = self.store.lock().await;
-            map.insert(key.clone(), value.to_vec());
-            Ok(())
-        }
-
-        async fn compare_and_swap(
-            &self,
-            key: &ResourceKey,
-            expected: Option<&[u8]>,
-            value: &[u8],
-        ) -> anyhow::Result<bool> {
-            let mut map = self.store.lock().await;
-            let current = map.get(key).cloned();
-            let matches = match (current.as_deref(), expected) {
-                (None, None) => true,
-                (Some(current), Some(expected)) => current == expected,
-                _ => false,
-            };
-            if !matches {
-                return Ok(false);
-            }
-            map.insert(key.clone(), value.to_vec());
-            Ok(true)
-        }
-
-        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
-            let mut map = self.store.lock().await;
-            map.remove(key);
-            Ok(())
-        }
-
-        async fn list_keys(
-            &self,
-            list: &ResourceList,
-            order: crate::control::Order,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            let map = self.store.lock().await;
-            let mut results = Vec::new();
-            for key in map.keys() {
-                if list.matches(key) {
-                    results.push(key.clone());
-                }
-            }
-            if order == crate::control::Order::Desc {
-                results.sort_by(|left, right| right.cmp(left));
-            } else {
-                results.sort();
-            }
-            Ok(results)
-        }
-    }
-
     #[tokio::test]
     async fn search_handles_unicode_content_without_panicking() {
-        let kv = Arc::new(MockKvStore::new());
+        let kv = Arc::new(MockKvStore::default());
         let book = KvKnowledgeBook::new(kv.clone());
 
         let entry = KnowledgeEntry {
@@ -823,7 +745,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_uses_document_store_when_enabled() {
-        let kv = Arc::new(MockKvStore::new());
+        let kv = Arc::new(MockKvStore::default());
         let documents = ephemeral_document_store();
         documents
             .upsert_documents(&[knowledge_document(
@@ -864,7 +786,7 @@ mod tests {
 
     #[tokio::test]
     async fn document_store_search_prefers_child_namespace_for_shadowed_paths() {
-        let kv = Arc::new(MockKvStore::new());
+        let kv = Arc::new(MockKvStore::default());
         let documents = ephemeral_document_store();
         documents
             .upsert_documents(&[
@@ -906,7 +828,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_inherits_from_ancestor_namespace() {
-        let kv = Arc::new(MockKvStore::new());
+        let kv = Arc::new(MockKvStore::default());
         let book = KvKnowledgeBook::new(kv.clone());
 
         let entry = KnowledgeEntry {
@@ -932,7 +854,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_prefers_local_override_over_ancestor() {
-        let kv = Arc::new(MockKvStore::new());
+        let kv = Arc::new(MockKvStore::default());
         let book = KvKnowledgeBook::new(kv.clone());
 
         for (ns, content) in [
@@ -962,7 +884,7 @@ mod tests {
 
     #[tokio::test]
     async fn normalize_entry_and_find_entry_cover_fallback_and_ambiguous_matches() {
-        let kv = Arc::new(MockKvStore::new());
+        let kv = Arc::new(MockKvStore::default());
         let book = KvKnowledgeBook::new(kv.clone());
 
         kv.set(
@@ -988,7 +910,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_scores_path_matches_and_respects_limit_ordering() {
-        let kv = Arc::new(MockKvStore::new());
+        let kv = Arc::new(MockKvStore::default());
         let book = KvKnowledgeBook::new(kv.clone());
 
         for (path, content) in [
@@ -1022,7 +944,7 @@ mod tests {
 
     #[tokio::test]
     async fn execute_tool_covers_write_get_search_and_unknown_paths() {
-        let kv = Arc::new(MockKvStore::new());
+        let kv = Arc::new(MockKvStore::default());
         let book = KvKnowledgeBook::new(kv.clone());
 
         let wrote = execute_tool(

--- a/src/harness/knowledge/mod.rs
+++ b/src/harness/knowledge/mod.rs
@@ -620,6 +620,7 @@ mod tests {
         document_ref, document_source, ephemeral_document_store, Document, DocumentRef,
         DOCUMENT_KIND_CONTENT, KIND_KNOWLEDGE,
     };
+    use crate::control::KeyValueStore;
     use crate::test_support::MockKvStore;
     use serde_json::json;
     use std::sync::Arc;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -420,11 +420,11 @@ mod tests {
     use crate::control::config::Config;
     use crate::control::{
         events::{LifecycleEvent, MessageDirection, SessionControlEvent, SessionMessageEvent},
-        keys::{ResourceKey, ResourceList},
         topics, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
         SharedSchedulerBackend,
     };
     use crate::gateway::rpc::{data_proto, manifests, resources_proto};
+    use crate::test_support::MockKvStore;
     use crate::worker::{mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator};
     use async_trait::async_trait;
     use axum::{body::Bytes, extract::State, http::StatusCode, routing::post, Router};
@@ -435,63 +435,6 @@ mod tests {
     use tempfile::tempdir;
     use tokio::net::TcpListener;
     use tokio::sync::Mutex;
-
-    #[derive(Default)]
-    struct MockKvStore {
-        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
-    }
-
-    #[async_trait]
-    impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self.data.lock().await.get(key).cloned())
-        }
-
-        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
-            self.data.lock().await.insert(key.clone(), value.to_vec());
-            Ok(())
-        }
-
-        async fn compare_and_swap(
-            &self,
-            key: &ResourceKey,
-            expected: Option<&[u8]>,
-            value: &[u8],
-        ) -> anyhow::Result<bool> {
-            let mut data = self.data.lock().await;
-            let current = data.get(key).cloned();
-            let matches = match (current.as_deref(), expected) {
-                (None, None) => true,
-                (Some(current), Some(expected)) => current == expected,
-                _ => false,
-            };
-            if matches {
-                data.insert(key.clone(), value.to_vec());
-            }
-            Ok(matches)
-        }
-
-        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
-            self.data.lock().await.remove(key);
-            Ok(())
-        }
-
-        async fn list_keys(
-            &self,
-            list: &ResourceList,
-            _order: crate::control::Order,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            let mut keys = self
-                .data
-                .lock()
-                .await
-                .keys()
-                .filter_map(|key| list.matches(key).then(|| key.clone()))
-                .collect::<Vec<_>>();
-            keys.sort();
-            Ok(keys)
-        }
-    }
 
     #[derive(Default)]
     struct MockPubSub {

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -384,76 +384,17 @@ mod tests {
         qualify_mcp_tool_name, visible_tools_for_agent, AgentRuntime,
     };
     use crate::control::config::{proto, Config, ProviderConfig, Secret};
-    use crate::control::{
-        keys::{ResourceKey, ResourceList},
-        ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
-    };
+    use crate::control::{ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt};
     use crate::gateway::rpc::{data_proto, manifests, protobuf_value, resources_proto};
     use crate::harness::llm::{image_data_part, text_part};
     use crate::harness::mcp::McpConnectionConfig;
+    use crate::test_support::MockKvStore;
     use futures::stream;
     use prost::Message;
     use std::collections::HashMap;
     use std::pin::Pin;
     use std::sync::Arc;
     use tokio::sync::Mutex;
-
-    #[derive(Default)]
-    struct MockKvStore {
-        data: Mutex<HashMap<ResourceKey, Vec<u8>>>,
-    }
-
-    #[async_trait::async_trait]
-    impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self.data.lock().await.get(key).cloned())
-        }
-
-        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
-            self.data.lock().await.insert(key.clone(), value.to_vec());
-            Ok(())
-        }
-
-        async fn compare_and_swap(
-            &self,
-            key: &ResourceKey,
-            expected: Option<&[u8]>,
-            value: &[u8],
-        ) -> anyhow::Result<bool> {
-            let mut data = self.data.lock().await;
-            let current = data.get(key).cloned();
-            let matches = match (current.as_deref(), expected) {
-                (None, None) => true,
-                (Some(current), Some(expected)) => current == expected,
-                _ => false,
-            };
-            if matches {
-                data.insert(key.clone(), value.to_vec());
-            }
-            Ok(matches)
-        }
-
-        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
-            self.data.lock().await.remove(key);
-            Ok(())
-        }
-
-        async fn list_keys(
-            &self,
-            list: &ResourceList,
-            _order: crate::control::Order,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            let mut keys = self
-                .data
-                .lock()
-                .await
-                .keys()
-                .filter_map(|key| list.matches(key).then(|| key.clone()))
-                .collect::<Vec<_>>();
-            keys.sort();
-            Ok(keys)
-        }
-    }
 
     #[derive(Default)]
     struct MockPubSub;

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -394,7 +394,6 @@ mod tests {
     use std::collections::HashMap;
     use std::pin::Pin;
     use std::sync::Arc;
-    use tokio::sync::Mutex;
 
     #[derive(Default)]
     struct MockPubSub;

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -1107,13 +1107,13 @@ mod tests {
     use crate::control::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::{
         events::{MessageDirection, SessionMessageEvent},
-        keys::{ResourceKey, ResourceList},
         ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::connectors::session_message_final_response;
     use crate::gateway::rpc::{data_proto, manifests, resources_proto};
     use crate::harness::executor::ExecutionSink;
     use crate::harness::sessions;
+    use crate::test_support::MockKvStore;
     use crate::worker::{
         mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator,
         WorkerEventHandler,
@@ -1548,63 +1548,6 @@ mod tests {
             max,
             window: "1h".to_string(),
             subject_scope: String::new(),
-        }
-    }
-
-    #[derive(Default)]
-    struct MockKvStore {
-        data: AsyncMutex<HashMap<ResourceKey, Vec<u8>>>,
-    }
-
-    #[async_trait]
-    impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self.data.lock().await.get(key).cloned())
-        }
-
-        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
-            self.data.lock().await.insert(key.clone(), value.to_vec());
-            Ok(())
-        }
-
-        async fn compare_and_swap(
-            &self,
-            key: &ResourceKey,
-            expected: Option<&[u8]>,
-            value: &[u8],
-        ) -> anyhow::Result<bool> {
-            let mut data = self.data.lock().await;
-            let current = data.get(key).cloned();
-            let matches = match (current.as_deref(), expected) {
-                (None, None) => true,
-                (Some(current), Some(expected)) => current == expected,
-                _ => false,
-            };
-            if matches {
-                data.insert(key.clone(), value.to_vec());
-            }
-            Ok(matches)
-        }
-
-        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
-            self.data.lock().await.remove(key);
-            Ok(())
-        }
-
-        async fn list_keys(
-            &self,
-            list: &ResourceList,
-            _order: crate::control::Order,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            let mut keys = self
-                .data
-                .lock()
-                .await
-                .keys()
-                .filter_map(|key| list.matches(key).then(|| key.clone()))
-                .collect::<Vec<_>>();
-            keys.sort();
-            Ok(keys)
         }
     }
 

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -1531,11 +1531,10 @@ mod tests {
     };
     use crate::control::config::Config;
     use crate::control::{
-        keys::{self, ResourceKey, ResourceList},
-        ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
+        keys, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
     };
     use crate::gateway::rpc::{data_proto, manifests, resources_proto};
-    use crate::test_support::{PlatformJwtEnvGuard, TEST_PLATFORM_JWT_ISSUER};
+    use crate::test_support::{MockKvStore, PlatformJwtEnvGuard, TEST_PLATFORM_JWT_ISSUER};
     use crate::worker::{
         mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator,
         WorkerEventHandler,
@@ -1552,75 +1551,6 @@ mod tests {
     use serde_json::json;
     use std::{collections::HashMap, pin::Pin, sync::Arc};
     use tokio::sync::Mutex as AsyncMutex;
-
-    #[derive(Default)]
-    struct MockKvStore {
-        entries: Arc<tokio::sync::RwLock<HashMap<ResourceKey, Vec<u8>>>>,
-    }
-
-    #[async_trait]
-    impl KeyValueStore for MockKvStore {
-        async fn get(&self, key: &ResourceKey) -> anyhow::Result<Option<Vec<u8>>> {
-            Ok(self.entries.read().await.get(key).cloned())
-        }
-
-        async fn set(&self, key: &ResourceKey, value: &[u8]) -> anyhow::Result<()> {
-            self.entries
-                .write()
-                .await
-                .insert(key.clone(), value.to_vec());
-            Ok(())
-        }
-
-        async fn compare_and_swap(
-            &self,
-            key: &ResourceKey,
-            expected: Option<&[u8]>,
-            value: &[u8],
-        ) -> anyhow::Result<bool> {
-            let mut entries = self.entries.write().await;
-            let current = entries.get(key).cloned();
-            if current.as_deref() == expected {
-                entries.insert(key.clone(), value.to_vec());
-                Ok(true)
-            } else {
-                Ok(false)
-            }
-        }
-
-        async fn delete(&self, key: &ResourceKey) -> anyhow::Result<()> {
-            self.entries.write().await.remove(key);
-            Ok(())
-        }
-
-        async fn list_keys(
-            &self,
-            list: &ResourceList,
-            _order: crate::control::Order,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            Ok(self
-                .entries
-                .read()
-                .await
-                .keys()
-                .filter(|key| list.matches(key))
-                .cloned()
-                .collect())
-        }
-
-        async fn list_entries_page(
-            &self,
-            list: &ResourceList,
-            before_name: Option<&str>,
-            limit: usize,
-        ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
-            Ok(crate::control::page_entries_desc(
-                self.list_entries(list, crate::control::Order::Asc).await?,
-                before_name,
-                limit,
-            ))
-        }
-    }
 
     #[derive(Default)]
     struct MockPubSub;

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -1530,9 +1530,7 @@ mod tests {
         DEFAULT_MAX_LIST_LIMIT,
     };
     use crate::control::config::Config;
-    use crate::control::{
-        keys, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
-    };
+    use crate::control::{keys, ControlPlane, MessagePublisher, ProtoKeyValueStoreExt};
     use crate::gateway::rpc::{data_proto, manifests, resources_proto};
     use crate::test_support::{MockKvStore, PlatformJwtEnvGuard, TEST_PLATFORM_JWT_ISSUER};
     use crate::worker::{


### PR DESCRIPTION
## Summary
- migrate ad hoc generic KV test mocks to the shared `test_support::MockKvStore`
- keep specialized mocks where tests need custom failure injection or behavior
- reduce duplicate mock implementations before the list-options migration

## Stack
- Base: `main`
- Next: #140

## Validation
- `cargo metadata --locked`
- `cargo fmt --all --check`
- `cargo build --locked --bins`
- `cargo test --locked`
