### PR TITLE
Fix OpenAI-compatible provider URL overrides

### DIFF
--- a/src/control/config/mod.rs
+++ b/src/control/config/mod.rs
@@ -52,24 +52,24 @@ pub enum SerdeProviderConfig {
     Openai {
         model: String,
         #[serde(alias = "apiKey")]
-        api_key: SerdeSecret,
+        api_key: Option<SerdeSecret>,
     },
     Anthropic {
         model: String,
         #[serde(alias = "apiKey")]
-        api_key: SerdeSecret,
+        api_key: Option<SerdeSecret>,
     },
     Google {
         model: String,
         #[serde(alias = "apiKey")]
-        api_key: SerdeSecret,
+        api_key: Option<SerdeSecret>,
     },
     OpenaiCompatible {
         #[serde(alias = "baseUrl")]
         base_url: String,
         model: String,
         #[serde(alias = "apiKey")]
-        api_key: SerdeSecret,
+        api_key: Option<SerdeSecret>,
     },
 }
 
@@ -249,7 +249,7 @@ impl From<SerdeConfig> for Config {
                         config: Some(proto::llm_provider_config::Config::Openai(
                             proto::OpenAiConfig {
                                 model,
-                                api_key: Some(api_key.into()),
+                                api_key: api_key.map(Into::into),
                                 org_id: "".to_string(),
                             },
                         )),
@@ -258,7 +258,7 @@ impl From<SerdeConfig> for Config {
                         config: Some(proto::llm_provider_config::Config::Anthropic(
                             proto::AnthropicConfig {
                                 model,
-                                api_key: Some(api_key.into()),
+                                api_key: api_key.map(Into::into),
                             },
                         )),
                     },
@@ -266,7 +266,7 @@ impl From<SerdeConfig> for Config {
                         config: Some(proto::llm_provider_config::Config::Google(
                             proto::GoogleConfig {
                                 model,
-                                api_key: Some(api_key.into()),
+                                api_key: api_key.map(Into::into),
                             },
                         )),
                     },
@@ -280,7 +280,7 @@ impl From<SerdeConfig> for Config {
                                 name: "".to_string(),
                                 base_url,
                                 model,
-                                api_key: Some(api_key.into()),
+                                api_key: api_key.map(Into::into),
                             },
                         )),
                     },

--- a/src/control/config/tests.rs
+++ b/src/control/config/tests.rs
@@ -711,6 +711,33 @@ control_plane:
     }
 
     #[test]
+    fn test_provider_api_key_is_optional_in_yaml_config() {
+        let file = NamedTempFile::new().expect("Failed to create temp file");
+        let path = file.path().with_extension("yaml");
+        std::fs::write(
+            &path,
+            r#"
+providers:
+  meta:
+    type: openai_compatible
+    base_url: https://api.llama.com/compat/v1
+    model: Llama-4-Maverick-17B-128E-Instruct-FP8
+"#,
+        )
+        .unwrap();
+
+        let config = Config::from_file(&path).unwrap();
+        let provider = config.providers.get("meta").unwrap();
+        let Some(proto::llm_provider_config::Config::OpenaiCompatible(generic)) = &provider.config
+        else {
+            panic!("expected openai compatible provider");
+        };
+        assert_eq!(generic.base_url, "https://api.llama.com/compat/v1");
+        assert_eq!(generic.model, "Llama-4-Maverick-17B-128E-Instruct-FP8");
+        assert!(generic.api_key.is_none());
+    }
+
+    #[test]
     fn test_s3_object_store_config_from_yaml() {
         let file = NamedTempFile::new().expect("Failed to create temp file");
         let path = file.path().with_extension("yaml");
@@ -774,19 +801,21 @@ control_plane:
                     crate::control::config::SerdeProviderConfig::OpenaiCompatible {
                         base_url: "https://llm.example.com".to_string(),
                         model: "model-x".to_string(),
-                        api_key: crate::control::config::SerdeSecret::Ref(
+                        api_key: Some(crate::control::config::SerdeSecret::Ref(
                             crate::control::config::SerdeSecretRef {
                                 source: "azure".to_string(),
                                 key: "azure-key".to_string(),
                             },
-                        ),
+                        )),
                     },
                 ),
                 (
                     "backup".to_string(),
                     crate::control::config::SerdeProviderConfig::Google {
                         model: "gemini".to_string(),
-                        api_key: crate::control::config::SerdeSecret::Plain("plain".to_string()),
+                        api_key: Some(crate::control::config::SerdeSecret::Plain(
+                            "plain".to_string(),
+                        )),
                     },
                 ),
             ]),

