### PR TITLE
Add clickable resource URIs and split-pane viewer in talon-chat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5614,7 +5614,6 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "reqwest 0.12.28",
- "tokio",
  "tonic 0.12.3",
  "tonic-web",
 ]

--- a/packages/talon-chat/.storybook/preview.tsx
+++ b/packages/talon-chat/.storybook/preview.tsx
@@ -38,6 +38,9 @@ const preview: Preview = {
           ? "linear-gradient(to top, rgba(24,24,27,0.96), rgba(24,24,27,0.78) 58%, rgba(24,24,27,0))"
           : "linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0))",
         "--talon-chat-scrollbar-thumb": isDark ? "rgba(212,212,216,0.38)" : "rgba(113,113,122,0.52)",
+        "--talon-chat-link-fg": isDark ? "#34d399" : "#047857",
+        "--talon-chat-accent-fg": isDark ? "#34d399" : "#047857",
+        "--talon-chat-resource-pane-bg": isDark ? "#18181b" : "#ffffff",
         "--talon-chat-avatar-bg": isDark ? "#fafafa" : "#18181b",
         "--talon-chat-avatar-fg": isDark ? "#18181b" : "#ffffff",
         "--copilot-input-bg": isDark ? "rgba(39,39,42,0.94)" : "rgba(255,255,255,0.96)",

--- a/packages/talon-chat/README.md
+++ b/packages/talon-chat/README.md
@@ -152,6 +152,44 @@ talon-cli auth local-token \
 
 In production, mint frontend tokens through your trusted backend after OIDC-authenticated authorization.
 
+## Resource URIs
+
+Assistant and user messages can include Talon resource URIs:
+
+| Scheme | Format | Example |
+| --- | --- | --- |
+| Artifact | `artifact://<namespace>/<agent>/<session>/<artifact_id>` | `artifact://Tenant:acme:Ops/writer/sess-1/draft` |
+| File | `file://<namespace>/<file_name>` | `file://Tenant:acme:Ops/memory-brand-guidelines` |
+
+Bare URIs (and markdown links with those schemes) render as clickable links.
+In `TalonSession`, clicking a resource opens a **split pane** next to the chat
+when the gateway client exposes the matching service:
+
+```tsx
+const gatewayClient = createTalonClient({ baseUrl, authToken });
+// gatewayClient.artifacts and gatewayClient.files are used automatically.
+
+<TalonSession
+  namespace="support"
+  agent="docs"
+  gatewayClient={gatewayClient}
+  sessionId={sessionId}
+/>
+```
+
+- **Artifacts** load via `artifacts.readArtifact` (caller agent/session headers
+  are attached from the session props for owner reads).
+- **Files** load via `files.readFile` with `{ file: { uri } }`.
+- Hosts can take over with `onResourceClick` (no built-in pane) or override
+  loading with `fetchResource`.
+- `TalonChannel` linkifies and calls `onResourceClick` only; it does not open a
+  built-in pane yet.
+
+Helpers `parseResourceUri`, `isResourceUri`, and `linkifyResourceUris` are
+exported for host apps.
+
+OS-style paths like `file:///tmp/foo` are **not** treated as Talon file URIs.
+
 ## Storybook and Chromatic
 
 Run the component preview locally:

--- a/packages/talon-chat/package.json
+++ b/packages/talon-chat/package.json
@@ -39,7 +39,8 @@
     "prepack": "pnpm run build",
     "prebuild-storybook": "pnpm --dir ../../sdk/js/talon-client build",
     "screenshots": "node scripts/capture-storybook-screenshots.mjs",
-    "storybook": "storybook dev -p 6006"
+    "storybook": "storybook dev -p 6006",
+    "test": "node --experimental-strip-types --test src/lib/resourceUris.test.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/talon-chat/package.json
+++ b/packages/talon-chat/package.json
@@ -40,7 +40,10 @@
     "prebuild-storybook": "pnpm --dir ../../sdk/js/talon-client build",
     "screenshots": "node scripts/capture-storybook-screenshots.mjs",
     "storybook": "storybook dev -p 6006",
-    "test": "node --experimental-strip-types --test src/lib/resourceUris.test.ts"
+    "test": "node --experimental-strip-types --test \"src/**/*.test.{ts,tsx}\""
+  },
+  "engines": {
+    "node": ">=22.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/talon-chat/src/TalonChannel.stories.tsx
+++ b/packages/talon-chat/src/TalonChannel.stories.tsx
@@ -66,3 +66,41 @@ export const ReadOnly: Story = {
     disableUserInput: true,
   },
 };
+
+const resourceChannelMessages = [
+  {
+    id: "ch-resource-1",
+    authorKind: "agent",
+    author: "writer",
+    content:
+      "Posted draft artifact://Tenant:acme:Ops/writer/sess-1/final-draft and file://Tenant:acme:Ops/memory-brand-guidelines for review.\n\n" +
+      "Also a labeled link: [brand guidelines](file://Tenant:acme:Ops/memory-brand-guidelines).",
+    createdAt: "2026-06-05T16:20:00.000Z",
+    sourceAgent: "writer",
+    sourceSessionId: "sess-1",
+  },
+  {
+    id: "ch-resource-2",
+    authorKind: "user",
+    author: "sightline",
+    content: "Thanks — I'll open those from the session view.",
+    createdAt: "2026-06-05T16:21:00.000Z",
+  },
+];
+
+/** Channel messages linkify resource URIs; host receives onResourceClick (no built-in pane). */
+export const ResourceUris: Story = {
+  name: "Resource URIs (onResourceClick)",
+  args: {
+    gatewayClient: {
+      channels: {
+        listMessages: async () => ({ messages: resourceChannelMessages, hasMore: false }),
+        postMessage: async () => ({}),
+      },
+    },
+    onResourceClick: (uri: string) => {
+      window.alert(`channel onResourceClick: ${uri}`);
+    },
+    formatTimestamp: () => "Jun 5, 2026, 9:20 AM",
+  },
+};

