### PR TITLE
Add A2A wait-for-message tool

### DIFF
--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -52,6 +52,12 @@ pub struct LoopMessage {
     pub tool_call_id: Option<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ExecutedToolCall {
+    result: String,
+    stop_after_result: bool,
+}
+
 impl LoopMessage {
     pub fn text(role: impl Into<String>, content: impl Into<String>) -> Self {
         let content = content.into();
@@ -735,6 +741,7 @@ impl AgentExecutor {
             context.push(assistant_message);
 
             if !tool_calls.is_empty() {
+                let mut stop_after_tool_result = None;
                 for tool in &tool_calls {
                     let input = Self::tool_call_input(tool);
                     let tool_type = self.tool_type(&tool.name).await;
@@ -753,10 +760,12 @@ impl AgentExecutor {
                     )
                     .await?;
                     sink.on_tool_call(&tool.id, &tool.name, &input).await;
-                    let result = self
+                    let executed = self
                         .execute_tool_call_result(tool)
                         .instrument(tool_span.clone())
                         .await;
+                    let stop_after_result = executed.stop_after_result;
+                    let result = executed.result;
                     telemetry::record_tool_result(&tool_span, &result);
                     sink.on_tool_result_recorded(&tool.id, &tool.name, &result)
                         .await?;
@@ -772,6 +781,14 @@ impl AgentExecutor {
                     .await?;
                     sink.on_tool_result(&tool.id, &tool.name, &result).await;
                     context.push(tool_result_loop_message(&tool.id, &result));
+                    if stop_after_result {
+                        stop_after_tool_result = Some(result);
+                        break;
+                    }
+                }
+                if let Some(result) = stop_after_tool_result {
+                    sink.on_done().await;
+                    return Ok(result);
                 }
                 continue;
             }
@@ -783,8 +800,8 @@ impl AgentExecutor {
 
     pub async fn execute_tool_call(&self, tool: &ToolCall) -> (Value, String) {
         let input = Self::tool_call_input(tool);
-        let result = self.execute_tool_call_result(tool).await;
-        (input, result)
+        let executed = self.execute_tool_call_result(tool).await;
+        (input, executed.result)
     }
 
     pub fn tool_call_input(tool: &ToolCall) -> Value {
@@ -811,12 +828,19 @@ impl AgentExecutor {
         }
     }
 
-    async fn execute_tool_call_result(&self, tool: &ToolCall) -> String {
-        let result = match self.execute_tool(&tool.name, &tool.arguments).await {
-            Ok(result) => result,
-            Err(error) => tool_error_result(&tool.name, &error),
-        };
-        result
+    async fn execute_tool_call_result(&self, tool: &ToolCall) -> ExecutedToolCall {
+        match self.execute_tool(&tool.name, &tool.arguments).await {
+            Ok(result) => ExecutedToolCall {
+                result,
+                stop_after_result: crate::harness::native_tools::tool_requests_worker_stop(
+                    &tool.name,
+                ),
+            },
+            Err(error) => ExecutedToolCall {
+                result: tool_error_result(&tool.name, &error),
+                stop_after_result: false,
+            },
+        }
     }
 
     async fn execute_tool(&self, name: &str, input: &str) -> Result<String> {
@@ -854,9 +878,9 @@ mod tests {
         LoopMessage,
     };
     use crate::control::config::Config;
-    use crate::control::ControlPlane;
+    use crate::control::{keys, ControlPlane, ProtoKeyValueStoreExt};
     use crate::gateway::rpc::{
-        manifests,
+        data_proto, manifests,
         protobuf_value::{value::Kind as ProtoValueKind, ListValue, Value as ProtoValue},
     };
     use crate::harness::llm::provider::{
@@ -865,6 +889,7 @@ mod tests {
     };
     use crate::harness::memory::Embedding;
     use crate::harness::skills::registry::ToolRegistry;
+    use crate::test_support::{MockKvStore, RecordingPubSub};
     use anyhow::Result;
     use async_trait::async_trait;
     use serde_json::json;
@@ -964,6 +989,155 @@ mod tests {
         async fn completion(&self, prompt: &str) -> Result<String> {
             Ok(prompt.to_string())
         }
+    }
+
+    struct WaitToolThenReplyLlm {
+        seen_messages: Arc<Mutex<Vec<Vec<ChatMessage>>>>,
+        call_count: Arc<Mutex<usize>>,
+    }
+
+    impl Default for WaitToolThenReplyLlm {
+        fn default() -> Self {
+            Self {
+                seen_messages: Arc::new(Mutex::new(Vec::new())),
+                call_count: Arc::new(Mutex::new(0)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for WaitToolThenReplyLlm {
+        async fn generate_embedding(&self, _text: &str) -> Result<Embedding> {
+            Ok(vec![0.0; 8])
+        }
+
+        async fn chat_completion(&self, _request: ChatRequest) -> Result<ChatResponse> {
+            unreachable!("stream_chat_completion is used in this test");
+        }
+
+        async fn stream_chat_completion(&self, request: ChatRequest) -> Result<ChatStream> {
+            self.seen_messages
+                .lock()
+                .unwrap()
+                .push(request.messages.clone());
+            let mut call_count = self.call_count.lock().unwrap();
+            let stream = if *call_count == 0 {
+                *call_count += 1;
+                Box::pin(futures::stream::iter(vec![Ok(tool_call_delta_event(
+                    crate::harness::llm::provider::ToolCallDelta {
+                        index: 0,
+                        id: Some("tool-1".to_string()),
+                        name: Some(
+                            crate::harness::native_tools::AGENT_WAIT_FOR_MESSAGE_TOOL.to_string(),
+                        ),
+                        arguments: Some("{\"target\":\"critic-1\"}".to_string()),
+                    },
+                ))])) as ChatStream
+            } else {
+                Box::pin(futures::stream::once(async {
+                    Ok(text_delta_event("recovered after wait error".to_string()))
+                })) as ChatStream
+            };
+            Ok(stream)
+        }
+
+        async fn completion(&self, prompt: &str) -> Result<String> {
+            Ok(prompt.to_string())
+        }
+    }
+
+    struct WaitThenScheduleLlm {
+        seen_messages: Arc<Mutex<Vec<Vec<ChatMessage>>>>,
+    }
+
+    impl Default for WaitThenScheduleLlm {
+        fn default() -> Self {
+            Self {
+                seen_messages: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for WaitThenScheduleLlm {
+        async fn generate_embedding(&self, _text: &str) -> Result<Embedding> {
+            Ok(vec![0.0; 8])
+        }
+
+        async fn chat_completion(&self, _request: ChatRequest) -> Result<ChatResponse> {
+            unreachable!("stream_chat_completion is used in this test");
+        }
+
+        async fn stream_chat_completion(&self, request: ChatRequest) -> Result<ChatStream> {
+            self.seen_messages
+                .lock()
+                .unwrap()
+                .push(request.messages.clone());
+            Ok(Box::pin(futures::stream::iter(vec![
+                Ok(tool_call_delta_event(crate::harness::llm::provider::ToolCallDelta {
+                    index: 0,
+                    id: Some("wait-tool".to_string()),
+                    name: Some(
+                        crate::harness::native_tools::AGENT_WAIT_FOR_MESSAGE_TOOL.to_string(),
+                    ),
+                    arguments: Some("{\"target\":\"critic-1\"}".to_string()),
+                })),
+                Ok(tool_call_delta_event(crate::harness::llm::provider::ToolCallDelta {
+                    index: 1,
+                    id: Some("schedule-tool".to_string()),
+                    name: Some("create_schedule".to_string()),
+                    arguments: Some(
+                        "{\"name\":\"should-not-run\",\"kind\":\"every\",\"interval_seconds\":60,\"input_message\":\"ping\"}"
+                            .to_string(),
+                    ),
+                })),
+            ])))
+        }
+
+        async fn completion(&self, prompt: &str) -> Result<String> {
+            Ok(prompt.to_string())
+        }
+    }
+
+    async fn control_plane_with_wire() -> ControlPlane {
+        let kv = Arc::new(MockKvStore::default());
+        let cp = ControlPlane::builder(kv.clone(), Arc::new(RecordingPubSub::default())).build();
+        kv.set_msg(
+            &keys::session("Tenant:acme:Workspace:main", "writer", "writer-session"),
+            &data_proto::Session {
+                id: "writer-session".to_string(),
+                agent: "writer".to_string(),
+                ns: "Tenant:acme:Workspace:main".to_string(),
+                status: "PROCESSING".to_string(),
+                created_at: 1,
+                last_active: 1,
+                metadata: [(
+                    "wire.a2a.talon.impalasys.com/critic-1".to_string(),
+                    "Tenant:acme:Workspace:main/critic/critic-session".to_string(),
+                )]
+                .into_iter()
+                .collect(),
+                labels: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+        kv.set_msg(
+            &keys::session("Tenant:acme:Workspace:main", "critic", "critic-session"),
+            &data_proto::Session {
+                id: "critic-session".to_string(),
+                agent: "critic".to_string(),
+                ns: "Tenant:acme:Workspace:main".to_string(),
+                status: "PROCESSING".to_string(),
+                created_at: 1,
+                last_active: 1,
+                metadata: Default::default(),
+                labels: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+        cp
     }
 
     struct DelayedToolThenReplyLlm {
@@ -1539,6 +1713,129 @@ mod tests {
             .expect("expected a tool observation");
         assert!(observation.contains("\"ok\":false"));
         assert!(observation.contains("interval_seconds must be at least 300"));
+    }
+
+    #[tokio::test]
+    async fn executor_stops_after_wait_for_message_tool_result() {
+        let llm = Arc::new(WaitToolThenReplyLlm::default());
+        let registry = Arc::new(tokio::sync::RwLock::new(ToolRegistry::new()));
+        let spec = manifests::AgentSpec::default();
+        let executor = AgentExecutor::new_with_session(
+            llm.clone(),
+            "test-provider".to_string(),
+            "test-model".to_string(),
+            ContextAssembler::new("."),
+            registry.clone(),
+            Arc::new(Config::default()),
+            "Tenant:acme:Workspace:main".to_string(),
+            "writer".to_string(),
+            "writer-session".to_string(),
+            control_plane_with_wire().await,
+            spec.clone(),
+            HashMap::new(),
+        );
+        {
+            let mut reg = registry.write().await;
+            crate::harness::native_tools::register_tools(&mut reg, &spec);
+        }
+
+        let mut context = ExecutionContext::new("writer");
+        context.push(LoopMessage::text("user", "Ask the critic and wait."));
+        let sink = CaptureSink::new();
+        let reply = executor.execute(&mut context, &sink, None).await.unwrap();
+
+        assert!(reply.contains("\"status\":\"WAITING\""), "reply={reply}");
+        assert!(reply.contains("Waiting for a message from critic-1."));
+        assert_eq!(*llm.call_count.lock().unwrap(), 1);
+        let events = sink.events();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Action { name, .. }
+                if name == crate::harness::native_tools::AGENT_WAIT_FOR_MESSAGE_TOOL
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Observation { name, .. }
+                if name == crate::harness::native_tools::AGENT_WAIT_FOR_MESSAGE_TOOL
+        )));
+        assert!(events.iter().any(|event| matches!(event, AgentEvent::Done)));
+    }
+
+    #[tokio::test]
+    async fn executor_continues_after_invalid_wait_for_message_tool_result() {
+        let llm = Arc::new(WaitToolThenReplyLlm::default());
+        let registry = Arc::new(tokio::sync::RwLock::new(ToolRegistry::new()));
+        let spec = manifests::AgentSpec::default();
+        let executor = AgentExecutor::new_with_session(
+            llm.clone(),
+            "test-provider".to_string(),
+            "test-model".to_string(),
+            ContextAssembler::new("."),
+            registry.clone(),
+            Arc::new(Config::default()),
+            "Tenant:acme:Workspace:main".to_string(),
+            "writer".to_string(),
+            "writer-session".to_string(),
+            ControlPlane::noop(),
+            spec.clone(),
+            HashMap::new(),
+        );
+        {
+            let mut reg = registry.write().await;
+            crate::harness::native_tools::register_tools(&mut reg, &spec);
+        }
+
+        let mut context = ExecutionContext::new("writer");
+        context.push(LoopMessage::text("user", "Ask the critic and wait."));
+        let sink = CaptureSink::new();
+        let reply = executor.execute(&mut context, &sink, None).await.unwrap();
+
+        assert_eq!(*llm.call_count.lock().unwrap(), 1);
+        assert_eq!(llm.seen_messages.lock().unwrap().len(), 2);
+        assert!(reply.contains("recovered after wait error"));
+    }
+
+    #[tokio::test]
+    async fn executor_does_not_run_later_tool_calls_after_wait_for_message() {
+        let llm = Arc::new(WaitThenScheduleLlm::default());
+        let registry = Arc::new(tokio::sync::RwLock::new(ToolRegistry::new()));
+        let spec = manifests::AgentSpec::default();
+        let executor = AgentExecutor::new_with_session(
+            llm.clone(),
+            "test-provider".to_string(),
+            "test-model".to_string(),
+            ContextAssembler::new("."),
+            registry.clone(),
+            Arc::new(Config::default()),
+            "Tenant:acme:Workspace:main".to_string(),
+            "writer".to_string(),
+            "writer-session".to_string(),
+            control_plane_with_wire().await,
+            spec.clone(),
+            HashMap::new(),
+        );
+        {
+            let mut reg = registry.write().await;
+            crate::harness::native_tools::register_tools(&mut reg, &spec);
+        }
+
+        let mut context = ExecutionContext::new("writer");
+        context.push(LoopMessage::text("user", "Ask the critic and wait."));
+        let sink = CaptureSink::new();
+        let reply = executor.execute(&mut context, &sink, None).await.unwrap();
+
+        assert!(reply.contains("\"status\":\"WAITING\""), "reply={reply}");
+        assert_eq!(llm.seen_messages.lock().unwrap().len(), 1);
+        let events = sink.events();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Action { name, .. }
+                if name == crate::harness::native_tools::AGENT_WAIT_FOR_MESSAGE_TOOL
+        )));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Action { name, .. } if name == "create_schedule"
+        )));
     }
 
     struct SlowStreamingLlm;

--- a/src/harness/native_tools.rs
+++ b/src/harness/native_tools.rs
@@ -36,6 +36,7 @@ pub const DELEGATE_TASK_TOOL: &str = "delegate_task";
 pub const AGENT_OPEN_TOOL: &str = "agent_open";
 pub const AGENT_SEND_TOOL: &str = "agent_send";
 pub const AGENT_STATUS_TOOL: &str = "agent_status";
+pub const AGENT_WAIT_FOR_MESSAGE_TOOL: &str = "agent_wait_for_message";
 pub const GET_TASK_TOOL: &str = "get_task";
 pub const LIST_TASKS_TOOL: &str = "list_tasks";
 pub const UPDATE_TASK_TOOL: &str = "update_task";
@@ -66,6 +67,10 @@ pub(super) const OP_READ: &str = "read";
 pub(super) const OP_METADATA: &str = "metadata";
 pub(super) const OP_PROMOTE: &str = "promote";
 const MAX_ACCESS_TTL_SECONDS: i64 = 30 * 24 * 60 * 60;
+
+pub fn tool_requests_worker_stop(name: &str) -> bool {
+    name == AGENT_WAIT_FOR_MESSAGE_TOOL
+}
 
 pub fn register_skill_tools(registry: &mut ToolRegistry, skills: &[NamespaceSkill]) {
     let names = namespace::effective_skill_names(skills);
@@ -3368,6 +3373,7 @@ mod tests {
             json!(["critic"])
         );
         assert!(registry.get_tool(AGENT_SEND_TOOL).is_some());
+        assert!(registry.get_tool(AGENT_WAIT_FOR_MESSAGE_TOOL).is_some());
         assert!(registry.get_tool(DELEGATE_TASK_TOOL).is_none());
     }
 
@@ -3380,6 +3386,9 @@ mod tests {
         );
         assert!(no_connection_registry.get_tool(AGENT_OPEN_TOOL).is_none());
         assert!(no_connection_registry.get_tool(AGENT_SEND_TOOL).is_some());
+        assert!(no_connection_registry
+            .get_tool(AGENT_WAIT_FOR_MESSAGE_TOOL)
+            .is_some());
 
         let mut external_registry = ToolRegistry::new();
         register_tools(
@@ -3388,6 +3397,9 @@ mod tests {
         );
         assert!(external_registry.get_tool(AGENT_OPEN_TOOL).is_none());
         assert!(external_registry.get_tool(AGENT_SEND_TOOL).is_some());
+        assert!(external_registry
+            .get_tool(AGENT_WAIT_FOR_MESSAGE_TOOL)
+            .is_some());
     }
 
     #[test]

--- a/src/harness/tools/a2a.rs
+++ b/src/harness/tools/a2a.rs
@@ -103,6 +103,21 @@ pub(super) fn register(registry: &mut ToolRegistry, spec: &manifests::AgentSpec)
             "required": ["target"]
         }),
     );
+
+    registry.register_builtin(
+        super::AGENT_WAIT_FOR_MESSAGE_TOOL,
+        "Stop this worker turn while waiting for a message from an opened A2A agent wire. Use this after agent_send when you need the other agent to respond.",
+        json!({
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": "Opened wire name, such as critic-1. In child sessions, owner refers to the session that opened this wire."
+                }
+            },
+            "required": ["target"]
+        }),
+    );
 }
 
 pub(super) async fn execute(
@@ -132,6 +147,11 @@ pub(super) async fn execute(
         }
         super::AGENT_STATUS_TOOL => {
             agent_status(cp, current_namespace, current_agent, current_session, args)
+                .await
+                .map(Some)
+        }
+        super::AGENT_WAIT_FOR_MESSAGE_TOOL => {
+            agent_wait_for_message(cp, current_namespace, current_agent, current_session, args)
                 .await
                 .map(Some)
         }
@@ -249,6 +269,52 @@ async fn agent_status(
     });
 
     Ok(format!("{}\n{}", serde_json::to_string(&summary)?, detail))
+}
+
+async fn agent_wait_for_message(
+    cp: &ControlPlane,
+    current_namespace: &str,
+    current_agent: &str,
+    current_session: &str,
+    args: &Value,
+) -> Result<String> {
+    let target_alias = normalize_agent_uri(super::req_str(args, "target")?)?;
+    let target = load_wire(
+        cp,
+        current_namespace,
+        current_agent,
+        current_session,
+        &target_alias,
+    )
+    .await?
+    .ok_or_else(|| anyhow!("agent wire '{}' is not open", target_alias))?;
+
+    let session = cp
+        .kv
+        .get_msg::<data_proto::Session>(&keys::session(
+            &target.namespace,
+            &target.agent,
+            &target.session_id,
+        ))
+        .await?
+        .ok_or_else(|| anyhow!("target agent session '{}' not found", target.session_id))?;
+    let queue = queued_message_status(cp, &target, None).await?;
+    let active = active_message_id(cp, &target, None).await?;
+    let pending = queue.pending_count;
+    let wire_status = wire_status(&session, pending, active.as_deref());
+    let summary = json!({
+        "status": "WAITING",
+        "target": target_alias,
+        "wireStatus": wire_status,
+        "pending": pending,
+        "active": active,
+    });
+
+    Ok(format!(
+        "{}\nWaiting for a message from {}. The worker will stop this turn and resume when an inbound message is dispatched; do not poll agent_status.",
+        serde_json::to_string(&summary)?,
+        target_alias
+    ))
 }
 
 pub(super) async fn open_or_reuse_wire(

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -349,6 +349,7 @@ fn builtin_tool_names() -> &'static [&'static str] {
         crate::harness::native_tools::AGENT_OPEN_TOOL,
         crate::harness::native_tools::AGENT_SEND_TOOL,
         crate::harness::native_tools::AGENT_STATUS_TOOL,
+        crate::harness::native_tools::AGENT_WAIT_FOR_MESSAGE_TOOL,
         crate::harness::native_tools::UPDATE_TASK_TOOL,
         crate::harness::native_tools::GET_GOAL_TOOL,
         crate::harness::native_tools::LIST_GOALS_TOOL,
@@ -693,6 +694,7 @@ mod tests {
         assert!(names.contains(&crate::harness::native_tools::CREATE_ARTIFACT_TOOL));
         assert!(names.contains(&crate::harness::native_tools::UPDATE_ARTIFACT_TOOL));
         assert!(names.contains(&crate::harness::native_tools::DELEGATE_TASK_TOOL));
+        assert!(names.contains(&crate::harness::native_tools::AGENT_WAIT_FOR_MESSAGE_TOOL));
         assert!(names.contains(&crate::harness::native_tools::READ_SESSION_MESSAGES_TOOL));
         assert!(names.contains(&crate::harness::native_tools::SEARCH_MEMORY_TOOL));
         assert!(names.contains(&crate::harness::native_tools::READ_MEMORY_TOOL));

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -95,6 +95,7 @@ pub(super) enum SessionCompletionStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PreparedSubmissionState {
     ContinueExecution,
+    StopAfterToolResult,
     FinalResponseReady { content: String },
 }
 
@@ -201,6 +202,7 @@ async fn prepare_context_for_claimed_submission(
             });
         }
 
+        let mut stop_after_tool_results = false;
         let mut results_by_call_id = BTreeMap::new();
         while index < journal_entries.len() {
             let entry = &journal_entries[index];
@@ -298,6 +300,14 @@ async fn prepare_context_for_claimed_submission(
             runtime
                 .context
                 .push(tool_result_loop_message(&tool.id, &result));
+            stop_after_tool_results |=
+                crate::harness::native_tools::tool_requests_worker_stop(&tool.name);
+        }
+        if stop_after_tool_results {
+            return Ok(PreparedSubmission {
+                state: PreparedSubmissionState::StopAfterToolResult,
+                projection_parts,
+            });
         }
     }
 
@@ -720,6 +730,10 @@ impl WorkerEventHandler {
                 prepared_submission.state
             {
                 sink.seed_recovered_final_text_part(&content);
+                sink.on_done().await;
+                return Ok((SessionCompletionStatus::Completed, sink.summary()));
+            }
+            if prepared_submission.state == PreparedSubmissionState::StopAfterToolResult {
                 sink.on_done().await;
                 return Ok((SessionCompletionStatus::Completed, sink.summary()));
             }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #161
* #162

Introduce agent_wait_for_message and a native-tool stop signal so the worker records the tool result, commits the current assistant projection, and releases the session instead of re-entering the LLM loop.