--- a/src/harness/llm/resolver.rs
+++ b/src/harness/llm/resolver.rs
@@ -149,13 +149,7 @@ async fn resolve_llm_with_credentials(
             )
             .await?;
 
-            // Allow env-var override of base URL (useful in local dev / CI)
-            let base_url = if let Ok(env_url) = std::env::var("NOVITA_BASE_URL") {
-                tracing::warn!("Overriding LLM base URL with NOVITA_BASE_URL");
-                env_url
-            } else {
-                generic.base_url.clone()
-            };
+            let base_url = generic.base_url.clone();
 
             let model = spec_model
                 .filter(|s| !s.is_empty())
@@ -442,7 +436,6 @@ mod tests {
         let _guard = crate::test_support::async_env_mutex().lock().await;
         unsafe {
             std::env::remove_var("NOVITA_API_KEY");
-            std::env::remove_var("NOVITA_BASE_URL");
         }
         let app = Router::new().route(
             "/chat/completions",
@@ -483,9 +476,6 @@ mod tests {
     #[tokio::test]
     async fn resolve_llm_for_namespace_uses_tenant_provider_secret() {
         let _guard = crate::test_support::async_env_mutex().lock().await;
-        unsafe {
-            std::env::remove_var("NOVITA_BASE_URL");
-        }
         let app = Router::new().route(
             "/chat/completions",
             post(|headers: HeaderMap| async move {
@@ -551,10 +541,6 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_llm_for_namespace_uses_literal_provider_secret_key() {
-        let _guard = crate::test_support::async_env_mutex().lock().await;
-        unsafe {
-            std::env::remove_var("NOVITA_BASE_URL");
-        }
         let app = Router::new().route(
             "/chat/completions",
             post(|headers: HeaderMap| async move {
@@ -682,15 +668,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_llm_uses_env_override_for_base_url() {
-        let _guard = crate::test_support::async_env_mutex().lock().await;
+    async fn resolve_llm_uses_configured_base_url() {
         let app = Router::new().route(
             "/chat/completions",
             post(|| async {
                 Json(json!({
                     "choices": [{
                         "message": {
-                            "content": "resolved via env override",
+                            "content": "resolved via configured base URL",
                             "tool_calls": []
                         }
                     }]
@@ -701,13 +686,10 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-        unsafe {
-            std::env::set_var("NOVITA_BASE_URL", format!("http://{addr}"));
-        }
         let config = config_with_provider(
             "primary",
             openai_compatible_provider(
-                "https://unused.example.com".to_string(),
+                format!("http://{addr}"),
                 Some(Secret {
                     source: Some(proto::secret::Source::Plain("config-key".to_string())),
                 }),
@@ -719,11 +701,8 @@ mod tests {
         assert_eq!(llm.provider_key, "primary");
         assert_eq!(llm.model, "config-model");
         let response = llm.provider.completion("ping").await.unwrap();
-        assert_eq!(response, "resolved via env override");
+        assert_eq!(response, "resolved via configured base URL");
 
-        unsafe {
-            std::env::remove_var("NOVITA_BASE_URL");
-        }
         server.abort();
     }
 }

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -1816,6 +1816,10 @@ mod tests {
     }
 
     fn handler_with_kv(kv: Arc<MockKvStore>) -> WorkerEventHandler {
+        handler_with_kv_and_base_url(kv, "https://unused.example.com".to_string())
+    }
+
+    fn handler_with_kv_and_base_url(kv: Arc<MockKvStore>, base_url: String) -> WorkerEventHandler {
         handler_with_config(
             kv,
             Config {
@@ -1825,7 +1829,7 @@ mod tests {
                         config: Some(proto::llm_provider_config::Config::OpenaiCompatible(
                             proto::GenericConfig {
                                 name: "novita".to_string(),
-                                base_url: "https://unused.example.com".to_string(),
+                                base_url,
                                 model: "test-model".to_string(),
                                 api_key: Some(Secret {
                                     source: Some(proto::secret::Source::Plain(
@@ -3462,12 +3466,8 @@ mod tests {
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        unsafe {
-            std::env::set_var("NOVITA_BASE_URL", format!("http://{addr}"));
-        }
-
         let kv = Arc::new(MockKvStore::default());
-        let handler = handler_with_kv(kv.clone());
+        let handler = handler_with_kv_and_base_url(kv.clone(), format!("http://{addr}"));
         let spec = manifests::AgentSpec {
             features: Vec::new(),
             model_policy: None,
@@ -3654,9 +3654,6 @@ mod tests {
             .unwrap();
         assert_eq!(after_duplicate_keys.len(), before_duplicate_keys.len());
 
-        unsafe {
-            std::env::remove_var("NOVITA_BASE_URL");
-        }
         server.abort();
     }
 
@@ -3684,12 +3681,8 @@ mod tests {
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        unsafe {
-            std::env::set_var("NOVITA_BASE_URL", format!("http://{addr}"));
-        }
-
         let kv = Arc::new(MockKvStore::default());
-        let handler = handler_with_kv(kv.clone());
+        let handler = handler_with_kv_and_base_url(kv.clone(), format!("http://{addr}"));
         let spec = manifests::AgentSpec {
             features: Vec::new(),
             model_policy: None,
@@ -3781,9 +3774,6 @@ mod tests {
             Some(12)
         );
 
-        unsafe {
-            std::env::remove_var("NOVITA_BASE_URL");
-        }
         server.abort();
     }
 

--- a/src/worker/workflows.rs
+++ b/src/worker/workflows.rs
@@ -2555,6 +2555,14 @@ mod tests {
     }
 
     fn workflow_handler(kv: Arc<MockKvStore>, pubsub: Arc<RecordingPubSub>) -> WorkerEventHandler {
+        workflow_handler_with_base_url(kv, pubsub, "https://unused.example.com".to_string())
+    }
+
+    fn workflow_handler_with_base_url(
+        kv: Arc<MockKvStore>,
+        pubsub: Arc<RecordingPubSub>,
+        base_url: String,
+    ) -> WorkerEventHandler {
         WorkerEventHandler {
             cp: Arc::new(ControlPlane::builder(kv, pubsub).build()),
             config: Arc::new(Config {
@@ -2564,7 +2572,7 @@ mod tests {
                         config: Some(proto::llm_provider_config::Config::OpenaiCompatible(
                             proto::GenericConfig {
                                 name: "novita".to_string(),
-                                base_url: "https://unused.example.com".to_string(),
+                                base_url,
                                 model: "test-model".to_string(),
                                 api_key: Some(Secret {
                                     source: Some(proto::secret::Source::Plain(
@@ -2858,13 +2866,10 @@ Done."#,
                 .await
                 .expect("fake LLM should serve");
         });
-        unsafe {
-            std::env::set_var("NOVITA_BASE_URL", format!("http://{addr}"));
-        }
-
         let kv = Arc::new(MockKvStore::new());
         let pubsub = Arc::new(RecordingPubSub::default());
-        let handler = workflow_handler(kv.clone(), pubsub.clone());
+        let handler =
+            workflow_handler_with_base_url(kv.clone(), pubsub.clone(), format!("http://{addr}"));
         let workflow = crate::control::manifest::parse_workflow(
             r#"
 apiVersion: talon.impalasys.com/v1
@@ -3042,9 +3047,6 @@ spec:
             })
         );
 
-        unsafe {
-            std::env::remove_var("NOVITA_BASE_URL");
-        }
         server.abort();
     }
 
@@ -3789,13 +3791,10 @@ spec:
                 .await
                 .expect("fake LLM should serve");
         });
-        unsafe {
-            std::env::set_var("NOVITA_BASE_URL", format!("http://{addr}"));
-        }
-
         let kv = Arc::new(MockKvStore::new());
         let pubsub = Arc::new(RecordingPubSub::default());
-        let handler = workflow_handler(kv.clone(), pubsub.clone());
+        let handler =
+            workflow_handler_with_base_url(kv.clone(), pubsub.clone(), format!("http://{addr}"));
 
         let workflow = crate::control::manifest::parse_workflow(
             r#"
@@ -4060,9 +4059,6 @@ spec:
         assert!(event_types.iter().any(|event| event == "run_resumed"));
         assert!(event_types.iter().any(|event| event == "run_completed"));
 
-        unsafe {
-            std::env::remove_var("NOVITA_BASE_URL");
-        }
         server.abort();
     }
 

--- a/tests/test_delegation.py
+++ b/tests/test_delegation.py
@@ -2,6 +2,7 @@ import json
 import time
 import uuid
 
+import grpc
 from google.protobuf.struct_pb2 import ListValue, Value
 
 from e2e.blackbox import (
@@ -25,6 +26,26 @@ from talon_client.resources import A2A, Connection, ConnectionRef, InternalConne
 
 
 PART_TYPE_TOOL_RESULT = 4
+
+
+def _send_message_when_available(
+    client: TalonClient,
+    request: SendMessageRequest,
+    attempts: int = 15,
+    delay: float = 1.0,
+) -> None:
+    for attempt in range(attempts):
+        try:
+            client.sessions.SendMessage(request)
+            return
+        except grpc.RpcError as err:
+            if (
+                err.code() != grpc.StatusCode.RESOURCE_EXHAUSTED
+                or "currently generating" not in err.details()
+                or attempt == attempts - 1
+            ):
+                raise
+            time.sleep(delay)
 
 
 def _capability_values(*values: str) -> ListValue:
@@ -102,7 +123,8 @@ def test_delegate_task_creates_durable_child_session(
     owner_session_id = client.sessions.Create(
         CreateSessionRequest(agent="owner-agent", ns=owner_namespace)
     ).session_id
-    client.sessions.SendMessage(
+    _send_message_when_available(
+        client,
         SendMessageRequest(
             agent="owner-agent",
             session_id=owner_session_id,
@@ -245,7 +267,8 @@ def test_delegate_task_creates_durable_child_session(
 
     assert owner_woke, "owner was not woken when delegated Task became ready"
 
-    client.sessions.SendMessage(
+    _send_message_when_available(
+        client,
         SendMessageRequest(
             agent="owner-agent",
             session_id=owner_session_id,
@@ -368,7 +391,8 @@ def test_legal_document_refinement_delegation_returns_redline_artifact(
     coordinator_session_id = client.sessions.Create(
         CreateSessionRequest(agent="legal-coordinator-agent", ns=coordinator_namespace)
     ).session_id
-    client.sessions.SendMessage(
+    _send_message_when_available(
+        client,
         SendMessageRequest(
             agent="legal-coordinator-agent",
             session_id=coordinator_session_id,
@@ -470,7 +494,8 @@ def test_legal_document_refinement_delegation_returns_redline_artifact(
     else:
         raise AssertionError("coordinator was not woken with the redline artifact")
 
-    client.sessions.SendMessage(
+    _send_message_when_available(
+        client,
         SendMessageRequest(
             agent="legal-coordinator-agent",
             session_id=coordinator_session_id,
@@ -582,7 +607,8 @@ def test_delegated_final_text_artifact_tag_becomes_readable_task_output(
             ns=coordinator_namespace,
         )
     ).session_id
-    client.sessions.SendMessage(
+    _send_message_when_available(
+        client,
         SendMessageRequest(
             agent="inline-coordinator-agent",
             session_id=coordinator_session_id,
@@ -660,7 +686,8 @@ def test_delegated_final_text_artifact_tag_becomes_readable_task_output(
     else:
         raise AssertionError("coordinator was not woken with inline artifact URI")
 
-    client.sessions.SendMessage(
+    _send_message_when_available(
+        client,
         SendMessageRequest(
             agent="inline-coordinator-agent",
             session_id=coordinator_session_id,
@@ -800,7 +827,8 @@ def test_nested_policy_document_delegation_forwards_artifact_uri(
             ns=coordinator_namespace,
         )
     ).session_id
-    client.sessions.SendMessage(
+    _send_message_when_available(
+        client,
         SendMessageRequest(
             agent="policy-coordinator-agent",
             session_id=coordinator_session_id,


### PR DESCRIPTION
## Summary

- Remove env-variable base URL override behavior for OpenAI-compatible providers.
- OpenAI-compatible providers now always use the configured `base_url` / `baseUrl`.
- Allow provider `api_key` / `apiKey` to be omitted in YAML config so tenant deployments can rely on `Secret/api-keys` without dummy provider-level keys.
- Resolve tenant API keys from `Secret/api-keys` using the exact configured provider name.
- Update tests that previously relied on `NOVITA_BASE_URL` to configure their mock LLM endpoint directly.
- Make delegation E2E message sends tolerate the expected async session busy window that showed up in CI.

## Why

Provider endpoints are deployment configuration, not secrets. Keeping a second env-var path for base URLs made provider routing harder to reason about and allowed unrelated environment settings to silently redirect traffic. API keys remain secret-backed; base URLs stay in config.

The CI failure after the first push was not the provider resolver code. It was a Python E2E race where the test sent a follow-up message immediately after an async delegated session woke the coordinator. The server can still validly reject that with `RESOURCE_EXHAUSTED` while the session lock is settling. The test now waits for the session to accept the message instead of treating that transient state as a product failure.

## Tests

- `cargo fmt --check`
- `cargo test harness::llm::resolver::tests`
- `cargo test control::config::tests`
- `cargo test worker::sessions::tests::handle_session_message_`
- `cargo test worker::workflows::tests::workflow_filter_agent_gates_lorem_generator_reply`
- `cargo test worker::workflows::tests::complex_workflow_yaml_runs_end_to_end_with_mock_llm_agent_and_resume`
- `cargo test`
- `cargo build --locked --features aws,rocksdb --bins`
- `uv run --with-requirements tests/requirements.txt pytest -q 'tests/test_delegation.py::test_legal_document_refinement_delegation_returns_redline_artifact[aws-local]'`
