### PR TITLE
Resolve tenant LLM provider secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5568,14 +5568,9 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "reqwest 0.12.28",
- "tokio",
  "tonic 0.12.3",
  "tonic-web",
 ]
-
-[[package]]
-name = "talon-install-hooks"
-version = "0.0.0"
 
 [[package]]
 name = "tempfile"

--- a/src/control/keys.rs
+++ b/src/control/keys.rs
@@ -347,6 +347,10 @@ pub fn agent_prefix(namespace: &str) -> ResourceList {
     direct_child_prefix(namespace, &[], Some("Agent"))
 }
 
+pub fn secret(namespace: &str, name: &str) -> ResourceKey {
+    resource_key(namespace, &[], "Secret", name)
+}
+
 pub fn file(namespace: &str, name: &str) -> ResourceKey {
     resource_key(namespace, &[], "File", name)
 }

--- a/src/control/resources.rs
+++ b/src/control/resources.rs
@@ -562,6 +562,17 @@ impl ResourceStore {
             .transpose()
     }
 
+    pub async fn get_secret(
+        &self,
+        namespace: &str,
+        name: &str,
+    ) -> Result<Option<resources_proto::Secret>> {
+        self.get_by_key(&keys::secret(namespace, name))
+            .await?
+            .map(secret_from_resource)
+            .transpose()
+    }
+
     async fn get_by_key(
         &self,
         key: &keys::ResourceKey,
@@ -632,6 +643,31 @@ pub fn agent_from_resource(resource: resources_proto::Resource) -> Result<resour
         },
     };
     Ok(resources_proto::Agent {
+        metadata: Some(metadata),
+        spec: Some(spec),
+        status: Some(status),
+    })
+}
+
+pub fn secret_from_resource(
+    resource: resources_proto::Resource,
+) -> Result<resources_proto::Secret> {
+    if resource.kind != "Secret" {
+        return Err(anyhow!("expected Secret resource, got {}", resource.kind));
+    }
+    let metadata = resource
+        .metadata
+        .ok_or_else(|| anyhow!("Secret resource metadata is required"))?;
+    let Some(resources_proto::resource_spec::Kind::Secret(spec)) =
+        resource.spec.and_then(|spec| spec.kind)
+    else {
+        return Err(anyhow!("Secret resource is missing typed Secret spec"));
+    };
+    let status = match resource.status.and_then(|status| status.kind) {
+        Some(resources_proto::resource_status::Kind::Secret(status)) => status,
+        _ => resources_proto::CommonResourceStatus::default(),
+    };
+    Ok(resources_proto::Secret {
         metadata: Some(metadata),
         spec: Some(spec),
         status: Some(status),

--- a/src/harness/llm/resolver.rs
+++ b/src/harness/llm/resolver.rs
@@ -5,9 +5,11 @@ use anyhow::{anyhow, Context, Result};
 use std::sync::Arc;
 
 use crate::control::config::secrets::SecretExt;
-use crate::control::config::Config;
+use crate::control::config::{proto, Config, Secret};
+use crate::control::ControlPlane;
 use crate::gateway::rpc::manifests::{self, AgentSpec};
 use crate::harness::llm::LlmProvider;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 
 pub struct ResolvedLlm {
     pub provider: Arc<dyn LlmProvider + Send + Sync>,
@@ -39,6 +41,34 @@ pub fn resolve_model_profile(policy: Option<&manifests::ModelPolicy>) -> Option<
 /// Returns an error when the selected provider is missing, unsupported, or
 /// cannot resolve its credentials.
 pub async fn resolve_llm(spec: &AgentSpec, config: &Config) -> Result<ResolvedLlm> {
+    resolve_llm_with_credentials(spec, config, None).await
+}
+
+pub async fn resolve_llm_for_namespace(
+    spec: &AgentSpec,
+    config: &Config,
+    cp: &ControlPlane,
+    namespace: &str,
+) -> Result<ResolvedLlm> {
+    resolve_llm_with_credentials(
+        spec,
+        config,
+        Some(TenantCredentialContext { cp, namespace }),
+    )
+    .await
+}
+
+#[derive(Clone, Copy)]
+struct TenantCredentialContext<'a> {
+    cp: &'a ControlPlane,
+    namespace: &'a str,
+}
+
+async fn resolve_llm_with_credentials(
+    spec: &AgentSpec,
+    config: &Config,
+    credentials: Option<TenantCredentialContext<'_>>,
+) -> Result<ResolvedLlm> {
     let selected_model = resolve_model_profile(spec.model_policy.as_ref());
     let spec_provider = selected_model.map(|m| m.provider.as_str());
     let spec_model = selected_model.map(|m| m.name.as_str());
@@ -62,14 +92,14 @@ pub async fn resolve_llm(spec: &AgentSpec, config: &Config) -> Result<ResolvedLl
         .ok_or_else(|| anyhow!("LLM provider '{}' not found in config", provider_name))?;
 
     match &provider_cfg.config {
-        Some(crate::control::config::proto::llm_provider_config::Config::Openai(openai)) => {
-            let api_key = openai
-                .api_key
-                .as_ref()
-                .context("OpenAI provider config is missing api_key")?
-                .resolve()
-                .await
-                .with_context(|| format!("Failed to resolve API key for '{}'", provider_name))?;
+        Some(proto::llm_provider_config::Config::Openai(openai)) => {
+            let api_key = resolve_provider_api_key(
+                provider_name,
+                openai.api_key.as_ref(),
+                credentials,
+                "OpenAI provider config is missing api_key",
+            )
+            .await?;
 
             let base_url = std::env::var("OPENAI_BASE_URL")
                 .unwrap_or_else(|_| "https://api.openai.com/v1".to_string());
@@ -88,14 +118,14 @@ pub async fn resolve_llm(spec: &AgentSpec, config: &Config) -> Result<ResolvedLl
                 model,
             })
         }
-        Some(crate::control::config::proto::llm_provider_config::Config::Anthropic(anthropic)) => {
-            let api_key = anthropic
-                .api_key
-                .as_ref()
-                .context("Anthropic provider config is missing api_key")?
-                .resolve()
-                .await
-                .with_context(|| format!("Failed to resolve API key for '{}'", provider_name))?;
+        Some(proto::llm_provider_config::Config::Anthropic(anthropic)) => {
+            let api_key = resolve_provider_api_key(
+                provider_name,
+                anthropic.api_key.as_ref(),
+                credentials,
+                "Anthropic provider config is missing api_key",
+            )
+            .await?;
             let model = spec_model
                 .filter(|s| !s.is_empty())
                 .unwrap_or(&anthropic.model)
@@ -110,16 +140,14 @@ pub async fn resolve_llm(spec: &AgentSpec, config: &Config) -> Result<ResolvedLl
                 model,
             })
         }
-        Some(crate::control::config::proto::llm_provider_config::Config::OpenaiCompatible(
-            generic,
-        )) => {
-            let api_key = generic
-                .api_key
-                .as_ref()
-                .context("OpenAI-compatible provider config is missing api_key")?
-                .resolve()
-                .await
-                .with_context(|| format!("Failed to resolve API key for '{}'", provider_name))?;
+        Some(proto::llm_provider_config::Config::OpenaiCompatible(generic)) => {
+            let api_key = resolve_provider_api_key(
+                provider_name,
+                generic.api_key.as_ref(),
+                credentials,
+                "OpenAI-compatible provider config is missing api_key",
+            )
+            .await?;
 
             // Allow env-var override of base URL (useful in local dev / CI)
             let base_url = if let Ok(env_url) = std::env::var("NOVITA_BASE_URL") {
@@ -144,12 +172,10 @@ pub async fn resolve_llm(spec: &AgentSpec, config: &Config) -> Result<ResolvedLl
                 model,
             })
         }
-        Some(crate::control::config::proto::llm_provider_config::Config::Google(_)) => {
-            Err(anyhow!(
-                "LLM provider '{}' uses Google config, which is not supported by this runtime yet",
-                provider_name
-            ))
-        }
+        Some(proto::llm_provider_config::Config::Google(_)) => Err(anyhow!(
+            "LLM provider '{}' uses Google config, which is not supported by this runtime yet",
+            provider_name
+        )),
         None => Err(anyhow!(
             "LLM provider '{}' has no config; refusing to fall back to a mock provider",
             provider_name
@@ -157,14 +183,121 @@ pub async fn resolve_llm(spec: &AgentSpec, config: &Config) -> Result<ResolvedLl
     }
 }
 
+async fn resolve_provider_api_key(
+    provider_name: &str,
+    configured: Option<&Secret>,
+    credentials: Option<TenantCredentialContext<'_>>,
+    missing_config_message: &'static str,
+) -> Result<String> {
+    if let Some(credentials) = credentials {
+        if let Some(tenant_namespace) = tenant_root_namespace(credentials.namespace) {
+            return resolve_tenant_provider_api_key(
+                credentials.cp,
+                &tenant_namespace,
+                provider_name,
+            )
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "Tenant namespace '{}' requires Secret '{}' in namespace '{}' to contain API key '{}'",
+                    credentials.namespace,
+                    API_KEYS_SECRET_NAME,
+                    tenant_namespace,
+                    provider_name
+                )
+            });
+        }
+    }
+
+    configured
+        .context(missing_config_message)?
+        .resolve()
+        .await
+        .with_context(|| format!("Failed to resolve API key for '{}'", provider_name))
+}
+
+pub const API_KEYS_SECRET_NAME: &str = "api-keys";
+
+async fn resolve_tenant_provider_api_key(
+    cp: &ControlPlane,
+    tenant_namespace: &str,
+    provider_name: &str,
+) -> Result<Option<String>> {
+    let store = crate::control::resources::ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+    let Some(secret) = store
+        .get_secret(tenant_namespace, API_KEYS_SECRET_NAME)
+        .await?
+    else {
+        return Ok(None);
+    };
+    let Some(spec) = secret.spec else {
+        return Ok(None);
+    };
+    let Some(encoded) = provider_api_key_value(&spec.data, provider_name) else {
+        return Ok(None);
+    };
+    let raw = BASE64_STANDARD
+        .decode(encoded.as_bytes())
+        .with_context(|| {
+            format!(
+                "Secret '{}' provider API key must be base64-encoded",
+                API_KEYS_SECRET_NAME
+            )
+        })?;
+    let api_key = String::from_utf8(raw).with_context(|| {
+        format!(
+            "Secret '{}' provider API key must be UTF-8",
+            API_KEYS_SECRET_NAME
+        )
+    })?;
+    if api_key.trim().is_empty() {
+        return Err(anyhow!(
+            "Secret '{}' in namespace '{}' has empty API key for provider '{}'",
+            API_KEYS_SECRET_NAME,
+            tenant_namespace,
+            provider_name
+        ));
+    }
+    tracing::debug!(
+        provider = provider_name,
+        secret_namespace = tenant_namespace,
+        secret_name = %API_KEYS_SECRET_NAME,
+        "Resolved tenant LLM provider secret"
+    );
+    Ok(Some(api_key))
+}
+
+pub fn tenant_root_namespace(namespace: &str) -> Option<String> {
+    let mut segments = namespace.split(':');
+    match (segments.next(), segments.next()) {
+        (Some("Tenant"), Some(tenant_id)) if !tenant_id.trim().is_empty() => {
+            Some(format!("Tenant:{tenant_id}"))
+        }
+        _ => None,
+    }
+}
+
+fn provider_api_key_value<'a>(
+    data: &'a std::collections::HashMap<String, String>,
+    provider_name: &str,
+) -> Option<&'a String> {
+    data.get(provider_name)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{resolve_llm, resolve_model_profile};
+    use super::{
+        resolve_llm, resolve_llm_for_namespace, resolve_model_profile, API_KEYS_SECRET_NAME,
+    };
     use crate::control::config::{proto, Config, ProviderConfig, Secret};
