### PR TITLE
Add list options for KV listing

### DIFF
--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -1794,7 +1794,7 @@ mod tests {
             .unwrap());
 
         let keys = kv
-            .list_keys(&list, talon::control::Order::Asc)
+            .list_keys(&list, talon::control::Order::Asc.into())
             .await
             .unwrap();
         assert_eq!(keys, vec![a.clone(), b.clone(), new.clone()]);

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -1793,10 +1793,7 @@ mod tests {
             .await
             .unwrap());
 
-        let keys = kv
-            .list_keys(&list, talon::control::Order::Asc.into())
-            .await
-            .unwrap();
+        let keys = kv.list_keys(&list, None).await.unwrap();
         assert_eq!(keys, vec![a.clone(), b.clone(), new.clone()]);
 
         kv.delete(&b).await.unwrap();

--- a/src/control/delegation.rs
+++ b/src/control/delegation.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use crate::control::resource_model::{self, TypedResource};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, scheduling, ControlPlane, Order, ProtoKeyValueStoreExt};
+use crate::control::{keys, scheduling, ControlPlane, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{data_proto, resources_proto};
 
 // Task resource label: marks a Task as created through agent delegation.
@@ -590,7 +590,7 @@ async fn grant_child_artifacts_to_owner(
         .kv
         .list_entries(
             &keys::artifact_prefix(&session.ns, &session.agent, &session.id),
-            Order::Asc.into(),
+            None,
         )
         .await?;
     let mut result_artifacts = Vec::new();

--- a/src/control/delegation.rs
+++ b/src/control/delegation.rs
@@ -590,7 +590,7 @@ async fn grant_child_artifacts_to_owner(
         .kv
         .list_entries(
             &keys::artifact_prefix(&session.ns, &session.agent, &session.id),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await?;
     let mut result_artifacts = Vec::new();

--- a/src/control/kv/dynamodb.rs
+++ b/src/control/kv/dynamodb.rs
@@ -232,9 +232,9 @@ impl KeyValueStore for DynamoDbKvStore {
     async fn list_keys(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> Result<Vec<ResourceKey>> {
-        self.query_list(list, options, false)
+        self.query_list(list, options.unwrap_or_default(), false)
             .await
             .map(|rows| rows.into_iter().map(|(key, _)| key).collect())
     }
@@ -242,13 +242,15 @@ impl KeyValueStore for DynamoDbKvStore {
     async fn list_entries(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        self.query_list(list, options, true).await.map(|rows| {
-            rows.into_iter()
-                .filter_map(|(key, value)| value.map(|value| (key, value)))
-                .collect()
-        })
+        self.query_list(list, options.unwrap_or_default(), true)
+            .await
+            .map(|rows| {
+                rows.into_iter()
+                    .filter_map(|(key, value)| value.map(|value| (key, value)))
+                    .collect()
+            })
     }
 
     async fn list_keys_page(

--- a/src/control/kv/dynamodb.rs
+++ b/src/control/kv/dynamodb.rs
@@ -3,7 +3,7 @@
 
 use crate::control::{
     keys::{ResourceKey, ResourceList},
-    KeyValueStore, Order,
+    KeyValueStore, ListOptions, Order,
 };
 use anyhow::{anyhow, Result};
 use aws_config::meta::region::RegionProviderChain;
@@ -66,12 +66,10 @@ impl DynamoDbKvStore {
     async fn query_list(
         &self,
         list: &ResourceList,
-        before_name: Option<&str>,
-        limit: Option<usize>,
-        order: Order,
+        options: ListOptions<'_>,
         include_values: bool,
     ) -> Result<Vec<(ResourceKey, Option<Vec<u8>>)>> {
-        if limit == Some(0) {
+        if options.limit == Some(0) {
             return Ok(Vec::new());
         }
 
@@ -87,29 +85,18 @@ impl DynamoDbKvStore {
             );
             key_condition = "#pk = :pk AND begins_with(#sk, :sk_prefix)".to_string();
         }
-        if let (Some(kind), Some(before_name)) = (list.kind.as_deref(), before_name) {
-            key_condition = "#pk = :pk AND #sk BETWEEN :sk_prefix AND :before_sk".to_string();
-            values.insert(
-                ":before_sk".to_string(),
-                AttributeValue::S(sk_for_kind_name(kind, before_name)),
-            );
-        } else if before_name.is_some() {
-            return Err(anyhow!(
-                "dynamodb list pagination requires a resource kind when before_name is set"
-            ));
-        }
-
         let mut start_key = None;
         let mut rows = Vec::new();
         loop {
-            let remaining_limit = limit
+            let remaining_limit = options
+                .limit
                 .and_then(|limit| limit.checked_sub(rows.len()))
                 .unwrap_or(usize::MAX);
             if remaining_limit == 0 {
                 break;
             }
 
-            let page_limit = if limit.is_some() {
+            let page_limit = if options.limit.is_some() {
                 Some(i32::try_from(remaining_limit.min(1000))?)
             } else {
                 None
@@ -119,7 +106,7 @@ impl DynamoDbKvStore {
                 .query()
                 .table_name(&self.table)
                 .consistent_read(true)
-                .scan_index_forward(order != Order::Desc)
+                .scan_index_forward(options.order != Order::Desc)
                 .key_condition_expression(key_condition.clone())
                 .set_expression_attribute_names(Some(names.clone()))
                 .set_expression_attribute_values(Some(values.clone()))
@@ -131,7 +118,16 @@ impl DynamoDbKvStore {
             let output = request.send().await?;
             for item in output.items() {
                 let key = key_from_item(item)?;
-                if before_name.is_some_and(|before| key.name.as_str() >= before) {
+                if options
+                    .before_name
+                    .is_some_and(|before| key.name.as_str() >= before)
+                {
+                    continue;
+                }
+                if options
+                    .after_name
+                    .is_some_and(|after| key.name.as_str() <= after)
+                {
                     continue;
                 }
                 let value = if include_values {
@@ -140,7 +136,7 @@ impl DynamoDbKvStore {
                     None
                 };
                 rows.push((key, value));
-                if limit.is_some_and(|limit| rows.len() >= limit) {
+                if options.limit.is_some_and(|limit| rows.len() >= limit) {
                     return Ok(rows);
                 }
             }
@@ -233,8 +229,12 @@ impl KeyValueStore for DynamoDbKvStore {
         Ok(())
     }
 
-    async fn list_keys(&self, list: &ResourceList, order: Order) -> Result<Vec<ResourceKey>> {
-        self.query_list(list, None, None, order, false)
+    async fn list_keys(
+        &self,
+        list: &ResourceList,
+        options: ListOptions<'_>,
+    ) -> Result<Vec<ResourceKey>> {
+        self.query_list(list, options, false)
             .await
             .map(|rows| rows.into_iter().map(|(key, _)| key).collect())
     }
@@ -242,15 +242,13 @@ impl KeyValueStore for DynamoDbKvStore {
     async fn list_entries(
         &self,
         list: &ResourceList,
-        order: Order,
+        options: ListOptions<'_>,
     ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        self.query_list(list, None, None, order, true)
-            .await
-            .map(|rows| {
-                rows.into_iter()
-                    .filter_map(|(key, value)| value.map(|value| (key, value)))
-                    .collect()
-            })
+        self.query_list(list, options, true).await.map(|rows| {
+            rows.into_iter()
+                .filter_map(|(key, value)| value.map(|value| (key, value)))
+                .collect()
+        })
     }
 
     async fn list_keys_page(
@@ -263,9 +261,13 @@ impl KeyValueStore for DynamoDbKvStore {
             .kind
             .as_ref()
             .ok_or_else(|| anyhow!("dynamodb list_keys_page requires a resource kind"))?;
-        self.query_list(list, before_name, Some(limit), Order::Desc, false)
-            .await
-            .map(|rows| rows.into_iter().map(|(key, _)| key).collect())
+        self.query_list(
+            list,
+            ListOptions::desc().before_name(before_name).limit(limit),
+            false,
+        )
+        .await
+        .map(|rows| rows.into_iter().map(|(key, _)| key).collect())
     }
 
     async fn list_entries_page(
@@ -278,13 +280,17 @@ impl KeyValueStore for DynamoDbKvStore {
             .kind
             .as_ref()
             .ok_or_else(|| anyhow!("dynamodb list_entries_page requires a resource kind"))?;
-        self.query_list(list, before_name, Some(limit), Order::Desc, true)
-            .await
-            .map(|rows| {
-                rows.into_iter()
-                    .filter_map(|(key, value)| value.map(|value| (key, value)))
-                    .collect()
-            })
+        self.query_list(
+            list,
+            ListOptions::desc().before_name(before_name).limit(limit),
+            true,
+        )
+        .await
+        .map(|rows| {
+            rows.into_iter()
+                .filter_map(|(key, value)| value.map(|value| (key, value)))
+                .collect()
+        })
     }
 }
 

--- a/src/control/kv/postgres.rs
+++ b/src/control/kv/postgres.rs
@@ -585,8 +585,9 @@ impl KeyValueStore for PostgresKvStore {
     async fn list_keys(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> Result<Vec<ResourceKey>> {
+        let options = options.unwrap_or_default();
         let query = list_keys_query(&self.table, list.kind.is_some(), options);
         let span = tracing::debug_span!(
             "PostgresKvStore.list_keys",
@@ -644,8 +645,9 @@ impl KeyValueStore for PostgresKvStore {
     async fn list_entries(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let options = options.unwrap_or_default();
         let query = list_entries_query(&self.table, list.kind.is_some(), options);
         let span = tracing::debug_span!(
             "PostgresKvStore.list_entries",
@@ -838,7 +840,7 @@ mod tests {
         list_entries_page_query, list_entries_query, list_keys_page_query, list_keys_query,
         rename_migration_index_statement, set_query, PostgresKvStore,
     };
-    use crate::control::{keys, KeyValueStore, Order};
+    use crate::control::{keys, KeyValueStore, ListOptions, Order};
     use crate::test_support::{docker_test_guard, PostgresContainer};
     use std::time::Duration;
 
@@ -920,10 +922,13 @@ mod tests {
         store.set(&other, b"three").await.unwrap();
         assert_eq!(store.get(&a).await.unwrap(), Some(b"one".to_vec()));
 
-        let listed = store.list_keys(&list, Order::Asc.into()).await.unwrap();
+        let listed = store.list_keys(&list, None).await.unwrap();
         assert_eq!(listed, vec![a.clone(), b.clone()]);
         assert_eq!(
-            store.list_keys(&list, Order::Desc.into()).await.unwrap(),
+            store
+                .list_keys(&list, Some(ListOptions::desc()))
+                .await
+                .unwrap(),
             vec![b.clone(), a.clone()]
         );
 
@@ -940,11 +945,14 @@ mod tests {
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 
-        let entries = store.list_entries(&list, Order::Asc.into()).await.unwrap();
+        let entries = store.list_entries(&list, None).await.unwrap();
         assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
         assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
         assert_eq!(
-            store.list_entries(&list, Order::Desc.into()).await.unwrap(),
+            store
+                .list_entries(&list, Some(ListOptions::desc()))
+                .await
+                .unwrap(),
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 

--- a/src/control/kv/postgres.rs
+++ b/src/control/kv/postgres.rs
@@ -3,7 +3,7 @@
 
 use crate::control::{
     keys::{ResourceKey, ResourceList},
-    KeyValueStore, Order,
+    KeyValueStore, ListOptions, Order,
 };
 use anyhow::{bail, Result};
 use sqlx::{pool::PoolConnection, postgres::PgPoolOptions, PgConnection, PgPool, Postgres, Row};
@@ -80,24 +80,57 @@ fn list_order_sql(order: Order) -> &'static str {
     }
 }
 
-fn list_keys_query(table: &str, has_kind: bool, order: Order) -> String {
-    let kind_clause = if has_kind { "AND kind = $3" } else { "" };
-    let direction = list_order_sql(order);
+fn list_filter_clause(has_kind: bool, options: ListOptions<'_>) -> String {
+    let mut next_bind = if has_kind { 4 } else { 3 };
+    let mut clauses = Vec::new();
+    if has_kind {
+        clauses.push("AND kind = $3".to_string());
+    }
+    if options.before_name.is_some() {
+        clauses.push(format!("AND name < ${next_bind}"));
+        next_bind += 1;
+    }
+    if options.after_name.is_some() {
+        clauses.push(format!("AND name > ${next_bind}"));
+    }
+    clauses.join(" ")
+}
+
+fn list_limit_clause(has_kind: bool, options: ListOptions<'_>) -> String {
+    let mut next_bind = if has_kind { 4 } else { 3 };
+    if options.before_name.is_some() {
+        next_bind += 1;
+    }
+    if options.after_name.is_some() {
+        next_bind += 1;
+    }
+    if options.limit.is_some() {
+        format!(" LIMIT ${next_bind}")
+    } else {
+        String::new()
+    }
+}
+
+fn list_keys_query(table: &str, has_kind: bool, options: ListOptions<'_>) -> String {
+    let filter_clause = list_filter_clause(has_kind, options);
+    let limit_clause = list_limit_clause(has_kind, options);
+    let direction = list_order_sql(options.order);
     format!(
         "SELECT namespace, parent_path, kind, name FROM {}
-         WHERE namespace = $1 AND parent_path = $2 {kind_clause}
-         ORDER BY kind {direction}, name {direction}",
+         WHERE namespace = $1 AND parent_path = $2 {filter_clause}
+         ORDER BY kind {direction}, name {direction}{limit_clause}",
         quoted_identifier(table)
     )
 }
 
-fn list_entries_query(table: &str, has_kind: bool, order: Order) -> String {
-    let kind_clause = if has_kind { "AND kind = $3" } else { "" };
-    let direction = list_order_sql(order);
+fn list_entries_query(table: &str, has_kind: bool, options: ListOptions<'_>) -> String {
+    let filter_clause = list_filter_clause(has_kind, options);
+    let limit_clause = list_limit_clause(has_kind, options);
+    let direction = list_order_sql(options.order);
     format!(
         "SELECT namespace, parent_path, kind, name, value FROM {}
-         WHERE namespace = $1 AND parent_path = $2 {kind_clause}
-         ORDER BY kind {direction}, name {direction}",
+         WHERE namespace = $1 AND parent_path = $2 {filter_clause}
+         ORDER BY kind {direction}, name {direction}{limit_clause}",
         quoted_identifier(table)
     )
 }
@@ -549,8 +582,12 @@ impl KeyValueStore for PostgresKvStore {
         Ok(())
     }
 
-    async fn list_keys(&self, list: &ResourceList, order: Order) -> Result<Vec<ResourceKey>> {
-        let query = list_keys_query(&self.table, list.kind.is_some(), order);
+    async fn list_keys(
+        &self,
+        list: &ResourceList,
+        options: ListOptions<'_>,
+    ) -> Result<Vec<ResourceKey>> {
+        let query = list_keys_query(&self.table, list.kind.is_some(), options);
         let span = tracing::debug_span!(
             "PostgresKvStore.list_keys",
             "db.system" = "postgresql",
@@ -571,6 +608,15 @@ impl KeyValueStore for PostgresKvStore {
             .bind(&list.parent.parent_path);
         if let Some(kind) = &list.kind {
             query = query.bind(kind);
+        }
+        if let Some(before_name) = options.before_name {
+            query = query.bind(before_name);
+        }
+        if let Some(after_name) = options.after_name {
+            query = query.bind(after_name);
+        }
+        if let Some(limit) = options.limit {
+            query = query.bind(limit as i64);
         }
         let mut conn = acquire_connection(&self.pool, self.settings, &span).await?;
         let query_span = tracing::debug_span!(
@@ -598,9 +644,9 @@ impl KeyValueStore for PostgresKvStore {
     async fn list_entries(
         &self,
         list: &ResourceList,
-        order: Order,
+        options: ListOptions<'_>,
     ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        let query = list_entries_query(&self.table, list.kind.is_some(), order);
+        let query = list_entries_query(&self.table, list.kind.is_some(), options);
         let span = tracing::debug_span!(
             "PostgresKvStore.list_entries",
             "db.system" = "postgresql",
@@ -622,6 +668,15 @@ impl KeyValueStore for PostgresKvStore {
             .bind(&list.parent.parent_path);
         if let Some(kind) = &list.kind {
             query = query.bind(kind);
+        }
+        if let Some(before_name) = options.before_name {
+            query = query.bind(before_name);
+        }
+        if let Some(after_name) = options.after_name {
+            query = query.bind(after_name);
+        }
+        if let Some(limit) = options.limit {
+            query = query.bind(limit as i64);
         }
         let mut conn = acquire_connection(&self.pool, self.settings, &span).await?;
         let query_span = tracing::debug_span!(
@@ -798,13 +853,13 @@ mod tests {
         assert!(compare_and_swap_query("talon_kv", true).contains("AND value = $6"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
         assert!(delete_query("talon_kv").contains("WHERE namespace = $1"));
-        assert!(list_keys_query("talon_kv", true, Order::Asc).contains("AND kind = $3"));
-        assert!(list_keys_query("talon_kv", true, Order::Desc)
+        assert!(list_keys_query("talon_kv", true, Order::Asc.into()).contains("AND kind = $3"));
+        assert!(list_keys_query("talon_kv", true, Order::Desc.into())
             .contains("ORDER BY kind DESC, name DESC"));
         assert!(list_keys_page_query("talon_kv").contains("ORDER BY name DESC"));
         assert!(list_entries_page_query("talon_kv")
             .contains("SELECT namespace, parent_path, kind, name, value"));
-        assert!(list_entries_query("talon_kv", false, Order::Asc)
+        assert!(list_entries_query("talon_kv", false, Order::Asc.into())
             .contains("ORDER BY kind ASC, name ASC"));
         assert_eq!(
             rename_migration_index_statement("talon_kv", "talon_kv_structured_key_migration"),
@@ -865,10 +920,10 @@ mod tests {
         store.set(&other, b"three").await.unwrap();
         assert_eq!(store.get(&a).await.unwrap(), Some(b"one".to_vec()));
 
-        let listed = store.list_keys(&list, Order::Asc).await.unwrap();
+        let listed = store.list_keys(&list, Order::Asc.into()).await.unwrap();
         assert_eq!(listed, vec![a.clone(), b.clone()]);
         assert_eq!(
-            store.list_keys(&list, Order::Desc).await.unwrap(),
+            store.list_keys(&list, Order::Desc.into()).await.unwrap(),
             vec![b.clone(), a.clone()]
         );
 
@@ -885,11 +940,11 @@ mod tests {
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 
-        let entries = store.list_entries(&list, Order::Asc).await.unwrap();
+        let entries = store.list_entries(&list, Order::Asc.into()).await.unwrap();
         assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
         assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
         assert_eq!(
-            store.list_entries(&list, Order::Desc).await.unwrap(),
+            store.list_entries(&list, Order::Desc.into()).await.unwrap(),
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 

--- a/src/control/kv/rocksdb.rs
+++ b/src/control/kv/rocksdb.rs
@@ -331,8 +331,9 @@ impl KeyValueStore for RocksDbKvStore {
     async fn list_keys(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> Result<Vec<ResourceKey>> {
+        let options = options.unwrap_or_default();
         if options.limit == Some(0) {
             return Ok(Vec::new());
         }
@@ -413,8 +414,9 @@ impl KeyValueStore for RocksDbKvStore {
     async fn list_entries(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let options = options.unwrap_or_default();
         if options.limit == Some(0) {
             return Ok(Vec::new());
         }
@@ -678,12 +680,15 @@ mod tests {
         store.set(&other, b"o").await.unwrap();
 
         let list = keys::session_prefix("default", "agent-a");
-        let keys = store.list_keys(&list, Order::Asc.into()).await.unwrap();
+        let keys = store.list_keys(&list, None).await.unwrap();
         assert_eq!(
             keys.iter().map(|key| key.name.as_str()).collect::<Vec<_>>(),
             vec!["alpha", "beta", "gamma"]
         );
-        let desc_keys = store.list_keys(&list, Order::Desc.into()).await.unwrap();
+        let desc_keys = store
+            .list_keys(&list, Some(ListOptions::desc()))
+            .await
+            .unwrap();
         assert_eq!(
             desc_keys
                 .iter()
@@ -691,7 +696,10 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["gamma", "beta", "alpha"]
         );
-        let desc_entries = store.list_entries(&list, Order::Desc.into()).await.unwrap();
+        let desc_entries = store
+            .list_entries(&list, Some(ListOptions::desc()))
+            .await
+            .unwrap();
         assert_eq!(
             desc_entries
                 .iter()

--- a/src/control/kv/rocksdb.rs
+++ b/src/control/kv/rocksdb.rs
@@ -3,7 +3,7 @@
 
 use crate::control::{
     keys::{ResourceKey, ResourceList},
-    KeyValueStore, Order,
+    KeyValueStore, ListOptions, Order,
 };
 use anyhow::{anyhow, bail, Result};
 use rocksdb::{
@@ -45,6 +45,15 @@ fn reverse_seek_bytes(prefix: &[u8]) -> Vec<u8> {
     let mut seek = prefix.to_vec();
     seek.push(0xff);
     seek
+}
+
+fn key_matches_options(key: &ResourceKey, options: ListOptions<'_>) -> bool {
+    options
+        .before_name
+        .map_or(true, |cursor| key.name.as_str() < cursor)
+        && options
+            .after_name
+            .map_or(true, |cursor| key.name.as_str() > cursor)
 }
 
 fn parse_key(bytes: &[u8]) -> Result<ResourceKey> {
@@ -319,9 +328,16 @@ impl KeyValueStore for RocksDbKvStore {
         .await
     }
 
-    async fn list_keys(&self, list: &ResourceList, order: Order) -> Result<Vec<ResourceKey>> {
+    async fn list_keys(
+        &self,
+        list: &ResourceList,
+        options: ListOptions<'_>,
+    ) -> Result<Vec<ResourceKey>> {
+        if options.limit == Some(0) {
+            return Ok(Vec::new());
+        }
         let prefix = prefix_bytes(list);
-        let seek_key = (order == Order::Desc).then(|| reverse_seek_bytes(&prefix));
+        let seek_key = (options.order == Order::Desc).then(|| reverse_seek_bytes(&prefix));
         let span = tracing::debug_span!(
             "RocksDbKvStore.list_keys",
             "db.system" = "rocksdb",
@@ -345,7 +361,14 @@ impl KeyValueStore for RocksDbKvStore {
                             if !raw_key.starts_with(&prefix) {
                                 break;
                             }
-                            keys.push(parse_key(&raw_key)?);
+                            let key = parse_key(&raw_key)?;
+                            if !key_matches_options(&key, options) {
+                                continue;
+                            }
+                            keys.push(key);
+                            if options.limit.is_some_and(|limit| keys.len() >= limit) {
+                                break;
+                            }
                         }
                     } else {
                         for item in
@@ -355,7 +378,14 @@ impl KeyValueStore for RocksDbKvStore {
                             if !raw_key.starts_with(&prefix) {
                                 break;
                             }
-                            keys.push(parse_key(&raw_key)?);
+                            let key = parse_key(&raw_key)?;
+                            if !key_matches_options(&key, options) {
+                                continue;
+                            }
+                            keys.push(key);
+                            if options.limit.is_some_and(|limit| keys.len() >= limit) {
+                                break;
+                            }
                         }
                     }
                     Ok(keys)
@@ -372,10 +402,13 @@ impl KeyValueStore for RocksDbKvStore {
     async fn list_entries(
         &self,
         list: &ResourceList,
-        order: Order,
+        options: ListOptions<'_>,
     ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        if options.limit == Some(0) {
+            return Ok(Vec::new());
+        }
         let prefix = prefix_bytes(list);
-        let seek_key = (order == Order::Desc).then(|| reverse_seek_bytes(&prefix));
+        let seek_key = (options.order == Order::Desc).then(|| reverse_seek_bytes(&prefix));
         let span = tracing::debug_span!(
             "RocksDbKvStore.list_entries",
             "db.system" = "rocksdb",
@@ -401,8 +434,15 @@ impl KeyValueStore for RocksDbKvStore {
                             if !raw_key.starts_with(&prefix) {
                                 break;
                             }
+                            let key = parse_key(&raw_key)?;
+                            if !key_matches_options(&key, options) {
+                                continue;
+                            }
                             value_bytes += value.len();
-                            entries.push((parse_key(&raw_key)?, value.to_vec()));
+                            entries.push((key, value.to_vec()));
+                            if options.limit.is_some_and(|limit| entries.len() >= limit) {
+                                break;
+                            }
                         }
                     } else {
                         for item in
@@ -412,8 +452,15 @@ impl KeyValueStore for RocksDbKvStore {
                             if !raw_key.starts_with(&prefix) {
                                 break;
                             }
+                            let key = parse_key(&raw_key)?;
+                            if !key_matches_options(&key, options) {
+                                continue;
+                            }
                             value_bytes += value.len();
-                            entries.push((parse_key(&raw_key)?, value.to_vec()));
+                            entries.push((key, value.to_vec()));
+                            if options.limit.is_some_and(|limit| entries.len() >= limit) {
+                                break;
+                            }
                         }
                     }
                     Ok((entries, value_bytes))
@@ -609,12 +656,12 @@ mod tests {
         store.set(&other, b"o").await.unwrap();
 
         let list = keys::session_prefix("default", "agent-a");
-        let keys = store.list_keys(&list, Order::Asc).await.unwrap();
+        let keys = store.list_keys(&list, Order::Asc.into()).await.unwrap();
         assert_eq!(
             keys.iter().map(|key| key.name.as_str()).collect::<Vec<_>>(),
             vec!["alpha", "beta", "gamma"]
         );
-        let desc_keys = store.list_keys(&list, Order::Desc).await.unwrap();
+        let desc_keys = store.list_keys(&list, Order::Desc.into()).await.unwrap();
         assert_eq!(
             desc_keys
                 .iter()
@@ -622,7 +669,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["gamma", "beta", "alpha"]
         );
-        let desc_entries = store.list_entries(&list, Order::Desc).await.unwrap();
+        let desc_entries = store.list_entries(&list, Order::Desc.into()).await.unwrap();
         assert_eq!(
             desc_entries
                 .iter()

--- a/src/control/kv/rocksdb.rs
+++ b/src/control/kv/rocksdb.rs
@@ -47,13 +47,13 @@ fn reverse_seek_bytes(prefix: &[u8]) -> Vec<u8> {
     seek
 }
 
-fn key_matches_options(key: &ResourceKey, options: ListOptions<'_>) -> bool {
-    options
-        .before_name
-        .map_or(true, |cursor| key.name.as_str() < cursor)
-        && options
-            .after_name
-            .map_or(true, |cursor| key.name.as_str() > cursor)
+fn key_matches_options(
+    key: &ResourceKey,
+    before_name: Option<&str>,
+    after_name: Option<&str>,
+) -> bool {
+    before_name.map_or(true, |cursor| key.name.as_str() < cursor)
+        && after_name.map_or(true, |cursor| key.name.as_str() > cursor)
 }
 
 fn parse_key(bytes: &[u8]) -> Result<ResourceKey> {
@@ -338,6 +338,9 @@ impl KeyValueStore for RocksDbKvStore {
         }
         let prefix = prefix_bytes(list);
         let seek_key = (options.order == Order::Desc).then(|| reverse_seek_bytes(&prefix));
+        let limit = options.limit;
+        let before_name = options.before_name.map(str::to_owned);
+        let after_name = options.after_name.map(str::to_owned);
         let span = tracing::debug_span!(
             "RocksDbKvStore.list_keys",
             "db.system" = "rocksdb",
@@ -362,11 +365,15 @@ impl KeyValueStore for RocksDbKvStore {
                                 break;
                             }
                             let key = parse_key(&raw_key)?;
-                            if !key_matches_options(&key, options) {
+                            if !key_matches_options(
+                                &key,
+                                before_name.as_deref(),
+                                after_name.as_deref(),
+                            ) {
                                 continue;
                             }
                             keys.push(key);
-                            if options.limit.is_some_and(|limit| keys.len() >= limit) {
+                            if limit.is_some_and(|limit| keys.len() >= limit) {
                                 break;
                             }
                         }
@@ -379,11 +386,15 @@ impl KeyValueStore for RocksDbKvStore {
                                 break;
                             }
                             let key = parse_key(&raw_key)?;
-                            if !key_matches_options(&key, options) {
+                            if !key_matches_options(
+                                &key,
+                                before_name.as_deref(),
+                                after_name.as_deref(),
+                            ) {
                                 continue;
                             }
                             keys.push(key);
-                            if options.limit.is_some_and(|limit| keys.len() >= limit) {
+                            if limit.is_some_and(|limit| keys.len() >= limit) {
                                 break;
                             }
                         }
@@ -409,6 +420,9 @@ impl KeyValueStore for RocksDbKvStore {
         }
         let prefix = prefix_bytes(list);
         let seek_key = (options.order == Order::Desc).then(|| reverse_seek_bytes(&prefix));
+        let limit = options.limit;
+        let before_name = options.before_name.map(str::to_owned);
+        let after_name = options.after_name.map(str::to_owned);
         let span = tracing::debug_span!(
             "RocksDbKvStore.list_entries",
             "db.system" = "rocksdb",
@@ -435,12 +449,16 @@ impl KeyValueStore for RocksDbKvStore {
                                 break;
                             }
                             let key = parse_key(&raw_key)?;
-                            if !key_matches_options(&key, options) {
+                            if !key_matches_options(
+                                &key,
+                                before_name.as_deref(),
+                                after_name.as_deref(),
+                            ) {
                                 continue;
                             }
                             value_bytes += value.len();
                             entries.push((key, value.to_vec()));
-                            if options.limit.is_some_and(|limit| entries.len() >= limit) {
+                            if limit.is_some_and(|limit| entries.len() >= limit) {
                                 break;
                             }
                         }
@@ -453,12 +471,16 @@ impl KeyValueStore for RocksDbKvStore {
                                 break;
                             }
                             let key = parse_key(&raw_key)?;
-                            if !key_matches_options(&key, options) {
+                            if !key_matches_options(
+                                &key,
+                                before_name.as_deref(),
+                                after_name.as_deref(),
+                            ) {
                                 continue;
                             }
                             value_bytes += value.len();
                             entries.push((key, value.to_vec()));
-                            if options.limit.is_some_and(|limit| entries.len() >= limit) {
+                            if limit.is_some_and(|limit| entries.len() >= limit) {
                                 break;
                             }
                         }

--- a/src/control/kv/sqlite.rs
+++ b/src/control/kv/sqlite.rs
@@ -428,8 +428,9 @@ impl KeyValueStore for SqliteKvStore {
     async fn list_keys(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> Result<Vec<ResourceKey>> {
+        let options = options.unwrap_or_default();
         let query = list_keys_query(&self.table, list.kind.is_some(), options);
         let span = tracing::debug_span!(
             "SqliteKvStore.list_keys",
@@ -488,8 +489,9 @@ impl KeyValueStore for SqliteKvStore {
     async fn list_entries(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
+        let options = options.unwrap_or_default();
         let query = list_entries_query(&self.table, list.kind.is_some(), options);
         let span = tracing::debug_span!(
             "SqliteKvStore.list_entries",
@@ -810,22 +812,28 @@ mod tests {
         store.set(&other, b"three").await.unwrap();
         assert_eq!(store.get(&a).await.unwrap(), Some(b"one".to_vec()));
 
-        let listed = store.list_keys(&list, Order::Asc.into()).await.unwrap();
+        let listed = store.list_keys(&list, None).await.unwrap();
         assert_eq!(listed, vec![a.clone(), b.clone()]);
         assert_eq!(
-            store.list_keys(&list, Order::Desc.into()).await.unwrap(),
+            store
+                .list_keys(&list, Some(ListOptions::desc()))
+                .await
+                .unwrap(),
             vec![b.clone(), a.clone()]
         );
         assert_eq!(
             store
-                .list_keys(&list, ListOptions::default().after_name(Some("a")))
+                .list_keys(&list, Some(ListOptions::default().after_name(Some("a"))))
                 .await
                 .unwrap(),
             vec![b.clone()]
         );
         assert_eq!(
             store
-                .list_keys(&list, ListOptions::desc().before_name(Some("b")).limit(1))
+                .list_keys(
+                    &list,
+                    Some(ListOptions::desc().before_name(Some("b")).limit(1)),
+                )
                 .await
                 .unwrap(),
             vec![a.clone()]
@@ -844,16 +852,19 @@ mod tests {
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 
-        let entries = store.list_entries(&list, Order::Asc.into()).await.unwrap();
+        let entries = store.list_entries(&list, None).await.unwrap();
         assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
         assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
         assert_eq!(
-            store.list_entries(&list, Order::Desc.into()).await.unwrap(),
+            store
+                .list_entries(&list, Some(ListOptions::desc()))
+                .await
+                .unwrap(),
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
         assert_eq!(
             store
-                .list_entries(&list, ListOptions::desc().limit(1))
+                .list_entries(&list, Some(ListOptions::desc().limit(1)))
                 .await
                 .unwrap(),
             vec![(b.clone(), b"two".to_vec())]

--- a/src/control/kv/sqlite.rs
+++ b/src/control/kv/sqlite.rs
@@ -3,7 +3,7 @@
 
 use crate::control::{
     keys::{ResourceKey, ResourceList},
-    KeyValueStore, Order,
+    KeyValueStore, ListOptions,
 };
 use anyhow::{bail, Result};
 use sqlx::{
@@ -425,8 +425,12 @@ impl KeyValueStore for SqliteKvStore {
         Ok(())
     }
 
-    async fn list_keys(&self, list: &ResourceList, order: Order) -> Result<Vec<ResourceKey>> {
-        let query = list_keys_query(&self.table, list.kind.is_some(), order);
+    async fn list_keys(
+        &self,
+        list: &ResourceList,
+        options: ListOptions<'_>,
+    ) -> Result<Vec<ResourceKey>> {
+        let query = list_keys_query(&self.table, list.kind.is_some(), options);
         let span = tracing::debug_span!(
             "SqliteKvStore.list_keys",
             "db.system" = "sqlite",
@@ -448,6 +452,15 @@ impl KeyValueStore for SqliteKvStore {
             .bind(&list.parent.parent_path);
         if let Some(kind) = &list.kind {
             query = query.bind(kind);
+        }
+        if let Some(before_name) = options.before_name {
+            query = query.bind(before_name);
+        }
+        if let Some(after_name) = options.after_name {
+            query = query.bind(after_name);
+        }
+        if let Some(limit) = options.limit {
+            query = query.bind(limit as i64);
         }
         let mut conn = acquire_connection(&self.pool, self.settings, &span).await?;
         let query_span = tracing::debug_span!(
@@ -475,9 +488,9 @@ impl KeyValueStore for SqliteKvStore {
     async fn list_entries(
         &self,
         list: &ResourceList,
-        order: Order,
+        options: ListOptions<'_>,
     ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        let query = list_entries_query(&self.table, list.kind.is_some(), order);
+        let query = list_entries_query(&self.table, list.kind.is_some(), options);
         let span = tracing::debug_span!(
             "SqliteKvStore.list_entries",
             "db.system" = "sqlite",
@@ -500,6 +513,15 @@ impl KeyValueStore for SqliteKvStore {
             .bind(&list.parent.parent_path);
         if let Some(kind) = &list.kind {
             query = query.bind(kind);
+        }
+        if let Some(before_name) = options.before_name {
+            query = query.bind(before_name);
+        }
+        if let Some(after_name) = options.after_name {
+            query = query.bind(after_name);
+        }
+        if let Some(limit) = options.limit {
+            query = query.bind(limit as i64);
         }
         let mut conn = acquire_connection(&self.pool, self.settings, &span).await?;
         let query_span = tracing::debug_span!(
@@ -664,7 +686,7 @@ mod tests {
         set_query, sqlite_pool, SqliteKvStore,
     };
     use crate::control::kv::sqlite_url_for_path;
-    use crate::control::{keys, KeyValueStore, Order};
+    use crate::control::{keys, KeyValueStore, ListOptions, Order};
     use tempfile::tempdir;
 
     #[test]
@@ -679,13 +701,13 @@ mod tests {
         assert!(compare_and_swap_query("talon_kv", true).contains("AND value = ?6"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
         assert!(delete_query("talon_kv").contains("WHERE namespace = ?1"));
-        assert!(list_keys_query("talon_kv", true, Order::Asc).contains("AND kind = ?3"));
-        assert!(list_keys_query("talon_kv", true, Order::Desc)
+        assert!(list_keys_query("talon_kv", true, Order::Asc.into()).contains("AND kind = ?3"));
+        assert!(list_keys_query("talon_kv", true, Order::Desc.into())
             .contains("ORDER BY kind DESC, name DESC"));
         assert!(list_keys_page_query("talon_kv").contains("ORDER BY name DESC"));
         assert!(list_entries_page_query("talon_kv")
             .contains("SELECT namespace, parent_path, kind, name, value"));
-        assert!(list_entries_query("talon_kv", false, Order::Asc)
+        assert!(list_entries_query("talon_kv", false, Order::Asc.into())
             .contains("ORDER BY kind ASC, name ASC"));
     }
 
@@ -788,11 +810,25 @@ mod tests {
         store.set(&other, b"three").await.unwrap();
         assert_eq!(store.get(&a).await.unwrap(), Some(b"one".to_vec()));
 
-        let listed = store.list_keys(&list, Order::Asc).await.unwrap();
+        let listed = store.list_keys(&list, Order::Asc.into()).await.unwrap();
         assert_eq!(listed, vec![a.clone(), b.clone()]);
         assert_eq!(
-            store.list_keys(&list, Order::Desc).await.unwrap(),
+            store.list_keys(&list, Order::Desc.into()).await.unwrap(),
             vec![b.clone(), a.clone()]
+        );
+        assert_eq!(
+            store
+                .list_keys(&list, ListOptions::default().after_name(Some("a")))
+                .await
+                .unwrap(),
+            vec![b.clone()]
+        );
+        assert_eq!(
+            store
+                .list_keys(&list, ListOptions::desc().before_name(Some("b")).limit(1))
+                .await
+                .unwrap(),
+            vec![a.clone()]
         );
 
         assert_eq!(
@@ -808,12 +844,19 @@ mod tests {
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 
-        let entries = store.list_entries(&list, Order::Asc).await.unwrap();
+        let entries = store.list_entries(&list, Order::Asc.into()).await.unwrap();
         assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
         assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
         assert_eq!(
-            store.list_entries(&list, Order::Desc).await.unwrap(),
+            store.list_entries(&list, Order::Desc.into()).await.unwrap(),
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
+        );
+        assert_eq!(
+            store
+                .list_entries(&list, ListOptions::desc().limit(1))
+                .await
+                .unwrap(),
+            vec![(b.clone(), b"two".to_vec())]
         );
 
         assert!(store

--- a/src/control/kv/sqlite_sql.rs
+++ b/src/control/kv/sqlite_sql.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use super::shared::quoted_identifier;
-use crate::control::Order;
+use crate::control::{ListOptions, Order};
 
 pub(crate) fn create_table_statement(table: &str) -> String {
     let table = quoted_identifier(table);
@@ -72,24 +72,57 @@ fn list_order_sql(order: Order) -> &'static str {
     }
 }
 
-pub(crate) fn list_keys_query(table: &str, has_kind: bool, order: Order) -> String {
-    let kind_clause = if has_kind { "AND kind = ?3" } else { "" };
-    let direction = list_order_sql(order);
+fn list_filter_clause(has_kind: bool, options: ListOptions<'_>) -> String {
+    let mut next_bind = if has_kind { 4 } else { 3 };
+    let mut clauses = Vec::new();
+    if has_kind {
+        clauses.push("AND kind = ?3".to_string());
+    }
+    if options.before_name.is_some() {
+        clauses.push(format!("AND name < ?{next_bind}"));
+        next_bind += 1;
+    }
+    if options.after_name.is_some() {
+        clauses.push(format!("AND name > ?{next_bind}"));
+    }
+    clauses.join(" ")
+}
+
+fn list_limit_clause(has_kind: bool, options: ListOptions<'_>) -> String {
+    let mut next_bind = if has_kind { 4 } else { 3 };
+    if options.before_name.is_some() {
+        next_bind += 1;
+    }
+    if options.after_name.is_some() {
+        next_bind += 1;
+    }
+    if options.limit.is_some() {
+        format!(" LIMIT ?{next_bind}")
+    } else {
+        String::new()
+    }
+}
+
+pub(crate) fn list_keys_query(table: &str, has_kind: bool, options: ListOptions<'_>) -> String {
+    let filter_clause = list_filter_clause(has_kind, options);
+    let limit_clause = list_limit_clause(has_kind, options);
+    let direction = list_order_sql(options.order);
     format!(
         "SELECT namespace, parent_path, kind, name FROM {}
-         WHERE namespace = ?1 AND parent_path = ?2 {kind_clause}
-         ORDER BY kind {direction}, name {direction}",
+         WHERE namespace = ?1 AND parent_path = ?2 {filter_clause}
+         ORDER BY kind {direction}, name {direction}{limit_clause}",
         quoted_identifier(table)
     )
 }
 
-pub(crate) fn list_entries_query(table: &str, has_kind: bool, order: Order) -> String {
-    let kind_clause = if has_kind { "AND kind = ?3" } else { "" };
-    let direction = list_order_sql(order);
+pub(crate) fn list_entries_query(table: &str, has_kind: bool, options: ListOptions<'_>) -> String {
+    let filter_clause = list_filter_clause(has_kind, options);
+    let limit_clause = list_limit_clause(has_kind, options);
+    let direction = list_order_sql(options.order);
     format!(
         "SELECT namespace, parent_path, kind, name, value FROM {}
-         WHERE namespace = ?1 AND parent_path = ?2 {kind_clause}
-         ORDER BY kind {direction}, name {direction}",
+         WHERE namespace = ?1 AND parent_path = ?2 {filter_clause}
+         ORDER BY kind {direction}, name {direction}{limit_clause}",
         quoted_identifier(table)
     )
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -201,7 +201,7 @@ pub trait KeyValueStore: Send + Sync {
     async fn list_keys(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> anyhow::Result<Vec<ResourceKey>>;
 
     /// List direct children, ordered by resource name descending.
@@ -216,7 +216,7 @@ pub trait KeyValueStore: Send + Sync {
     ) -> anyhow::Result<Vec<ResourceKey>> {
         self.list_keys(
             list,
-            ListOptions::desc().before_name(before_name).limit(limit),
+            Some(ListOptions::desc().before_name(before_name).limit(limit)),
         )
         .await
     }
@@ -233,7 +233,7 @@ pub trait KeyValueStore: Send + Sync {
     ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
         self.list_entries(
             list,
-            ListOptions::desc().before_name(before_name).limit(limit),
+            Some(ListOptions::desc().before_name(before_name).limit(limit)),
         )
         .await
     }
@@ -242,7 +242,7 @@ pub trait KeyValueStore: Send + Sync {
     async fn list_entries(
         &self,
         list: &ResourceList,
-        options: ListOptions<'_>,
+        options: Option<ListOptions<'_>>,
     ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
         let keys = self.list_keys(list, options).await?;
         let mut entries = Vec::with_capacity(keys.len());
@@ -420,7 +420,7 @@ impl KeyValueStore for NoopKeyValueStore {
     async fn list_keys(
         &self,
         _list: &ResourceList,
-        _options: ListOptions<'_>,
+        _options: Option<ListOptions<'_>>,
     ) -> anyhow::Result<Vec<ResourceKey>> {
         Ok(Vec::new())
     }
@@ -939,7 +939,7 @@ mod tests {
     use super::{
         build_control_plane, configured_scheduler, configured_scheduler_callback_auth_from_env,
         ensure_builtin_namespaces, message_broker_config, sqlite_database_url, KeyValueStore,
-        ListOptions, Order, ProtoKeyValueStoreExt,
+        ListOptions, ProtoKeyValueStoreExt,
     };
     use crate::control::config::proto;
     use crate::control::config::proto::{scheduler_callback_auth_config, scheduler_config, secret};
@@ -1168,28 +1168,30 @@ mod tests {
         kv.set(&b, b"two").await.unwrap();
         kv.set(&other, b"three").await.unwrap();
 
-        let entries = kv.list_entries(&list, Order::Asc.into()).await.unwrap();
+        let entries = kv.list_entries(&list, None).await.unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
         assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
         assert_eq!(
-            kv.list_entries(&list, Order::Desc.into()).await.unwrap(),
+            kv.list_entries(&list, Some(ListOptions::desc()))
+                .await
+                .unwrap(),
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
         assert_eq!(
-            kv.list_entries(&list, ListOptions::desc().limit(1))
+            kv.list_entries(&list, Some(ListOptions::desc().limit(1)))
                 .await
                 .unwrap(),
             vec![(b.clone(), b"two".to_vec())]
         );
         assert_eq!(
-            kv.list_entries(&list, ListOptions::default().after_name(Some("a")))
+            kv.list_entries(&list, Some(ListOptions::default().after_name(Some("a"))))
                 .await
                 .unwrap(),
             vec![(b.clone(), b"two".to_vec())]
         );
         assert_eq!(
-            kv.list_entries(&list, ListOptions::desc().before_name(Some("b")))
+            kv.list_entries(&list, Some(ListOptions::desc().before_name(Some("b"))))
                 .await
                 .unwrap(),
             vec![(a.clone(), b"one".to_vec())]

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -34,6 +34,120 @@ pub enum Order {
     Desc,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ListOptions<'a> {
+    pub order: Order,
+    pub limit: Option<usize>,
+    pub before_name: Option<&'a str>,
+    pub after_name: Option<&'a str>,
+}
+
+impl Default for ListOptions<'_> {
+    fn default() -> Self {
+        Self {
+            order: Order::Asc,
+            limit: None,
+            before_name: None,
+            after_name: None,
+        }
+    }
+}
+
+impl<'a> ListOptions<'a> {
+    pub fn asc() -> Self {
+        Self::default()
+    }
+
+    pub fn desc() -> Self {
+        Self {
+            order: Order::Desc,
+            ..Self::default()
+        }
+    }
+
+    pub fn ordered(order: Order) -> Self {
+        Self {
+            order,
+            ..Self::default()
+        }
+    }
+
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    pub fn before_name(mut self, before_name: Option<&'a str>) -> Self {
+        self.before_name = before_name;
+        self
+    }
+
+    pub fn after_name(mut self, after_name: Option<&'a str>) -> Self {
+        self.after_name = after_name;
+        self
+    }
+}
+
+impl From<Order> for ListOptions<'static> {
+    fn from(order: Order) -> Self {
+        Self::ordered(order)
+    }
+}
+
+pub fn apply_list_options_to_keys(
+    mut keys: Vec<ResourceKey>,
+    options: ListOptions<'_>,
+) -> Vec<ResourceKey> {
+    if options.limit == Some(0) {
+        return Vec::new();
+    }
+
+    keys.retain(|key| {
+        options
+            .before_name
+            .map_or(true, |cursor| key.name.as_str() < cursor)
+            && options
+                .after_name
+                .map_or(true, |cursor| key.name.as_str() > cursor)
+    });
+    if options.order == Order::Desc {
+        keys.sort_by(|left, right| right.cmp(left));
+    } else {
+        keys.sort();
+    }
+    if let Some(limit) = options.limit {
+        keys.truncate(limit);
+    }
+    keys
+}
+
+pub fn apply_list_options_to_entries(
+    mut entries: Vec<(ResourceKey, Vec<u8>)>,
+    options: ListOptions<'_>,
+) -> Vec<(ResourceKey, Vec<u8>)> {
+    if options.limit == Some(0) {
+        return Vec::new();
+    }
+
+    entries.retain(|(key, _)| {
+        options
+            .before_name
+            .map_or(true, |cursor| key.name.as_str() < cursor)
+            && options
+                .after_name
+                .map_or(true, |cursor| key.name.as_str() > cursor)
+    });
+    if options.order == Order::Desc {
+        entries.sort_by(|left, right| right.0.cmp(&left.0));
+    } else {
+        entries.sort_by(|left, right| left.0.cmp(&right.0));
+    }
+    if let Some(limit) = options.limit {
+        entries.truncate(limit);
+    }
+    entries
+}
+
 pub fn page_keys_desc(
     mut keys: Vec<ResourceKey>,
     before_name: Option<&str>,
@@ -87,7 +201,7 @@ pub trait KeyValueStore: Send + Sync {
     async fn list_keys(
         &self,
         list: &ResourceList,
-        order: Order,
+        options: ListOptions<'_>,
     ) -> anyhow::Result<Vec<ResourceKey>>;
 
     /// List direct children, ordered by resource name descending.
@@ -100,11 +214,11 @@ pub trait KeyValueStore: Send + Sync {
         before_name: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<ResourceKey>> {
-        Ok(page_keys_desc(
-            self.list_keys(list, Order::Asc).await?,
-            before_name,
-            limit,
-        ))
+        self.list_keys(
+            list,
+            ListOptions::desc().before_name(before_name).limit(limit),
+        )
+        .await
     }
 
     /// List direct child key/value pairs, ordered by resource name descending.
@@ -117,20 +231,20 @@ pub trait KeyValueStore: Send + Sync {
         before_name: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
-        Ok(page_entries_desc(
-            self.list_entries(list, Order::Asc).await?,
-            before_name,
-            limit,
-        ))
+        self.list_entries(
+            list,
+            ListOptions::desc().before_name(before_name).limit(limit),
+        )
+        .await
     }
 
     /// List all matching direct child key/value pairs.
     async fn list_entries(
         &self,
         list: &ResourceList,
-        order: Order,
+        options: ListOptions<'_>,
     ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
-        let keys = self.list_keys(list, order).await?;
+        let keys = self.list_keys(list, options).await?;
         let mut entries = Vec::with_capacity(keys.len());
         for key in keys {
             if let Some(value) = self.get(&key).await? {
@@ -306,7 +420,7 @@ impl KeyValueStore for NoopKeyValueStore {
     async fn list_keys(
         &self,
         _list: &ResourceList,
-        _order: Order,
+        _options: ListOptions<'_>,
     ) -> anyhow::Result<Vec<ResourceKey>> {
         Ok(Vec::new())
     }
@@ -825,7 +939,7 @@ mod tests {
     use super::{
         build_control_plane, configured_scheduler, configured_scheduler_callback_auth_from_env,
         ensure_builtin_namespaces, message_broker_config, sqlite_database_url, KeyValueStore,
-        Order, ProtoKeyValueStoreExt,
+        ListOptions, Order, ProtoKeyValueStoreExt,
     };
     use crate::control::config::proto;
     use crate::control::config::proto::{scheduler_callback_auth_config, scheduler_config, secret};
@@ -1054,13 +1168,31 @@ mod tests {
         kv.set(&b, b"two").await.unwrap();
         kv.set(&other, b"three").await.unwrap();
 
-        let entries = kv.list_entries(&list, Order::Asc).await.unwrap();
+        let entries = kv.list_entries(&list, Order::Asc.into()).await.unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0], (a.clone(), b"one".to_vec()));
         assert_eq!(entries[1], (b.clone(), b"two".to_vec()));
         assert_eq!(
-            kv.list_entries(&list, Order::Desc).await.unwrap(),
+            kv.list_entries(&list, Order::Desc.into()).await.unwrap(),
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
+        );
+        assert_eq!(
+            kv.list_entries(&list, ListOptions::desc().limit(1))
+                .await
+                .unwrap(),
+            vec![(b.clone(), b"two".to_vec())]
+        );
+        assert_eq!(
+            kv.list_entries(&list, ListOptions::default().after_name(Some("a")))
+                .await
+                .unwrap(),
+            vec![(b.clone(), b"two".to_vec())]
+        );
+        assert_eq!(
+            kv.list_entries(&list, ListOptions::desc().before_name(Some("b")))
+                .await
+                .unwrap(),
+            vec![(a.clone(), b"one".to_vec())]
         );
 
         kv.delete(&a).await.unwrap();

--- a/src/control/resources.rs
+++ b/src/control/resources.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use crate::control::events;
-use crate::control::{keys, topics, KeyValueStore, MessagePublisher, Order};
+use crate::control::{keys, topics, KeyValueStore, MessagePublisher};
 use crate::gateway::rpc::resources_proto;
 use anyhow::{anyhow, Context, Result};
 use prost::Message;
@@ -423,10 +423,7 @@ impl ResourceStore {
     ) -> Result<Vec<resources_proto::Resource>> {
         let entries = self
             .kv
-            .list_entries(
-                &keys::ResourceParent::root(namespace).list(kind),
-                Order::Asc.into(),
-            )
+            .list_entries(&keys::ResourceParent::root(namespace).list(kind), None)
             .await?;
         let mut status_fetches = Vec::with_capacity(entries.len());
         for (key, value) in entries {

--- a/src/control/resources.rs
+++ b/src/control/resources.rs
@@ -425,7 +425,7 @@ impl ResourceStore {
             .kv
             .list_entries(
                 &keys::ResourceParent::root(namespace).list(kind),
-                Order::Asc,
+                Order::Asc.into(),
             )
             .await?;
         let mut status_fetches = Vec::with_capacity(entries.len());

--- a/src/control/usage.rs
+++ b/src/control/usage.rs
@@ -336,7 +336,7 @@ async fn usage_status_used(
             let prefix = format!("{rule_id}:subject=");
             let suffix = format!(":{window_start}");
             let mut max_used = 0;
-            for (key, value) in kv.list_entries(&parent, Order::Asc).await? {
+            for (key, value) in kv.list_entries(&parent, Order::Asc.into()).await? {
                 if key.name.starts_with(&prefix) && key.name.ends_with(&suffix) {
                     max_used = max_used.max(
                         decode_counter(&value)
@@ -515,7 +515,7 @@ async fn matched_limits(
         .into_iter()
         .map(|namespace| {
             let list_key = keys::ResourceParent::root(&namespace).list(Some("UsagePolicy"));
-            async move { kv.list_entries(&list_key, Order::Asc).await }
+            async move { kv.list_entries(&list_key, Order::Asc.into()).await }
         });
     for entries in futures::future::try_join_all(ancestor_fetches).await? {
         for (key, value) in entries {

--- a/src/control/usage.rs
+++ b/src/control/usage.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::control::{keys, KeyValueStore, Order};
+use crate::control::{keys, KeyValueStore};
 use crate::gateway::rpc::{harness_proto, resources_proto};
 use anyhow::{anyhow, bail, Context, Result};
 use prost::Message;
@@ -336,7 +336,7 @@ async fn usage_status_used(
             let prefix = format!("{rule_id}:subject=");
             let suffix = format!(":{window_start}");
             let mut max_used = 0;
-            for (key, value) in kv.list_entries(&parent, Order::Asc.into()).await? {
+            for (key, value) in kv.list_entries(&parent, None).await? {
                 if key.name.starts_with(&prefix) && key.name.ends_with(&suffix) {
                     max_used = max_used.max(
                         decode_counter(&value)
@@ -515,7 +515,7 @@ async fn matched_limits(
         .into_iter()
         .map(|namespace| {
             let list_key = keys::ResourceParent::root(&namespace).list(Some("UsagePolicy"));
-            async move { kv.list_entries(&list_key, Order::Asc.into()).await }
+            async move { kv.list_entries(&list_key, None).await }
         });
     for entries in futures::future::try_join_all(ancestor_fetches).await? {
         for (key, value) in entries {

--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -19,7 +19,7 @@ use crate::control::scheduling;
 use crate::control::{
     events::SessionMessagePartEventKind,
     keys::{self},
-    Order, ProtoKeyValueStoreExt,
+    ProtoKeyValueStoreExt,
 };
 use crate::gateway::auth::{self, AuthConfig};
 use crate::gateway::rpc::data_proto;
@@ -435,7 +435,7 @@ pub async fn list_tasks(
         Err(response) => return response,
     };
     let prefix = keys::session_prefix(&route.ns, &route.agent);
-    let session_keys = match gateway.kv.list_keys(&prefix, Order::Asc.into()).await {
+    let session_keys = match gateway.kv.list_keys(&prefix, None).await {
         Ok(keys) => keys,
         Err(err) => {
             tracing::error!(%err, "Failed to list A2A sessions");

--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -435,7 +435,7 @@ pub async fn list_tasks(
         Err(response) => return response,
     };
     let prefix = keys::session_prefix(&route.ns, &route.agent);
-    let session_keys = match gateway.kv.list_keys(&prefix, Order::Asc).await {
+    let session_keys = match gateway.kv.list_keys(&prefix, Order::Asc.into()).await {
         Ok(keys) => keys,
         Err(err) => {
             tracing::error!(%err, "Failed to list A2A sessions");

--- a/src/gateway/rest/a2a/tasks.rs
+++ b/src/gateway/rest/a2a/tasks.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use crate::control::{
     events,
     keys::{self, ResourceKey},
-    topics, Order, ProtoKeyValueStoreExt,
+    topics, ProtoKeyValueStoreExt,
 };
 use crate::gateway::server::Gateway;
 
@@ -304,7 +304,7 @@ pub(super) async fn list_a2a_session_task_ids(
         .kv
         .list_keys(
             &keys::session_message_prefix(&route.ns, &route.agent, session_id),
-            Order::Asc.into(),
+            None,
         )
         .await
         .map_err(|err| {
@@ -402,14 +402,10 @@ pub(super) async fn find_a2a_task_session(
     }
 
     let prefix = keys::session_prefix(&route.ns, &route.agent);
-    let session_keys = gateway
-        .kv
-        .list_keys(&prefix, Order::Asc.into())
-        .await
-        .map_err(|err| {
-            tracing::error!(%err, "Failed to list A2A sessions");
-            a2a_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to load task")
-        })?;
+    let session_keys = gateway.kv.list_keys(&prefix, None).await.map_err(|err| {
+        tracing::error!(%err, "Failed to list A2A sessions");
+        a2a_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to load task")
+    })?;
 
     let mut fallback = None;
     for key in session_keys {
@@ -468,7 +464,7 @@ async fn session_contains_a2a_task_message(
         .kv
         .list_keys(
             &keys::session_message_prefix(&route.ns, &route.agent, session_id),
-            Order::Asc.into(),
+            None,
         )
         .await
         .map_err(|err| {
@@ -550,7 +546,7 @@ pub(super) async fn load_a2a_task_from_session(
         .kv
         .list_keys(
             &keys::session_message_prefix(&route.ns, &route.agent, &task_ref.session_id),
-            Order::Asc.into(),
+            None,
         )
         .await
         .map_err(|err| {

--- a/src/gateway/rest/a2a/tasks.rs
+++ b/src/gateway/rest/a2a/tasks.rs
@@ -304,7 +304,7 @@ pub(super) async fn list_a2a_session_task_ids(
         .kv
         .list_keys(
             &keys::session_message_prefix(&route.ns, &route.agent, session_id),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await
         .map_err(|err| {
@@ -404,7 +404,7 @@ pub(super) async fn find_a2a_task_session(
     let prefix = keys::session_prefix(&route.ns, &route.agent);
     let session_keys = gateway
         .kv
-        .list_keys(&prefix, Order::Asc)
+        .list_keys(&prefix, Order::Asc.into())
         .await
         .map_err(|err| {
             tracing::error!(%err, "Failed to list A2A sessions");
@@ -468,7 +468,7 @@ async fn session_contains_a2a_task_message(
         .kv
         .list_keys(
             &keys::session_message_prefix(&route.ns, &route.agent, session_id),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await
         .map_err(|err| {
@@ -550,7 +550,7 @@ pub(super) async fn load_a2a_task_from_session(
         .kv
         .list_keys(
             &keys::session_message_prefix(&route.ns, &route.agent, &task_ref.session_id),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await
         .map_err(|err| {

--- a/src/gateway/rpc/auth.rs
+++ b/src/gateway/rpc/auth.rs
@@ -221,7 +221,7 @@ impl GrpcGatewayHandler {
         let entries = self
             .gateway
             .kv
-            .list_entries(&api_key_list(), Order::Asc)
+            .list_entries(&api_key_list(), Order::Asc.into())
             .await
             .map_err(|err| tonic::Status::internal(format!("failed to list API keys: {err}")))?;
         let mut api_keys = Vec::with_capacity(entries.len());

--- a/src/gateway/rpc/auth.rs
+++ b/src/gateway/rpc/auth.rs
@@ -4,7 +4,7 @@
 use super::{data_proto, proto, GrpcGatewayHandler};
 use crate::control::config::proto as config_proto;
 use crate::control::security::platform_jwt;
-use crate::control::{keys, ns, Order};
+use crate::control::{keys, ns};
 use crate::gateway::auth::{
     self as gateway_auth, AuthConfig, AuthMode, AuthzOperation, Claims, TalonGrantClaim,
 };
@@ -221,7 +221,7 @@ impl GrpcGatewayHandler {
         let entries = self
             .gateway
             .kv
-            .list_entries(&api_key_list(), Order::Asc.into())
+            .list_entries(&api_key_list(), None)
             .await
             .map_err(|err| tonic::Status::internal(format!("failed to list API keys: {err}")))?;
         let mut api_keys = Vec::with_capacity(entries.len());

--- a/src/gateway/rpc/channels.rs
+++ b/src/gateway/rpc/channels.rs
@@ -735,7 +735,7 @@ async fn matching_subscriptions(
         .kv
         .list_entries(
             &keys::channel_subscription_prefix(&message.ns, &message.channel),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await?;
     let mut subscriptions = Vec::new();
@@ -1012,7 +1012,7 @@ async fn delete_routed_session(
     let mut stack = vec![keys::session_parent(ns, agent, session_id)];
     while let Some(parent) = stack.pop() {
         let list = parent.list(None);
-        let children = kv.list_keys(&list, Order::Asc).await?;
+        let children = kv.list_keys(&list, Order::Asc.into()).await?;
         for child in children {
             stack.push(child.as_parent());
             kv.delete(&child).await?;

--- a/src/gateway/rpc/channels.rs
+++ b/src/gateway/rpc/channels.rs
@@ -7,7 +7,7 @@ use crate::control::resource_model::{
 };
 use crate::control::scheduling;
 use crate::control::topics;
-use crate::control::{events, keys, ControlPlane, KeyValueStore, Order};
+use crate::control::{events, keys, ControlPlane, KeyValueStore};
 use crate::control::{MessagePublisher, ProtoKeyValueStoreExt};
 use anyhow::Context;
 use futures::StreamExt;
@@ -735,7 +735,7 @@ async fn matching_subscriptions(
         .kv
         .list_entries(
             &keys::channel_subscription_prefix(&message.ns, &message.channel),
-            Order::Asc.into(),
+            None,
         )
         .await?;
     let mut subscriptions = Vec::new();
@@ -1012,7 +1012,7 @@ async fn delete_routed_session(
     let mut stack = vec![keys::session_parent(ns, agent, session_id)];
     while let Some(parent) = stack.pop() {
         let list = parent.list(None);
-        let children = kv.list_keys(&list, Order::Asc.into()).await?;
+        let children = kv.list_keys(&list, None).await?;
         for child in children {
             stack.push(child.as_parent());
             kv.delete(&child).await?;

--- a/src/gateway/rpc/knowledge.rs
+++ b/src/gateway/rpc/knowledge.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use super::{data_proto, proto, GrpcGatewayHandler};
+use crate::control::keys;
 use crate::control::ns;
 use crate::control::resources::ResourceStore;
 use crate::control::search::{DOCUMENT_KIND_CONTENT, KIND_KNOWLEDGE};
-use crate::control::{keys, Order};
 use crate::gateway::rpc::resources_proto;
 use crate::harness::knowledge::KnowledgeEntry;
 use std::collections::HashMap;
@@ -64,12 +64,9 @@ async fn list_namespace_knowledge(
         }
 
         let prefix = keys::knowledge_prefix(&candidate_ns);
-        let keys = kv
-            .list_keys(&prefix, Order::Asc.into())
-            .await
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to list knowledge artifacts: {}", e))
-            })?;
+        let keys = kv.list_keys(&prefix, None).await.map_err(|e| {
+            tonic::Status::internal(format!("Failed to list knowledge artifacts: {}", e))
+        })?;
 
         for key in keys {
             let path = keys::direct_child_name(&prefix, &key).unwrap_or_else(|| key.name.clone());

--- a/src/gateway/rpc/knowledge.rs
+++ b/src/gateway/rpc/knowledge.rs
@@ -64,9 +64,12 @@ async fn list_namespace_knowledge(
         }
 
         let prefix = keys::knowledge_prefix(&candidate_ns);
-        let keys = kv.list_keys(&prefix, Order::Asc).await.map_err(|e| {
-            tonic::Status::internal(format!("Failed to list knowledge artifacts: {}", e))
-        })?;
+        let keys = kv
+            .list_keys(&prefix, Order::Asc.into())
+            .await
+            .map_err(|e| {
+                tonic::Status::internal(format!("Failed to list knowledge artifacts: {}", e))
+            })?;
 
         for key in keys {
             let path = keys::direct_child_name(&prefix, &key).unwrap_or_else(|| key.name.clone());

--- a/src/gateway/rpc/namespaces.rs
+++ b/src/gateway/rpc/namespaces.rs
@@ -308,7 +308,7 @@ impl GrpcGatewayHandler {
         let keys = self
             .gateway
             .kv
-            .list_keys(&edge_prefix, Order::Asc)
+            .list_keys(&edge_prefix, Order::Asc.into())
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to list namespace references: {}", e))

--- a/src/gateway/rpc/namespaces.rs
+++ b/src/gateway/rpc/namespaces.rs
@@ -3,7 +3,7 @@
 
 use crate::control::resource_model::{self, NamespaceResourceExt, TypedResource};
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{events, keys, topics, Order};
+use crate::control::{events, keys, topics};
 use crate::gateway::rpc::{proto, resources_proto, GrpcGatewayHandler};
 use prost::Message;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -308,7 +308,7 @@ impl GrpcGatewayHandler {
         let keys = self
             .gateway
             .kv
-            .list_keys(&edge_prefix, Order::Asc.into())
+            .list_keys(&edge_prefix, None)
             .await
             .map_err(|e| {
                 tonic::Status::internal(format!("Failed to list namespace references: {}", e))

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -169,7 +169,7 @@ async fn delete_descendants(kv: &dyn KeyValueStore, parent: ResourceParent) -> a
     let mut stack = vec![parent];
     while let Some(parent) = stack.pop() {
         let list = parent.list(None);
-        let children = kv.list_keys(&list, Order::Asc).await?;
+        let children = kv.list_keys(&list, Order::Asc.into()).await?;
         for child in children {
             stack.push(child.as_parent());
             kv.delete(&child).await?;
@@ -189,7 +189,7 @@ async fn collect_session_tool_result_object_keys(
     for key in kv
         .list_keys(
             &keys::session_message_prefix(ns, agent, session_id),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await?
     {
@@ -223,14 +223,14 @@ async fn collect_session_tool_result_object_keys(
     for submission_key in kv
         .list_keys(
             &keys::session_submission_prefix(ns, agent, session_id),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await?
     {
         for (_, bytes) in kv
             .list_entries(
                 &keys::session_journal_entry_prefix(ns, agent, session_id, &submission_key.name),
-                Order::Asc,
+                Order::Asc.into(),
             )
             .await?
         {
@@ -387,9 +387,12 @@ async fn find_request_permission_message_id(
     request_id: &str,
 ) -> std::result::Result<Option<String>, tonic::Status> {
     let prefix = keys::session_message_prefix(ns, agent, session_id);
-    let message_keys = kv.list_keys(&prefix, Order::Asc).await.map_err(|err| {
-        tonic::Status::internal(format!("Failed to list session messages: {err}"))
-    })?;
+    let message_keys = kv
+        .list_keys(&prefix, Order::Asc.into())
+        .await
+        .map_err(|err| {
+            tonic::Status::internal(format!("Failed to list session messages: {err}"))
+        })?;
     for key in message_keys {
         let Some(bytes) = kv.get(&key).await.map_err(|err| {
             tonic::Status::internal(format!("Failed to fetch session message: {err}"))
@@ -726,7 +729,7 @@ impl GrpcGatewayHandler {
                 let keys = self
                     .gateway
                     .kv
-                    .list_keys(&msg_prefix, Order::Asc)
+                    .list_keys(&msg_prefix, Order::Asc.into())
                     .await
                     .map_err(|e| {
                         tracing::error!(
@@ -961,7 +964,7 @@ impl GrpcGatewayHandler {
         let keys = self
             .gateway
             .kv
-            .list_keys(&session_prefix, Order::Asc)
+            .list_keys(&session_prefix, Order::Asc.into())
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to list sessions: {}", e)))?;
 
@@ -2839,7 +2842,7 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::Internal);
 
         let session_keys = kv
-            .list_keys(&keys::session_prefix(ns, "assistant"), Order::Asc)
+            .list_keys(&keys::session_prefix(ns, "assistant"), Order::Asc.into())
             .await
             .unwrap();
         assert!(session_keys.is_empty());

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -6,7 +6,7 @@ use crate::control::cas::{session_object_key_prefix, SessionCasScope, METADATA_A
 use crate::control::scheduling;
 use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{events, keys, keys::ResourceParent, KeyValueStore, Order};
+use crate::control::{events, keys, keys::ResourceParent, KeyValueStore};
 use prost::Message;
 use serde_json::{json, Value};
 use std::collections::HashSet;
@@ -169,7 +169,7 @@ async fn delete_descendants(kv: &dyn KeyValueStore, parent: ResourceParent) -> a
     let mut stack = vec![parent];
     while let Some(parent) = stack.pop() {
         let list = parent.list(None);
-        let children = kv.list_keys(&list, Order::Asc.into()).await?;
+        let children = kv.list_keys(&list, None).await?;
         for child in children {
             stack.push(child.as_parent());
             kv.delete(&child).await?;
@@ -187,10 +187,7 @@ async fn collect_session_tool_result_object_keys(
     let expected_prefix = session_object_key_prefix(&SessionCasScope::new(ns, agent, session_id));
     let mut keys_to_delete = HashSet::new();
     for key in kv
-        .list_keys(
-            &keys::session_message_prefix(ns, agent, session_id),
-            Order::Asc.into(),
-        )
+        .list_keys(&keys::session_message_prefix(ns, agent, session_id), None)
         .await?
     {
         let message = match kv.get_msg::<data_proto::SessionMessage>(&key).await {
@@ -223,14 +220,14 @@ async fn collect_session_tool_result_object_keys(
     for submission_key in kv
         .list_keys(
             &keys::session_submission_prefix(ns, agent, session_id),
-            Order::Asc.into(),
+            None,
         )
         .await?
     {
         for (_, bytes) in kv
             .list_entries(
                 &keys::session_journal_entry_prefix(ns, agent, session_id, &submission_key.name),
-                Order::Asc.into(),
+                None,
             )
             .await?
         {
@@ -387,12 +384,9 @@ async fn find_request_permission_message_id(
     request_id: &str,
 ) -> std::result::Result<Option<String>, tonic::Status> {
     let prefix = keys::session_message_prefix(ns, agent, session_id);
-    let message_keys = kv
-        .list_keys(&prefix, Order::Asc.into())
-        .await
-        .map_err(|err| {
-            tonic::Status::internal(format!("Failed to list session messages: {err}"))
-        })?;
+    let message_keys = kv.list_keys(&prefix, None).await.map_err(|err| {
+        tonic::Status::internal(format!("Failed to list session messages: {err}"))
+    })?;
     for key in message_keys {
         let Some(bytes) = kv.get(&key).await.map_err(|err| {
             tonic::Status::internal(format!("Failed to fetch session message: {err}"))
@@ -729,7 +723,7 @@ impl GrpcGatewayHandler {
                 let keys = self
                     .gateway
                     .kv
-                    .list_keys(&msg_prefix, Order::Asc.into())
+                    .list_keys(&msg_prefix, None)
                     .await
                     .map_err(|e| {
                         tracing::error!(
@@ -964,7 +958,7 @@ impl GrpcGatewayHandler {
         let keys = self
             .gateway
             .kv
-            .list_keys(&session_prefix, Order::Asc.into())
+            .list_keys(&session_prefix, None)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to list sessions: {}", e)))?;
 
@@ -2842,7 +2836,7 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::Internal);
 
         let session_keys = kv
-            .list_keys(&keys::session_prefix(ns, "assistant"), Order::Asc.into())
+            .list_keys(&keys::session_prefix(ns, "assistant"), None)
             .await
             .unwrap();
         assert!(session_keys.is_empty());

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -4,7 +4,7 @@
 use crate::control::scheduling;
 use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{events, keys, KeyValueStore, MessagePublisher, Order};
+use crate::control::{events, keys, KeyValueStore, MessagePublisher};
 use crate::gateway::rpc::{data_proto, resources_proto, worker_proto};
 use crate::gateway::worker_conn::WorkerConnectionPool;
 use futures::{stream::SelectAll, Stream, StreamExt};
@@ -676,7 +676,7 @@ async fn latest_nonterminal_submission(
 ) -> std::result::Result<Option<data_proto::SessionSubmission>, tonic::Status> {
     let prefix = keys::session_submission_prefix(&target.ns, &target.agent, &target.session_id);
     let entries = kv
-        .list_entries(&prefix, Order::Asc.into())
+        .list_entries(&prefix, None)
         .await
         .map_err(|err| tonic::Status::internal(format!("Failed to list submissions: {err}")))?;
     let mut submissions = Vec::new();
@@ -700,7 +700,7 @@ async fn latest_submission(
 ) -> std::result::Result<Option<data_proto::SessionSubmission>, tonic::Status> {
     let prefix = keys::session_submission_prefix(&target.ns, &target.agent, &target.session_id);
     let entries = kv
-        .list_entries(&prefix, Order::Asc.into())
+        .list_entries(&prefix, None)
         .await
         .map_err(|err| tonic::Status::internal(format!("Failed to list submissions: {err}")))?;
     let mut submissions = Vec::new();

--- a/src/gateway/rpc/sessions/watcher.rs
+++ b/src/gateway/rpc/sessions/watcher.rs
@@ -676,7 +676,7 @@ async fn latest_nonterminal_submission(
 ) -> std::result::Result<Option<data_proto::SessionSubmission>, tonic::Status> {
     let prefix = keys::session_submission_prefix(&target.ns, &target.agent, &target.session_id);
     let entries = kv
-        .list_entries(&prefix, Order::Asc)
+        .list_entries(&prefix, Order::Asc.into())
         .await
         .map_err(|err| tonic::Status::internal(format!("Failed to list submissions: {err}")))?;
     let mut submissions = Vec::new();
@@ -700,7 +700,7 @@ async fn latest_submission(
 ) -> std::result::Result<Option<data_proto::SessionSubmission>, tonic::Status> {
     let prefix = keys::session_submission_prefix(&target.ns, &target.agent, &target.session_id);
     let entries = kv
-        .list_entries(&prefix, Order::Asc)
+        .list_entries(&prefix, Order::Asc.into())
         .await
         .map_err(|err| tonic::Status::internal(format!("Failed to list submissions: {err}")))?;
     let mut submissions = Vec::new();

--- a/src/gateway/rpc/workflows.rs
+++ b/src/gateway/rpc/workflows.rs
@@ -3,7 +3,7 @@
 
 use super::{data_proto, proto, resources_proto, worker_proto, GrpcGatewayHandler};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, KeyValueStore, Order, ProtoKeyValueStoreExt};
+use crate::control::{keys, KeyValueStore, ProtoKeyValueStoreExt};
 use crate::gateway::worker_conn::WorkerConnectionPool;
 use crate::worker::workflows;
 use futures::StreamExt;
@@ -456,10 +456,7 @@ async fn load_sorted_workflow_run_events(
     run_id: &str,
 ) -> Result<Vec<data_proto::WorkflowRunEvent>, tonic::Status> {
     let entries = kv
-        .list_entries(
-            &keys::workflow_run_event_prefix(ns, workflow, run_id),
-            Order::Asc.into(),
-        )
+        .list_entries(&keys::workflow_run_event_prefix(ns, workflow, run_id), None)
         .await
         .map_err(|err| tonic::Status::internal(err.to_string()))?;
 

--- a/src/gateway/rpc/workflows.rs
+++ b/src/gateway/rpc/workflows.rs
@@ -458,7 +458,7 @@ async fn load_sorted_workflow_run_events(
     let entries = kv
         .list_entries(
             &keys::workflow_run_event_prefix(ns, workflow, run_id),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await
         .map_err(|err| tonic::Status::internal(err.to_string()))?;

--- a/src/harness/knowledge/mod.rs
+++ b/src/harness/knowledge/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::control::resources::ResourceStore;
 use crate::control::search::{DocumentStore, DOCUMENT_KIND_CONTENT, KIND_KNOWLEDGE};
-use crate::control::{MessagePublisher, Order};
+use crate::control::MessagePublisher;
 use crate::gateway::rpc::{proto, resources_proto};
 
 #[derive(Default, serde::Serialize, serde::Deserialize)]
@@ -263,7 +263,7 @@ impl KvKnowledgeBook {
         let path_lower = path.to_lowercase();
         let matches = self
             .kv
-            .list_keys(&prefix, Order::Asc.into())
+            .list_keys(&prefix, None)
             .await?
             .into_iter()
             .filter(|candidate| {
@@ -467,7 +467,7 @@ impl KnowledgeBook for KvKnowledgeBook {
 
         for (depth, candidate_ns) in crate::control::ns::ancestry(ns).into_iter().enumerate() {
             let prefix = crate::control::keys::knowledge_prefix(&candidate_ns);
-            let keys = self.kv.list_keys(&prefix, Order::Asc.into()).await?;
+            let keys = self.kv.list_keys(&prefix, None).await?;
 
             for key in keys {
                 if let Some(bytes) = self.kv.get(&key).await.unwrap_or(None) {
@@ -556,7 +556,7 @@ impl KnowledgeBook for KvKnowledgeBook {
 
         for candidate_ns in namespaces {
             let prefix = crate::control::keys::knowledge_prefix(&candidate_ns);
-            let keys = self.kv.list_keys(&prefix, Order::Asc.into()).await?;
+            let keys = self.kv.list_keys(&prefix, None).await?;
 
             for key in keys {
                 let artifact_path =

--- a/src/harness/knowledge/mod.rs
+++ b/src/harness/knowledge/mod.rs
@@ -263,7 +263,7 @@ impl KvKnowledgeBook {
         let path_lower = path.to_lowercase();
         let matches = self
             .kv
-            .list_keys(&prefix, Order::Asc)
+            .list_keys(&prefix, Order::Asc.into())
             .await?
             .into_iter()
             .filter(|candidate| {
@@ -467,7 +467,7 @@ impl KnowledgeBook for KvKnowledgeBook {
 
         for (depth, candidate_ns) in crate::control::ns::ancestry(ns).into_iter().enumerate() {
             let prefix = crate::control::keys::knowledge_prefix(&candidate_ns);
-            let keys = self.kv.list_keys(&prefix, Order::Asc).await?;
+            let keys = self.kv.list_keys(&prefix, Order::Asc.into()).await?;
 
             for key in keys {
                 if let Some(bytes) = self.kv.get(&key).await.unwrap_or(None) {
@@ -556,7 +556,7 @@ impl KnowledgeBook for KvKnowledgeBook {
 
         for candidate_ns in namespaces {
             let prefix = crate::control::keys::knowledge_prefix(&candidate_ns);
-            let keys = self.kv.list_keys(&prefix, Order::Asc).await?;
+            let keys = self.kv.list_keys(&prefix, Order::Asc.into()).await?;
 
             for key in keys {
                 let artifact_path =

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use crate::control::resource_model::{self, TypedResource};
 use crate::control::resources::ResourceStore;
 use crate::control::scheduling;
-use crate::control::{delegation, keys, ControlPlane, Order, ProtoKeyValueStoreExt};
+use crate::control::{delegation, keys, ControlPlane, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{
     data_proto, manifests, protobuf_value::value::Kind as ProtoValueKind, resources_proto,
 };
@@ -576,7 +576,7 @@ pub async fn execute_tool_for_session(
             let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(100) as usize;
             let entries = cp
                 .kv
-                .list_entries(&keys::schedule_prefix(namespace), Order::Asc.into())
+                .list_entries(&keys::schedule_prefix(namespace), None)
                 .await?;
             let mut schedules = Vec::new();
             for (_key, value) in entries {
@@ -2152,10 +2152,7 @@ async fn list_session_goals(
 ) -> Result<Vec<data_proto::Goal>> {
     let mut goals = cp
         .kv
-        .list_entries(
-            &keys::goal_prefix(namespace, agent, session_id),
-            Order::Asc.into(),
-        )
+        .list_entries(&keys::goal_prefix(namespace, agent, session_id), None)
         .await?
         .into_iter()
         .filter_map(|(_, value)| data_proto::Goal::decode(value.as_slice()).ok())
@@ -3027,10 +3024,7 @@ mod tests {
         session_id: &str,
     ) -> Vec<String> {
         let entries = kv
-            .list_entries(
-                &keys::session_message_prefix(ns, agent, session_id),
-                Order::Asc.into(),
-            )
+            .list_entries(&keys::session_message_prefix(ns, agent, session_id), None)
             .await
             .unwrap();
         entries
@@ -4036,7 +4030,7 @@ mod tests {
                     "support-agent",
                     child_session_id,
                 ),
-                Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -576,7 +576,7 @@ pub async fn execute_tool_for_session(
             let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(100) as usize;
             let entries = cp
                 .kv
-                .list_entries(&keys::schedule_prefix(namespace), Order::Asc)
+                .list_entries(&keys::schedule_prefix(namespace), Order::Asc.into())
                 .await?;
             let mut schedules = Vec::new();
             for (_key, value) in entries {
@@ -2152,7 +2152,10 @@ async fn list_session_goals(
 ) -> Result<Vec<data_proto::Goal>> {
     let mut goals = cp
         .kv
-        .list_entries(&keys::goal_prefix(namespace, agent, session_id), Order::Asc)
+        .list_entries(
+            &keys::goal_prefix(namespace, agent, session_id),
+            Order::Asc.into(),
+        )
         .await?
         .into_iter()
         .filter_map(|(_, value)| data_proto::Goal::decode(value.as_slice()).ok())
@@ -3026,7 +3029,7 @@ mod tests {
         let entries = kv
             .list_entries(
                 &keys::session_message_prefix(ns, agent, session_id),
-                Order::Asc,
+                Order::Asc.into(),
             )
             .await
             .unwrap();
@@ -4033,7 +4036,7 @@ mod tests {
                     "support-agent",
                     child_session_id,
                 ),
-                Order::Asc,
+                Order::Asc.into(),
             )
             .await
             .unwrap();

--- a/src/harness/sessions/journal.rs
+++ b/src/harness/sessions/journal.rs
@@ -7,7 +7,7 @@ use prost::Message;
 use super::submission::{ensure_submission_attempt_current, update_submission_from_entry};
 use super::SessionJournalEntry;
 use crate::control::cas::CasStore;
-use crate::control::{keys, KeyValueStore, Order};
+use crate::control::{keys, KeyValueStore};
 use crate::gateway::rpc::data_proto::{
     session_journal_entry_payload, SessionExecutionPhase, SessionJournalEntryPayload,
     SessionJournalEntryPayloadCommit, SessionJournalEntryPayloadLlmResponse,
@@ -214,7 +214,7 @@ pub async fn list_journal_entries(
 ) -> Result<Vec<SessionJournalEntry>> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
     let entries = kv
-        .list_entries(&prefix, Order::Asc.into())
+        .list_entries(&prefix, None)
         .await?
         .into_iter()
         .map(|(_, bytes)| SessionJournalEntry::decode(bytes.as_slice()).map_err(Into::into))
@@ -356,7 +356,7 @@ async fn committed_journal_entry(
 ) -> Result<Option<SessionJournalEntry>> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
     let mut found: Option<SessionJournalEntry> = None;
-    for (_, bytes) in kv.list_entries(&prefix, Order::Asc.into()).await? {
+    for (_, bytes) in kv.list_entries(&prefix, None).await? {
         let entry = SessionJournalEntry::decode(bytes.as_slice())?;
         if entry.phase == SessionExecutionPhase::Committed as i32
             && entry.committed_message_id.as_deref() == Some(committed_message_id)

--- a/src/harness/sessions/journal.rs
+++ b/src/harness/sessions/journal.rs
@@ -214,7 +214,7 @@ pub async fn list_journal_entries(
 ) -> Result<Vec<SessionJournalEntry>> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
     let entries = kv
-        .list_entries(&prefix, Order::Asc)
+        .list_entries(&prefix, Order::Asc.into())
         .await?
         .into_iter()
         .map(|(_, bytes)| SessionJournalEntry::decode(bytes.as_slice()).map_err(Into::into))
@@ -356,7 +356,7 @@ async fn committed_journal_entry(
 ) -> Result<Option<SessionJournalEntry>> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
     let mut found: Option<SessionJournalEntry> = None;
-    for (_, bytes) in kv.list_entries(&prefix, Order::Asc).await? {
+    for (_, bytes) in kv.list_entries(&prefix, Order::Asc.into()).await? {
         let entry = SessionJournalEntry::decode(bytes.as_slice())?;
         if entry.phase == SessionExecutionPhase::Committed as i32
             && entry.committed_message_id.as_deref() == Some(committed_message_id)

--- a/src/harness/skills/namespace.rs
+++ b/src/harness/skills/namespace.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::control::{keys, Order};
+use crate::control::keys;
 use crate::gateway::rpc::resources_proto;
 use anyhow::Result;
 use prost::Message;
@@ -25,7 +25,7 @@ pub async fn load_effective_skills(
 
     for candidate_ns in crate::control::ns::ancestry(namespace) {
         let prefix = keys::skill_prefix(&candidate_ns);
-        let skill_keys = kv.list_keys(&prefix, Order::Asc.into()).await?;
+        let skill_keys = kv.list_keys(&prefix, None).await?;
 
         for key in skill_keys {
             let name = key.name.clone();

--- a/src/harness/skills/namespace.rs
+++ b/src/harness/skills/namespace.rs
@@ -25,7 +25,7 @@ pub async fn load_effective_skills(
 
     for candidate_ns in crate::control::ns::ancestry(namespace) {
         let prefix = keys::skill_prefix(&candidate_ns);
-        let skill_keys = kv.list_keys(&prefix, Order::Asc).await?;
+        let skill_keys = kv.list_keys(&prefix, Order::Asc.into()).await?;
 
         for key in skill_keys {
             let name = key.name.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod test_support {
     use crate::control::keys::{ResourceKey, ResourceList};
     #[cfg(test)]
     use crate::control::security::platform_jwt;
-    use crate::control::{KeyValueStore, MessagePublisher, Order};
+    use crate::control::{KeyValueStore, ListOptions, MessagePublisher};
     use futures::stream;
     use std::collections::HashMap;
     #[cfg(test)]
@@ -185,21 +185,16 @@ pub mod test_support {
         async fn list_keys(
             &self,
             list: &ResourceList,
-            order: Order,
+            options: ListOptions<'_>,
         ) -> anyhow::Result<Vec<ResourceKey>> {
-            let mut keys = self
+            let keys = self
                 .data
                 .lock()
                 .await
                 .keys()
                 .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
-            if order == Order::Desc {
-                keys.sort_by(|left, right| right.cmp(left));
-            } else {
-                keys.sort();
-            }
-            Ok(keys)
+            Ok(crate::control::apply_list_options_to_keys(keys, options))
         }
 
         async fn list_keys_page(
@@ -208,11 +203,11 @@ pub mod test_support {
             before_name: Option<&str>,
             limit: usize,
         ) -> anyhow::Result<Vec<ResourceKey>> {
-            Ok(crate::control::page_keys_desc(
-                self.list_keys(list, Order::Asc).await?,
-                before_name,
-                limit,
-            ))
+            self.list_keys(
+                list,
+                ListOptions::desc().before_name(before_name).limit(limit),
+            )
+            .await
         }
 
         async fn list_entries_page(
@@ -221,11 +216,11 @@ pub mod test_support {
             before_name: Option<&str>,
             limit: usize,
         ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
-            Ok(crate::control::page_entries_desc(
-                self.list_entries(list, Order::Asc).await?,
-                before_name,
-                limit,
-            ))
+            self.list_entries(
+                list,
+                ListOptions::desc().before_name(before_name).limit(limit),
+            )
+            .await
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ pub mod test_support {
         async fn list_keys(
             &self,
             list: &ResourceList,
-            options: ListOptions<'_>,
+            options: Option<ListOptions<'_>>,
         ) -> anyhow::Result<Vec<ResourceKey>> {
             let keys = self
                 .data
@@ -194,7 +194,10 @@ pub mod test_support {
                 .keys()
                 .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
-            Ok(crate::control::apply_list_options_to_keys(keys, options))
+            Ok(crate::control::apply_list_options_to_keys(
+                keys,
+                options.unwrap_or_default(),
+            ))
         }
 
         async fn list_keys_page(
@@ -205,7 +208,7 @@ pub mod test_support {
         ) -> anyhow::Result<Vec<ResourceKey>> {
             self.list_keys(
                 list,
-                ListOptions::desc().before_name(before_name).limit(limit),
+                Some(ListOptions::desc().before_name(before_name).limit(limit)),
             )
             .await
         }
@@ -218,7 +221,7 @@ pub mod test_support {
         ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
             self.list_entries(
                 list,
-                ListOptions::desc().before_name(before_name).limit(limit),
+                Some(ListOptions::desc().before_name(before_name).limit(limit)),
             )
             .await
         }

--- a/src/worker/controllers/connectors.rs
+++ b/src/worker/controllers/connectors.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::control::resources::ResourceStore;
 use crate::control::security::platform_jwt;
-use crate::control::{keys, ControlPlane, KeyValueStore, Order, ProtoKeyValueStoreExt};
+use crate::control::{keys, ControlPlane, KeyValueStore, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{data_proto, external_proto, resources_proto};
 
 const CONNECTOR_INDEX_FIELD_SEP: &str = "\x1f";
@@ -75,7 +75,7 @@ impl ConnectorController {
         // Reconcile Connectors that may have been waiting for this class.
         for namespace_key in cp
             .kv
-            .list_keys(&keys::namespace_metadata_prefix(), Order::Asc.into())
+            .list_keys(&keys::namespace_metadata_prefix(), None)
             .await?
         {
             let namespace = namespace_key.name;
@@ -348,7 +348,7 @@ pub async fn delete_route_entries_for_uid(
     for (key, bytes) in kv
         .list_entries(
             &keys::connector_route_prefix(class_namespace, class_name),
-            Order::Asc.into(),
+            None,
         )
         .await?
     {
@@ -402,7 +402,7 @@ pub async fn delete_connector_class_entries(
 }
 
 async fn delete_entries(kv: &dyn KeyValueStore, prefix: &keys::ResourceList) -> Result<()> {
-    for key in kv.list_keys(prefix, Order::Asc.into()).await? {
+    for key in kv.list_keys(prefix, None).await? {
         kv.delete(&key).await?;
     }
     Ok(())

--- a/src/worker/controllers/connectors.rs
+++ b/src/worker/controllers/connectors.rs
@@ -75,7 +75,7 @@ impl ConnectorController {
         // Reconcile Connectors that may have been waiting for this class.
         for namespace_key in cp
             .kv
-            .list_keys(&keys::namespace_metadata_prefix(), Order::Asc)
+            .list_keys(&keys::namespace_metadata_prefix(), Order::Asc.into())
             .await?
         {
             let namespace = namespace_key.name;
@@ -348,7 +348,7 @@ pub async fn delete_route_entries_for_uid(
     for (key, bytes) in kv
         .list_entries(
             &keys::connector_route_prefix(class_namespace, class_name),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await?
     {
@@ -402,7 +402,7 @@ pub async fn delete_connector_class_entries(
 }
 
 async fn delete_entries(kv: &dyn KeyValueStore, prefix: &keys::ResourceList) -> Result<()> {
-    for key in kv.list_keys(prefix, Order::Asc).await? {
+    for key in kv.list_keys(prefix, Order::Asc.into()).await? {
         kv.delete(&key).await?;
     }
     Ok(())

--- a/src/worker/controllers/controller.rs
+++ b/src/worker/controllers/controller.rs
@@ -9,7 +9,7 @@ use crate::control::config::Config;
 use crate::control::events::ResourceChangedEvent;
 use crate::control::resource_model::{NamespaceResourceExt, TypedResource};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, ControlPlane, Order, ProtoKeyValueStoreExt};
+use crate::control::{keys, ControlPlane, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::resources_proto;
 
 #[derive(Clone)]
@@ -140,10 +140,7 @@ impl ControllerHost {
                             for namespace_key in self
                                 .cp
                                 .kv
-                                .list_keys(
-                                    &crate::control::keys::namespace_metadata_prefix(),
-                                    Order::Asc.into(),
-                                )
+                                .list_keys(&crate::control::keys::namespace_metadata_prefix(), None)
                                 .await?
                             {
                                 for class in store

--- a/src/worker/controllers/controller.rs
+++ b/src/worker/controllers/controller.rs
@@ -142,7 +142,7 @@ impl ControllerHost {
                                 .kv
                                 .list_keys(
                                     &crate::control::keys::namespace_metadata_prefix(),
-                                    Order::Asc,
+                                    Order::Asc.into(),
                                 )
                                 .await?
                             {

--- a/src/worker/controllers/deployment.rs
+++ b/src/worker/controllers/deployment.rs
@@ -376,7 +376,7 @@ impl DeploymentController {
             .kv
             .list_entries(
                 &keys::namespace_ref_prefix(Some(&selector.parent)),
-                Order::Asc,
+                Order::Asc.into(),
             )
             .await?;
         let mut namespaces = Vec::new();

--- a/src/worker/controllers/deployment.rs
+++ b/src/worker/controllers/deployment.rs
@@ -3,7 +3,7 @@
 
 use crate::control::resource_model::{NamespaceResourceExt, TypedResource};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, ControlPlane, Order, ProtoKeyValueStoreExt};
+use crate::control::{keys, ControlPlane, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::resources_proto;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
@@ -374,10 +374,7 @@ impl DeploymentController {
     ) -> Result<Vec<resources_proto::Namespace>> {
         let refs = cp
             .kv
-            .list_entries(
-                &keys::namespace_ref_prefix(Some(&selector.parent)),
-                Order::Asc.into(),
-            )
+            .list_entries(&keys::namespace_ref_prefix(Some(&selector.parent)), None)
             .await?;
         let mut namespaces = Vec::new();
         for (_, value) in refs {

--- a/src/worker/mcp_registry.rs
+++ b/src/worker/mcp_registry.rs
@@ -179,7 +179,7 @@ mod tests {
         async fn list_keys(
             &self,
             list: &ResourceList,
-            _order: crate::control::Order,
+            _options: crate::control::ListOptions<'_>,
         ) -> anyhow::Result<Vec<ResourceKey>> {
             let mut keys = self
                 .data

--- a/src/worker/mcp_registry.rs
+++ b/src/worker/mcp_registry.rs
@@ -179,17 +179,19 @@ mod tests {
         async fn list_keys(
             &self,
             list: &ResourceList,
-            _options: crate::control::ListOptions<'_>,
+            options: Option<crate::control::ListOptions<'_>>,
         ) -> anyhow::Result<Vec<ResourceKey>> {
-            let mut keys = self
+            let keys = self
                 .data
                 .lock()
                 .await
                 .keys()
                 .filter_map(|key| list.matches(key).then(|| key.clone()))
                 .collect::<Vec<_>>();
-            keys.sort();
-            Ok(keys)
+            Ok(crate::control::apply_list_options_to_keys(
+                keys,
+                options.unwrap_or_default(),
+            ))
         }
     }
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -824,7 +824,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc,
+                crate::control::Order::Asc.into(),
             )
             .await
             .unwrap();
@@ -938,7 +938,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc,
+                crate::control::Order::Asc.into(),
             )
             .await
             .unwrap();

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -824,7 +824,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();
@@ -938,7 +938,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use super::mcp_registry::McpRegistry;
 use crate::control::config::Config;
+use crate::control::ControlPlane;
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{ControlPlane, Order};
 use crate::gateway::rpc::data_proto;
 use crate::gateway::rpc::resources_proto;
 use crate::gateway::rpc::{manifests, protobuf_value::value::Kind as ProtoValueKind};
@@ -82,7 +82,7 @@ impl AgentRuntime {
 
         // 2. Load session history from KV
         let msg_prefix = crate::control::keys::session_message_prefix(ns, agent_id, session_id);
-        let msg_entries = cp.kv.list_entries(&msg_prefix, Order::Asc.into()).await?;
+        let msg_entries = cp.kv.list_entries(&msg_prefix, None).await?;
 
         let mut history = Vec::new();
         for (_, value) in msg_entries {

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -82,7 +82,7 @@ impl AgentRuntime {
 
         // 2. Load session history from KV
         let msg_prefix = crate::control::keys::session_message_prefix(ns, agent_id, session_id);
-        let msg_entries = cp.kv.list_entries(&msg_prefix, Order::Asc).await?;
+        let msg_entries = cp.kv.list_entries(&msg_prefix, Order::Asc.into()).await?;
 
         let mut history = Vec::new();
         for (_, value) in msg_entries {

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -1918,7 +1918,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();
@@ -2897,7 +2897,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();
@@ -3024,7 +3024,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();
@@ -3114,7 +3114,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();
@@ -3138,7 +3138,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();
@@ -3374,7 +3374,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -1918,7 +1918,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc,
+                crate::control::Order::Asc.into(),
             )
             .await
             .unwrap();
@@ -2897,7 +2897,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc,
+                crate::control::Order::Asc.into(),
             )
             .await
             .unwrap();
@@ -3024,7 +3024,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc,
+                crate::control::Order::Asc.into(),
             )
             .await
             .unwrap();
@@ -3114,7 +3114,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc,
+                crate::control::Order::Asc.into(),
             )
             .await
             .unwrap();
@@ -3138,7 +3138,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc,
+                crate::control::Order::Asc.into(),
             )
             .await
             .unwrap();
@@ -3374,7 +3374,7 @@ mod tests {
                     "assistant",
                     "session-1",
                 ),
-                crate::control::Order::Asc,
+                crate::control::Order::Asc.into(),
             )
             .await
             .unwrap();

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1452,7 +1452,7 @@ mod tests {
         async fn list_keys(
             &self,
             _list: &ResourceList,
-            _order: crate::control::Order,
+            _options: crate::control::ListOptions<'_>,
         ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(vec![])
         }
@@ -2326,7 +2326,7 @@ mod tests {
         let entry_keys = kv
             .list_keys(
                 &keys::session_journal_entry_prefix("conic", "infra", "session-1", "submission-1"),
-                crate::control::Order::Asc,
+                crate::control::Order::Asc.into(),
             )
             .await
             .unwrap();

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1452,7 +1452,7 @@ mod tests {
         async fn list_keys(
             &self,
             _list: &ResourceList,
-            _options: crate::control::ListOptions<'_>,
+            _options: Option<crate::control::ListOptions<'_>>,
         ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(vec![])
         }
@@ -2326,7 +2326,7 @@ mod tests {
         let entry_keys = kv
             .list_keys(
                 &keys::session_journal_entry_prefix("conic", "infra", "session-1", "submission-1"),
-                crate::control::Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -36,7 +36,7 @@ use crate::{
         resource_model::{self, ChannelResourceExt, NamespaceResourceExt, TypedResource},
         scheduling,
         security::platform_jwt,
-        Order, ProtoKeyValueStoreExt,
+        ProtoKeyValueStoreExt,
     },
     gateway::rpc::{data_proto, manifests, resources_proto},
 };
@@ -180,7 +180,7 @@ impl TalonOpsServer {
     async fn list_all_namespaces(&self) -> Result<Vec<resources_proto::Namespace>> {
         let keys = self
             .kv()
-            .list_keys(&keys::namespace_metadata_prefix(), Order::Asc.into())
+            .list_keys(&keys::namespace_metadata_prefix(), None)
             .await?;
         let namespaces = self
             .load_messages::<resources_proto::Namespace>(keys, 32)
@@ -229,7 +229,7 @@ impl TalonOpsServer {
     async fn list_channel_models(&self, namespace: &str) -> Result<Vec<resources_proto::Channel>> {
         let keys = self
             .kv()
-            .list_keys(&keys::channel_prefix(namespace), Order::Asc.into())
+            .list_keys(&keys::channel_prefix(namespace), None)
             .await?;
         self.load_messages::<resources_proto::Channel>(keys, 32)
             .await
@@ -304,7 +304,7 @@ impl TalonOpsServer {
         agent: &str,
     ) -> Result<Vec<data_proto::Session>> {
         let prefix = keys::session_prefix(namespace, agent);
-        let keys = self.kv().list_keys(&prefix, Order::Asc.into()).await?;
+        let keys = self.kv().list_keys(&prefix, None).await?;
         self.load_messages::<data_proto::Session>(keys, 32).await
     }
 
@@ -315,7 +315,7 @@ impl TalonOpsServer {
         session_id: &str,
     ) -> Result<Vec<data_proto::SessionMessage>> {
         let prefix = keys::session_message_prefix(namespace, agent, session_id);
-        let keys = self.kv().list_keys(&prefix, Order::Asc.into()).await?;
+        let keys = self.kv().list_keys(&prefix, None).await?;
         self.load_messages::<data_proto::SessionMessage>(keys, 32)
             .await
     }
@@ -326,7 +326,7 @@ impl TalonOpsServer {
     ) -> Result<Vec<resources_proto::Schedule>> {
         let keys = self
             .kv()
-            .list_keys(&keys::schedule_prefix(namespace), Order::Asc.into())
+            .list_keys(&keys::schedule_prefix(namespace), None)
             .await?;
         self.load_messages::<resources_proto::Schedule>(keys, 32)
             .await
@@ -880,7 +880,7 @@ impl TalonOpsServer {
         let limit = bounded_limit(&access, args.limit);
         let keys = self
             .kv()
-            .list_keys(&keys::mcp_server_prefix(&args.namespace), Order::Asc.into())
+            .list_keys(&keys::mcp_server_prefix(&args.namespace), None)
             .await
             .map_err(internal_mcp_error)?;
         let mut servers = Vec::new();

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -180,7 +180,7 @@ impl TalonOpsServer {
     async fn list_all_namespaces(&self) -> Result<Vec<resources_proto::Namespace>> {
         let keys = self
             .kv()
-            .list_keys(&keys::namespace_metadata_prefix(), Order::Asc)
+            .list_keys(&keys::namespace_metadata_prefix(), Order::Asc.into())
             .await?;
         let namespaces = self
             .load_messages::<resources_proto::Namespace>(keys, 32)
@@ -229,7 +229,7 @@ impl TalonOpsServer {
     async fn list_channel_models(&self, namespace: &str) -> Result<Vec<resources_proto::Channel>> {
         let keys = self
             .kv()
-            .list_keys(&keys::channel_prefix(namespace), Order::Asc)
+            .list_keys(&keys::channel_prefix(namespace), Order::Asc.into())
             .await?;
         self.load_messages::<resources_proto::Channel>(keys, 32)
             .await
@@ -304,7 +304,7 @@ impl TalonOpsServer {
         agent: &str,
     ) -> Result<Vec<data_proto::Session>> {
         let prefix = keys::session_prefix(namespace, agent);
-        let keys = self.kv().list_keys(&prefix, Order::Asc).await?;
+        let keys = self.kv().list_keys(&prefix, Order::Asc.into()).await?;
         self.load_messages::<data_proto::Session>(keys, 32).await
     }
 
@@ -315,7 +315,7 @@ impl TalonOpsServer {
         session_id: &str,
     ) -> Result<Vec<data_proto::SessionMessage>> {
         let prefix = keys::session_message_prefix(namespace, agent, session_id);
-        let keys = self.kv().list_keys(&prefix, Order::Asc).await?;
+        let keys = self.kv().list_keys(&prefix, Order::Asc.into()).await?;
         self.load_messages::<data_proto::SessionMessage>(keys, 32)
             .await
     }
@@ -326,7 +326,7 @@ impl TalonOpsServer {
     ) -> Result<Vec<resources_proto::Schedule>> {
         let keys = self
             .kv()
-            .list_keys(&keys::schedule_prefix(namespace), Order::Asc)
+            .list_keys(&keys::schedule_prefix(namespace), Order::Asc.into())
             .await?;
         self.load_messages::<resources_proto::Schedule>(keys, 32)
             .await
@@ -880,7 +880,7 @@ impl TalonOpsServer {
         let limit = bounded_limit(&access, args.limit);
         let keys = self
             .kv()
-            .list_keys(&keys::mcp_server_prefix(&args.namespace), Order::Asc)
+            .list_keys(&keys::mcp_server_prefix(&args.namespace), Order::Asc.into())
             .await
             .map_err(internal_mcp_error)?;
         let mut servers = Vec::new();

--- a/src/worker/workflows.rs
+++ b/src/worker/workflows.rs
@@ -11,8 +11,7 @@ use std::sync::Arc;
 
 use crate::control::resource_model::TypedResource;
 use crate::control::{
-    events, keys, topics, ControlPlane, KeyValueStore, MessagePublisher, Order,
-    ProtoKeyValueStoreExt,
+    events, keys, topics, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
 };
 use crate::gateway::rpc::{data_proto, resources_proto};
 use crate::harness::knowledge::KvKnowledgeBook;
@@ -1396,7 +1395,7 @@ pub async fn load_step_runs(
     for (_, bytes) in kv
         .list_entries(
             &keys::workflow_step_run_prefix(&run.ns, &run.workflow, &run.id),
-            Order::Asc.into(),
+            None,
         )
         .await?
     {
@@ -2610,7 +2609,7 @@ mod tests {
         let events = kv
             .list_entries(
                 &keys::workflow_run_event_prefix("default", "dispatch-only", &run.id),
-                Order::Asc.into(),
+                None,
             )
             .await
             .unwrap();
@@ -2676,19 +2675,16 @@ mod tests {
         workflow: &str,
         run_id: &str,
     ) -> Vec<String> {
-        kv.list_entries(
-            &keys::workflow_run_event_prefix(ns, workflow, run_id),
-            Order::Asc.into(),
-        )
-        .await
-        .expect("events should list")
-        .into_iter()
-        .map(|(_, bytes)| {
-            data_proto::WorkflowRunEvent::decode(bytes.as_slice())
-                .expect("event should decode")
-                .r#type
-        })
-        .collect()
+        kv.list_entries(&keys::workflow_run_event_prefix(ns, workflow, run_id), None)
+            .await
+            .expect("events should list")
+            .into_iter()
+            .map(|(_, bytes)| {
+                data_proto::WorkflowRunEvent::decode(bytes.as_slice())
+                    .expect("event should decode")
+                    .r#type
+            })
+            .collect()
     }
 
     async fn event_type_count(

--- a/src/worker/workflows.rs
+++ b/src/worker/workflows.rs
@@ -1396,7 +1396,7 @@ pub async fn load_step_runs(
     for (_, bytes) in kv
         .list_entries(
             &keys::workflow_step_run_prefix(&run.ns, &run.workflow, &run.id),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await?
     {
@@ -2610,7 +2610,7 @@ mod tests {
         let events = kv
             .list_entries(
                 &keys::workflow_run_event_prefix("default", "dispatch-only", &run.id),
-                Order::Asc,
+                Order::Asc.into(),
             )
             .await
             .unwrap();
@@ -2678,7 +2678,7 @@ mod tests {
     ) -> Vec<String> {
         kv.list_entries(
             &keys::workflow_run_event_prefix(ns, workflow, run_id),
-            Order::Asc,
+            Order::Asc.into(),
         )
         .await
         .expect("events should list")


### PR DESCRIPTION
## Summary
- add `ListOptions` for KV listing with default ascending, unbounded behavior
- thread order, limit, before, and after through `list_keys` and `list_entries`
- update backends and callsites to use the options API directly

## Stack
- Previous: #139
- Next: #141
- Base branch: `codex/mock-kv-store-tests`

## Validation
- `cargo metadata --locked`
- `cargo fmt --all --check`
- `cargo build --locked --bins`
- `cargo test --locked`
