### PR TITLE
Use list options for paged KV listing

### DIFF
--- a/src/control/delegation.rs
+++ b/src/control/delegation.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use crate::control::resource_model::{self, TypedResource};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, scheduling, ControlPlane, ProtoKeyValueStoreExt};
+use crate::control::{keys, scheduling, ControlPlane, ListOptions, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{data_proto, resources_proto};
 
 // Task resource label: marks a Task as created through agent delegation.
@@ -537,7 +537,14 @@ async fn latest_assistant_text(
     loop {
         let entries = cp
             .kv
-            .list_entries_page(&prefix, before_name.as_deref(), 64)
+            .list_entries(
+                &prefix,
+                Some(
+                    ListOptions::desc()
+                        .before_name(before_name.as_deref())
+                        .limit(64),
+                ),
+            )
             .await?;
         if entries.is_empty() {
             return Ok(None);

--- a/src/control/kv/dynamodb.rs
+++ b/src/control/kv/dynamodb.rs
@@ -252,48 +252,6 @@ impl KeyValueStore for DynamoDbKvStore {
                     .collect()
             })
     }
-
-    async fn list_keys_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<ResourceKey>> {
-        let _ = list
-            .kind
-            .as_ref()
-            .ok_or_else(|| anyhow!("dynamodb list_keys_page requires a resource kind"))?;
-        self.query_list(
-            list,
-            ListOptions::desc().before_name(before_name).limit(limit),
-            false,
-        )
-        .await
-        .map(|rows| rows.into_iter().map(|(key, _)| key).collect())
-    }
-
-    async fn list_entries_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        let _ = list
-            .kind
-            .as_ref()
-            .ok_or_else(|| anyhow!("dynamodb list_entries_page requires a resource kind"))?;
-        self.query_list(
-            list,
-            ListOptions::desc().before_name(before_name).limit(limit),
-            true,
-        )
-        .await
-        .map(|rows| {
-            rows.into_iter()
-                .filter_map(|(key, value)| value.map(|value| (key, value)))
-                .collect()
-        })
-    }
 }
 
 fn pk_for_key(key: &ResourceKey) -> String {

--- a/src/control/kv/postgres.rs
+++ b/src/control/kv/postgres.rs
@@ -695,7 +695,7 @@ mod tests {
         list_entries_query, list_keys_query, rename_migration_index_statement, set_query,
         PostgresKvStore,
     };
-    use crate::control::{keys, KeyValueStore, ListOptions, Order};
+    use crate::control::{keys, KeyValueStore, ListOptions};
     use crate::test_support::{docker_test_guard, PostgresContainer};
     use std::time::Duration;
 
@@ -710,8 +710,8 @@ mod tests {
         assert!(compare_and_swap_query("talon_kv", true).contains("AND value = $6"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
         assert!(delete_query("talon_kv").contains("WHERE namespace = $1"));
-        assert!(list_keys_query("talon_kv", true, Order::Asc.into()).contains("AND kind = $3"));
-        assert!(list_keys_query("talon_kv", true, Order::Desc.into())
+        assert!(list_keys_query("talon_kv", true, ListOptions::default()).contains("AND kind = $3"));
+        assert!(list_keys_query("talon_kv", true, ListOptions::desc())
             .contains("ORDER BY kind DESC, name DESC"));
         assert!(list_keys_query(
             "talon_kv",
@@ -719,8 +719,10 @@ mod tests {
             ListOptions::desc().before_name(Some("b")).limit(10)
         )
         .contains("AND name < $4"));
-        assert!(list_entries_query("talon_kv", false, Order::Asc.into())
-            .contains("ORDER BY kind ASC, name ASC"));
+        assert!(
+            list_entries_query("talon_kv", false, ListOptions::default())
+                .contains("ORDER BY kind ASC, name ASC")
+        );
         assert_eq!(
             rename_migration_index_statement("talon_kv", "talon_kv_structured_key_migration"),
             "ALTER INDEX IF EXISTS \"talon_kv_structured_key_migration_pkey\" RENAME TO \"talon_kv_pkey\""

--- a/src/control/kv/postgres.rs
+++ b/src/control/kv/postgres.rs
@@ -135,28 +135,6 @@ fn list_entries_query(table: &str, has_kind: bool, options: ListOptions<'_>) -> 
     )
 }
 
-fn list_keys_page_query(table: &str) -> String {
-    format!(
-        "SELECT namespace, parent_path, kind, name FROM {}
-         WHERE namespace = $1 AND parent_path = $2 AND kind = $3
-           AND ($4 IS NULL OR name < $4)
-         ORDER BY name DESC
-         LIMIT $5",
-        quoted_identifier(table)
-    )
-}
-
-fn list_entries_page_query(table: &str) -> String {
-    format!(
-        "SELECT namespace, parent_path, kind, name, value FROM {}
-         WHERE namespace = $1 AND parent_path = $2 AND kind = $3
-           AND ($4 IS NULL OR name < $4)
-         ORDER BY name DESC
-         LIMIT $5",
-        quoted_identifier(table)
-    )
-}
-
 fn legacy_columns_query() -> &'static str {
     "SELECT column_name FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = $1"
 }
@@ -708,137 +686,14 @@ impl KeyValueStore for PostgresKvStore {
         span.record("value_bytes", total_value_bytes as u64);
         Ok(entries)
     }
-
-    async fn list_keys_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<ResourceKey>> {
-        if limit == 0 {
-            return Ok(Vec::new());
-        }
-        let Some(kind) = &list.kind else {
-            bail!("paged resource listing requires an explicit resource kind");
-        };
-
-        let query = list_keys_page_query(&self.table);
-        let span = tracing::debug_span!(
-            "PostgresKvStore.list_keys_page",
-            "db.system" = "postgresql",
-            "db.operation" = "list_keys_page",
-            "talon.kv.table" = %self.table,
-            "talon.resource.kind" = %kind,
-            "postgres.pool.max_connections" = u64::from(self.settings.max_connections),
-            "postgres.pool.size_before" = field::Empty,
-            "postgres.pool.idle_before" = field::Empty,
-            "postgres.pool.size_after" = field::Empty,
-            "postgres.pool.idle_after" = field::Empty,
-            pool_wait_us = field::Empty,
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-            limit,
-        );
-        let mut conn = acquire_connection(&self.pool, self.settings, &span).await?;
-        let query_span = tracing::debug_span!(
-            parent: &span,
-            "PostgresKvStore.query",
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-        );
-        let query_started_at = Instant::now();
-        let rows = sqlx::query(&query)
-            .bind(&list.parent.namespace)
-            .bind(&list.parent.parent_path)
-            .bind(kind)
-            .bind(before_name)
-            .bind(limit as i64)
-            .fetch_all(&mut *conn)
-            .instrument(query_span.clone())
-            .instrument(span.clone())
-            .await?;
-        record_query_elapsed(&query_span, &span, query_started_at);
-        record_rows(&query_span, &span, rows.len());
-
-        let mut keys = Vec::with_capacity(rows.len());
-        for row in rows {
-            keys.push(key_from_row(&row)?);
-        }
-        Ok(keys)
-    }
-
-    async fn list_entries_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        if limit == 0 {
-            return Ok(Vec::new());
-        }
-        let Some(kind) = &list.kind else {
-            bail!("paged resource listing requires an explicit resource kind");
-        };
-
-        let query = list_entries_page_query(&self.table);
-        let span = tracing::debug_span!(
-            "PostgresKvStore.list_entries_page",
-            "db.system" = "postgresql",
-            "db.operation" = "list_entries_page",
-            "talon.kv.table" = %self.table,
-            "talon.resource.kind" = %kind,
-            "postgres.pool.max_connections" = u64::from(self.settings.max_connections),
-            "postgres.pool.size_before" = field::Empty,
-            "postgres.pool.idle_before" = field::Empty,
-            "postgres.pool.size_after" = field::Empty,
-            "postgres.pool.idle_after" = field::Empty,
-            pool_wait_us = field::Empty,
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-            value_bytes = field::Empty,
-            limit,
-        );
-        let mut conn = acquire_connection(&self.pool, self.settings, &span).await?;
-        let query_span = tracing::debug_span!(
-            parent: &span,
-            "PostgresKvStore.query",
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-            value_bytes = field::Empty,
-        );
-        let query_started_at = Instant::now();
-        let rows = sqlx::query(&query)
-            .bind(&list.parent.namespace)
-            .bind(&list.parent.parent_path)
-            .bind(kind)
-            .bind(before_name)
-            .bind(limit as i64)
-            .fetch_all(&mut *conn)
-            .instrument(query_span.clone())
-            .instrument(span.clone())
-            .await?;
-        record_query_elapsed(&query_span, &span, query_started_at);
-        record_rows(&query_span, &span, rows.len());
-
-        let mut entries = Vec::with_capacity(rows.len());
-        let mut total_value_bytes = 0usize;
-        for row in rows {
-            let value: Vec<u8> = row.try_get("value")?;
-            total_value_bytes += value.len();
-            entries.push((key_from_row(&row)?, value));
-        }
-        query_span.record("value_bytes", total_value_bytes as u64);
-        span.record("value_bytes", total_value_bytes as u64);
-        Ok(entries)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         compare_and_swap_query, create_table_statement, delete_query, get_query,
-        list_entries_page_query, list_entries_query, list_keys_page_query, list_keys_query,
-        rename_migration_index_statement, set_query, PostgresKvStore,
+        list_entries_query, list_keys_query, rename_migration_index_statement, set_query,
+        PostgresKvStore,
     };
     use crate::control::{keys, KeyValueStore, ListOptions, Order};
     use crate::test_support::{docker_test_guard, PostgresContainer};
@@ -858,9 +713,12 @@ mod tests {
         assert!(list_keys_query("talon_kv", true, Order::Asc.into()).contains("AND kind = $3"));
         assert!(list_keys_query("talon_kv", true, Order::Desc.into())
             .contains("ORDER BY kind DESC, name DESC"));
-        assert!(list_keys_page_query("talon_kv").contains("ORDER BY name DESC"));
-        assert!(list_entries_page_query("talon_kv")
-            .contains("SELECT namespace, parent_path, kind, name, value"));
+        assert!(list_keys_query(
+            "talon_kv",
+            true,
+            ListOptions::desc().before_name(Some("b")).limit(10)
+        )
+        .contains("AND name < $4"));
         assert!(list_entries_query("talon_kv", false, Order::Asc.into())
             .contains("ORDER BY kind ASC, name ASC"));
         assert_eq!(
@@ -933,15 +791,27 @@ mod tests {
         );
 
         assert_eq!(
-            store.list_keys_page(&list, None, 10).await.unwrap(),
+            store
+                .list_keys(&list, Some(ListOptions::desc().limit(10)))
+                .await
+                .unwrap(),
             vec![b.clone(), a.clone()]
         );
         assert_eq!(
-            store.list_keys_page(&list, Some("b"), 10).await.unwrap(),
+            store
+                .list_keys(
+                    &list,
+                    Some(ListOptions::desc().before_name(Some("b")).limit(10)),
+                )
+                .await
+                .unwrap(),
             vec![a.clone()]
         );
         assert_eq!(
-            store.list_entries_page(&list, None, 10).await.unwrap(),
+            store
+                .list_entries(&list, Some(ListOptions::desc().limit(10)))
+                .await
+                .unwrap(),
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 

--- a/src/control/kv/rocksdb.rs
+++ b/src/control/kv/rocksdb.rs
@@ -21,26 +21,6 @@ fn prefix_bytes(list: &ResourceList) -> Vec<u8> {
     list.canonical_prefix().into_bytes()
 }
 
-fn page_cursor_bytes(list: &ResourceList, kind: &str, before_name: &str) -> Vec<u8> {
-    key_bytes(&ResourceKey {
-        namespace: list.parent.namespace.clone(),
-        parent_path: list.parent.parent_path.clone(),
-        kind: kind.to_string(),
-        name: before_name.to_string(),
-    })
-}
-
-fn page_seek_bytes(prefix: &[u8], cursor: Option<&[u8]>) -> Vec<u8> {
-    match cursor {
-        Some(cursor) => cursor.to_vec(),
-        None => {
-            let mut seek = prefix.to_vec();
-            seek.push(0xff);
-            seek
-        }
-    }
-}
-
 fn reverse_seek_bytes(prefix: &[u8]) -> Vec<u8> {
     let mut seek = prefix.to_vec();
     seek.push(0xff);
@@ -499,128 +479,6 @@ impl KeyValueStore for RocksDbKvStore {
         .instrument(span)
         .await
     }
-
-    async fn list_keys_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<ResourceKey>> {
-        if limit == 0 {
-            return Ok(Vec::new());
-        }
-        let Some(kind) = &list.kind else {
-            bail!("paged resource listing requires an explicit resource kind");
-        };
-        let prefix = prefix_bytes(list);
-        let cursor = before_name.map(|before_name| page_cursor_bytes(list, kind, before_name));
-        let seek_key = page_seek_bytes(&prefix, cursor.as_deref());
-        let span = tracing::debug_span!(
-            "RocksDbKvStore.list_keys_page",
-            "db.system" = "rocksdb",
-            "db.operation" = "list_keys_page",
-            "talon.kv.path" = %self.path.as_str(),
-            "talon.resource.kind" = %kind,
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-            limit,
-        );
-        let span_for_body = span.clone();
-        async move {
-            let started_at = Instant::now();
-            let keys = self
-                .spawn_blocking("list_keys_page", move |db| {
-                    let mut keys = Vec::with_capacity(limit);
-                    for item in
-                        db.iterator(IteratorMode::From(&seek_key, rocksdb::Direction::Reverse))
-                    {
-                        let (raw_key, _) = item?;
-                        if !raw_key.starts_with(&prefix) {
-                            break;
-                        }
-                        if let Some(cursor) = cursor.as_deref() {
-                            if raw_key.as_ref() >= cursor {
-                                continue;
-                            }
-                        }
-                        keys.push(parse_key(&raw_key)?);
-                        if keys.len() >= limit {
-                            break;
-                        }
-                    }
-                    Ok(keys)
-                })
-                .await?;
-            record_elapsed(&span_for_body, started_at);
-            span_for_body.record("rows_returned", keys.len() as u64);
-            Ok(keys)
-        }
-        .instrument(span)
-        .await
-    }
-
-    async fn list_entries_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        if limit == 0 {
-            return Ok(Vec::new());
-        }
-        let Some(kind) = &list.kind else {
-            bail!("paged resource listing requires an explicit resource kind");
-        };
-        let prefix = prefix_bytes(list);
-        let cursor = before_name.map(|before_name| page_cursor_bytes(list, kind, before_name));
-        let seek_key = page_seek_bytes(&prefix, cursor.as_deref());
-        let span = tracing::debug_span!(
-            "RocksDbKvStore.list_entries_page",
-            "db.system" = "rocksdb",
-            "db.operation" = "list_entries_page",
-            "talon.kv.path" = %self.path.as_str(),
-            "talon.resource.kind" = %kind,
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-            value_bytes = field::Empty,
-            limit,
-        );
-        let span_for_body = span.clone();
-        async move {
-            let started_at = Instant::now();
-            let (entries, value_bytes) = self
-                .spawn_blocking("list_entries_page", move |db| {
-                    let mut entries = Vec::with_capacity(limit);
-                    let mut value_bytes = 0usize;
-                    for item in
-                        db.iterator(IteratorMode::From(&seek_key, rocksdb::Direction::Reverse))
-                    {
-                        let (raw_key, value) = item?;
-                        if !raw_key.starts_with(&prefix) {
-                            break;
-                        }
-                        if let Some(cursor) = cursor.as_deref() {
-                            if raw_key.as_ref() >= cursor {
-                                continue;
-                            }
-                        }
-                        value_bytes += value.len();
-                        entries.push((parse_key(&raw_key)?, value.to_vec()));
-                        if entries.len() >= limit {
-                            break;
-                        }
-                    }
-                    Ok((entries, value_bytes))
-                })
-                .await?;
-            record_elapsed(&span_for_body, started_at);
-            span_for_body.record("rows_returned", entries.len() as u64);
-            span_for_body.record("value_bytes", value_bytes as u64);
-            Ok(entries)
-        }
-        .instrument(span)
-        .await
-    }
 }
 
 #[cfg(test)]
@@ -708,13 +566,19 @@ mod tests {
             vec!["gamma", "beta", "alpha"]
         );
 
-        let page = store.list_keys_page(&list, None, 2).await.unwrap();
+        let page = store
+            .list_keys(&list, Some(ListOptions::desc().limit(2)))
+            .await
+            .unwrap();
         assert_eq!(
             page.iter().map(|key| key.name.as_str()).collect::<Vec<_>>(),
             vec!["gamma", "beta"]
         );
         let next = store
-            .list_entries_page(&list, Some("beta"), 2)
+            .list_entries(
+                &list,
+                Some(ListOptions::desc().before_name(Some("beta")).limit(2)),
+            )
             .await
             .unwrap();
         assert_eq!(next.len(), 1);

--- a/src/control/kv/sqlite.rs
+++ b/src/control/kv/sqlite.rs
@@ -20,8 +20,7 @@ use tracing::{field, Instrument, Span};
 use super::shared::{quoted_identifier, validate_identifier};
 use super::sqlite_sql::{
     compare_and_swap_query, create_migration_table_statement, create_table_statement, delete_query,
-    get_query, list_entries_page_query, list_entries_query, list_keys_page_query, list_keys_query,
-    set_query,
+    get_query, list_entries_query, list_keys_query, set_query,
 };
 
 fn key_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<ResourceKey> {
@@ -553,139 +552,13 @@ impl KeyValueStore for SqliteKvStore {
         span.record("value_bytes", total_value_bytes as u64);
         Ok(entries)
     }
-
-    async fn list_keys_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<ResourceKey>> {
-        if limit == 0 {
-            return Ok(Vec::new());
-        }
-        let Some(kind) = &list.kind else {
-            bail!("paged resource listing requires an explicit resource kind");
-        };
-
-        let query = list_keys_page_query(&self.table);
-        let span = tracing::debug_span!(
-            "SqliteKvStore.list_keys_page",
-            "db.system" = "sqlite",
-            "db.operation" = "list_keys_page",
-            "talon.kv.table" = %self.table,
-            "talon.resource.kind" = %kind,
-            "sqlite.pool.max_connections" = u64::from(self.settings.max_connections),
-            "sqlite.busy_timeout_ms" = busy_timeout_ms(self.settings),
-            "sqlite.pool.size_before" = field::Empty,
-            "sqlite.pool.idle_before" = field::Empty,
-            "sqlite.pool.size_after" = field::Empty,
-            "sqlite.pool.idle_after" = field::Empty,
-            pool_wait_us = field::Empty,
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-            limit,
-        );
-        let mut conn = acquire_connection(&self.pool, self.settings, &span).await?;
-        let query_span = tracing::debug_span!(
-            parent: &span,
-            "SqliteKvStore.query",
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-        );
-        let query_started_at = Instant::now();
-        let rows = sqlx::query(&query)
-            .bind(&list.parent.namespace)
-            .bind(&list.parent.parent_path)
-            .bind(kind)
-            .bind(before_name)
-            .bind(limit as i64)
-            .fetch_all(&mut *conn)
-            .instrument(query_span.clone())
-            .instrument(span.clone())
-            .await?;
-        record_query_elapsed(&query_span, &span, query_started_at);
-        record_rows(&query_span, &span, rows.len());
-
-        let mut keys = Vec::with_capacity(rows.len());
-        for row in rows {
-            keys.push(key_from_row(&row)?);
-        }
-        Ok(keys)
-    }
-
-    async fn list_entries_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<(ResourceKey, Vec<u8>)>> {
-        if limit == 0 {
-            return Ok(Vec::new());
-        }
-        let Some(kind) = &list.kind else {
-            bail!("paged resource listing requires an explicit resource kind");
-        };
-
-        let query = list_entries_page_query(&self.table);
-        let span = tracing::debug_span!(
-            "SqliteKvStore.list_entries_page",
-            "db.system" = "sqlite",
-            "db.operation" = "list_entries_page",
-            "talon.kv.table" = %self.table,
-            "talon.resource.kind" = %kind,
-            "sqlite.pool.max_connections" = u64::from(self.settings.max_connections),
-            "sqlite.busy_timeout_ms" = busy_timeout_ms(self.settings),
-            "sqlite.pool.size_before" = field::Empty,
-            "sqlite.pool.idle_before" = field::Empty,
-            "sqlite.pool.size_after" = field::Empty,
-            "sqlite.pool.idle_after" = field::Empty,
-            pool_wait_us = field::Empty,
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-            value_bytes = field::Empty,
-            limit,
-        );
-        let mut conn = acquire_connection(&self.pool, self.settings, &span).await?;
-        let query_span = tracing::debug_span!(
-            parent: &span,
-            "SqliteKvStore.query",
-            query_elapsed_us = field::Empty,
-            rows_returned = field::Empty,
-            value_bytes = field::Empty,
-        );
-        let query_started_at = Instant::now();
-        let rows = sqlx::query(&query)
-            .bind(&list.parent.namespace)
-            .bind(&list.parent.parent_path)
-            .bind(kind)
-            .bind(before_name)
-            .bind(limit as i64)
-            .fetch_all(&mut *conn)
-            .instrument(query_span.clone())
-            .instrument(span.clone())
-            .await?;
-        record_query_elapsed(&query_span, &span, query_started_at);
-        record_rows(&query_span, &span, rows.len());
-
-        let mut entries = Vec::with_capacity(rows.len());
-        let mut total_value_bytes = 0usize;
-        for row in rows {
-            let value: Vec<u8> = row.try_get("value")?;
-            total_value_bytes += value.len();
-            entries.push((key_from_row(&row)?, value));
-        }
-        query_span.record("value_bytes", total_value_bytes as u64);
-        span.record("value_bytes", total_value_bytes as u64);
-        Ok(entries)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         compare_and_swap_query, create_table_statement, delete_query, get_query,
-        list_entries_page_query, list_entries_query, list_keys_page_query, list_keys_query,
-        set_query, sqlite_pool, SqliteKvStore,
+        list_entries_query, list_keys_query, set_query, sqlite_pool, SqliteKvStore,
     };
     use crate::control::kv::sqlite_url_for_path;
     use crate::control::{keys, KeyValueStore, ListOptions, Order};
@@ -706,9 +579,12 @@ mod tests {
         assert!(list_keys_query("talon_kv", true, Order::Asc.into()).contains("AND kind = ?3"));
         assert!(list_keys_query("talon_kv", true, Order::Desc.into())
             .contains("ORDER BY kind DESC, name DESC"));
-        assert!(list_keys_page_query("talon_kv").contains("ORDER BY name DESC"));
-        assert!(list_entries_page_query("talon_kv")
-            .contains("SELECT namespace, parent_path, kind, name, value"));
+        assert!(list_keys_query(
+            "talon_kv",
+            true,
+            ListOptions::desc().before_name(Some("b")).limit(10)
+        )
+        .contains("AND name < ?4"));
         assert!(list_entries_query("talon_kv", false, Order::Asc.into())
             .contains("ORDER BY kind ASC, name ASC"));
     }
@@ -840,15 +716,27 @@ mod tests {
         );
 
         assert_eq!(
-            store.list_keys_page(&list, None, 10).await.unwrap(),
+            store
+                .list_keys(&list, Some(ListOptions::desc().limit(10)))
+                .await
+                .unwrap(),
             vec![b.clone(), a.clone()]
         );
         assert_eq!(
-            store.list_keys_page(&list, Some("b"), 10).await.unwrap(),
+            store
+                .list_keys(
+                    &list,
+                    Some(ListOptions::desc().before_name(Some("b")).limit(10)),
+                )
+                .await
+                .unwrap(),
             vec![a.clone()]
         );
         assert_eq!(
-            store.list_entries_page(&list, None, 10).await.unwrap(),
+            store
+                .list_entries(&list, Some(ListOptions::desc().limit(10)))
+                .await
+                .unwrap(),
             vec![(b.clone(), b"two".to_vec()), (a.clone(), b"one".to_vec())]
         );
 

--- a/src/control/kv/sqlite.rs
+++ b/src/control/kv/sqlite.rs
@@ -561,7 +561,7 @@ mod tests {
         list_entries_query, list_keys_query, set_query, sqlite_pool, SqliteKvStore,
     };
     use crate::control::kv::sqlite_url_for_path;
-    use crate::control::{keys, KeyValueStore, ListOptions, Order};
+    use crate::control::{keys, KeyValueStore, ListOptions};
     use tempfile::tempdir;
 
     #[test]
@@ -576,8 +576,8 @@ mod tests {
         assert!(compare_and_swap_query("talon_kv", true).contains("AND value = ?6"));
         assert!(compare_and_swap_query("talon_kv", false).contains("DO NOTHING"));
         assert!(delete_query("talon_kv").contains("WHERE namespace = ?1"));
-        assert!(list_keys_query("talon_kv", true, Order::Asc.into()).contains("AND kind = ?3"));
-        assert!(list_keys_query("talon_kv", true, Order::Desc.into())
+        assert!(list_keys_query("talon_kv", true, ListOptions::default()).contains("AND kind = ?3"));
+        assert!(list_keys_query("talon_kv", true, ListOptions::desc())
             .contains("ORDER BY kind DESC, name DESC"));
         assert!(list_keys_query(
             "talon_kv",
@@ -585,8 +585,10 @@ mod tests {
             ListOptions::desc().before_name(Some("b")).limit(10)
         )
         .contains("AND name < ?4"));
-        assert!(list_entries_query("talon_kv", false, Order::Asc.into())
-            .contains("ORDER BY kind ASC, name ASC"));
+        assert!(
+            list_entries_query("talon_kv", false, ListOptions::default())
+                .contains("ORDER BY kind ASC, name ASC")
+        );
     }
 
     #[test]

--- a/src/control/kv/sqlite_sql.rs
+++ b/src/control/kv/sqlite_sql.rs
@@ -127,28 +127,6 @@ pub(crate) fn list_entries_query(table: &str, has_kind: bool, options: ListOptio
     )
 }
 
-pub(crate) fn list_keys_page_query(table: &str) -> String {
-    format!(
-        "SELECT namespace, parent_path, kind, name FROM {}
-         WHERE namespace = ?1 AND parent_path = ?2 AND kind = ?3
-           AND (?4 IS NULL OR name < ?4)
-         ORDER BY name DESC
-         LIMIT ?5",
-        quoted_identifier(table)
-    )
-}
-
-pub(crate) fn list_entries_page_query(table: &str) -> String {
-    format!(
-        "SELECT namespace, parent_path, kind, name, value FROM {}
-         WHERE namespace = ?1 AND parent_path = ?2 AND kind = ?3
-           AND (?4 IS NULL OR name < ?4)
-         ORDER BY name DESC
-         LIMIT ?5",
-        quoted_identifier(table)
-    )
-}
-
 pub(crate) fn create_migration_table_statement(table: &str) -> String {
     create_table_statement(table).replacen("CREATE TABLE IF NOT EXISTS", "CREATE TABLE", 1)
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -148,36 +148,6 @@ pub fn apply_list_options_to_entries(
     entries
 }
 
-pub fn page_keys_desc(
-    mut keys: Vec<ResourceKey>,
-    before_name: Option<&str>,
-    limit: usize,
-) -> Vec<ResourceKey> {
-    if limit == 0 {
-        return Vec::new();
-    }
-
-    keys.retain(|key| before_name.map_or(true, |cursor| key.name.as_str() < cursor));
-    keys.sort_by(|left, right| right.name.cmp(&left.name));
-    keys.truncate(limit);
-    keys
-}
-
-pub fn page_entries_desc(
-    mut entries: Vec<(ResourceKey, Vec<u8>)>,
-    before_name: Option<&str>,
-    limit: usize,
-) -> Vec<(ResourceKey, Vec<u8>)> {
-    if limit == 0 {
-        return Vec::new();
-    }
-
-    entries.retain(|(key, _)| before_name.map_or(true, |cursor| key.name.as_str() < cursor));
-    entries.sort_by(|left, right| right.0.name.cmp(&left.0.name));
-    entries.truncate(limit);
-    entries
-}
-
 #[async_trait::async_trait]
 pub trait KeyValueStore: Send + Sync {
     /// Retrieve a raw byte sequence from the store
@@ -203,40 +173,6 @@ pub trait KeyValueStore: Send + Sync {
         list: &ResourceList,
         options: Option<ListOptions<'_>>,
     ) -> anyhow::Result<Vec<ResourceKey>>;
-
-    /// List direct children, ordered by resource name descending.
-    ///
-    /// `before_name` is an exclusive resource-name cursor. Production backends
-    /// should override this with a storage-level page read.
-    async fn list_keys_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> anyhow::Result<Vec<ResourceKey>> {
-        self.list_keys(
-            list,
-            Some(ListOptions::desc().before_name(before_name).limit(limit)),
-        )
-        .await
-    }
-
-    /// List direct child key/value pairs, ordered by resource name descending.
-    ///
-    /// `before_name` is an exclusive resource-name cursor. Production backends
-    /// should override this with a storage-level page read.
-    async fn list_entries_page(
-        &self,
-        list: &ResourceList,
-        before_name: Option<&str>,
-        limit: usize,
-    ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
-        self.list_entries(
-            list,
-            Some(ListOptions::desc().before_name(before_name).limit(limit)),
-        )
-        .await
-    }
 
     /// List all matching direct child key/value pairs.
     async fn list_entries(
@@ -422,24 +358,6 @@ impl KeyValueStore for NoopKeyValueStore {
         _list: &ResourceList,
         _options: Option<ListOptions<'_>>,
     ) -> anyhow::Result<Vec<ResourceKey>> {
-        Ok(Vec::new())
-    }
-
-    async fn list_keys_page(
-        &self,
-        _list: &ResourceList,
-        _before_name: Option<&str>,
-        _limit: usize,
-    ) -> anyhow::Result<Vec<ResourceKey>> {
-        Ok(Vec::new())
-    }
-
-    async fn list_entries_page(
-        &self,
-        _list: &ResourceList,
-        _before_name: Option<&str>,
-        _limit: usize,
-    ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
         Ok(Vec::new())
     }
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -88,12 +88,6 @@ impl<'a> ListOptions<'a> {
     }
 }
 
-impl From<Order> for ListOptions<'static> {
-    fn from(order: Order) -> Self {
-        Self::ordered(order)
-    }
-}
-
 pub fn apply_list_options_to_keys(
     mut keys: Vec<ResourceKey>,
     options: ListOptions<'_>,

--- a/src/gateway/rpc/channels.rs
+++ b/src/gateway/rpc/channels.rs
@@ -7,7 +7,7 @@ use crate::control::resource_model::{
 };
 use crate::control::scheduling;
 use crate::control::topics;
-use crate::control::{events, keys, ControlPlane, KeyValueStore};
+use crate::control::{events, keys, ControlPlane, KeyValueStore, ListOptions};
 use crate::control::{MessagePublisher, ProtoKeyValueStoreExt};
 use anyhow::Context;
 use futures::StreamExt;
@@ -586,10 +586,13 @@ impl GrpcGatewayHandler {
             let entries = self
                 .gateway
                 .kv
-                .list_entries_page(
+                .list_entries(
                     &keys::channel_message_prefix(&req.ns, &req.channel),
-                    scan_before_name.as_deref(),
-                    remaining,
+                    Some(
+                        ListOptions::desc()
+                            .before_name(scan_before_name.as_deref())
+                            .limit(remaining),
+                    ),
                 )
                 .await
                 .map_err(|e| {
@@ -1029,10 +1032,9 @@ async fn recent_channel_messages(
 ) -> anyhow::Result<Vec<data_proto::ChannelMessage>> {
     let entries = cp
         .kv
-        .list_entries_page(
+        .list_entries(
             &keys::channel_message_prefix(&message.ns, &message.channel),
-            None,
-            limit,
+            Some(ListOptions::desc().limit(limit)),
         )
         .await?;
 

--- a/src/gateway/rpc/files.rs
+++ b/src/gateway/rpc/files.rs
@@ -5,7 +5,7 @@ use super::{data_proto, proto, resources_proto, GrpcGatewayHandler};
 use crate::control::cas::{latest_file_object_key, CasStore};
 use crate::control::resource_model;
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, ProtoKeyValueStoreExt};
+use crate::control::{keys, ListOptions, ProtoKeyValueStoreExt};
 use crate::gateway::auth::Claims;
 use crate::require_auth;
 use anyhow::{anyhow, Context, Result};
@@ -914,7 +914,14 @@ impl proto::file_service_server::FileService for GrpcGatewayHandler {
             let entries = self
                 .gateway
                 .kv
-                .list_entries_page(&list, before_name.as_deref(), FILE_LIST_SCAN_PAGE_SIZE)
+                .list_entries(
+                    &list,
+                    Some(
+                        ListOptions::desc()
+                            .before_name(before_name.as_deref())
+                            .limit(FILE_LIST_SCAN_PAGE_SIZE),
+                    ),
+                )
                 .await
                 .map_err(to_status)?;
             if entries.is_empty() {
@@ -1139,7 +1146,14 @@ impl proto::artifact_service_server::ArtifactService for GrpcGatewayHandler {
             let entries = self
                 .gateway
                 .kv
-                .list_entries_page(&list, before_name.as_deref(), FILE_LIST_SCAN_PAGE_SIZE)
+                .list_entries(
+                    &list,
+                    Some(
+                        ListOptions::desc()
+                            .before_name(before_name.as_deref())
+                            .limit(FILE_LIST_SCAN_PAGE_SIZE),
+                    ),
+                )
                 .await
                 .map_err(to_status)?;
             if entries.is_empty() {

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -6,7 +6,7 @@ use crate::control::cas::{session_object_key_prefix, SessionCasScope, METADATA_A
 use crate::control::scheduling;
 use crate::control::topics;
 use crate::control::ProtoKeyValueStoreExt;
-use crate::control::{events, keys, keys::ResourceParent, KeyValueStore};
+use crate::control::{events, keys, keys::ResourceParent, KeyValueStore, ListOptions};
 use prost::Message;
 use serde_json::{json, Value};
 use std::collections::HashSet;
@@ -686,10 +686,13 @@ impl GrpcGatewayHandler {
                     let page = self
                         .gateway
                         .kv
-                        .list_keys_page(
+                        .list_keys(
                             &msg_prefix,
-                            page_before_name.as_deref(),
-                            SESSION_MESSAGE_KEY_SCAN_BATCH_SIZE,
+                            Some(
+                                ListOptions::desc()
+                                    .before_name(page_before_name.as_deref())
+                                    .limit(SESSION_MESSAGE_KEY_SCAN_BATCH_SIZE),
+                            ),
                         )
                         .await
                         .map_err(|e| {
@@ -859,10 +862,13 @@ impl GrpcGatewayHandler {
             let entries = self
                 .gateway
                 .kv
-                .list_entries_page(
+                .list_entries(
                     &msg_prefix,
-                    scan_before_name.as_deref(),
-                    SESSION_MESSAGE_KEY_SCAN_BATCH_SIZE,
+                    Some(
+                        ListOptions::desc()
+                            .before_name(scan_before_name.as_deref())
+                            .limit(SESSION_MESSAGE_KEY_SCAN_BATCH_SIZE),
+                    ),
                 )
                 .await
                 .map_err(|e| {

--- a/src/gateway/rpc/workflows.rs
+++ b/src/gateway/rpc/workflows.rs
@@ -3,7 +3,7 @@
 
 use super::{data_proto, proto, resources_proto, worker_proto, GrpcGatewayHandler};
 use crate::control::resources::ResourceStore;
-use crate::control::{keys, KeyValueStore, ProtoKeyValueStoreExt};
+use crate::control::{keys, KeyValueStore, ListOptions, ProtoKeyValueStoreExt};
 use crate::gateway::worker_conn::WorkerConnectionPool;
 use crate::worker::workflows;
 use futures::StreamExt;
@@ -131,10 +131,13 @@ impl GrpcGatewayHandler {
             let entries = self
                 .gateway
                 .kv
-                .list_entries_page(
+                .list_entries(
                     &prefix,
-                    scan_before_name.as_deref(),
-                    WORKFLOW_RUN_KEY_SCAN_BATCH_SIZE,
+                    Some(
+                        ListOptions::desc()
+                            .before_name(scan_before_name.as_deref())
+                            .limit(WORKFLOW_RUN_KEY_SCAN_BATCH_SIZE),
+                    ),
                 )
                 .await
                 .map_err(|err| tonic::Status::internal(err.to_string()))?;

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use crate::control::resource_model::{self, TypedResource};
 use crate::control::resources::ResourceStore;
 use crate::control::scheduling;
-use crate::control::{delegation, keys, ControlPlane, ProtoKeyValueStoreExt};
+use crate::control::{delegation, keys, ControlPlane, ListOptions, ProtoKeyValueStoreExt};
 use crate::gateway::rpc::{
     data_proto, manifests, protobuf_value::value::Kind as ProtoValueKind, resources_proto,
 };
@@ -758,10 +758,9 @@ async fn read_session_messages(
     let limit = opt_usize(args, "limit").unwrap_or(20).clamp(1, 100);
     let mut entries = cp
         .kv
-        .list_entries_page(
+        .list_entries(
             &keys::session_message_prefix(namespace, agent, session_id),
-            None,
-            limit,
+            Some(ListOptions::desc().limit(limit)),
         )
         .await?;
     let mut messages = Vec::new();

--- a/src/harness/sessions/journal.rs
+++ b/src/harness/sessions/journal.rs
@@ -7,7 +7,7 @@ use prost::Message;
 use super::submission::{ensure_submission_attempt_current, update_submission_from_entry};
 use super::SessionJournalEntry;
 use crate::control::cas::CasStore;
-use crate::control::{keys, KeyValueStore};
+use crate::control::{keys, KeyValueStore, ListOptions};
 use crate::gateway::rpc::data_proto::{
     session_journal_entry_payload, SessionExecutionPhase, SessionJournalEntryPayload,
     SessionJournalEntryPayloadCommit, SessionJournalEntryPayloadLlmResponse,
@@ -315,7 +315,7 @@ async fn next_journal_entry_id(
 ) -> Result<String> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
     let max_id = kv
-        .list_keys_page(&prefix, None, 1)
+        .list_keys(&prefix, Some(ListOptions::desc().limit(1)))
         .await?
         .into_iter()
         .next()
@@ -333,7 +333,7 @@ async fn latest_journal_entry(
 ) -> Result<Option<SessionJournalEntry>> {
     let prefix = keys::session_journal_entry_prefix(ns, agent, session_id, submission_id);
     let Some(key) = kv
-        .list_keys_page(&prefix, None, 1)
+        .list_keys(&prefix, Some(ListOptions::desc().limit(1)))
         .await?
         .into_iter()
         .next()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,32 +199,6 @@ pub mod test_support {
                 options.unwrap_or_default(),
             ))
         }
-
-        async fn list_keys_page(
-            &self,
-            list: &ResourceList,
-            before_name: Option<&str>,
-            limit: usize,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            self.list_keys(
-                list,
-                Some(ListOptions::desc().before_name(before_name).limit(limit)),
-            )
-            .await
-        }
-
-        async fn list_entries_page(
-            &self,
-            list: &ResourceList,
-            before_name: Option<&str>,
-            limit: usize,
-        ) -> anyhow::Result<Vec<(ResourceKey, Vec<u8>)>> {
-            self.list_entries(
-                list,
-                Some(ListOptions::desc().before_name(before_name).limit(limit)),
-            )
-            .await
-        }
     }
 
     #[derive(Default)]

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1456,14 +1456,6 @@ mod tests {
         ) -> anyhow::Result<Vec<ResourceKey>> {
             Ok(vec![])
         }
-        async fn list_keys_page(
-            &self,
-            _list: &ResourceList,
-            _before_key: Option<&str>,
-            _limit: usize,
-        ) -> anyhow::Result<Vec<ResourceKey>> {
-            Ok(vec![])
-        }
     }
 
     struct MockPubSub {

--- a/src/worker/talon_ops.rs
+++ b/src/worker/talon_ops.rs
@@ -36,7 +36,7 @@ use crate::{
         resource_model::{self, ChannelResourceExt, NamespaceResourceExt, TypedResource},
         scheduling,
         security::platform_jwt,
-        ProtoKeyValueStoreExt,
+        ListOptions, ProtoKeyValueStoreExt,
     },
     gateway::rpc::{data_proto, manifests, resources_proto},
 };
@@ -274,10 +274,13 @@ impl TalonOpsServer {
         }
         let mut entries = self
             .kv()
-            .list_entries_page(
+            .list_entries(
                 &keys::channel_message_prefix(namespace, channel),
-                before_message_id.filter(|value| !value.is_empty()),
-                limit.saturating_add(1),
+                Some(
+                    ListOptions::desc()
+                        .before_name(before_message_id.filter(|value| !value.is_empty()))
+                        .limit(limit.saturating_add(1)),
+                ),
             )
             .await?;
         let has_more = entries.len() > limit;

--- a/src/worker/workflows.rs
+++ b/src/worker/workflows.rs
@@ -11,7 +11,8 @@ use std::sync::Arc;
 
 use crate::control::resource_model::TypedResource;
 use crate::control::{
-    events, keys, topics, ControlPlane, KeyValueStore, MessagePublisher, ProtoKeyValueStoreExt,
+    events, keys, topics, ControlPlane, KeyValueStore, ListOptions, MessagePublisher,
+    ProtoKeyValueStoreExt,
 };
 use crate::gateway::rpc::{data_proto, resources_proto};
 use crate::harness::knowledge::KvKnowledgeBook;
@@ -2178,7 +2179,14 @@ async fn latest_assistant_text(
     let mut before_name = None;
     loop {
         let entries = kv
-            .list_entries_page(&prefix, before_name.as_deref(), 64)
+            .list_entries(
+                &prefix,
+                Some(
+                    ListOptions::desc()
+                        .before_name(before_name.as_deref())
+                        .limit(64),
+                ),
+            )
             .await?;
         if entries.is_empty() {
             return Ok(String::new());


### PR DESCRIPTION
## Summary
- migrate paged KV callers to `list_entries` and `list_keys` with `ListOptions`
- remove the separate `list_entries_page` and `list_keys_page` trait/backend paths
- keep pagination behavior expressed through options instead of parallel APIs

## Stack
- Previous: #140
- Base branch: `codex/kv-list-options`

## Validation
- `cargo metadata --locked`
- `cargo fmt --all --check`
- `cargo build --locked --bins`
- `cargo test --locked`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized pagination across channel messages, sessions, files, artifacts, and workflow runs for more consistent sorting and cursor-based navigation.
  * Improved retrieval of recent messages and journal entries, including reliable newest-first results.
  * Large tool results are now stored more efficiently while remaining accessible through the journal.

* **Refactor**
  * Simplified list navigation behavior across supported storage backends without changing existing user-facing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->