+    use crate::control::ControlPlane;
     use crate::gateway::rpc::manifests;
-    use axum::{routing::post, Json, Router};
+    use crate::gateway::rpc::resources_proto;
+    use axum::{http::HeaderMap, routing::post, Json, Router};
+    use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
     use serde_json::json;
     use std::collections::HashMap;
+    use std::sync::Arc;
     use tokio::net::TcpListener;
 
     fn config_with_provider(name: &str, provider: ProviderConfig) -> Config {
@@ -209,6 +342,43 @@ mod tests {
             a2a: None,
             runtime: None,
         }
+    }
+
+    async fn put_llm_provider_secret(
+        cp: &ControlPlane,
+        namespace: &str,
+        provider: &str,
+        api_key: &str,
+    ) {
+        let store = crate::control::resources::ResourceStore::new(cp.kv.clone(), cp.pubsub.clone());
+        store
+            .upsert(
+                namespace,
+                resources_proto::Resource {
+                    api_version: "talon.impalasys.com/v1".to_string(),
+                    kind: "Secret".to_string(),
+                    metadata: Some(resources_proto::ResourceMeta {
+                        namespace: namespace.to_string(),
+                        name: API_KEYS_SECRET_NAME.to_string(),
+                        ..Default::default()
+                    }),
+                    spec: Some(resources_proto::ResourceSpec {
+                        kind: Some(resources_proto::resource_spec::Kind::Secret(
+                            resources_proto::SecretSpec {
+                                r#type: String::new(),
+                                data: HashMap::from([(
+                                    provider.to_string(),
+                                    BASE64_STANDARD.encode(api_key.as_bytes()),
+                                )]),
+                                string_data: HashMap::new(),
+                            },
+                        )),
+                    }),
+                    status: None,
+                },
+            )
+            .await
+            .unwrap();
     }
 
     #[test]
