### PR TITLE
Harden delegated artifact outputs

### DIFF
--- a/src/control/delegation.rs
+++ b/src/control/delegation.rs
@@ -506,8 +506,9 @@ fn set_condition(
 
 fn delegated_task_message(req: &TaskDelegationRequest) -> String {
     format!(
-        "You have been assigned a Talon Task.\n\nTask: {}\nTask ID: {}/{}\nOwner: {}/{}\n\nInstructions:\n{}",
+        "You have been assigned a Talon Task.\n\nTask: {}\nTask name: {}\nTask ID: {}/{}\nOwner: {}/{}\n\nWhen the work is ready for owner review, attach any output artifact URI with update_task.output_artifact_uri and set phase to NEEDS_REVIEW. Use the Task name above for update_task.name; the full Task ID is only for display.\n\nInstructions:\n{}",
         req.title,
+        req.name,
         req.namespace,
         req.name,
         req.owner_namespace,

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -1186,6 +1186,13 @@ async fn create_artifact(
     }
     let title = req_str(args, "title")?;
     let media_type = opt_str(args, "media_type").unwrap_or("text/markdown");
+    if args.get("content").and_then(Value::as_str).is_none()
+        && opt_str(args, "content_base64").is_none()
+    {
+        return Err(anyhow!(
+            "create_artifact requires content or content_base64"
+        ));
+    }
     let content = artifact_content_bytes(args)?;
     let labels = string_map(args.get("labels"));
     let metadata = string_map(args.get("metadata"));
@@ -3351,6 +3358,23 @@ mod tests {
         assert_eq!(parsed_uri.session_id, "session-1");
         assert_eq!(parsed_uri.artifact_id, artifact_id);
 
+        let empty_create = execute_tool_for_session(
+            &cp,
+            "Tenant:acme:Workspace:main",
+            "writer",
+            "session-1",
+            &manifests::AgentSpec::default(),
+            CREATE_ARTIFACT_TOOL,
+            &json!({
+                "title": "Missing content",
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(empty_create
+            .to_string()
+            .contains("requires content or content_base64"));
+
         let read_output = execute_tool_for_session(
             &cp,
             "Tenant:acme:Workspace:main",
@@ -4724,6 +4748,29 @@ mod tests {
         .unwrap();
         let updated: Value = serde_json::from_str(&updated).unwrap();
         assert_eq!(updated["task"]["outputArtifactUris"][0], artifact_uri);
+
+        let updated_with_task_id = execute_tool_for_session(
+            &cp,
+            delegate_namespace,
+            "copywriter",
+            delegate_session_id,
+            &task_spec(&["update"]),
+            UPDATE_TASK_TOOL,
+            &json!({
+                "name": format!("{owner_namespace}/{task_name}"),
+                "phase": "NEEDS_REVIEW",
+                "progress_summary": "Draft announcement is still ready.",
+                "output_artifact_uri": artifact_uri
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let updated_with_task_id: Value = serde_json::from_str(&updated_with_task_id).unwrap();
+        assert_eq!(
+            updated_with_task_id["task"]["outputArtifactUris"][0],
+            artifact_uri
+        );
 
         let rejected = execute_tool_for_session(
             &cp,

--- a/src/harness/tools/artifacts.rs
+++ b/src/harness/tools/artifacts.rs
@@ -16,12 +16,16 @@ pub(super) fn register(registry: &mut ToolRegistry) {
             "properties": {
                 "title": { "type": "string", "description": "Human-readable artifact title." },
                 "media_type": { "type": "string", "description": "Media type. Defaults to text/markdown." },
-                "content": { "type": "string", "description": "Text content to store." },
+                "content": { "type": "string", "description": "Full text content to store. Required unless content_base64 is provided." },
                 "content_base64": { "type": "string", "description": "Base64 bytes to store instead of content." },
                 "labels": { "type": "object", "additionalProperties": { "type": "string" } },
                 "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
             },
-            "required": ["title"]
+            "required": ["title"],
+            "anyOf": [
+                { "required": ["content"] },
+                { "required": ["content_base64"] }
+            ]
         }),
     );
     registry.register_builtin(
@@ -43,10 +47,14 @@ pub(super) fn register(registry: &mut ToolRegistry) {
             "properties": {
                 "artifact_uri": { "type": "string" },
                 "media_type": { "type": "string", "description": "Media type. Defaults to the artifact's current media type." },
-                "content": { "type": "string", "description": "Text content to store." },
+                "content": { "type": "string", "description": "Full text content to store. Required unless content_base64 is provided." },
                 "content_base64": { "type": "string", "description": "Base64 bytes to store instead of content." }
             },
-            "required": ["artifact_uri"]
+            "required": ["artifact_uri"],
+            "anyOf": [
+                { "required": ["content"] },
+                { "required": ["content_base64"] }
+            ]
         }),
     );
     registry.register_builtin(

--- a/src/harness/tools/tasks.rs
+++ b/src/harness/tools/tasks.rs
@@ -26,7 +26,18 @@ fn task_namespace<'a>(args: &'a Value, current_namespace: &'a str) -> Result<&'a
 
 struct AuthorizedTaskUpdate {
     namespace: String,
+    name: String,
     delegated: bool,
+}
+
+fn split_task_id(value: &str) -> Option<(&str, &str)> {
+    let (namespace, name) = value.split_once('/')?;
+    let namespace = namespace.trim();
+    let name = name.trim();
+    if namespace.is_empty() || name.is_empty() || name.contains('/') {
+        return None;
+    }
+    Some((namespace, name))
 }
 
 async fn authorized_update_task_namespace(
@@ -36,8 +47,22 @@ async fn authorized_update_task_namespace(
     current_agent: &str,
     current_session: &str,
 ) -> Result<AuthorizedTaskUpdate> {
-    let namespace = super::opt_str(args, "namespace").unwrap_or(current_namespace);
-    let name = super::req_str(args, "name")?;
+    let raw_name = super::req_str(args, "name")?;
+    let explicit_namespace = super::opt_str(args, "namespace");
+    let (namespace, name) = if let Some((id_namespace, id_name)) = split_task_id(raw_name) {
+        if let Some(namespace) = explicit_namespace {
+            if namespace != id_namespace {
+                return Err(anyhow!(
+                    "task namespace '{}' does not match Task ID namespace '{}'",
+                    namespace,
+                    id_namespace
+                ));
+            }
+        }
+        (id_namespace, id_name)
+    } else {
+        (explicit_namespace.unwrap_or(current_namespace), raw_name)
+    };
     let session = cp
         .kv
         .get_msg::<data_proto::Session>(&keys::session(
@@ -64,6 +89,7 @@ async fn authorized_update_task_namespace(
             if assigned_namespace == Some(namespace) && assigned_name == Some(name) {
                 return Ok(AuthorizedTaskUpdate {
                     namespace: namespace.to_string(),
+                    name: name.to_string(),
                     delegated: true,
                 });
             }
@@ -79,6 +105,7 @@ async fn authorized_update_task_namespace(
     if namespace == current_namespace {
         return Ok(AuthorizedTaskUpdate {
             namespace: namespace.to_string(),
+            name: name.to_string(),
             delegated: false,
         });
     }
@@ -285,7 +312,6 @@ pub(super) async fn execute(
                 current_session,
             )
             .await?;
-            let name = super::req_str(args, "name")?;
             let output_artifact_uris = super::task_output_artifact_uris_from_args(
                 cp,
                 current_agent,
@@ -295,7 +321,7 @@ pub(super) async fn execute(
             .await?;
             let store = ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
             let resource = store
-                .patch_status_with(&authorized.namespace, "Task", name, None, |_, status| {
+                .patch_status_with(&authorized.namespace, "Task", &authorized.name, None, |_, status| {
                     let mut task_status = match status.kind.take() {
                         Some(resources_proto::resource_status::Kind::Task(status)) => status,
                         _ => resources_proto::TaskStatus::default(),
@@ -309,7 +335,7 @@ pub(super) async fn execute(
                             return Err(anyhow!(
                                 "delegated session '{}' cannot update task '{}' because it is not the active execution session",
                                 current_session,
-                                name
+                                authorized.name
                             ));
                         }
                     }


### PR DESCRIPTION
## Summary

Harden delegated artifact handoff after testing the Conic copywriter stack locally
against a real Novita/GLM model.

## What changed

- Accept `namespace/name` Task IDs in `update_task.name` for delegated sessions,
  while preserving the existing cross-namespace authorization check.
- Add the canonical Task name to delegated child prompts and explicitly instruct
  delegates to attach output artifacts with `output_artifact_uri` and mark work
  `NEEDS_REVIEW`.
- Require `create_artifact` to receive `content` or `content_base64` at runtime.
- Advertise the same content requirement in the `create_artifact` and
  `update_artifact` tool schemas.
- Add regression coverage for qualified Task IDs and title-only artifact creates.

## Why

The local Conic copywriter run exposed two real-model failure modes that the mock
E2E path did not catch:

1. The delegated agent copied the displayed `Task ID` (`namespace/name`) into
   `update_task.name`. The tool expected only the resource name, so the update was
   rejected even though the session was authorized for that exact delegated task.
2. GLM issued a `create_artifact` call with only a title and no content. Talon
   accepted the call path far enough that the visible tool result was empty,
   leaving the task running without a usable artifact.

These fixes keep the Task authorization model intact while making the tool
surface match what real agents naturally do.

## Validation

- `cargo fmt`
- `cargo test create_artifact_stores_canonical_session_owned_cas_object`
- `cargo test delegated_session_can_update_its_owner_namespace_task_only`
- `uv run --with-requirements tests/requirements.txt python -m pytest tests/test_delegation.py -q`
  - non-AWS-local cases passed (`8 passed`)
  - AWS-local parametrization failed to start because this local binary was not
    built with the DynamoDB driver feature: `DynamoDB database driver is not enabled in this build`
- Rebuilt local Docker Compose gateway/worker and tested Conic CMO ->
  blog-post-copywriter with Novita/GLM using copied local `.env`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for task identifiers with explicit namespace prefixes.
  * Expanded delegated-task instructions with task names and review update guidance.
  * Artifact creation and updates now accept either text content or Base64-encoded content.

* **Bug Fixes**
  * Added validation and clearer errors when artifact content is missing.
  * Improved task update handling and preserved output artifact references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->