--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -91,6 +91,11 @@ export type TalonChannelProps = {
   formatTimestamp?: (message: ChannelMessage) => string;
   renderMessageActions?: (message: ChannelMessage) => React.ReactNode;
   commands?: TalonChannelCommand[];
+  /**
+   * Called when an artifact:// or file:// link is clicked in a channel message.
+   * Channels do not open a built-in split pane in phase 1.
+   */
+  onResourceClick?: (uri: string) => void;
 };
 
 export type UseTalonChannelMessagesOptions = {
@@ -485,6 +490,7 @@ export function TalonChannel({
   formatTimestamp,
   renderMessageActions,
   commands,
+  onResourceClick,
 }: TalonChannelProps) {
   const [draft, setDraft] = useState("");
   const [isPosting, setIsPosting] = useState(false);
@@ -672,7 +678,7 @@ export function TalonChannel({
                       {messageActions ? <div style={{ marginLeft: "auto" }}>{messageActions}</div> : null}
                     </div>
                     <div style={{ marginTop: 8, whiteSpace: "normal", overflowWrap: "anywhere", fontSize: 14, lineHeight: 1.6 }}>
-                      <MarkdownMessage>{message.content || ""}</MarkdownMessage>
+                      <MarkdownMessage onResourceClick={onResourceClick}>{message.content || ""}</MarkdownMessage>
                     </div>
                   </div>
                 );

--- a/packages/talon-chat/src/TalonSession.stories.tsx
+++ b/packages/talon-chat/src/TalonSession.stories.tsx
@@ -82,11 +82,6 @@ const gatewayClient: GatewayClientLike = {
   sessions: {
     create: async () => ({ sessionId: "storybook-session" }),
     clear: async () => ({}),
-    get: async () => ({
-      sessionId: "storybook-session",
-      messages: fixedMessages,
-      state: "IDLE",
-    }),
     listMessages: async () => ({
       messages: fixedMessages,
       hasMore: false,
@@ -205,11 +200,6 @@ function createStreamingGatewayClient() {
         submitted = false;
         return {};
       },
-      get: async () => ({
-        sessionId: "storybook-streaming-session",
-        messages: submitted ? fixedMessages : [],
-        state: submitted ? "IDLE" : "RUNNING",
-      }),
       listMessages: async () => ({
         messages: submitted ? fixedMessages : [],
         hasMore: false,
@@ -271,6 +261,17 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+const waitForResourcePaneOpen: NonNullable<Story["play"]> = async ({ canvasElement }) => {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (canvasElement.querySelector('[data-testid="talon-resource-pane"][data-open="true"]')) {
+      return;
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 50));
+  }
+  throw new Error("Timed out waiting for resource pane to open");
+};
 
 export const ExistingSession: Story = {};
 
@@ -380,11 +381,6 @@ function createSessionClient(messages: typeof resourceCatalogMessages): GatewayC
   return {
     create: async () => ({ sessionId: "storybook-session" }),
     clear: async () => ({}),
-    get: async () => ({
-      sessionId: "storybook-session",
-      messages,
-      state: "IDLE",
-    }),
     listMessages: async () => ({
       messages,
       hasMore: false,
@@ -399,7 +395,7 @@ function createSessionClient(messages: typeof resourceCatalogMessages): GatewayC
 const resourceGatewayClient: GatewayClientLike = {
   sessions: createSessionClient(resourceCatalogMessages),
   artifacts: {
-    readArtifact: async ({ artifactUri }: { artifactUri: string }) => {
+    readArtifact: async ({ artifactUri }) => {
       if (artifactUri === ARTIFACT_DENIED_URI) {
         throw new Error("PermissionDenied: artifact access denied");
       }
@@ -460,7 +456,7 @@ const resourceGatewayClient: GatewayClientLike = {
     }),
   },
   files: {
-    readFile: async ({ file }: { file?: { uri?: string } }) => {
+    readFile: async ({ file }) => {
       const uri = file?.uri ?? "";
       if (uri === FILE_JSON_URI) {
         return {
@@ -550,11 +546,22 @@ export const ResourceUris: Story = {
 
 function AutoOpenResourceLink({ uri }: { uri: string }) {
   useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      const link = document.querySelector<HTMLAnchorElement>(`a[data-resource-uri="${uri}"], a[href="${uri}"]`);
-      link?.click();
-    }, 450);
-    return () => window.clearTimeout(timeoutId);
+    const selector = `a[data-resource-uri="${CSS.escape(uri)}"]`;
+    let cancelled = false;
+    const deadline = Date.now() + 5000;
+    const tick = () => {
+      if (cancelled) return;
+      const link = document.querySelector<HTMLAnchorElement>(selector);
+      if (link) {
+        link.click();
+        return;
+      }
+      if (Date.now() < deadline) window.setTimeout(tick, 50);
+    };
+    tick();
+    return () => {
+      cancelled = true;
+    };
   }, [uri]);
   return null;
 }
@@ -573,6 +580,7 @@ export const ResourcePaneMarkdownArtifact: Story = {
       <TalonSession {...args} />
     </ResourceSessionFrame>
   ),
+  play: waitForResourcePaneOpen,
 };
 
 /** Auto-opens a markdown file URI. */
@@ -589,6 +597,7 @@ export const ResourcePaneMarkdownFile: Story = {
       <TalonSession {...args} />
     </ResourceSessionFrame>
   ),
+  play: waitForResourcePaneOpen,
 };
 
 /** Auto-opens JSON content rendered as monospace pre. */
@@ -604,6 +613,7 @@ export const ResourcePaneJson: Story = {
       <TalonSession {...args} />
     </ResourceSessionFrame>
   ),
+  play: waitForResourcePaneOpen,
 };
 
 /** Auto-opens image/* content. */
@@ -619,6 +629,7 @@ export const ResourcePaneImage: Story = {
       <TalonSession {...args} />
     </ResourceSessionFrame>
   ),
+  play: waitForResourcePaneOpen,
 };
 
 /** Auto-opens binary resource with download affordance. */
@@ -634,6 +645,7 @@ export const ResourcePaneBinaryDownload: Story = {
       <TalonSession {...args} />
     </ResourceSessionFrame>
   ),
+  play: waitForResourcePaneOpen,
 };
 
 /** Access denied error state in the pane. */
@@ -649,6 +661,7 @@ export const ResourcePaneAccessDenied: Story = {
       <TalonSession {...args} />
     </ResourceSessionFrame>
   ),
+  play: waitForResourcePaneOpen,
 };
 
 /** Slow fetch shows the loading state, then content. */
@@ -664,6 +677,7 @@ export const ResourcePaneLoading: Story = {
       <TalonSession {...args} />
     </ResourceSessionFrame>
   ),
+  play: waitForResourcePaneOpen,
 };
 
 /** Host owns open/view via onResourceClick (no built-in pane). */

--- a/packages/talon-chat/src/TalonSession.stories.tsx
+++ b/packages/talon-chat/src/TalonSession.stories.tsx
@@ -312,3 +312,392 @@ export const StreamingResponse: Story = {
     );
   },
 };
+
+const encoder = new TextEncoder();
+
+const ARTIFACT_MD_URI = "artifact://Tenant:acme:Ops/writer/storybook-session/final-draft";
+const ARTIFACT_JSON_URI = "artifact://Tenant:acme:Ops/writer/storybook-session/metrics-json";
+const ARTIFACT_TEXT_URI = "artifact://Tenant:acme:Ops/writer/storybook-session/plain-notes";
+const ARTIFACT_DENIED_URI = "artifact://Tenant:acme:Ops/writer/storybook-session/secret";
+const ARTIFACT_SLOW_URI = "artifact://Tenant:acme:Ops/writer/storybook-session/slow-draft";
+const FILE_MD_URI = "file://Tenant:acme:Ops/memory-brand-guidelines";
+const FILE_JSON_URI = "file://Tenant:acme:Ops/config-snapshot";
+const FILE_IMAGE_URI = "file://Tenant:acme:Ops/diagram-png";
+const FILE_BINARY_URI = "file://Tenant:acme:Ops/export-bin";
+
+// 1x1 green PNG
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+function tinyPngBytes() {
+  const binary = atob(TINY_PNG_BASE64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+const resourceCatalogMessages = [
+  {
+    id: "resource-user-1",
+    role: "ROLE_USER",
+    parts: [{ type: "text", text: "Show me the draft, guidelines, and other sample resources." }],
+    createdAt: "2026-06-05T16:20:00.000Z",
+  },
+  {
+    id: "resource-assistant-1",
+    role: "ROLE_ASSISTANT",
+    parts: [
+      {
+        type: "text",
+        text: [
+          "### Markdown resources",
+          "",
+          `- Artifact draft: ${ARTIFACT_MD_URI}`,
+          `- Promoted file: ${FILE_MD_URI}`,
+          `- Labeled link: [open draft](${ARTIFACT_MD_URI})`,
+          "",
+          "### Other media types",
+          "",
+          `- JSON artifact: ${ARTIFACT_JSON_URI}`,
+          `- Plain text: ${ARTIFACT_TEXT_URI}`,
+          `- JSON file: ${FILE_JSON_URI}`,
+          `- Image file: ${FILE_IMAGE_URI}`,
+          `- Binary download: ${FILE_BINARY_URI}`,
+          "",
+          "### Errors / latency",
+          "",
+          `- Access denied: ${ARTIFACT_DENIED_URI}`,
+          `- Slow load (1.2s): ${ARTIFACT_SLOW_URI}`,
+          "",
+          "Bare URIs and markdown links both open the split pane. Click the same URI again to close.",
+        ].join("\n"),
+      },
+    ],
+    createdAt: "2026-06-05T16:20:08.000Z",
+  },
+];
+
+function createSessionClient(messages: typeof resourceCatalogMessages): GatewayClientLike["sessions"] {
+  return {
+    create: async () => ({ sessionId: "storybook-session" }),
+    clear: async () => ({}),
+    get: async () => ({
+      sessionId: "storybook-session",
+      messages,
+      state: "IDLE",
+    }),
+    listMessages: async () => ({
+      messages,
+      hasMore: false,
+      state: "IDLE",
+    }),
+    submitTurn: async function* () {},
+    streamParts: async function* () {},
+    stopGeneration: async () => ({}),
+  };
+}
+
+const resourceGatewayClient: GatewayClientLike = {
+  sessions: createSessionClient(resourceCatalogMessages),
+  artifacts: {
+    readArtifact: async ({ artifactUri }: { artifactUri: string }) => {
+      if (artifactUri === ARTIFACT_DENIED_URI) {
+        throw new Error("PermissionDenied: artifact access denied");
+      }
+      if (artifactUri === ARTIFACT_SLOW_URI) {
+        await delay(1200);
+        return {
+          artifact: {
+            id: "slow-draft",
+            title: "Slow draft",
+            mediaType: "text/markdown",
+          },
+          content: encoder.encode("# Slow draft\n\nLoaded after a short delay for the loading state.\n"),
+          signedUrl: "",
+        };
+      }
+      if (artifactUri === ARTIFACT_JSON_URI) {
+        return {
+          artifact: {
+            id: "metrics-json",
+            title: "Metrics snapshot",
+            mediaType: "application/json",
+          },
+          content: encoder.encode(JSON.stringify({ p99_ms: 42, error_rate: 0.001, region: "us-west" }, null, 2)),
+          signedUrl: "",
+        };
+      }
+      if (artifactUri === ARTIFACT_TEXT_URI) {
+        return {
+          artifact: {
+            id: "plain-notes",
+            title: "Plain notes",
+            mediaType: "text/plain",
+          },
+          content: encoder.encode("line 1\nline 2\nno markdown rendering here\n"),
+          signedUrl: "",
+        };
+      }
+      return {
+        artifact: {
+          id: "final-draft",
+          title: "Final draft",
+          mediaType: "text/markdown",
+          sessionId: "storybook-session",
+          createdByAgent: "writer",
+        },
+        content: encoder.encode(
+          `# Final draft\n\nThis mock artifact was opened from \`${artifactUri}\`.\n\n- Item one\n- Item two\n\nNested link: ${FILE_MD_URI}\n`,
+        ),
+        signedUrl: "",
+      };
+    },
+    getArtifactMetadata: async () => ({
+      artifact: {
+        id: "final-draft",
+        title: "Final draft",
+        mediaType: "text/markdown",
+      },
+    }),
+  },
+  files: {
+    readFile: async ({ file }: { file?: { uri?: string } }) => {
+      const uri = file?.uri ?? "";
+      if (uri === FILE_JSON_URI) {
+        return {
+          file: {
+            metadata: { name: "config-snapshot", namespace: "Tenant:acme:Ops" },
+            spec: { path: "/exports/config.json", mediaType: "application/json" },
+          },
+          content: encoder.encode(JSON.stringify({ featureFlags: { resourcePane: true }, version: 3 }, null, 2)),
+          signedUrl: "",
+        };
+      }
+      if (uri === FILE_IMAGE_URI) {
+        return {
+          file: {
+            metadata: { name: "diagram-png", namespace: "Tenant:acme:Ops" },
+            spec: { path: "/assets/diagram.png", mediaType: "image/png" },
+          },
+          content: tinyPngBytes(),
+          signedUrl: "",
+        };
+      }
+      if (uri === FILE_BINARY_URI) {
+        return {
+          file: {
+            metadata: { name: "export-bin", namespace: "Tenant:acme:Ops" },
+            spec: { path: "/exports/blob.bin", mediaType: "application/octet-stream" },
+          },
+          content: new Uint8Array([0, 1, 2, 3, 4, 5]),
+          signedUrl: "https://example.com/mock-download/export.bin",
+        };
+      }
+      return {
+        file: {
+          metadata: { name: "memory-brand-guidelines", namespace: "Tenant:acme:Ops" },
+          spec: {
+            path: "/memory/brand-guidelines.md",
+            mediaType: "text/markdown",
+          },
+        },
+        content: encoder.encode(
+          `# Brand guidelines\n\nUse plain language.\n\nOpened from \`${uri}\`.\n`,
+        ),
+        signedUrl: "",
+      };
+    },
+    getFileMetadata: async () => ({
+      file: {
+        metadata: { name: "memory-brand-guidelines" },
+        spec: { path: "/memory/brand-guidelines.md", mediaType: "text/markdown" },
+      },
+    }),
+  },
+};
+
+function ResourceSessionFrame(props: { children: React.ReactNode; maxWidth?: number }) {
+  return (
+    <div style={{ height: "100%", padding: 24, overflow: "hidden" }}>
+      <div
+        style={{
+          height: "min(720px, calc(100vh - 48px))",
+          maxWidth: props.maxWidth ?? 960,
+          margin: "0 auto",
+          border: "1px dotted var(--talon-chat-border, rgba(212,212,216,0.7))",
+          background: "var(--talon-chat-surface, #fff)",
+        }}
+      >
+        {props.children}
+      </div>
+    </div>
+  );
+}
+
+/** Click bare + labeled artifact:// and file:// URIs; pane opens beside chat. */
+export const ResourceUris: Story = {
+  name: "Resource URIs (click to open pane)",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+    placeholder: "Click a resource URI in the assistant message...",
+  },
+  render: (args) => (
+    <ResourceSessionFrame>
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+function AutoOpenResourceLink({ uri }: { uri: string }) {
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      const link = document.querySelector<HTMLAnchorElement>(`a[data-resource-uri="${uri}"], a[href="${uri}"]`);
+      link?.click();
+    }, 450);
+    return () => window.clearTimeout(timeoutId);
+  }, [uri]);
+  return null;
+}
+
+/** Auto-opens a markdown artifact so the split pane is visible without clicking. */
+export const ResourcePaneMarkdownArtifact: Story = {
+  name: "Resource pane · markdown artifact",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+    placeholder: "Resource pane preview...",
+  },
+  render: (args) => (
+    <ResourceSessionFrame>
+      <AutoOpenResourceLink uri={ARTIFACT_MD_URI} />
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+/** Auto-opens a markdown file URI. */
+export const ResourcePaneMarkdownFile: Story = {
+  name: "Resource pane · markdown file",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+    placeholder: "Resource pane preview...",
+  },
+  render: (args) => (
+    <ResourceSessionFrame>
+      <AutoOpenResourceLink uri={FILE_MD_URI} />
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+/** Auto-opens JSON content rendered as monospace pre. */
+export const ResourcePaneJson: Story = {
+  name: "Resource pane · JSON",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+  },
+  render: (args) => (
+    <ResourceSessionFrame>
+      <AutoOpenResourceLink uri={ARTIFACT_JSON_URI} />
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+/** Auto-opens image/* content. */
+export const ResourcePaneImage: Story = {
+  name: "Resource pane · image",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+  },
+  render: (args) => (
+    <ResourceSessionFrame>
+      <AutoOpenResourceLink uri={FILE_IMAGE_URI} />
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+/** Auto-opens binary resource with download affordance. */
+export const ResourcePaneBinaryDownload: Story = {
+  name: "Resource pane · binary download",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+  },
+  render: (args) => (
+    <ResourceSessionFrame>
+      <AutoOpenResourceLink uri={FILE_BINARY_URI} />
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+/** Access denied error state in the pane. */
+export const ResourcePaneAccessDenied: Story = {
+  name: "Resource pane · access denied",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+  },
+  render: (args) => (
+    <ResourceSessionFrame>
+      <AutoOpenResourceLink uri={ARTIFACT_DENIED_URI} />
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+/** Slow fetch shows the loading state, then content. */
+export const ResourcePaneLoading: Story = {
+  name: "Resource pane · loading",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+  },
+  render: (args) => (
+    <ResourceSessionFrame>
+      <AutoOpenResourceLink uri={ARTIFACT_SLOW_URI} />
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+/** Host owns open/view via onResourceClick (no built-in pane). */
+export const ResourceUrisHostCallback: Story = {
+  name: "Resource URIs · host onResourceClick",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+    placeholder: "Clicks call onResourceClick only...",
+    onResourceClick: (uri: string) => {
+      // Storybook actions panel alternative for local preview
+      window.alert(`onResourceClick: ${uri}`);
+    },
+  },
+  render: (args) => (
+    <ResourceSessionFrame maxWidth={560}>
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+/** Styled links only — no artifacts/files client and no callback. */
+export const ResourceUrisNoClient: Story = {
+  name: "Resource URIs · styled only (no client)",
+  args: {
+    gatewayClient: {
+      sessions: createSessionClient(resourceCatalogMessages),
+    },
+    sessionId: "storybook-session",
+    placeholder: "Links are styled but pane cannot open...",
+  },
+  render: (args) => (
+    <ResourceSessionFrame maxWidth={560}>
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -214,20 +214,34 @@ function resourceCallHeaders(agent: string, sessionId: string | null | undefined
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
+/** Strict base64 shape: length multiple of 4 and only base64 alphabet + padding. */
+const BASE64_CONTENT_RE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+function looksLikeBase64(value: string): boolean {
+  if (value.length === 0 || value.length % 4 !== 0) return false;
+  // Avoid treating short plain words as base64 (e.g. "test" is valid alphabet).
+  if (value.length < 16) return false;
+  return BASE64_CONTENT_RE.test(value);
+}
+
 function bytesFromContent(content: unknown): Uint8Array | undefined {
   if (content == null) return undefined;
   if (content instanceof Uint8Array) return content;
   if (typeof content === "string") {
     if (content.length === 0) return new Uint8Array(0);
-    // Connect JSON may base64-encode bytes; try UTF-8 first for plain text mocks.
-    try {
-      const binary = atob(content);
-      const bytes = new Uint8Array(binary.length);
-      for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
-      return bytes;
-    } catch {
-      return new TextEncoder().encode(content);
+    // Connect JSON may base64-encode bytes. Only decode when the string looks like
+    // base64; otherwise treat as literal UTF-8 text (mocks and plain responses).
+    if (looksLikeBase64(content)) {
+      try {
+        const binary = atob(content);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+        return bytes;
+      } catch {
+        // Fall through to UTF-8 if padded base64 shape still fails to decode.
+      }
     }
+    return new TextEncoder().encode(content);
   }
   if (ArrayBuffer.isView(content)) {
     return new Uint8Array(content.buffer, content.byteOffset, content.byteLength);

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -23,6 +23,11 @@ import {
   type TalonChatCommand,
 } from "./lib/commands";
 import { MarkdownMessage } from "./lib/MarkdownMessage";
+import { ResourcePane } from "./lib/ResourcePane";
+import {
+  parseResourceUri,
+  type ResourceViewModel,
+} from "./lib/resourceUris";
 import { streamSessionPartEvents, type StreamEventItem } from "./lib/uiStream";
 
 const useSafeLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
@@ -42,10 +47,24 @@ export type SessionServiceClientLike = {
 
 export type CasServiceClientLike = Pick<TalonClient["cas"], "getObject">;
 
+export type ArtifactServiceClientLike = Pick<
+  TalonClient["artifacts"],
+  "readArtifact" | "getArtifactMetadata"
+>;
+
+export type FileServiceClientLike = Pick<
+  TalonClient["files"],
+  "readFile" | "getFileMetadata"
+>;
+
 export type GatewayClientLike = {
   sessions: SessionServiceClientLike;
   cas?: CasServiceClientLike;
+  artifacts?: ArtifactServiceClientLike;
+  files?: FileServiceClientLike;
 };
+
+export type { ResourceViewModel };
 
 export type TalonSessionCommandTarget = {
   type: "session";
@@ -156,6 +175,15 @@ export type TalonSessionProps = {
   allowMessageEditing?: boolean;
   onMessageEdit?: (context: TalonSessionMessageEditContext) => Promise<boolean | void> | boolean | void;
   enableDebugMessageEditing?: boolean;
+  /**
+   * Called when an artifact:// or file:// link is clicked.
+   * If omitted, the built-in split pane opens when the matching client is available.
+   */
+  onResourceClick?: (uri: string) => void;
+  /**
+   * Override content fetch for the built-in resource pane (both kinds).
+   */
+  fetchResource?: (uri: string, signal: AbortSignal) => Promise<ResourceViewModel>;
 };
 
 export type TalonCopilotProps = TalonSessionProps;
@@ -174,6 +202,112 @@ const CONNECTOR_DELIVERY_SKIPPED = "skipped";
 
 function border(color: string) {
   return `1px solid ${color}`;
+}
+
+const HANDLE_CALLER_AGENT_HEADER = "x-talon-agent";
+const HANDLE_CALLER_SESSION_HEADER = "x-talon-session-id";
+
+function resourceCallHeaders(agent: string, sessionId: string | null | undefined) {
+  const headers: Record<string, string> = {};
+  if (agent) headers[HANDLE_CALLER_AGENT_HEADER] = agent;
+  if (sessionId) headers[HANDLE_CALLER_SESSION_HEADER] = sessionId;
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+function bytesFromContent(content: unknown): Uint8Array | undefined {
+  if (content == null) return undefined;
+  if (content instanceof Uint8Array) return content;
+  if (typeof content === "string") {
+    if (content.length === 0) return new Uint8Array(0);
+    // Connect JSON may base64-encode bytes; try UTF-8 first for plain text mocks.
+    try {
+      const binary = atob(content);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+      return bytes;
+    } catch {
+      return new TextEncoder().encode(content);
+    }
+  }
+  if (ArrayBuffer.isView(content)) {
+    return new Uint8Array(content.buffer, content.byteOffset, content.byteLength);
+  }
+  return undefined;
+}
+
+async function fetchResourceFromGateway(options: {
+  uri: string;
+  gatewayClient: GatewayClientLike;
+  agent: string;
+  sessionId: string | null;
+  signal: AbortSignal;
+}): Promise<ResourceViewModel> {
+  const { uri, gatewayClient, agent, sessionId, signal } = options;
+  const parsed = parseResourceUri(uri);
+  if (!parsed) {
+    throw new Error(`Unsupported resource URI: ${uri}`);
+  }
+
+  const headers = resourceCallHeaders(agent, sessionId);
+  const callOptions = {
+    signal,
+    ...(headers ? { headers } : {}),
+  };
+
+  if (parsed.kind === "artifact") {
+    const artifacts = gatewayClient.artifacts;
+    if (!artifacts?.readArtifact) {
+      throw new Error("Gateway client does not expose artifacts.readArtifact().");
+    }
+    const response = await (artifacts.readArtifact as any)(
+      { artifactUri: parsed.uri },
+      callOptions,
+    );
+    const artifact = response?.artifact ?? {};
+    const mediaType =
+      artifact.mediaType || artifact.media_type || "application/octet-stream";
+    const title =
+      (typeof artifact.title === "string" && artifact.title) || parsed.artifactId;
+    return {
+      kind: "artifact",
+      uri: parsed.uri,
+      title,
+      mediaType,
+      content: bytesFromContent(response?.content),
+      signedUrl: response?.signedUrl || response?.signed_url || undefined,
+      sessionId: parsed.sessionId,
+      agent: parsed.agent,
+    };
+  }
+
+  const files = gatewayClient.files;
+  if (!files?.readFile) {
+    throw new Error("Gateway client does not expose files.readFile().");
+  }
+  const response = await (files.readFile as any)(
+    { file: { uri: parsed.uri } },
+    callOptions,
+  );
+  const file = response?.file ?? {};
+  const meta = file.metadata ?? {};
+  const spec = file.spec ?? {};
+  const mediaType =
+    spec.mediaType ||
+    spec.media_type ||
+    "application/octet-stream";
+  const title =
+    (typeof meta.name === "string" && meta.name) ||
+    (typeof spec.path === "string" && spec.path.split("/").filter(Boolean).pop()) ||
+    parsed.fileName;
+  return {
+    kind: "file",
+    uri: parsed.uri,
+    title,
+    mediaType,
+    content: bytesFromContent(response?.content),
+    signedUrl: response?.signedUrl || response?.signed_url || undefined,
+    path: typeof spec.path === "string" ? spec.path : undefined,
+  };
 }
 
 const talonChatFontFamily =
@@ -826,6 +960,8 @@ export function TalonSession({
   allowMessageEditing = false,
   onMessageEdit,
   enableDebugMessageEditing = false,
+  onResourceClick: onResourceClickProp,
+  fetchResource,
 }: TalonSessionProps) {
   const [messages, setMessages] = useState<CopilotMessage[]>(emptyMessages);
   const [input, setInput] = useState("");
@@ -837,6 +973,14 @@ export function TalonSession({
   const [streamEvents, setStreamEvents] = useState<StreamEventItem[]>([]);
   const [expandedThinkingMessages, setExpandedThinkingMessages] = useState<Record<string, boolean>>({});
   const [expandedToolItems, setExpandedToolItems] = useState<Record<string, boolean>>({});
+  const [openResourceUri, setOpenResourceUri] = useState<string | null>(null);
+  /** False while the pane plays its close transition before unmount. */
+  const [resourcePaneOpen, setResourcePaneOpen] = useState(false);
+  const [resourceView, setResourceView] = useState<ResourceViewModel | null>(null);
+  const [resourceLoading, setResourceLoading] = useState(false);
+  const [resourceError, setResourceError] = useState<Error | null>(null);
+  const resourceAbortRef = useRef<AbortController | null>(null);
+  const missingResourceClientWarnedRef = useRef(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingMessageValue, setEditingMessageValue] = useState("");
   const [reviewActionMessageId, setReviewActionMessageId] = useState<string | null>(null);
@@ -1092,6 +1236,118 @@ export function TalonSession({
     [updateSessionMessage],
   );
 
+  const loadResource = useCallback(
+    async (uri: string) => {
+      resourceAbortRef.current?.abort();
+      const controller = new AbortController();
+      resourceAbortRef.current = controller;
+      setResourceLoading(true);
+      setResourceError(null);
+      setResourceView(null);
+
+      try {
+        let view: ResourceViewModel;
+        if (fetchResource) {
+          view = await fetchResource(uri, controller.signal);
+        } else {
+          view = await fetchResourceFromGateway({
+            uri,
+            gatewayClient,
+            agent,
+            sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null,
+            signal: controller.signal,
+          });
+        }
+        if (controller.signal.aborted) return;
+        setResourceView(view);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setResourceError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!controller.signal.aborted) {
+          setResourceLoading(false);
+        }
+      }
+    },
+    [agent, fetchResource, gatewayClient, sessionId],
+  );
+
+  const clearResourcePaneState = useCallback(() => {
+    resourceAbortRef.current?.abort();
+    resourceAbortRef.current = null;
+    setOpenResourceUri(null);
+    setResourcePaneOpen(false);
+    setResourceView(null);
+    setResourceError(null);
+    setResourceLoading(false);
+  }, []);
+
+  const closeResourcePane = useCallback(() => {
+    // Animate closed; unmount after ResourcePane fires onExitComplete.
+    resourceAbortRef.current?.abort();
+    resourceAbortRef.current = null;
+    setResourcePaneOpen(false);
+  }, []);
+
+  const handleResourcePaneExitComplete = useCallback(() => {
+    setOpenResourceUri(null);
+    setResourceView(null);
+    setResourceError(null);
+    setResourceLoading(false);
+  }, []);
+
+  const handleResourceClick = useCallback(
+    (uri: string) => {
+      if (onResourceClickProp) {
+        onResourceClickProp(uri);
+        return;
+      }
+
+      const parsed = parseResourceUri(uri);
+      if (!parsed) return;
+
+      if (openResourceUri === parsed.uri && resourcePaneOpen) {
+        closeResourcePane();
+        return;
+      }
+
+      const canFetchArtifact =
+        Boolean(fetchResource) || Boolean(gatewayClient?.artifacts?.readArtifact);
+      const canFetchFile = Boolean(fetchResource) || Boolean(gatewayClient?.files?.readFile);
+      const canOpen =
+        (parsed.kind === "artifact" && canFetchArtifact) ||
+        (parsed.kind === "file" && canFetchFile);
+
+      if (!canOpen) {
+        if (!missingResourceClientWarnedRef.current && typeof console !== "undefined") {
+          missingResourceClientWarnedRef.current = true;
+          console.warn(
+            "[talon-chat] Resource link clicked but no artifacts/files client (or fetchResource) is available.",
+          );
+        }
+        return;
+      }
+
+      setOpenResourceUri(parsed.uri);
+      setResourcePaneOpen(true);
+      void loadResource(parsed.uri);
+    },
+    [
+      closeResourcePane,
+      fetchResource,
+      gatewayClient,
+      loadResource,
+      onResourceClickProp,
+      openResourceUri,
+      resourcePaneOpen,
+    ],
+  );
+
+  // Reset open resource pane when the session identity changes.
+  useEffect(() => {
+    clearResourcePaneState();
+  }, [namespace, agent, sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const copyMessageContent = useCallback(async (message: CopilotMessage) => {
     const nextContent = editableMessageContent(message);
     if (!nextContent.trim()) {
@@ -1242,7 +1498,7 @@ export function TalonSession({
                       if (item.type === "text") {
                         return (
                           <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-assistant-fg, inherit)" }}>
-                            <MarkdownMessage>{item.text}</MarkdownMessage>
+                            <MarkdownMessage onResourceClick={handleResourceClick}>{item.text}</MarkdownMessage>
                           </div>
                         );
                       }
@@ -1465,7 +1721,7 @@ export function TalonSession({
                       if (item.type === "text") {
                         return (
                           <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "normal", overflowWrap: "anywhere" }}>
-                            <MarkdownMessage>{item.text}</MarkdownMessage>
+                            <MarkdownMessage onResourceClick={handleResourceClick}>{item.text}</MarkdownMessage>
                           </div>
                         );
                       }
@@ -1550,7 +1806,9 @@ export function TalonSession({
                     })}
                   </div>
                 ) : (
-                  message.role === "assistant" ? <MarkdownMessage>{content}</MarkdownMessage> : content
+                  message.role === "assistant" ? (
+                    <MarkdownMessage onResourceClick={handleResourceClick}>{content}</MarkdownMessage>
+                  ) : content
                 )}
               </div>
             )}
@@ -1667,7 +1925,7 @@ export function TalonSession({
         </div>
       );
     });
-  }, [allowMessageEditing, cancelEditingMessage, copyMessageContent, editingMessageId, editingMessageValue, enableDebugMessageEditing, expandedThinkingMessages, expandedToolItems, isLoading, loadingNow, loadingStartedAt, messages, objectUrlForRef, reviewActionMessageId, saveEditingMessage, startEditingMessage, toggleThinkingMessage, toggleToolItem, updateConnectorDeliveryStatus]);
+  }, [allowMessageEditing, cancelEditingMessage, copyMessageContent, editingMessageId, editingMessageValue, enableDebugMessageEditing, expandedThinkingMessages, expandedToolItems, handleResourceClick, isLoading, loadingNow, loadingStartedAt, messages, objectUrlForRef, reviewActionMessageId, saveEditingMessage, startEditingMessage, toggleThinkingMessage, toggleToolItem, updateConnectorDeliveryStatus]);
 
   const resolvedHistoryPageSize = Math.max(
     1,
@@ -1893,6 +2151,8 @@ export function TalonSession({
   const clearLocalSession = useCallback(() => {
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
+    resourceAbortRef.current?.abort();
+    resourceAbortRef.current = null;
     setMessages(emptyMessages);
     messagesRef.current = emptyMessages;
     setStreamEvents([]);
@@ -1903,6 +2163,10 @@ export function TalonSession({
     setLoadingStartedAt(null);
     setExpandedThinkingMessages({});
     setExpandedToolItems({});
+    setOpenResourceUri(null);
+    setResourceView(null);
+    setResourceError(null);
+    setResourceLoading(false);
     autoScrollPinnedRef.current = true;
   }, []);
 
@@ -2370,111 +2634,148 @@ export function TalonSession({
           }
         `}
       </style>
-      <div style={{ position: "relative", flex: 1, minHeight: 0 }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flex: 1,
+          minHeight: 0,
+          minWidth: 0,
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
         <div
-          className="talon-session-transcript"
-          data-testid="copilot-transcript"
-          ref={scrollContainerRef}
-          onScroll={handleTranscriptScroll}
-          style={{ height: "100%", overflowY: "auto", overflowX: "hidden", minHeight: 0 }}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            // Fills remaining space so chat + pane land at an even 50/50 when open.
+            flex: "1 1 auto",
+            minWidth: 0,
+            minHeight: 0,
+            transition: "flex 280ms cubic-bezier(0.22, 1, 0.36, 1)",
+          }}
         >
-          <div style={{ maxWidth: 896, margin: "0 auto", padding: "1.5rem", display: "flex", flexDirection: "column", gap: "2rem" }}>
-          {renderedMessages}
+          <div style={{ position: "relative", flex: 1, minHeight: 0 }}>
+            <div
+              className="talon-session-transcript"
+              data-testid="copilot-transcript"
+              ref={scrollContainerRef}
+              onScroll={handleTranscriptScroll}
+              style={{ height: "100%", overflowY: "auto", overflowX: "hidden", minHeight: 0 }}
+            >
+              <div style={{ maxWidth: 896, margin: "0 auto", padding: "1.5rem", display: "flex", flexDirection: "column", gap: "2rem" }}>
+              {renderedMessages}
 
-          {isLoading && messages[messages.length - 1]?.role === "user" ? (
-            <div style={{ width: "100%" }}>
-              <div style={{ fontSize: 13, fontWeight: 500, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                {formatWorkingDuration(loadingStartedAt, loadingNow)}
+              {isLoading && messages[messages.length - 1]?.role === "user" ? (
+                <div style={{ width: "100%" }}>
+                  <div style={{ fontSize: 13, fontWeight: 500, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                    {formatWorkingDuration(loadingStartedAt, loadingNow)}
+                  </div>
+                </div>
+              ) : null}
+
+              {error ? (
+                <div style={{ display: "flex", gap: "1rem" }}>
+                  <div style={{ flexShrink: 0 }}>
+                    <div style={{ width: 24, height: 24, borderRadius: 999, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(254,226,226,1)", border: border("rgba(252,165,165,1)") }}>
+                      <Activity size="14" color="rgba(220,38,38,1)" strokeWidth={1.75} />
+                    </div>
+                  </div>
+                  <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: "rgba(220,38,38,1)" }}>System Incident</span>
+                    <div style={{ fontSize: 13, borderRadius: 10, background: "rgba(254,242,242,1)", border: border("rgba(252,165,165,0.6)"), color: "rgba(220,38,38,1)", padding: 12, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>
+                      {error.message || "An error occurred while connecting to the agent."}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+              <div ref={bottomRef} />
               </div>
             </div>
-          ) : null}
-
-          {error ? (
-            <div style={{ display: "flex", gap: "1rem" }}>
-              <div style={{ flexShrink: 0 }}>
-                <div style={{ width: 24, height: 24, borderRadius: 999, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(254,226,226,1)", border: border("rgba(252,165,165,1)") }}>
-                  <Activity size="14" color="rgba(220,38,38,1)" strokeWidth={1.75} />
-                </div>
-              </div>
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
-                <span style={{ fontSize: 13, fontWeight: 600, color: "rgba(220,38,38,1)" }}>System Incident</span>
-                <div style={{ fontSize: 13, borderRadius: 10, background: "rgba(254,242,242,1)", border: border("rgba(252,165,165,0.6)"), color: "rgba(220,38,38,1)", padding: 12, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>
-                  {error.message || "An error occurred while connecting to the agent."}
-                </div>
-              </div>
-            </div>
-          ) : null}
-          <div ref={bottomRef} />
+            {scrollThumb.visible ? (
+              <div
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  top: scrollThumb.top,
+                  right: 2,
+                  width: 5,
+                  height: scrollThumb.height,
+                  borderRadius: 999,
+                  background: "var(--talon-chat-scrollbar-thumb, rgba(113,113,122,0.52))",
+                  pointerEvents: "none",
+                }}
+              />
+            ) : null}
           </div>
+
+          {disabled ? null : (
+            <div
+              style={{
+                position: "sticky",
+                bottom: 0,
+                zIndex: 10,
+                flexShrink: 0,
+                display: "flex",
+                justifyContent: "center",
+                width: "100%",
+                boxSizing: "border-box",
+                padding: "1.5rem",
+                background: "var(--talon-chat-composer-bg, linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0)))",
+                backdropFilter: "blur(10px)",
+              }}
+            >
+              <div style={{ width: "100%", maxWidth: "var(--talon-chat-composer-max-width, 896px)", paddingBottom: 8 }}>
+                <TalonChatComposer
+                  value={input}
+                  onValueChange={setInput}
+                  onSubmit={(nextInput) => void submitMessage(nextInput)}
+                  placeholder={placeholder}
+                  variant={composerVariant}
+                  autoFocus={autoFocus}
+                  rows={inputRows}
+                  canSubmit={Boolean((input || "").trim() || imageAttachments.length > 0) && !isLoading}
+                  isGenerating={isLoading}
+                  canStop={Boolean(currentSession)}
+                  commandMenuItems={commandMenuItems}
+                  startAdornment={composerStartAdornment}
+                  endAdornment={composerEndAdornment}
+                  imageAttachments={imageAttachments.map((attachment) => ({
+                    id: attachment.id,
+                    filename: attachment.file.name,
+                    previewUrl: attachment.previewUrl,
+                    status: attachment.status,
+                    error: attachment.error,
+                  }))}
+                  imageUploadEnabled={Boolean(onImageUpload)}
+                  imageAccept={imageAccept}
+                  onImageFilesSelected={addImageFiles}
+                  onRemoveImageAttachment={removeImageAttachment}
+                  onStop={() => {
+                    void stopGeneration().catch((err: any) =>
+                      setError(err instanceof Error ? err : new Error("Failed to stop generation")),
+                    );
+                  }}
+                />
+              </div>
+            </div>
+          )}
         </div>
-        {scrollThumb.visible ? (
-          <div
-            aria-hidden="true"
-            style={{
-              position: "absolute",
-              top: scrollThumb.top,
-              right: 2,
-              width: 5,
-              height: scrollThumb.height,
-              borderRadius: 999,
-              background: "var(--talon-chat-scrollbar-thumb, rgba(113,113,122,0.52))",
-              pointerEvents: "none",
-            }}
+
+        {openResourceUri ? (
+          <ResourcePane
+            uri={openResourceUri}
+            resource={resourceView}
+            isLoading={resourceLoading}
+            error={resourceError}
+            open={resourcePaneOpen}
+            onClose={closeResourcePane}
+            onExitComplete={handleResourcePaneExitComplete}
+            onResourceClick={handleResourceClick}
           />
         ) : null}
       </div>
-
-      {disabled ? null : (
-        <div
-          style={{
-            position: "sticky",
-            bottom: 0,
-            zIndex: 10,
-            flexShrink: 0,
-            display: "flex",
-            justifyContent: "center",
-            width: "100%",
-            boxSizing: "border-box",
-            padding: "1.5rem",
-            background: "var(--talon-chat-composer-bg, linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0)))",
-            backdropFilter: "blur(10px)",
-          }}
-        >
-          <div style={{ width: "100%", maxWidth: "var(--talon-chat-composer-max-width, 896px)", paddingBottom: 8 }}>
-            <TalonChatComposer
-              value={input}
-              onValueChange={setInput}
-              onSubmit={(nextInput) => void submitMessage(nextInput)}
-              placeholder={placeholder}
-              variant={composerVariant}
-              autoFocus={autoFocus}
-              rows={inputRows}
-              canSubmit={Boolean((input || "").trim() || imageAttachments.length > 0) && !isLoading}
-              isGenerating={isLoading}
-              canStop={Boolean(currentSession)}
-              commandMenuItems={commandMenuItems}
-              startAdornment={composerStartAdornment}
-              endAdornment={composerEndAdornment}
-              imageAttachments={imageAttachments.map((attachment) => ({
-                id: attachment.id,
-                filename: attachment.file.name,
-                previewUrl: attachment.previewUrl,
-                status: attachment.status,
-                error: attachment.error,
-              }))}
-              imageUploadEnabled={Boolean(onImageUpload)}
-              imageAccept={imageAccept}
-              onImageFilesSelected={addImageFiles}
-              onRemoveImageAttachment={removeImageAttachment}
-              onStop={() => {
-                void stopGeneration().catch((err: any) =>
-                  setError(err instanceof Error ? err : new Error("Failed to stop generation")),
-                );
-              }}
-            />
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -7,9 +7,59 @@ export type GatewayClientLike = {
     "create" | "clear" | "listMessages" | "submitTurn" | "streamParts" | "stopGeneration"
   > & Partial<Pick<TalonClient["sessions"], "appendMessage" | "updateMessage">>;
   cas?: CasServiceClientLike;
+  artifacts?: ArtifactServiceClientLike;
+  files?: FileServiceClientLike;
 };
 
 export type CasServiceClientLike = Pick<TalonClient["cas"], "getObject">;
+
+export type ArtifactServiceClientLike = Pick<
+  TalonClient["artifacts"],
+  "readArtifact" | "getArtifactMetadata"
+>;
+
+export type FileServiceClientLike = Pick<
+  TalonClient["files"],
+  "readFile" | "getFileMetadata"
+>;
+
+export type ResourceUriKind = "artifact" | "file";
+
+export type ParsedResourceUri =
+  | {
+      kind: "artifact";
+      uri: string;
+      namespace: string;
+      agent: string;
+      sessionId: string;
+      artifactId: string;
+    }
+  | {
+      kind: "file";
+      uri: string;
+      namespace: string;
+      fileName: string;
+    };
+
+export type ResourceViewModel = {
+  kind: ResourceUriKind;
+  uri: string;
+  title: string;
+  mediaType: string;
+  content?: Uint8Array | string;
+  signedUrl?: string;
+  path?: string;
+  sessionId?: string;
+  agent?: string;
+};
+
+export function parseResourceUri(value: string): ParsedResourceUri | null;
+export function isResourceUri(value: string): boolean;
+export function linkifyResourceUris(markdown: string): string;
+export function toResourceMarkdownHref(uri: string): string;
+export function resourceUriFromHref(href: string | null | undefined): string | null;
+export function resourceUriShortLabel(uri: string): string;
+export const RESOURCE_MARKDOWN_HREF_PREFIX: string;
 
 export type ToolInvocationItem = {
   toolCallId: string;
@@ -217,6 +267,15 @@ export type TalonSessionProps = {
   allowMessageEditing?: boolean;
   onMessageEdit?: (context: TalonSessionMessageEditContext) => Promise<boolean | void> | boolean | void;
   enableDebugMessageEditing?: boolean;
+  /**
+   * Called when an artifact:// or file:// link is clicked.
+   * If omitted, the built-in split pane opens when the matching client is available.
+   */
+  onResourceClick?: (uri: string) => void;
+  /**
+   * Override content fetch for the built-in resource pane (both kinds).
+   */
+  fetchResource?: (uri: string, signal: AbortSignal) => Promise<ResourceViewModel>;
 };
 
 export type TalonCopilotProps = TalonSessionProps;
@@ -273,6 +332,11 @@ export type TalonChannelProps = {
   formatTimestamp?: (message: ChannelMessage) => string;
   renderMessageActions?: (message: ChannelMessage) => React.ReactNode;
   commands?: TalonChannelCommand[];
+  /**
+   * Called when an artifact:// or file:// link is clicked in a channel message.
+   * Channels do not open a built-in split pane in phase 1.
+   */
+  onResourceClick?: (uri: string) => void;
 };
 
 export type UseTalonChannelMessagesOptions = {

--- a/packages/talon-chat/src/index.ts
+++ b/packages/talon-chat/src/index.ts
@@ -1,7 +1,10 @@
 export {
   TalonSession,
   TalonCopilot,
+  type ArtifactServiceClientLike,
+  type FileServiceClientLike,
   type GatewayClientLike,
+  type ResourceViewModel,
   type TalonSessionCommand,
   type TalonSessionCommandTarget,
   type TalonSessionProps,
@@ -13,6 +16,17 @@ export {
   type TalonImageUploadResult,
   type TalonSessionPendingImageAttachment,
 } from "./TalonSession";
+export {
+  isResourceUri,
+  linkifyResourceUris,
+  parseResourceUri,
+  RESOURCE_MARKDOWN_HREF_PREFIX,
+  resourceUriFromHref,
+  resourceUriShortLabel,
+  toResourceMarkdownHref,
+  type ParsedResourceUri,
+  type ResourceUriKind,
+} from "./lib/resourceUris";
 export {
   TalonChannel,
   useTalonChannelMessages,

--- a/packages/talon-chat/src/lib/MarkdownMessage.tsx
+++ b/packages/talon-chat/src/lib/MarkdownMessage.tsx
@@ -1,13 +1,27 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 import { Streamdown } from "streamdown";
+import { linkifyResourceUris, resourceUriFromHref } from "./resourceUris";
 
 function border(color: string) {
   return `1px solid ${color}`;
 }
 
-export function MarkdownMessage({ children }: { children: string }) {
+export type MarkdownMessageProps = {
+  children: string;
+  /**
+   * Called when an `artifact://` or `file://` link is clicked.
+   * Prevents default navigation for resource URIs.
+   */
+  onResourceClick?: (uri: string) => void;
+};
+
+export function MarkdownMessage({ children, onResourceClick }: MarkdownMessageProps) {
+  // Resource links are rewritten to harden-safe hash hrefs (#talon-resource/…)
+  // so Streamdown's default rehype-harden does not replace them with [blocked].
+  const linkified = useMemo(() => linkifyResourceUris(children), [children]);
+
   const compactListChildren = (content: React.ReactNode): React.ReactNode =>
     React.Children.map(content, (child) => {
       if (!React.isValidElement(child)) {
@@ -134,7 +148,38 @@ export function MarkdownMessage({ children }: { children: string }) {
               }}
             />
           ),
-          a: (props) => <a {...props} style={{ color: "inherit", textDecoration: "underline" }} />,
+          a: (props) => {
+            const href = typeof props.href === "string" ? props.href : "";
+            const dataUri =
+              typeof (props as { "data-resource-uri"?: string })["data-resource-uri"] === "string"
+                ? (props as { "data-resource-uri"?: string })["data-resource-uri"]
+                : undefined;
+            const resourceUri = resourceUriFromHref(dataUri || href);
+
+            if (resourceUri) {
+              return (
+                <a
+                  {...props}
+                  href={href.startsWith("#") ? href : `#`}
+                  data-resource-uri={resourceUri}
+                  title={resourceUri}
+                  style={{
+                    color: "var(--talon-chat-link-fg, var(--talon-chat-accent-fg, #047857))",
+                    textDecoration: "underline",
+                    cursor: "pointer",
+                    wordBreak: "break-all",
+                  }}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onResourceClick?.(resourceUri);
+                  }}
+                />
+              );
+            }
+
+            return <a {...props} style={{ color: "inherit", textDecoration: "underline" }} />;
+          },
           blockquote: (props) => (
             <blockquote
               {...props}
@@ -148,7 +193,7 @@ export function MarkdownMessage({ children }: { children: string }) {
           ),
         }}
       >
-        {children}
+        {linkified}
       </Streamdown>
     </div>
   );

--- a/packages/talon-chat/src/lib/MarkdownMessage.tsx
+++ b/packages/talon-chat/src/lib/MarkdownMessage.tsx
@@ -156,7 +156,7 @@ export function MarkdownMessage({ children, onResourceClick }: MarkdownMessagePr
                 : undefined;
             const resourceUri = resourceUriFromHref(dataUri || href);
 
-            if (resourceUri) {
+            if (resourceUri && onResourceClick) {
               return (
                 <a
                   {...props}

--- a/packages/talon-chat/src/lib/ResourcePane.tsx
+++ b/packages/talon-chat/src/lib/ResourcePane.tsx
@@ -98,15 +98,21 @@ export function ResourcePane({
   }, [open, onExitComplete]);
 
   useEffect(() => {
-    if (!resource || !isImageMediaType(resource.mediaType)) {
-      setBlobUrl(null);
-      return;
-    }
-    if (resource.signedUrl) {
+    // Build a blob URL for:
+    // - image/* inline rendering when no signedUrl, and
+    // - non-text/non-markdown binary downloads when content is only available as bytes.
+    if (!resource || resource.signedUrl) {
       setBlobUrl(null);
       return;
     }
     if (!(resource.content instanceof Uint8Array) || resource.content.byteLength === 0) {
+      setBlobUrl(null);
+      return;
+    }
+    const isImage = isImageMediaType(resource.mediaType);
+    const isInlineText =
+      isTextMediaType(resource.mediaType) || isMarkdownMediaType(resource.mediaType);
+    if (!isImage && isInlineText) {
       setBlobUrl(null);
       return;
     }

--- a/packages/talon-chat/src/lib/ResourcePane.tsx
+++ b/packages/talon-chat/src/lib/ResourcePane.tsx
@@ -219,7 +219,7 @@ export function ResourcePane({
               flexShrink: 0,
             }}
           >
-            <X size={16} strokeWidth={1.9} />
+            <X size="16" strokeWidth={1.9} />
           </button>
         </header>
 

--- a/packages/talon-chat/src/lib/ResourcePane.tsx
+++ b/packages/talon-chat/src/lib/ResourcePane.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
+import { MarkdownMessage } from "./MarkdownMessage";
+import {
+  parseResourceUri,
+  type ResourceViewModel,
+} from "./resourceUris";
+
+function border(color: string) {
+  return `1px solid ${color}`;
+}
+
+const MAX_INLINE_TEXT_BYTES = 3 * 1024 * 1024;
+const PANE_TRANSITION_MS = 280;
+
+function mediaTypeBase(mediaType: string): string {
+  return mediaType.split(";")[0]?.trim().toLowerCase() || "";
+}
+
+function decodeContentAsText(content: Uint8Array | string | undefined): string | null {
+  if (content == null) return null;
+  if (typeof content === "string") return content;
+  if (content.byteLength > MAX_INLINE_TEXT_BYTES) return null;
+  try {
+    return new TextDecoder("utf-8", { fatal: false }).decode(content);
+  } catch {
+    return null;
+  }
+}
+
+function isMarkdownMediaType(mediaType: string): boolean {
+  const base = mediaTypeBase(mediaType);
+  return base === "text/markdown" || base === "text/x-markdown";
+}
+
+function isTextMediaType(mediaType: string): boolean {
+  const base = mediaTypeBase(mediaType);
+  return base.startsWith("text/") || base === "application/json" || base === "";
+}
+
+function isImageMediaType(mediaType: string): boolean {
+  return mediaTypeBase(mediaType).startsWith("image/");
+}
+
+export type ResourcePaneProps = {
+  uri: string;
+  resource: ResourceViewModel | null;
+  isLoading: boolean;
+  error: Error | null;
+  onClose: () => void;
+  onResourceClick?: (uri: string) => void;
+  /** When false, the pane animates closed before unmount (parent controls exit). */
+  open?: boolean;
+  /** Fired after the close transition finishes so the parent can unmount. */
+  onExitComplete?: () => void;
+};
+
+export function ResourcePane({
+  uri,
+  resource,
+  isLoading,
+  error,
+  onClose,
+  onResourceClick,
+  open = true,
+  onExitComplete,
+}: ResourcePaneProps) {
+  const parsed = useMemo(() => parseResourceUri(uri), [uri]);
+  const title =
+    resource?.title ||
+    (parsed?.kind === "artifact"
+      ? parsed.artifactId
+      : parsed?.kind === "file"
+        ? parsed.fileName
+        : uri);
+  const mediaType = resource?.mediaType || "";
+
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  // Enter animation: mount closed, then flip open on the next frame.
+  const [entered, setEntered] = useState(false);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      // Double rAF so the browser paints the closed state before transitioning.
+      requestAnimationFrame(() => setEntered(true));
+    });
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  useEffect(() => {
+    if (open) return;
+    const timer = window.setTimeout(() => {
+      onExitComplete?.();
+    }, PANE_TRANSITION_MS);
+    return () => window.clearTimeout(timer);
+  }, [open, onExitComplete]);
+
+  useEffect(() => {
+    if (!resource || !isImageMediaType(resource.mediaType)) {
+      setBlobUrl(null);
+      return;
+    }
+    if (resource.signedUrl) {
+      setBlobUrl(null);
+      return;
+    }
+    if (!(resource.content instanceof Uint8Array) || resource.content.byteLength === 0) {
+      setBlobUrl(null);
+      return;
+    }
+    const bytes = resource.content;
+    const copy = new Uint8Array(bytes.byteLength);
+    copy.set(bytes);
+    const blob = new Blob([copy.buffer], {
+      type: mediaTypeBase(resource.mediaType) || "application/octet-stream",
+    });
+    const url = URL.createObjectURL(blob);
+    setBlobUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [resource]);
+
+  const textContent = useMemo(() => {
+    if (!resource) return null;
+    if (!isTextMediaType(resource.mediaType) && !isMarkdownMediaType(resource.mediaType)) {
+      return null;
+    }
+    return decodeContentAsText(resource.content);
+  }, [resource]);
+
+  const imageSrc = resource?.signedUrl || blobUrl || null;
+  const downloadHref = resource?.signedUrl || blobUrl || null;
+  const isVisible = open && entered;
+
+  return (
+    <aside
+      className="talon-resource-pane"
+      data-testid="talon-resource-pane"
+      data-open={isVisible ? "true" : "false"}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        // Width-driven split animates more reliably than flex-basis alone.
+        flex: "0 0 auto",
+        width: isVisible ? "50%" : "0%",
+        minWidth: 0,
+        minHeight: 0,
+        height: "100%",
+        overflow: "hidden",
+        borderLeft: isVisible
+          ? border("var(--talon-chat-divider, rgba(212,212,216,0.7))")
+          : "1px solid transparent",
+        background: "var(--talon-chat-resource-pane-bg, var(--talon-chat-composer-bg, transparent))",
+        boxSizing: "border-box",
+        opacity: isVisible ? 1 : 0,
+        transform: isVisible ? "translateX(0)" : "translateX(1rem)",
+        transition: [
+          `width ${PANE_TRANSITION_MS}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+          `opacity ${Math.round(PANE_TRANSITION_MS * 0.85)}ms ease`,
+          `transform ${PANE_TRANSITION_MS}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+          `border-color ${PANE_TRANSITION_MS}ms ease`,
+        ].join(", "),
+        willChange: "width, opacity, transform",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          // Keep pane content at a stable width during the open animation so
+          // text doesn't reflow as the shell expands.
+          width: "100%",
+          minWidth: "min(100%, 18rem)",
+          height: "100%",
+          minHeight: 0,
+          opacity: isVisible ? 1 : 0.4,
+          transition: `opacity ${Math.round(PANE_TRANSITION_MS * 0.7)}ms ease`,
+        }}
+      >
+        <header
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "0.85rem 1rem",
+            borderBottom: border("var(--talon-chat-divider, rgba(212,212,216,0.7))"),
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: 14,
+              fontWeight: 600,
+              lineHeight: 1.35,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+            title={title}
+          >
+            {title}
+          </div>
+          <button
+            type="button"
+            aria-label="Close resource pane"
+            onClick={onClose}
+            style={{
+              border: "none",
+              background: "transparent",
+              cursor: "pointer",
+              padding: 4,
+              borderRadius: 6,
+              color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))",
+              flexShrink: 0,
+            }}
+          >
+            <X size={16} strokeWidth={1.9} />
+          </button>
+        </header>
+
+        <div
+          style={{
+            flex: 1,
+            minHeight: 0,
+            overflowY: "auto",
+            overflowX: "hidden",
+            padding: "1rem",
+            fontSize: 13,
+            lineHeight: 1.55,
+          }}
+        >
+          {isLoading ? (
+            <div style={{ color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>Loading…</div>
+          ) : null}
+
+          {!isLoading && error ? (
+            <div
+              style={{
+                borderRadius: 10,
+                border: border("rgba(252,165,165,0.6)"),
+                background: "rgba(254,242,242,1)",
+                color: "rgba(220,38,38,1)",
+                padding: 12,
+                fontSize: 13,
+              }}
+            >
+              {formatResourceError(error)}
+            </div>
+          ) : null}
+
+          {!isLoading && !error && resource ? (
+            isMarkdownMediaType(resource.mediaType) && textContent != null ? (
+              <MarkdownMessage onResourceClick={onResourceClick}>{textContent}</MarkdownMessage>
+            ) : isTextMediaType(resource.mediaType) && textContent != null ? (
+              <pre
+                style={{
+                  margin: 0,
+                  padding: "0.75rem",
+                  overflowX: "auto",
+                  borderRadius: 12,
+                  border: border("rgba(148,163,184,0.24)"),
+                  background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))",
+                  fontFamily: "ui-monospace, SFMono-Regular, monospace",
+                  fontSize: 12,
+                  whiteSpace: "pre-wrap",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {textContent}
+              </pre>
+            ) : isImageMediaType(resource.mediaType) && imageSrc ? (
+              <img
+                src={imageSrc}
+                alt={title}
+                style={{
+                  maxWidth: "100%",
+                  height: "auto",
+                  borderRadius: 8,
+                  border: border("rgba(148,163,184,0.24)"),
+                }}
+              />
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <div style={{ color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
+                  This resource is not shown inline
+                  {mediaType ? ` (${mediaType})` : ""}.
+                </div>
+                {downloadHref ? (
+                  <a
+                    href={downloadHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    download={title}
+                    style={{
+                      color: "var(--talon-chat-link-fg, var(--talon-chat-accent-fg, #047857))",
+                      textDecoration: "underline",
+                      fontWeight: 600,
+                    }}
+                  >
+                    Download
+                  </a>
+                ) : null}
+              </div>
+            )
+          ) : null}
+        </div>
+      </div>
+
+      <style>
+        {`
+          @media (max-width: 640px) {
+            .talon-resource-pane {
+              position: absolute !important;
+              inset: 0 !important;
+              width: 100% !important;
+              max-width: none !important;
+              flex: 1 1 auto !important;
+              border-left: none !important;
+              z-index: 20;
+              background: var(--talon-chat-resource-pane-bg, #fff);
+              transform: none !important;
+            }
+            .talon-resource-pane[data-open="false"] {
+              opacity: 0 !important;
+              pointer-events: none;
+            }
+          }
+        `}
+      </style>
+    </aside>
+  );
+}
+
+function formatResourceError(error: Error): string {
+  const message = error.message || "Failed to load resource";
+  const lower = message.toLowerCase();
+  if (lower.includes("permission") || lower.includes("denied") || lower.includes("403")) {
+    return "Access denied";
+  }
+  if (lower.includes("not found") || lower.includes("404")) {
+    return "Not found";
+  }
+  return message;
+}

--- a/packages/talon-chat/src/lib/ResourcePane.tsx
+++ b/packages/talon-chat/src/lib/ResourcePane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { X } from "lucide-react";
 import { MarkdownMessage } from "./MarkdownMessage";
 import {
@@ -77,6 +77,7 @@ export function ResourcePane({
         : uri);
   const mediaType = resource?.mediaType || "";
 
+  const paneRef = useRef<HTMLElement>(null);
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
   // Enter animation: mount closed, then flip open on the next frame.
   const [entered, setEntered] = useState(false);
@@ -98,21 +99,11 @@ export function ResourcePane({
   }, [open, onExitComplete]);
 
   useEffect(() => {
-    // Build a blob URL for:
-    // - image/* inline rendering when no signedUrl, and
-    // - non-text/non-markdown binary downloads when content is only available as bytes.
     if (!resource || resource.signedUrl) {
       setBlobUrl(null);
       return;
     }
     if (!(resource.content instanceof Uint8Array) || resource.content.byteLength === 0) {
-      setBlobUrl(null);
-      return;
-    }
-    const isImage = isImageMediaType(resource.mediaType);
-    const isInlineText =
-      isTextMediaType(resource.mediaType) || isMarkdownMediaType(resource.mediaType);
-    if (!isImage && isInlineText) {
       setBlobUrl(null);
       return;
     }
@@ -129,6 +120,17 @@ export function ResourcePane({
     };
   }, [resource]);
 
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
   const textContent = useMemo(() => {
     if (!resource) return null;
     if (!isTextMediaType(resource.mediaType) && !isMarkdownMediaType(resource.mediaType)) {
@@ -141,11 +143,19 @@ export function ResourcePane({
   const downloadHref = resource?.signedUrl || blobUrl || null;
   const isVisible = open && entered;
 
+  useEffect(() => {
+    if (!isVisible) return;
+    paneRef.current?.focus({ preventScroll: true });
+  }, [isVisible]);
+
   return (
     <aside
+      ref={paneRef}
       className="talon-resource-pane"
+      aria-label={title}
       data-testid="talon-resource-pane"
       data-open={isVisible ? "true" : "false"}
+      tabIndex={-1}
       style={{
         display: "flex",
         flexDirection: "column",

--- a/packages/talon-chat/src/lib/resourceUris.test.ts
+++ b/packages/talon-chat/src/lib/resourceUris.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  isResourceUri,
+  linkifyResourceUris,
+  parseResourceUri,
+  resourceUriFromHref,
+  resourceUriShortLabel,
+  toResourceMarkdownHref,
+} from "./resourceUris.ts";
+
+describe("parseResourceUri", () => {
+  it("parses artifact URIs with colon namespaces", () => {
+    const uri = "artifact://Tenant:acme:Ops/writer/sess-1/draft";
+    const parsed = parseResourceUri(uri);
+    assert.deepEqual(parsed, {
+      kind: "artifact",
+      uri,
+      namespace: "Tenant:acme:Ops",
+      agent: "writer",
+      sessionId: "sess-1",
+      artifactId: "draft",
+    });
+  });
+
+  it("parses file URIs with colon namespaces", () => {
+    const uri = "file://Tenant:acme:Ops/memory-brand-guidelines";
+    const parsed = parseResourceUri(uri);
+    assert.deepEqual(parsed, {
+      kind: "file",
+      uri,
+      namespace: "Tenant:acme:Ops",
+      fileName: "memory-brand-guidelines",
+    });
+  });
+
+  it("strips trailing prose punctuation", () => {
+    const parsed = parseResourceUri("file://ns/name.");
+    assert.equal(parsed?.uri, "file://ns/name");
+    assert.equal(parseResourceUri("artifact://ns/a/s/id,").uri, "artifact://ns/a/s/id");
+    assert.equal(parseResourceUri("file://ns/name;").uri, "file://ns/name");
+    assert.equal(parseResourceUri("file://ns/name)").uri, "file://ns/name");
+    assert.equal(parseResourceUri("file://ns/name]").uri, "file://ns/name");
+  });
+
+  it("rejects OS-style file paths", () => {
+    assert.equal(parseResourceUri("file:///tmp/foo"), null);
+    assert.equal(parseResourceUri("file:///Users/me/file.txt"), null);
+    assert.equal(parseResourceUri("file://ns/a/b"), null);
+  });
+
+  it("rejects wrong artifact segment counts", () => {
+    assert.equal(parseResourceUri("artifact://ns/agent"), null);
+    assert.equal(parseResourceUri("artifact://ns/a/s"), null);
+    assert.equal(parseResourceUri("artifact://ns/a/s/id/extra"), null);
+  });
+
+  it("rejects empty segments", () => {
+    assert.equal(parseResourceUri("file://ns/"), null);
+    assert.equal(parseResourceUri("file:///name"), null);
+    assert.equal(parseResourceUri("artifact://ns//s/id"), null);
+  });
+
+  it("rejects unrelated schemes", () => {
+    assert.equal(parseResourceUri("https://example.com"), null);
+    assert.equal(parseResourceUri(""), null);
+  });
+});
+
+describe("isResourceUri", () => {
+  it("returns true only for parseable resource URIs", () => {
+    assert.equal(isResourceUri("file://ns/name"), true);
+    assert.equal(isResourceUri("artifact://ns/a/s/id"), true);
+    assert.equal(isResourceUri("file:///tmp/x"), false);
+  });
+});
+
+describe("toResourceMarkdownHref / resourceUriFromHref", () => {
+  it("round-trips artifact and file URIs through harden-safe hash hrefs", () => {
+    const artifact = "artifact://Tenant:acme:Ops/writer/sess-1/draft";
+    const file = "file://Tenant:acme:Ops/memory-brand-guidelines";
+    const artifactHref = toResourceMarkdownHref(artifact);
+    const fileHref = toResourceMarkdownHref(file);
+    assert.ok(artifactHref.startsWith("#talon-resource/"));
+    assert.ok(fileHref.startsWith("#talon-resource/"));
+    assert.equal(resourceUriFromHref(artifactHref), artifact);
+    assert.equal(resourceUriFromHref(fileHref), file);
+  });
+
+  it("accepts raw resource URIs as hrefs", () => {
+    assert.equal(resourceUriFromHref("file://ns/name"), "file://ns/name");
+    assert.equal(resourceUriFromHref("artifact://ns/a/s/id"), "artifact://ns/a/s/id");
+  });
+
+  it("returns null for non-resource hrefs", () => {
+    assert.equal(resourceUriFromHref("https://example.com"), null);
+    assert.equal(resourceUriFromHref("#section"), null);
+    assert.equal(resourceUriFromHref(""), null);
+  });
+});
+
+describe("linkifyResourceUris", () => {
+  it("linkifies bare artifact and file URIs with harden-safe hrefs", () => {
+    const input =
+      "See artifact://Tenant:acme:Ops/writer/sess-1/draft and file://Tenant:acme:Ops/memory-brand.";
+    const out = linkifyResourceUris(input);
+    const artifact = "artifact://Tenant:acme:Ops/writer/sess-1/draft";
+    const file = "file://Tenant:acme:Ops/memory-brand";
+    assert.ok(out.includes(`[${artifact}](${toResourceMarkdownHref(artifact)})`));
+    assert.ok(out.includes(`[${file}](${toResourceMarkdownHref(file)}).`));
+    assert.ok(!out.includes(`](${artifact})`));
+    assert.ok(!out.includes(`](${file})`));
+  });
+
+  it("does not linkify inside fenced code blocks", () => {
+    const input = "Before\n```\nfile://ns/name\n```\nAfter file://ns/other";
+    const out = linkifyResourceUris(input);
+    assert.ok(out.includes("```\nfile://ns/name\n```"));
+    assert.ok(out.includes(`[file://ns/other](${toResourceMarkdownHref("file://ns/other")})`));
+  });
+
+  it("rewrites already-linked resource destinations to harden-safe hrefs", () => {
+    const input = "[label](file://ns/name) and [file://ns/other](file://ns/other)";
+    const out = linkifyResourceUris(input);
+    assert.ok(out.includes(`[label](${toResourceMarkdownHref("file://ns/name")})`));
+    assert.ok(out.includes(`[file://ns/other](${toResourceMarkdownHref("file://ns/other")})`));
+    assert.ok(!out.includes("](file://"));
+  });
+
+  it("handles multi-URI lines and list items", () => {
+    const input = "- draft: artifact://ns/a/s/id\n- guidelines: file://ns/guidelines";
+    const out = linkifyResourceUris(input);
+    assert.ok(out.includes(`[artifact://ns/a/s/id](${toResourceMarkdownHref("artifact://ns/a/s/id")})`));
+    assert.ok(out.includes(`[file://ns/guidelines](${toResourceMarkdownHref("file://ns/guidelines")})`));
+  });
+
+  it("leaves non-resource text unchanged", () => {
+    assert.equal(linkifyResourceUris("hello world"), "hello world");
+    assert.equal(linkifyResourceUris("visit https://example.com"), "visit https://example.com");
+  });
+});
+
+describe("resourceUriShortLabel", () => {
+  it("returns artifact id or file name", () => {
+    assert.equal(resourceUriShortLabel("artifact://ns/a/s/draft"), "draft");
+    assert.equal(resourceUriShortLabel("file://ns/memory-brand"), "memory-brand");
+    assert.equal(resourceUriShortLabel("not-a-uri"), "not-a-uri");
+  });
+});

--- a/packages/talon-chat/src/lib/resourceUris.test.ts
+++ b/packages/talon-chat/src/lib/resourceUris.test.ts
@@ -34,13 +34,12 @@ describe("parseResourceUri", () => {
     });
   });
 
-  it("strips trailing prose punctuation", () => {
-    const parsed = parseResourceUri("file://ns/name.");
-    assert.equal(parsed?.uri, "file://ns/name");
-    assert.equal(parseResourceUri("artifact://ns/a/s/id,").uri, "artifact://ns/a/s/id");
-    assert.equal(parseResourceUri("file://ns/name;").uri, "file://ns/name");
-    assert.equal(parseResourceUri("file://ns/name)").uri, "file://ns/name");
-    assert.equal(parseResourceUri("file://ns/name]").uri, "file://ns/name");
+  it("preserves terminal punctuation in valid resource identifiers", () => {
+    assert.equal(parseResourceUri("file://ns/name.")?.uri, "file://ns/name.");
+    assert.equal(parseResourceUri("artifact://ns/a/s/id,")?.uri, "artifact://ns/a/s/id,");
+    assert.equal(parseResourceUri("file://ns/name;")?.uri, "file://ns/name;");
+    assert.equal(parseResourceUri("file://ns/name)")?.uri, "file://ns/name)");
+    assert.equal(parseResourceUri("file://ns/name]")?.uri, "file://ns/name]");
   });
 
   it("rejects OS-style file paths", () => {
@@ -138,6 +137,23 @@ describe("linkifyResourceUris", () => {
     const input = "See the draft (file://ns/name) and notes.";
     const out = linkifyResourceUris(input);
     assert.ok(out.includes(`([file://ns/name](${toResourceMarkdownHref("file://ns/name")}))`));
+  });
+
+  it("keeps trailing prose punctuation outside generated links", () => {
+    const input = "See file://ns/name. Then artifact://ns/a/s/id, plus file://ns/other; and file://ns/end]";
+    const out = linkifyResourceUris(input);
+    assert.ok(out.includes(`[file://ns/name](${toResourceMarkdownHref("file://ns/name")}).`));
+    assert.ok(out.includes(`[artifact://ns/a/s/id](${toResourceMarkdownHref("artifact://ns/a/s/id")}),`));
+    assert.ok(out.includes(`[file://ns/other](${toResourceMarkdownHref("file://ns/other")});`));
+    assert.ok(out.includes(`[file://ns/end](${toResourceMarkdownHref("file://ns/end")})]`));
+  });
+
+  it("does not linkify inside inline code spans", () => {
+    const input = "`file://ns/name` and `see artifact://ns/a/s/id` but file://ns/other";
+    const out = linkifyResourceUris(input);
+    assert.ok(out.includes("`file://ns/name`"));
+    assert.ok(out.includes("`see artifact://ns/a/s/id`"));
+    assert.ok(out.includes(`[file://ns/other](${toResourceMarkdownHref("file://ns/other")})`));
   });
 
   it("leaves non-resource text unchanged", () => {

--- a/packages/talon-chat/src/lib/resourceUris.test.ts
+++ b/packages/talon-chat/src/lib/resourceUris.test.ts
@@ -134,6 +134,12 @@ describe("linkifyResourceUris", () => {
     assert.ok(out.includes(`[file://ns/guidelines](${toResourceMarkdownHref("file://ns/guidelines")})`));
   });
 
+  it("linkifies parenthesized prose URIs", () => {
+    const input = "See the draft (file://ns/name) and notes.";
+    const out = linkifyResourceUris(input);
+    assert.ok(out.includes(`([file://ns/name](${toResourceMarkdownHref("file://ns/name")}))`));
+  });
+
   it("leaves non-resource text unchanged", () => {
     assert.equal(linkifyResourceUris("hello world"), "hello world");
     assert.equal(linkifyResourceUris("visit https://example.com"), "visit https://example.com");

--- a/packages/talon-chat/src/lib/resourceUris.ts
+++ b/packages/talon-chat/src/lib/resourceUris.ts
@@ -1,0 +1,259 @@
+export type ResourceUriKind = "artifact" | "file";
+
+export type ParsedResourceUri =
+  | {
+      kind: "artifact";
+      uri: string;
+      namespace: string;
+      agent: string;
+      sessionId: string;
+      artifactId: string;
+    }
+  | {
+      kind: "file";
+      uri: string;
+      namespace: string;
+      fileName: string;
+    };
+
+const TRAILING_PROSE_PUNCTUATION = /[.,;)\]]+$/;
+
+/** Bare resource URI matchers (scheme through first whitespace/markdown delimiter). */
+const BARE_RESOURCE_URI_RE = /(?:artifact|file):\/\/[^\s<>"'`)\]]+/g;
+
+/**
+ * Markdown href prefix that survives Streamdown's rehype-harden.
+ *
+ * Harden hard-blocks `file:` and cannot parse `artifact://…` as a WHATWG URL,
+ * so it replaces those links with a "[blocked]" indicator. Hash-only hrefs are
+ * always allowed, so we encode the real URI in the fragment.
+ */
+export const RESOURCE_MARKDOWN_HREF_PREFIX = "#talon-resource/";
+
+function stripTrailingProsePunctuation(value: string): string {
+  return value.replace(TRAILING_PROSE_PUNCTUATION, "");
+}
+
+function isValidUriSegment(segment: string): boolean {
+  if (!segment || segment.trim().length === 0) return false;
+  if (segment.includes("/") || segment.includes("\0")) return false;
+  for (const char of segment) {
+    const code = char.charCodeAt(0);
+    if (code < 0x20 || code === 0x7f) return false;
+  }
+  return true;
+}
+
+/**
+ * Parse a Talon resource URI (`artifact://…` or `file://…`).
+ * Returns null for OS-style paths like `file:///tmp/foo` (wrong segment count).
+ */
+export function parseResourceUri(value: string): ParsedResourceUri | null {
+  const trimmed = stripTrailingProsePunctuation(value.trim());
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith("artifact://")) {
+    const rest = trimmed.slice("artifact://".length);
+    const parts = rest.split("/");
+    if (parts.length !== 4) return null;
+    const [namespace, agent, sessionId, artifactId] = parts;
+    if (
+      !isValidUriSegment(namespace) ||
+      !isValidUriSegment(agent) ||
+      !isValidUriSegment(sessionId) ||
+      !isValidUriSegment(artifactId)
+    ) {
+      return null;
+    }
+    return {
+      kind: "artifact",
+      uri: `artifact://${namespace}/${agent}/${sessionId}/${artifactId}`,
+      namespace,
+      agent,
+      sessionId,
+      artifactId,
+    };
+  }
+
+  if (trimmed.startsWith("file://")) {
+    const rest = trimmed.slice("file://".length);
+    const parts = rest.split("/");
+    // Reject file:///tmp/foo (empty first segment) and multi-segment OS paths.
+    if (parts.length !== 2) return null;
+    const [namespace, fileName] = parts;
+    if (!isValidUriSegment(namespace) || !isValidUriSegment(fileName)) {
+      return null;
+    }
+    return {
+      kind: "file",
+      uri: `file://${namespace}/${fileName}`,
+      namespace,
+      fileName,
+    };
+  }
+
+  return null;
+}
+
+export function isResourceUri(value: string): boolean {
+  return parseResourceUri(value) !== null;
+}
+
+/** Encode a resource URI as a markdown/href value that rehype-harden will not block. */
+export function toResourceMarkdownHref(uri: string): string {
+  return `${RESOURCE_MARKDOWN_HREF_PREFIX}${encodeURIComponent(uri)}`;
+}
+
+/**
+ * Recover a resource URI from a markdown href or data attribute.
+ * Accepts hash-encoded hrefs, raw artifact:// / file://, and null otherwise.
+ */
+export function resourceUriFromHref(href: string | null | undefined): string | null {
+  if (!href) return null;
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith(RESOURCE_MARKDOWN_HREF_PREFIX)) {
+    try {
+      const decoded = decodeURIComponent(trimmed.slice(RESOURCE_MARKDOWN_HREF_PREFIX.length));
+      return parseResourceUri(decoded)?.uri ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  return parseResourceUri(trimmed)?.uri ?? null;
+}
+
+function isInsideCodeFence(markdown: string, index: number): boolean {
+  // Count fence opens before index; odd count means inside a fenced block.
+  const before = markdown.slice(0, index);
+  let fenceCount = 0;
+  const fenceRe = /^[ \t]{0,3}(`{3,}|~{3,})/gm;
+  let match: RegExpExecArray | null;
+  while ((match = fenceRe.exec(before)) !== null) {
+    fenceCount += 1;
+  }
+  return fenceCount % 2 === 1;
+}
+
+function isAlreadyLinked(markdown: string, start: number, end: number): boolean {
+  // Skip if already inside a markdown link destination: ](uri) or [label](uri)
+  const after = markdown.slice(end);
+  if (/^\s*\)/.test(after)) {
+    // Look back for preceding ](
+    const before = markdown.slice(0, start);
+    if (/\]\(\s*$/.test(before) || /\(\s*$/.test(before)) {
+      return true;
+    }
+  }
+  // Already a full markdown link of the form [uri](uri) where the match is the label
+  const before = markdown.slice(Math.max(0, start - 1), start);
+  if (before === "[") {
+    const afterLabel = markdown.slice(end);
+    if (/^\]\([^)]*\)/.test(afterLabel)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Rewrite markdown link destinations that use raw artifact:// or file:// hrefs
+ * into harden-safe hash hrefs. Leaves labels and non-resource links alone.
+ */
+function rewriteResourceLinkDestinations(markdown: string): string {
+  // Match ](artifact://…) and ](file://…) destinations.
+  const destRe = /\]\(((?:artifact|file):\/\/[^)\s]+)\)/g;
+  let result = "";
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  destRe.lastIndex = 0;
+
+  while ((match = destRe.exec(markdown)) !== null) {
+    const full = match[0];
+    const dest = match[1];
+    const start = match.index;
+
+    if (isInsideCodeFence(markdown, start)) {
+      continue;
+    }
+
+    const parsed = parseResourceUri(dest);
+    if (!parsed) {
+      continue;
+    }
+
+    result += markdown.slice(lastIndex, start);
+    result += `](${toResourceMarkdownHref(parsed.uri)})`;
+    lastIndex = start + full.length;
+  }
+
+  result += markdown.slice(lastIndex);
+  return result;
+}
+
+/**
+ * Fence-aware preprocessor: convert bare artifact:// and file:// URIs into
+ * markdown links, and rewrite existing resource link destinations to
+ * harden-safe hash hrefs.
+ */
+export function linkifyResourceUris(markdown: string): string {
+  if (!markdown || (!markdown.includes("artifact://") && !markdown.includes("file://"))) {
+    return markdown;
+  }
+
+  // First rewrite already-authored [label](artifact://…) / [label](file://…).
+  let working = rewriteResourceLinkDestinations(markdown);
+
+  let result = "";
+  let lastIndex = 0;
+  BARE_RESOURCE_URI_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = BARE_RESOURCE_URI_RE.exec(working)) !== null) {
+    const raw = match[0];
+    const start = match.index;
+    const end = start + raw.length;
+
+    if (isInsideCodeFence(working, start) || isAlreadyLinked(working, start, end)) {
+      continue;
+    }
+
+    const parsed = parseResourceUri(raw);
+    if (!parsed) {
+      continue;
+    }
+
+    // Preserve any trailing punctuation that parseResourceUri stripped.
+    const rawWithoutTrailing = stripTrailingProsePunctuation(raw);
+    const actualTrailing = raw.slice(rawWithoutTrailing.length);
+
+    result += working.slice(lastIndex, start);
+    result += `[${parsed.uri}](${toResourceMarkdownHref(parsed.uri)})`;
+    result += actualTrailing;
+    lastIndex = end;
+  }
+
+  result += working.slice(lastIndex);
+  return result;
+}
+
+export type ResourceViewModel = {
+  kind: ResourceUriKind;
+  uri: string;
+  title: string;
+  mediaType: string;
+  content?: Uint8Array | string;
+  signedUrl?: string;
+  path?: string;
+  sessionId?: string;
+  agent?: string;
+};
+
+/** Short display label for a resource URI (artifact id or file name). */
+export function resourceUriShortLabel(uri: string): string {
+  const parsed = parseResourceUri(uri);
+  if (!parsed) return uri;
+  return parsed.kind === "artifact" ? parsed.artifactId : parsed.fileName;
+}

--- a/packages/talon-chat/src/lib/resourceUris.ts
+++ b/packages/talon-chat/src/lib/resourceUris.ts
@@ -49,7 +49,7 @@ function isValidUriSegment(segment: string): boolean {
  * Returns null for OS-style paths like `file:///tmp/foo` (wrong segment count).
  */
 export function parseResourceUri(value: string): ParsedResourceUri | null {
-  const trimmed = stripTrailingProsePunctuation(value.trim());
+  const trimmed = value.trim();
   if (!trimmed) return null;
 
   if (trimmed.startsWith("artifact://")) {
@@ -137,6 +137,27 @@ function isInsideCodeFence(markdown: string, index: number): boolean {
   return fenceCount % 2 === 1;
 }
 
+function isInsideInlineCode(markdown: string, index: number): boolean {
+  const lineStart = markdown.lastIndexOf("\n", index - 1) + 1;
+  const before = markdown.slice(lineStart, index);
+  const backtickRunRe = /`+/g;
+  let activeRunLength: number | null = null;
+  let match: RegExpExecArray | null;
+  while ((match = backtickRunRe.exec(before)) !== null) {
+    const runLength = match[0].length;
+    if (activeRunLength === null) {
+      activeRunLength = runLength;
+    } else if (runLength === activeRunLength) {
+      activeRunLength = null;
+    }
+  }
+  return activeRunLength !== null;
+}
+
+function isInsideCode(markdown: string, index: number): boolean {
+  return isInsideCodeFence(markdown, index) || isInsideInlineCode(markdown, index);
+}
+
 function isAlreadyLinked(markdown: string, start: number, end: number): boolean {
   // Skip only when this span is already a markdown link destination: ](uri)
   // Do not treat parenthesized prose like (file://ns/name) as linked.
@@ -175,7 +196,7 @@ function rewriteResourceLinkDestinations(markdown: string): string {
     const dest = match[1];
     const start = match.index;
 
-    if (isInsideCodeFence(markdown, start)) {
+    if (isInsideCode(markdown, start)) {
       continue;
     }
 
@@ -216,17 +237,17 @@ export function linkifyResourceUris(markdown: string): string {
     const start = match.index;
     const end = start + raw.length;
 
-    if (isInsideCodeFence(working, start) || isAlreadyLinked(working, start, end)) {
+    if (isInsideCode(working, start) || isAlreadyLinked(working, start, end)) {
       continue;
     }
 
-    const parsed = parseResourceUri(raw);
+    const rawWithoutTrailing = stripTrailingProsePunctuation(raw);
+    const parsed = parseResourceUri(rawWithoutTrailing);
     if (!parsed) {
       continue;
     }
 
-    // Preserve any trailing punctuation that parseResourceUri stripped.
-    const rawWithoutTrailing = stripTrailingProsePunctuation(raw);
+    // Preserve prose punctuation outside the generated link.
     const actualTrailing = raw.slice(rawWithoutTrailing.length);
 
     result += working.slice(lastIndex, start);

--- a/packages/talon-chat/src/lib/resourceUris.ts
+++ b/packages/talon-chat/src/lib/resourceUris.ts
@@ -138,12 +138,12 @@ function isInsideCodeFence(markdown: string, index: number): boolean {
 }
 
 function isAlreadyLinked(markdown: string, start: number, end: number): boolean {
-  // Skip if already inside a markdown link destination: ](uri) or [label](uri)
+  // Skip only when this span is already a markdown link destination: ](uri)
+  // Do not treat parenthesized prose like (file://ns/name) as linked.
   const after = markdown.slice(end);
   if (/^\s*\)/.test(after)) {
-    // Look back for preceding ](
     const before = markdown.slice(0, start);
-    if (/\]\(\s*$/.test(before) || /\(\s*$/.test(before)) {
+    if (/\]\(\s*$/.test(before)) {
       return true;
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,19 +10,19 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^7.0.3
-        version: 7.0.3(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))
+        version: 7.0.3(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))(supports-color@8.1.1)
       '@shikijs/twoslash':
         specifier: ^4.3.1
-        version: 4.3.1(typescript@6.0.3)
+        version: 4.3.1(supports-color@8.1.1)(typescript@6.0.3)
       '@tailwindcss/vite':
         specifier: ^4.3.2
         version: 4.3.2(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       astro:
         specifier: ^7.0.9
-        version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
+        version: 7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
       blume:
         specifier: ^1.0.3
-        version: 1.0.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@shikijs/themes@4.3.1)(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vercel/functions@3.7.5(ws@8.20.1))(esbuild@0.28.1)(prettier@3.9.5)(rollup@4.60.4)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(ws@8.20.1)(yaml@2.9.0)
+        version: 1.0.3(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@shikijs/themes@4.3.1)(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vercel/functions@3.7.5(ws@8.20.1))(esbuild@0.28.1)(prettier@3.9.5)(rollup@4.60.4)(supports-color@8.1.1)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(ws@8.20.1)(yaml@2.9.0)
 
   packages/talon-chat:
     dependencies:
@@ -40,7 +40,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       streamdown:
         specifier: ^2.5.0
-        version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)
     devDependencies:
       '@impalasys/talon-client':
         specifier: workspace:0.1.17
@@ -53,7 +53,7 @@ importers:
         version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@storybook/react-vite':
         specifier: ^10.4.2
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(supports-color@8.1.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@types/react':
         specifier: ^19.2.2
         version: 19.2.14
@@ -68,7 +68,7 @@ importers:
         version: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(supports-color@8.1.1)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -152,7 +152,7 @@ importers:
         version: 2.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tailgrids/icons':
         specifier: ^2.0.0
-        version: 2.0.0(typescript@5.9.3)
+        version: 2.0.0(supports-color@8.1.1)(typescript@5.9.3)
       '@tailwindcss/postcss':
         specifier: ^4.1.13
         version: 4.3.0
@@ -178,8 +178,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.3.0
+        version: 4.3.0
       lucide-react:
         specifier: ^0.400.0
         version: 0.400.0(react@19.2.3)
@@ -194,7 +194,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       streamdown:
         specifier: ^2.5.0
-        version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.6.0
@@ -207,10 +207,10 @@ importers:
         version: 2.12.0
       '@bufbuild/protoc-gen-es':
         specifier: 2.11.0
-        version: 2.11.0(@bufbuild/protobuf@2.12.0)
+        version: 2.11.0(@bufbuild/protobuf@2.12.0)(supports-color@8.1.1)
       '@bufbuild/protoplugin':
         specifier: ^2.11.0
-        version: 2.12.0
+        version: 2.12.0(supports-color@8.1.1)
       '@playwright/test':
         specifier: ^1.56.1
         version: 1.60.0
@@ -237,16 +237,16 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.2.0(vite@7.3.6(@types/node@25.5.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 5.2.0(supports-color@8.1.1)(vite@7.3.6(@types/node@25.5.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       jest:
         specifier: ^30.2.0
-        version: 30.4.2(@types/node@25.5.2)
+        version: 30.4.2(@types/node@25.5.2)(supports-color@8.1.1)
       jest-environment-jsdom:
         specifier: ^30.2.0
-        version: 30.4.1
+        version: 30.4.1(supports-color@8.1.1)
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.5.2))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@30.4.1(supports-color@8.1.1))(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.5.2)(supports-color@8.1.1))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -308,24 +308,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@astrojs/compiler-binding-linux-arm64-musl@0.3.1':
     resolution: {integrity: sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@astrojs/compiler-binding-linux-x64-gnu@0.3.1':
     resolution: {integrity: sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@astrojs/compiler-binding-linux-x64-musl@0.3.1':
     resolution: {integrity: sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@astrojs/compiler-binding-wasm32-wasi@0.3.1':
     resolution: {integrity: sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==}
@@ -631,21 +635,25 @@ packages:
     resolution: {integrity: sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@bruits/satteri-linux-arm64-musl@0.9.5':
     resolution: {integrity: sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@bruits/satteri-linux-x64-gnu@0.9.5':
     resolution: {integrity: sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@bruits/satteri-linux-x64-musl@0.9.5':
     resolution: {integrity: sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@bruits/satteri-wasm32-wasi@0.9.5':
     resolution: {integrity: sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==}
@@ -1190,89 +1198,105 @@ packages:
     resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.3.2':
     resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.3.2':
     resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.3.2':
     resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.3.2':
     resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.3.2':
     resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.3.2':
     resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.35.3':
     resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.35.3':
     resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.35.3':
     resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.35.3':
     resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.35.3':
     resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.35.3':
     resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.35.3':
     resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.35.3':
     resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.35.3':
     resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
@@ -1570,48 +1594,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -1687,41 +1719,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
@@ -1868,36 +1908,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1971,66 +2017,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -2392,48 +2451,56 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
     resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
     resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2521,24 +2588,28 @@ packages:
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@takumi-rs/core-linux-arm64-musl@1.8.7':
     resolution: {integrity: sha512-akVy80ztI2as/b0n0EVCfHNKhibp+Od4ioP49PtX2rQMi6KDtqv3aoCIjaBls8oxzv+4x77/2U9fsWIO2XZQjg==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@takumi-rs/core-linux-x64-gnu@1.8.7':
     resolution: {integrity: sha512-SV1YesGs/HfC1CMpSF5SqS6KbL4hDLvD2m54JcfB+X/0xatmo/CS2XleqoIXhSmR+95X8Of5g2vg1a4TAdpcug==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@takumi-rs/core-linux-x64-musl@1.8.7':
     resolution: {integrity: sha512-zprYQ/ivPDmYX4tFaONiAzoDJNTANA3kqfIe7SMHZ2YhkfEhYnr3PE3XtBytgB4W/VlTc9WQLyD77SKwPnPuFw==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@takumi-rs/core-win32-arm64-msvc@1.8.7':
     resolution: {integrity: sha512-2S5YcgIj/c0E3sLzWDcxzlXoPvEjR2xC1v7yODe0CvimlRx95Df6rJ9idTS6E1KNUjDaTfqxTr8Ud4gWqYrrPg==}
@@ -2879,41 +2950,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4712,6 +4791,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
@@ -4833,24 +4916,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6952,7 +7039,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@astrojs/markdown-remark@7.2.1':
+  '@astrojs/markdown-remark@7.2.1(supports-color@8.1.1)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/prism': 4.0.2
@@ -6962,8 +7049,8 @@ snapshots:
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
+      remark-gfm: 4.0.1(supports-color@8.1.1)
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       unified: 11.0.5
@@ -6989,19 +7076,19 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.5
 
-  '@astrojs/mdx@7.0.3(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))':
+  '@astrojs/mdx@7.0.3(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))(supports-color@8.1.1)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
-      '@astrojs/markdown-remark': 7.2.1
-      '@mdx-js/mdx': 3.1.1
+      '@astrojs/markdown-remark': 7.2.1(supports-color@8.1.1)
+      '@mdx-js/mdx': 3.1.1(supports-color@8.1.1)
       acorn: 8.16.0
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
       es-module-lexer: 2.3.1
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       piccolore: 0.1.3
       rehype-raw: 7.0.0
-      remark-gfm: 4.0.1
+      remark-gfm: 4.0.1(supports-color@8.1.1)
       remark-smartypants: 3.0.2
       source-map: 0.7.6
       unist-util-visit: 5.1.0
@@ -7011,11 +7098,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/node@11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))':
+  '@astrojs/node@11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))(supports-color@8.1.1)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
-      send: 1.2.1
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
+      send: 1.2.1(supports-color@8.1.1)
       server-destroy: 1.0.1
     transitivePeerDependencies:
       - supports-color
@@ -7024,12 +7111,12 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@6.0.1(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(yaml@2.9.0)':
+  '@astrojs/react@6.0.1(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react': 5.2.0(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 5.2.0(supports-color@8.1.1)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       devalue: 5.8.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -7057,14 +7144,14 @@ snapshots:
       is-docker: 4.0.0
       package-manager-detector: 1.6.0
 
-  '@astrojs/vercel@11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))(react@19.2.3)(rollup@4.60.4)(ws@8.20.1)':
+  '@astrojs/vercel@11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))(react@19.2.3)(rollup@4.60.4)(supports-color@8.1.1)(ws@8.20.1)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@vercel/analytics': 1.6.1(react@19.2.3)
       '@vercel/functions': 3.7.5(ws@8.20.1)
-      '@vercel/nft': 1.10.2(rollup@4.60.4)
+      '@vercel/nft': 1.10.2(rollup@4.60.4)(supports-color@8.1.1)
       '@vercel/routing-utils': 5.3.3
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
       esbuild: 0.28.1
       tinyglobby: 0.2.17
     transitivePeerDependencies:
@@ -7093,20 +7180,20 @@ snapshots:
 
   '@babel/compat-data@7.29.3': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7135,19 +7222,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.28.6':
+  '@babel/helper-module-imports@7.28.6(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7170,108 +7257,108 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.0(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -7284,7 +7371,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -7292,7 +7379,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7342,26 +7429,26 @@ snapshots:
 
   '@bufbuild/protobuf@2.12.0': {}
 
-  '@bufbuild/protoc-gen-es@2.11.0(@bufbuild/protobuf@2.12.0)':
+  '@bufbuild/protoc-gen-es@2.11.0(@bufbuild/protobuf@2.12.0)(supports-color@8.1.1)':
     dependencies:
-      '@bufbuild/protoplugin': 2.11.0
+      '@bufbuild/protoplugin': 2.11.0(supports-color@8.1.1)
     optionalDependencies:
       '@bufbuild/protobuf': 2.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@bufbuild/protoplugin@2.11.0':
+  '@bufbuild/protoplugin@2.11.0(supports-color@8.1.1)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
-      '@typescript/vfs': 1.6.4(typescript@5.4.5)
+      '@typescript/vfs': 1.6.4(supports-color@8.1.1)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@bufbuild/protoplugin@2.12.0':
+  '@bufbuild/protoplugin@2.12.0(supports-color@8.1.1)':
     dependencies:
       '@bufbuild/protobuf': 2.12.0
-      '@typescript/vfs': 1.6.4(typescript@5.4.5)
+      '@typescript/vfs': 1.6.4(supports-color@8.1.1)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -7910,13 +7997,13 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2':
+  '@jest/core@30.4.2(supports-color@8.1.1)':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
-      '@jest/reporters': 30.4.1
+      '@jest/reporters': 30.4.1(supports-color@8.1.1)
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@types/node': 25.5.2
       ansi-escapes: 4.3.2
@@ -7926,15 +8013,15 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@25.5.2)
+      jest-config: 30.4.2(@types/node@25.5.2)(supports-color@8.1.1)
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
-      jest-resolve-dependencies: 30.4.2
-      jest-runner: 30.4.2
-      jest-runtime: 30.4.2
-      jest-snapshot: 30.4.1
+      jest-resolve-dependencies: 30.4.2(supports-color@8.1.1)
+      jest-runner: 30.4.2(supports-color@8.1.1)
+      jest-runtime: 30.4.2(supports-color@8.1.1)
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
       jest-util: 30.4.1
       jest-validate: 30.4.1
       jest-watcher: 30.4.1
@@ -7948,7 +8035,7 @@ snapshots:
 
   '@jest/diff-sequences@30.4.0': {}
 
-  '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
+  '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0(supports-color@8.1.1))':
     dependencies:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
@@ -7957,7 +8044,7 @@ snapshots:
       '@types/node': 25.5.2
       jest-mock: 30.4.1
       jest-util: 30.4.1
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@8.1.1)
 
   '@jest/environment@30.4.1':
     dependencies:
@@ -7970,10 +8057,10 @@ snapshots:
     dependencies:
       '@jest/get-type': 30.1.0
 
-  '@jest/expect@30.4.1':
+  '@jest/expect@30.4.1(supports-color@8.1.1)':
     dependencies:
       expect: 30.4.1
-      jest-snapshot: 30.4.1
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7988,10 +8075,10 @@ snapshots:
 
   '@jest/get-type@30.1.0': {}
 
-  '@jest/globals@30.4.1':
+  '@jest/globals@30.4.1(supports-color@8.1.1)':
     dependencies:
       '@jest/environment': 30.4.1
-      '@jest/expect': 30.4.1
+      '@jest/expect': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       jest-mock: 30.4.1
     transitivePeerDependencies:
@@ -8002,12 +8089,12 @@ snapshots:
       '@types/node': 25.5.2
       jest-regex-util: 30.4.0
 
-  '@jest/reporters@30.4.1':
+  '@jest/reporters@30.4.1(supports-color@8.1.1)':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 30.4.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 25.5.2
@@ -8017,9 +8104,9 @@ snapshots:
       glob: 10.5.0
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
+      istanbul-lib-source-maps: 5.0.6(supports-color@8.1.1)
       istanbul-reports: 3.2.0
       jest-message-util: 30.4.1
       jest-util: 30.4.1
@@ -8061,12 +8148,12 @@ snapshots:
       jest-haste-map: 30.4.1
       slash: 3.0.0
 
-  '@jest/transform@30.4.1':
+  '@jest/transform@30.4.1(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 7.0.1
+      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -8156,11 +8243,11 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
-  '@mapbox/node-pre-gyp@2.0.3':
+  '@mapbox/node-pre-gyp@2.0.3(supports-color@8.1.1)':
     dependencies:
       consola: 3.4.2
       detect-libc: 2.1.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.8.0
@@ -8171,7 +8258,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
-  '@mdx-js/mdx@3.1.1':
+  '@mdx-js/mdx@3.1.1(supports-color@8.1.1)':
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -8183,14 +8270,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0
-      remark-mdx: 3.1.1
-      remark-parse: 11.0.0
+      rehype-recma: 1.0.0(supports-color@8.1.1)
+      remark-mdx: 3.1.1(supports-color@8.1.1)
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -8211,7 +8298,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.30)
       ajv: 8.20.0
@@ -8221,8 +8308,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.5.2(express@5.2.1(supports-color@8.1.1))
       hono: 4.12.30
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -8252,6 +8339,13 @@ snapshots:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -8506,7 +8600,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
@@ -8602,10 +8696,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
-  '@scalar/astro@0.4.9(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))':
+  '@scalar/astro@0.4.9(astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))':
     dependencies:
       '@scalar/client-side-rendering': 0.3.2
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
 
   '@scalar/client-side-rendering@0.3.2':
     dependencies:
@@ -8692,11 +8786,11 @@ snapshots:
       '@shikijs/core': 4.3.1
       '@shikijs/types': 4.3.1
 
-  '@shikijs/twoslash@4.3.1(typescript@6.0.3)':
+  '@shikijs/twoslash@4.3.1(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@shikijs/core': 4.3.1
       '@shikijs/types': 4.3.1
-      twoslash: 0.3.9(typescript@6.0.3)
+      twoslash: 0.3.9(supports-color@8.1.1)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -8777,16 +8871,16 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
+  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(supports-color@8.1.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0(rollup@4.60.4)
       '@storybook/builder-vite': 10.4.2(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
-      '@storybook/react': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)
+      '@storybook/react': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(supports-color@8.1.1)(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.3
-      react-docgen: 8.0.3
+      react-docgen: 8.0.3(supports-color@8.1.1)
       react-dom: 19.2.3(react@19.2.3)
       resolve: 1.22.12
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -8801,12 +8895,12 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)':
+  '@storybook/react@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
-      react-docgen: 8.0.3
+      react-docgen: 8.0.3(supports-color@8.1.1)
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.3(react@19.2.3)
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -8817,54 +8911,54 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0(supports-color@8.1.1))
 
-  '@svgr/core@8.1.0(typescript@5.9.3)':
+  '@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@8.1.1))
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
@@ -8877,11 +8971,11 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -8891,12 +8985,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailgrids/icons@2.0.0(typescript@5.9.3)':
+  '@tailgrids/icons@2.0.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
       fs-extra: 11.3.5
     transitivePeerDependencies:
       - supports-color
@@ -9380,16 +9474,16 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript/vfs@1.6.4(typescript@5.4.5)':
+  '@typescript/vfs@1.6.4(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript/vfs@1.6.4(typescript@6.0.3)':
+  '@typescript/vfs@1.6.4(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -9510,9 +9604,9 @@ snapshots:
     optionalDependencies:
       ws: 8.20.1
 
-  '@vercel/nft@1.10.2(rollup@4.60.4)':
+  '@vercel/nft@1.10.2(rollup@4.60.4)(supports-color@8.1.1)':
     dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3
+      '@mapbox/node-pre-gyp': 2.0.3(supports-color@8.1.1)
       '@rollup/pluginutils': 5.4.0(rollup@4.60.4)
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -9544,11 +9638,11 @@ snapshots:
     optionalDependencies:
       ajv: 6.15.0
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@25.5.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(supports-color@8.1.1)(vite@7.3.6(@types/node@25.5.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.0(supports-color@8.1.1))
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -9556,11 +9650,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(supports-color@8.1.1)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.0(supports-color@8.1.1))
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -9761,7 +9855,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0):
+  astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
       '@astrojs/internal-helpers': 0.10.1
@@ -9817,7 +9911,7 @@ snapshots:
       yargs-parser: 22.0.0
       zod: 4.4.3
     optionalDependencies:
-      '@astrojs/markdown-remark': 7.2.1
+      '@astrojs/markdown-remark': 7.2.1(supports-color@8.1.1)
       sharp: 0.35.3(@types/node@25.5.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -9860,25 +9954,25 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-jest@30.4.1(@babel/core@7.29.0):
+  babel-jest@30.4.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 30.4.1
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.4.0(@babel/core@7.29.0)
+      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
+      babel-preset-jest: 30.4.0(@babel/core@7.29.0(supports-color@8.1.1))
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-istanbul@7.0.1:
+  babel-plugin-istanbul@7.0.1(supports-color@8.1.1):
     dependencies:
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
-      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -9891,30 +9985,30 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0(supports-color@8.1.1))
 
-  babel-preset-jest@30.4.0(@babel/core@7.29.0):
+  babel-preset-jest@30.4.0(@babel/core@7.29.0(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       babel-plugin-jest-hoist: 30.4.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0(supports-color@8.1.1))
 
   bail@2.0.2: {}
 
@@ -9928,33 +10022,33 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
-  blume@1.0.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@shikijs/themes@4.3.1)(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vercel/functions@3.7.5(ws@8.20.1))(esbuild@0.28.1)(prettier@3.9.5)(rollup@4.60.4)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(ws@8.20.1)(yaml@2.9.0):
+  blume@1.0.3(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@shikijs/themes@4.3.1)(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vercel/functions@3.7.5(ws@8.20.1))(esbuild@0.28.1)(prettier@3.9.5)(rollup@4.60.4)(supports-color@8.1.1)(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(ws@8.20.1)(yaml@2.9.0):
     dependencies:
       '@astrojs/check': 0.9.9(prettier@3.9.5)(typescript@6.0.3)
       '@astrojs/markdown-satteri': 0.3.3
-      '@astrojs/mdx': 7.0.3(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))
-      '@astrojs/node': 11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))
-      '@astrojs/react': 6.0.1(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(yaml@2.9.0)
-      '@astrojs/vercel': 11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))(react@19.2.3)(rollup@4.60.4)(ws@8.20.1)
+      '@astrojs/mdx': 7.0.3(@astrojs/markdown-satteri@0.3.3)(astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))(supports-color@8.1.1)
+      '@astrojs/node': 11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))(supports-color@8.1.1)
+      '@astrojs/react': 6.0.1(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)(yaml@2.9.0)
+      '@astrojs/vercel': 11.0.2(astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))(react@19.2.3)(rollup@4.60.4)(supports-color@8.1.1)(ws@8.20.1)
       '@clack/prompts': 1.7.0
       '@iconify-json/lucide': 1.2.116
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.3
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@8.1.1)(zod@3.25.76)
       '@orama/orama': 3.1.18
       '@pierre/diffs': 1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@scalar/astro': 0.4.9(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))
+      '@scalar/astro': 0.4.9(astro@7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0))
       '@scalar/openapi-parser': 0.28.8
       '@scalar/openapi-types': 0.9.1
       '@shikijs/transformers': 4.3.1
-      '@shikijs/twoslash': 4.3.1(typescript@6.0.3)
+      '@shikijs/twoslash': 4.3.1(supports-color@8.1.1)(typescript@6.0.3)
       '@tailwindcss/typography': 0.5.20(tailwindcss@4.3.0)
       '@tailwindcss/vite': 4.3.2(vite@8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@takumi-rs/core': 1.8.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@takumi-rs/helpers': 1.8.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@vercel/analytics': 2.0.1(react@19.2.3)
       ai: 5.0.188(zod@3.25.76)
-      astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro: 7.0.9(@astrojs/markdown-remark@7.2.1(supports-color@8.1.1))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.5.2)(@vercel/functions@3.7.5(ws@8.20.1))(jiti@2.7.0)(rollup@4.60.4)(yaml@2.9.0)
       babel-plugin-react-compiler: 1.0.0
       citty: 0.1.6
       consola: 3.4.2
@@ -10033,11 +10127,11 @@ snapshots:
       - ws
       - yaml
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -10248,7 +10342,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -10500,9 +10594,11 @@ snapshots:
 
   dayjs@1.11.20: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decimal.js@10.6.0: {}
 
@@ -10851,25 +10947,25 @@ snapshots:
       jest-mock: 30.4.1
       jest-util: 30.4.1
 
-  express-rate-limit@8.5.2(express@5.2.1):
+  express-rate-limit@8.5.2(express@5.2.1(supports-color@8.1.1)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@8.1.1)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -10880,9 +10976,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1(supports-color@8.1.1)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -10925,9 +11021,9 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -11141,7 +11237,7 @@ snapshots:
       '@ungap/structured-clone': 1.3.1
       unist-util-position: 5.0.0
 
-  hast-util-to-estree@3.1.3:
+  hast-util-to-estree@3.1.3(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -11151,9 +11247,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -11176,7 +11272,7 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
-  hast-util-to-jsx-runtime@2.3.6:
+  hast-util-to-jsx-runtime@2.3.6(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
@@ -11185,9 +11281,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -11256,17 +11352,17 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11368,13 +11464,13 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@6.0.3:
+  istanbul-lib-instrument@6.0.3(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/parser': 7.29.3
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 7.8.0
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -11384,10 +11480,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@8.1.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -11415,10 +11511,10 @@ snapshots:
       jest-util: 30.4.1
       p-limit: 3.1.0
 
-  jest-circus@30.4.2:
+  jest-circus@30.4.2(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.4.1
-      '@jest/expect': 30.4.1
+      '@jest/expect': 30.4.1(supports-color@8.1.1)
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       '@types/node': 25.5.2
@@ -11429,8 +11525,8 @@ snapshots:
       jest-each: 30.4.1
       jest-matcher-utils: 30.4.1
       jest-message-util: 30.4.1
-      jest-runtime: 30.4.2
-      jest-snapshot: 30.4.1
+      jest-runtime: 30.4.2(supports-color@8.1.1)
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
       jest-util: 30.4.1
       p-limit: 3.1.0
       pretty-format: 30.4.1
@@ -11441,15 +11537,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@25.5.2):
+  jest-cli@30.4.2(@types/node@25.5.2)(supports-color@8.1.1):
     dependencies:
-      '@jest/core': 30.4.2
+      '@jest/core': 30.4.2(supports-color@8.1.1)
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@25.5.2)
+      jest-config: 30.4.2(@types/node@25.5.2)(supports-color@8.1.1)
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.2
@@ -11460,25 +11556,25 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@25.5.2):
+  jest-config@30.4.2(@types/node@25.5.2)(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.4.0
       '@jest/test-sequencer': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.0)
+      babel-jest: 30.4.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.4.2
+      jest-circus: 30.4.2(supports-color@8.1.1)
       jest-docblock: 30.4.0
       jest-environment-node: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
-      jest-runner: 30.4.2
+      jest-runner: 30.4.2(supports-color@8.1.1)
       jest-util: 30.4.1
       jest-validate: 30.4.1
       parse-json: 5.2.0
@@ -11510,11 +11606,11 @@ snapshots:
       jest-util: 30.4.1
       pretty-format: 30.4.1
 
-  jest-environment-jsdom@30.4.1:
+  jest-environment-jsdom@30.4.1(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.4.1
-      '@jest/environment-jsdom-abstract': 30.4.1(jsdom@26.1.0)
-      jsdom: 26.1.0
+      '@jest/environment-jsdom-abstract': 30.4.1(jsdom@26.1.0(supports-color@8.1.1))
+      jsdom: 26.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -11582,10 +11678,10 @@ snapshots:
 
   jest-regex-util@30.4.0: {}
 
-  jest-resolve-dependencies@30.4.2:
+  jest-resolve-dependencies@30.4.2(supports-color@8.1.1):
     dependencies:
       jest-regex-util: 30.4.0
-      jest-snapshot: 30.4.1
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11600,12 +11696,12 @@ snapshots:
       slash: 3.0.0
       unrs-resolver: 1.11.1
 
-  jest-runner@30.4.2:
+  jest-runner@30.4.2(supports-color@8.1.1):
     dependencies:
       '@jest/console': 30.4.1
       '@jest/environment': 30.4.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@types/node': 25.5.2
       chalk: 4.1.2
@@ -11618,7 +11714,7 @@ snapshots:
       jest-leak-detector: 30.4.1
       jest-message-util: 30.4.1
       jest-resolve: 30.4.1
-      jest-runtime: 30.4.2
+      jest-runtime: 30.4.2(supports-color@8.1.1)
       jest-util: 30.4.1
       jest-watcher: 30.4.1
       jest-worker: 30.4.1
@@ -11627,14 +11723,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@30.4.2:
+  jest-runtime@30.4.2(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
-      '@jest/globals': 30.4.1
+      '@jest/globals': 30.4.1(supports-color@8.1.1)
       '@jest/source-map': 30.0.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@types/node': 25.5.2
       chalk: 4.1.2
@@ -11647,26 +11743,26 @@ snapshots:
       jest-mock: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
-      jest-snapshot: 30.4.1
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
       jest-util: 30.4.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@30.4.1:
+  jest-snapshot@30.4.1(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/types': 7.29.0
       '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0(supports-color@8.1.1))
       chalk: 4.1.2
       expect: 30.4.1
       graceful-fs: 4.2.11
@@ -11717,12 +11813,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@25.5.2):
+  jest@30.4.2(@types/node@25.5.2)(supports-color@8.1.1):
     dependencies:
-      '@jest/core': 30.4.2
+      '@jest/core': 30.4.2(supports-color@8.1.1)
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@25.5.2)
+      jest-cli: 30.4.2(@types/node@25.5.2)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11749,14 +11845,18 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@26.1.0:
+  js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
+  jsdom@26.1.0(supports-color@8.1.1):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -11970,14 +12070,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -11995,67 +12095,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@8.1.1):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@8.1.1)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-table: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1:
+  mdast-util-mdx-expression@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0:
+  mdast-util-mdx-jsx@3.2.0(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -12063,7 +12163,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -12072,23 +12172,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0:
+  mdast-util-mdx@3.0.0(supports-color@8.1.1):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1:
+  mdast-util-mdxjs-esm@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -12402,10 +12502,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@8.1.1):
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -12888,10 +12988,10 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  react-docgen@8.0.3:
+  react-docgen@8.0.3(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/traverse': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -13004,11 +13104,11 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
-  rehype-recma@1.0.0:
+  rehype-recma@1.0.0(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
-      hast-util-to-estree: 3.1.3
+      hast-util-to-estree: 3.1.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13023,28 +13123,28 @@ snapshots:
       hast-util-to-html: 9.0.5
       unified: 11.0.5
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@8.1.1)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.1:
+  remark-mdx@3.1.1(supports-color@8.1.1):
     dependencies:
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@8.1.1)
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -13184,9 +13284,9 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -13240,9 +13340,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -13256,12 +13356,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13417,10 +13517,10 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  streamdown@2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  streamdown@2.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@8.1.1):
     dependencies:
       clsx: 2.1.1
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
       html-url-attributes: 3.0.1
       marked: 17.0.6
       mermaid: 11.15.0
@@ -13429,8 +13529,8 @@ snapshots:
       rehype-harden: 1.1.8
       rehype-raw: 7.0.0
       rehype-sanitize: 6.0.0
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
+      remark-gfm: 4.0.1(supports-color@8.1.1)
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       remend: 1.3.0
       tailwind-merge: 3.6.0
@@ -13626,12 +13726,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.5.2))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.0(supports-color@8.1.1))(@jest/transform@30.4.1(supports-color@8.1.1))(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.5.2)(supports-color@8.1.1))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@25.5.2)
+      jest: 30.4.2(@types/node@25.5.2)(supports-color@8.1.1)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -13640,10 +13740,11 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 30.4.1
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.0)
+      babel-jest: 30.4.1(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      esbuild: 0.28.1
       jest-util: 30.4.1
 
   tsconfig-paths@4.2.0:
@@ -13654,13 +13755,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(supports-color@8.1.1)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -13684,9 +13785,9 @@ snapshots:
 
   twoslash-protocol@0.3.9: {}
 
-  twoslash@0.3.9(typescript@6.0.3):
+  twoslash@0.3.9(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
-      '@typescript/vfs': 1.6.4(typescript@6.0.3)
+      '@typescript/vfs': 1.6.4(supports-color@8.1.1)(typescript@6.0.3)
       twoslash-protocol: 0.3.9
       typescript: 6.0.3
     transitivePeerDependencies:

--- a/src/gateway/rpc/files.rs
+++ b/src/gateway/rpc/files.rs
@@ -689,10 +689,11 @@ impl GrpcGatewayHandler {
         artifact_uri: &str,
         operation: &str,
         caller: HandleCaller,
+        metadata: &MetadataMap,
     ) -> Result<(ArtifactUri, data_proto::Artifact)> {
         let uri = parse_artifact_uri(artifact_uri)?;
         let artifact = self.load_artifact_by_uri(&uri).await?;
-        authorize_artifact_access(self, &uri, operation, caller, artifact_uri).await?;
+        authorize_artifact_access(self, &uri, operation, caller, artifact_uri, metadata).await?;
         Ok((uri, artifact))
     }
 
@@ -1026,6 +1027,7 @@ impl proto::file_service_server::FileService for GrpcGatewayHandler {
                 &req.get_ref().artifact_uri,
                 OP_PROMOTE,
                 handle_caller_from_request(self, &req),
+                req.metadata(),
             )
             .await
             .map_err(to_status)?;
@@ -1088,6 +1090,7 @@ impl proto::artifact_service_server::ArtifactService for GrpcGatewayHandler {
                 &req.get_ref().artifact_uri,
                 OP_READ,
                 handle_caller_from_request(self, &req),
+                req.metadata(),
             )
             .await
             .map_err(to_status)?;
@@ -1115,6 +1118,7 @@ impl proto::artifact_service_server::ArtifactService for GrpcGatewayHandler {
                 &req.get_ref().artifact_uri,
                 OP_METADATA,
                 handle_caller_from_request(self, &req),
+                req.metadata(),
             )
             .await
             .map_err(to_status)?;
@@ -1186,9 +1190,10 @@ impl proto::artifact_service_server::ArtifactService for GrpcGatewayHandler {
         req: Request<proto::GrantArtifactRequest>,
     ) -> std::result::Result<Response<proto::ArtifactUriResponse>, Status> {
         let caller = handle_caller_from_request(self, &req);
+        let metadata = req.metadata().clone();
         let req = req.into_inner();
         let (uri, _) = self
-            .resolve_artifact_uri(&req.artifact_uri, OP_READ, caller.clone())
+            .resolve_artifact_uri(&req.artifact_uri, OP_READ, caller.clone(), &metadata)
             .await
             .map_err(to_status)?;
         let operations = if req.operations.is_empty() {
@@ -1436,10 +1441,37 @@ async fn authorize_artifact_access(
     operation: &str,
     caller: HandleCaller,
     artifact_uri: &str,
+    metadata: &MetadataMap,
 ) -> Result<()> {
-    if caller.agent == uri.agent && caller.session_id == uri.session_id {
+    // Owner session (matching agent + session) may always read/metadata/promote.
+    if !caller.agent.trim().is_empty()
+        && !caller.session_id.trim().is_empty()
+        && caller.agent == uri.agent
+        && caller.session_id == uri.session_id
+    {
         return Ok(());
     }
+
+    // Namespace-scoped JWTs with read on the artifact's namespace may read
+    // content/metadata (same model as ListArtifacts). Do not relax promote/write.
+    if matches!(operation, OP_READ | OP_METADATA) {
+        if let Some(auth_config) = &handler.gateway.auth_config {
+            if auth_config.mode == crate::gateway::auth::AuthMode::Jwt
+                && crate::gateway::auth::check_auth_for_operation(
+                    metadata,
+                    auth_config,
+                    crate::gateway::auth::AuthzOperation::Read,
+                    &uri.namespace,
+                    None,
+                    None,
+                )
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+    }
+
     if caller.agent.trim().is_empty() || caller.session_id.trim().is_empty() {
         return Err(permission_denied(
             "artifact uri requires caller agent and session identity",
@@ -2202,6 +2234,207 @@ mod tests {
         .unwrap()
         .into_inner();
         assert_eq!(granted_read.content, b"final draft");
+    }
+
+    #[tokio::test]
+    async fn namespace_jwt_can_read_artifact_content_and_metadata() {
+        use crate::control::security::platform_jwt;
+        use crate::gateway::auth::TalonGrantClaim;
+        use crate::test_support::{PlatformJwtEnvGuard, TEST_PLATFORM_JWT_ISSUER};
+
+        let _guard = PlatformJwtEnvGuard::acquire().await;
+        let objects = Arc::new(InMemoryObjectStore::default());
+        let control_plane = ControlPlane::builder(
+            Arc::new(MockKvStore::default()),
+            Arc::new(RecordingPubSub::default()),
+        )
+        .objects(objects.clone())
+        .build();
+        let handler = GrpcGatewayHandler {
+            gateway: Arc::new(Gateway::from_control_plane(
+                Some(AuthConfig::jwt_platform()),
+                control_plane,
+            )),
+        };
+
+        let namespace = "Tenant:acme:Workspace:main";
+        let other_namespace = "Tenant:other:Workspace:main";
+        let artifact_id = "artifact-ns-read";
+        let session_id = "session-1";
+        let object_ref = CasStore::new(objects)
+            .put_artifact(
+                namespace,
+                "writer",
+                session_id,
+                artifact_id,
+                b"namespace readable",
+                "text/markdown",
+                HashMap::new(),
+            )
+            .await
+            .unwrap();
+        handler
+            .gateway
+            .kv
+            .set_msg(
+                &keys::artifact(namespace, "writer", session_id, artifact_id),
+                &data_proto::Artifact {
+                    id: artifact_id.to_string(),
+                    session_id: session_id.to_string(),
+                    title: "NS draft".to_string(),
+                    media_type: "text/markdown".to_string(),
+                    object_ref: Some(object_ref),
+                    created_by_agent: "writer".to_string(),
+                    created_at: chrono::Utc::now().timestamp_micros(),
+                    labels: HashMap::new(),
+                    metadata: HashMap::new(),
+                },
+            )
+            .await
+            .unwrap();
+        let artifact_uri = format!("artifact://{namespace}/writer/{session_id}/{artifact_id}");
+
+        let sign = |grants: Vec<TalonGrantClaim>| {
+            platform_jwt::PlatformJwtKey::from_pem(platform_jwt::TEST_RSA_PRIVATE_KEY)
+                .unwrap()
+                .sign(&Claims {
+                    iss: Some(TEST_PLATFORM_JWT_ISSUER.to_string()),
+                    sub: "oidc:operator".to_string(),
+                    aud: platform_jwt::TALON_GATEWAY_AUDIENCE.to_string(),
+                    iat: Some(1),
+                    exp: 10000000000,
+                    ns: None,
+                    agent: None,
+                    session: None,
+                    channel: None,
+                    origins: Vec::new(),
+                    grants,
+                })
+                .unwrap()
+        };
+
+        let allowed_token = sign(vec![TalonGrantClaim {
+            kind: "read".to_string(),
+            namespace: Some(namespace.to_string()),
+            agent: None,
+            session: None,
+            channel: None,
+        }]);
+        let wrong_ns_token = sign(vec![TalonGrantClaim {
+            kind: "read".to_string(),
+            namespace: Some(other_namespace.to_string()),
+            agent: None,
+            session: None,
+            channel: None,
+        }]);
+        let agent_scoped_token = sign(vec![TalonGrantClaim {
+            kind: "read".to_string(),
+            namespace: Some(namespace.to_string()),
+            agent: Some("other-agent".to_string()),
+            session: None,
+            channel: None,
+        }]);
+
+        let mut allowed_req = Request::new(proto::ReadArtifactRequest {
+            artifact_uri: artifact_uri.clone(),
+        });
+        allowed_req.metadata_mut().insert(
+            "authorization",
+            format!("Bearer {allowed_token}").parse().unwrap(),
+        );
+        // Namespace operator JWT has no agent/session claims.
+        allowed_req.extensions_mut().insert(Claims {
+            iss: Some(TEST_PLATFORM_JWT_ISSUER.to_string()),
+            sub: "oidc:operator".to_string(),
+            aud: platform_jwt::TALON_GATEWAY_AUDIENCE.to_string(),
+            iat: Some(1),
+            exp: 10000000000,
+            ns: None,
+            agent: None,
+            session: None,
+            channel: None,
+            origins: Vec::new(),
+            grants: vec![TalonGrantClaim {
+                kind: "read".to_string(),
+                namespace: Some(namespace.to_string()),
+                agent: None,
+                session: None,
+                channel: None,
+            }],
+        });
+
+        let allowed_read =
+            proto::artifact_service_server::ArtifactService::read_artifact(&handler, allowed_req)
+                .await
+                .unwrap()
+                .into_inner();
+        assert_eq!(allowed_read.content, b"namespace readable");
+
+        let mut metadata_req = Request::new(proto::GetArtifactMetadataRequest {
+            artifact_uri: artifact_uri.clone(),
+        });
+        metadata_req.metadata_mut().insert(
+            "authorization",
+            format!("Bearer {allowed_token}").parse().unwrap(),
+        );
+        let metadata = proto::artifact_service_server::ArtifactService::get_artifact_metadata(
+            &handler,
+            metadata_req,
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert_eq!(metadata.artifact.unwrap().title, "NS draft");
+
+        let mut denied_req = Request::new(proto::ReadArtifactRequest {
+            artifact_uri: artifact_uri.clone(),
+        });
+        denied_req.metadata_mut().insert(
+            "authorization",
+            format!("Bearer {wrong_ns_token}").parse().unwrap(),
+        );
+        let denied =
+            proto::artifact_service_server::ArtifactService::read_artifact(&handler, denied_req)
+                .await
+                .unwrap_err();
+        assert_eq!(denied.code(), tonic::Code::PermissionDenied);
+
+        // Agent-scoped grant without matching agent selector cannot use the
+        // namespace-read path when check_auth is called with agent=None (grant
+        // agent selector fails), and has no owner/session identity.
+        let mut agent_scoped_req = Request::new(proto::ReadArtifactRequest {
+            artifact_uri: artifact_uri.clone(),
+        });
+        agent_scoped_req.metadata_mut().insert(
+            "authorization",
+            format!("Bearer {agent_scoped_token}").parse().unwrap(),
+        );
+        agent_scoped_req.extensions_mut().insert(Claims {
+            iss: Some(TEST_PLATFORM_JWT_ISSUER.to_string()),
+            sub: "oidc:agent-user".to_string(),
+            aud: platform_jwt::TALON_GATEWAY_AUDIENCE.to_string(),
+            iat: Some(1),
+            exp: 10000000000,
+            ns: None,
+            agent: Some("other-agent".to_string()),
+            session: None,
+            channel: None,
+            origins: Vec::new(),
+            grants: vec![TalonGrantClaim {
+                kind: "read".to_string(),
+                namespace: Some(namespace.to_string()),
+                agent: Some("other-agent".to_string()),
+                session: None,
+                channel: None,
+            }],
+        });
+        let agent_denied = proto::artifact_service_server::ArtifactService::read_artifact(
+            &handler,
+            agent_scoped_req,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(agent_denied.code(), tonic::Code::PermissionDenied);
     }
 
     #[tokio::test]

--- a/src/gateway/rpc/files.rs
+++ b/src/gateway/rpc/files.rs
@@ -1193,7 +1193,7 @@ impl proto::artifact_service_server::ArtifactService for GrpcGatewayHandler {
         let metadata = req.metadata().clone();
         let req = req.into_inner();
         let (uri, _) = self
-            .resolve_artifact_uri(&req.artifact_uri, OP_READ, caller.clone(), &metadata)
+            .resolve_artifact_uri(&req.artifact_uri, OP_WRITE, caller.clone(), &metadata)
             .await
             .map_err(to_status)?;
         let operations = if req.operations.is_empty() {
@@ -2385,6 +2385,23 @@ mod tests {
         .unwrap()
         .into_inner();
         assert_eq!(metadata.artifact.unwrap().title, "NS draft");
+
+        let mut grant_req = Request::new(proto::GrantArtifactRequest {
+            artifact_uri: artifact_uri.clone(),
+            target_agent: "critic".to_string(),
+            target_session_id: "session-2".to_string(),
+            operations: vec![OP_READ.to_string()],
+            ttl_seconds: 60,
+        });
+        grant_req.metadata_mut().insert(
+            "authorization",
+            format!("Bearer {allowed_token}").parse().unwrap(),
+        );
+        let grant_denied =
+            proto::artifact_service_server::ArtifactService::grant_artifact(&handler, grant_req)
+                .await
+                .unwrap_err();
+        assert_eq!(grant_denied.code(), tonic::Code::PermissionDenied);
 
         let mut denied_req = Request::new(proto::ReadArtifactRequest {
             artifact_uri: artifact_uri.clone(),


### PR DESCRIPTION
## Summary
- Linkify bare and markdown-linked `artifact://` and `file://` URIs in `@impalasys/talon-chat` messages as clickable links.
- Open selected resources in an animated 50/50 split pane (title header only) with text/markdown, JSON, image, and download rendering.
- Encode resource hrefs as harden-safe `#talon-resource/…` hashes so Streamdown does not mark them `[blocked]`.
- Extend `GatewayClientLike` with optional `artifacts` / `files` clients; support host `onResourceClick` / `fetchResource` overrides.
- Gateway: allow namespace-scoped JWT operators to `ReadArtifact` / `GetArtifactMetadata` (aligned with list access).

## Test plan
- [x] `node --experimental-strip-types --test packages/talon-chat/src/lib/resourceUris.test.ts`
- [x] Pre-push: `cargo fmt`, `cargo build --locked --bins`, `cargo test --locked` (778+ unit tests)
- [ ] Storybook: **Resource URIs (click to open pane)** — click links open/close pane
- [ ] Storybook: auto-open pane stories render content (markdown, JSON, image, denied, loading)
- [ ] Sightline: session with artifact/file URI opens pane using full gateway client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clickable `artifact://` and `file://` links in chat messages, with optional host callbacks.
  * Open resources in a side pane (Markdown, text/code, images, downloads, loading states, and access errors).
  * Added resource URI parsing/linkification utilities and exported view-model helpers.
  * Added Storybook coverage for resource URI and pane behaviors.
* **Bug Fixes**
  * Improved namespace-scoped JWT authorization for reading artifact content/metadata (while preventing write/grant).
* **Documentation**
  * Added a “Resource URIs” section with supported schemes and click/pane behavior details.
* **Tests / Chores**
  * Added a Node `--test` runner script for resource URI utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->