@@ -308,6 +478,207 @@ mod tests {
         assert_eq!(response, "resolved via spec provider");
 
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn resolve_llm_for_namespace_uses_tenant_provider_secret() {
+        let _guard = crate::test_support::async_env_mutex().lock().await;
+        unsafe {
+            std::env::remove_var("NOVITA_BASE_URL");
+        }
+        let app = Router::new().route(
+            "/chat/completions",
+            post(|headers: HeaderMap| async move {
+                assert_eq!(
+                    headers
+                        .get(axum::http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok()),
+                    Some("Bearer tenant-key")
+                );
+                Json(json!({
+                    "choices": [{
+                        "message": {
+                            "content": "resolved via tenant secret",
+                            "tool_calls": []
+                        }
+                    }]
+                }))
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        unsafe {
+            std::env::set_var("OPENAI_BASE_URL", format!("http://{addr}"));
+        }
+
+        let kv = Arc::new(crate::test_support::MockKvStore::default());
+        let cp = ControlPlane::builder(
+            kv,
+            Arc::new(crate::test_support::RecordingPubSub::default()),
+        )
+        .build();
+        put_llm_provider_secret(&cp, "Tenant:acme", "openai", "tenant-key").await;
+        let config = config_with_provider(
+            "openai",
+            ProviderConfig {
+                config: Some(proto::llm_provider_config::Config::Openai(
+                    proto::OpenAiConfig {
+                        model: "config-model".to_string(),
+                        api_key: None,
+                        org_id: String::new(),
+                    },
+                )),
+            },
+        );
+        let llm = resolve_llm_for_namespace(
+            &manifests::AgentSpec::default(),
+            &config,
+            &cp,
+            "Tenant:acme:Workspace:main",
+        )
+        .await
+        .unwrap();
+        assert_eq!(llm.provider_key, "openai");
+        let response = llm.provider.completion("ping").await.unwrap();
+        assert_eq!(response, "resolved via tenant secret");
+
+        unsafe {
+            std::env::remove_var("OPENAI_BASE_URL");
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn resolve_llm_for_namespace_uses_literal_provider_secret_key() {
+        let _guard = crate::test_support::async_env_mutex().lock().await;
+        unsafe {
+            std::env::remove_var("NOVITA_BASE_URL");
+        }
+        let app = Router::new().route(
+            "/chat/completions",
+            post(|headers: HeaderMap| async move {
+                assert_eq!(
+                    headers
+                        .get(axum::http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok()),
+                    Some("Bearer tenant-azure-key")
+                );
+                Json(json!({
+                    "choices": [{
+                        "message": {
+                            "content": "resolved via literal tenant key",
+                            "tool_calls": []
+                        }
+                    }]
+                }))
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let kv = Arc::new(crate::test_support::MockKvStore::default());
+        let cp = ControlPlane::builder(
+            kv,
+            Arc::new(crate::test_support::RecordingPubSub::default()),
+        )
+        .build();
+        put_llm_provider_secret(&cp, "Tenant:acme", "azure_openai", "tenant-azure-key").await;
+        let config = config_with_provider(
+            "azure_openai",
+            openai_compatible_provider(format!("http://{addr}"), None),
+        );
+        let llm = resolve_llm_for_namespace(
+            &manifests::AgentSpec::default(),
+            &config,
+            &cp,
+            "Tenant:acme:Workspace:main",
+        )
+        .await
+        .unwrap();
+        assert_eq!(llm.provider_key, "azure_openai");
+        let response = llm.provider.completion("ping").await.unwrap();
+        assert_eq!(response, "resolved via literal tenant key");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn resolve_llm_for_namespace_ignores_workspace_provider_secret() {
+        let kv = Arc::new(crate::test_support::MockKvStore::default());
+        let cp = ControlPlane::builder(
+            kv,
+            Arc::new(crate::test_support::RecordingPubSub::default()),
+        )
+        .build();
+        put_llm_provider_secret(&cp, "Tenant:acme:Workspace:main", "openai", "workspace-key").await;
+        let config = config_with_provider(
+            "openai",
+            ProviderConfig {
+                config: Some(proto::llm_provider_config::Config::Openai(
+                    proto::OpenAiConfig {
+                        model: "config-model".to_string(),
+                        api_key: None,
+                        org_id: String::new(),
+                    },
+                )),
+            },
+        );
+        let err = match resolve_llm_for_namespace(
+            &manifests::AgentSpec::default(),
+            &config,
+            &cp,
+            "Tenant:acme:Workspace:main",
+        )
+        .await
+        {
+            Ok(_) => panic!("workspace-scoped provider Secret should be ignored"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("requires Secret 'api-keys' in namespace 'Tenant:acme'"));
+    }
+
+    #[tokio::test]
+    async fn resolve_llm_for_tenant_namespace_does_not_fallback_to_provider_config() {
+        let kv = Arc::new(crate::test_support::MockKvStore::default());
+        let cp = ControlPlane::builder(
+            kv,
+            Arc::new(crate::test_support::RecordingPubSub::default()),
+        )
+        .build();
+        let config = config_with_provider(
+            "openai",
+            ProviderConfig {
+                config: Some(proto::llm_provider_config::Config::Openai(
+                    proto::OpenAiConfig {
+                        model: "config-model".to_string(),
+                        api_key: Some(Secret {
+                            source: Some(proto::secret::Source::Plain(
+                                "global-key-must-not-be-used".to_string(),
+                            )),
+                        }),
+                        org_id: String::new(),
+                    },
+                )),
+            },
+        );
+        let err = match resolve_llm_for_namespace(
+            &manifests::AgentSpec::default(),
+            &config,
+            &cp,
+            "Tenant:acme:Workspace:main",
+        )
+        .await
+        {
+            Ok(_) => panic!("tenant namespace should not use provider-level fallback key"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("requires Secret 'api-keys' in namespace 'Tenant:acme'"));
     }
 
     #[tokio::test]

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -120,7 +120,8 @@ impl AgentRuntime {
         }
 
         // 3. Resolve LLM from AgentSpec + Config
-        let llm = crate::harness::llm::resolver::resolve_llm(&spec, config).await?;
+        let llm =
+            crate::harness::llm::resolver::resolve_llm_for_namespace(&spec, config, cp, ns).await?;
 
         // 4. Build tool registry (builtins + future MCP servers)
         let mut mcp_tools = std::collections::HashMap::new();


### PR DESCRIPTION
## Summary

- resolve LLM provider API keys from a tenant-root Secret for Tenant:<tenant-id> namespaces and children
- prevent Tenant:<tenant-id> namespaces from falling back to provider-level/global configured API keys
- keep provider-level fallback for non-tenant namespaces
- add typed Secret lookup helpers in the resource store
- wire runtime LLM resolution through the agent namespace so Tenant:<tenant-id> namespaces can use tenant-scoped keys
- normalize `Cargo.lock` after main removed the Cargo workspace, so `cargo metadata --locked` and locked CI builds do not try to rewrite the lockfile

## Secret convention

Use one tenant-root Secret named `api-keys` for provider API keys. Workspace or deeper namespace Secrets are intentionally ignored for this pass; `Tenant:acme:Workspace:main` resolves from `Tenant:acme`.

```yaml
apiVersion: talon.impalasys.com/v1
kind: Secret
metadata:
  namespace: Tenant:acme
  name: api-keys
spec:
  stringData:
    openai: sk-...
    novita: ...
    deepseek: ...
    azure_openai: ...
```

The key must exactly match the configured provider id. For Tenant:<tenant-id> namespaces and descendants, a missing tenant API key is an error. Runtime does not fall back to the configured provider key for tenant namespaces. The resolver does not rely on `spec.type`.

## Validation

- `cargo metadata --locked --format-version 1`
- `cargo fmt --all --check`
- `cargo build --locked --bins`
- `cargo test --locked`
- `cargo test --locked harness::llm::resolver::tests::resolve_llm_for_namespace -- --nocapture`
- `cargo test --locked harness::llm::resolver::tests::resolve_llm_for_tenant_namespace_does_not_fallback_to_provider_config -- --nocapture`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving AI provider credentials from tenant-scoped Secrets.
  * Added typed Secret retrieval for improved resource access.
  * Added canonical Secret resource key generation.

* **Bug Fixes**
  * Agents now use namespace-aware credential resolution.
  * Missing tenant credentials produce clear errors instead of silently falling back to provider-level keys or mock providers.
  * Invalid or unsupported provider credential configurations are rejected explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->