### PR TITLE
Fix tool-call streaming progress

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -1536,6 +1536,7 @@ export function TalonSession({
 
                       const toolKey = `${message.id}-work-tool-${item.toolCallId || index}`;
                       const isToolExpanded = expandedToolItems[toolKey] ?? false;
+                      const isRunningTool = isLiveAssistantMessage && item.result === undefined;
                       return (
                         <div key={toolKey}>
                           <button
@@ -1560,6 +1561,11 @@ export function TalonSession({
                             <span style={{ minWidth: 0, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                               Called <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{item.toolName}</span>
                             </span>
+                            {isRunningTool ? (
+                              <span style={{ flexShrink: 0, borderRadius: 999, background: "var(--talon-chat-tool-running-bg, rgba(14,165,233,0.12))", color: "var(--talon-chat-tool-running-fg, #0369a1)", padding: "0.1rem 0.45rem", fontSize: 11, fontWeight: 700 }}>
+                                Running
+                              </span>
+                            ) : null}
                             <ChevronRight
                               className="talon-session-tool-chevron"
                               size="14"
@@ -1759,6 +1765,7 @@ export function TalonSession({
 
                       const toolKey = `${message.id}-timeline-tool-${item.toolCallId || index}`;
                       const isToolExpanded = expandedToolItems[toolKey] ?? false;
+                      const isRunningTool = isLiveAssistantMessage && item.result === undefined;
                       return (
                         <div key={toolKey}>
                           <button
@@ -1783,6 +1790,11 @@ export function TalonSession({
                             <span style={{ minWidth: 0, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                               Called <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{item.toolName}</span>
                             </span>
+                            {isRunningTool ? (
+                              <span style={{ flexShrink: 0, borderRadius: 999, background: "var(--talon-chat-tool-running-bg, rgba(14,165,233,0.12))", color: "var(--talon-chat-tool-running-fg, #0369a1)", padding: "0.1rem 0.45rem", fontSize: 11, fontWeight: 700 }}>
+                                Running
+                              </span>
+                            ) : null}
                             <ChevronRight
                               className="talon-session-tool-chevron"
                               size="14"
@@ -2507,14 +2519,14 @@ export function TalonSession({
       }, { signal: controller.signal });
 
       submitTurnStarted = true;
-      const { assistantText } = await streamSessionPartEvents({
+      const { hasAssistantEvent } = await streamSessionPartEvents({
         events: turnStream,
         setMessages,
         setStreamEvents,
         signal: controller.signal,
       });
 
-      if (!assistantText) {
+      if (!hasAssistantEvent) {
         await waitForCanonicalAssistantUpdate(session, baselineAssistantSignature);
       } else {
         await refreshNewestSessionPage(session);

--- a/packages/talon-chat/src/lib/uiStream.ts
+++ b/packages/talon-chat/src/lib/uiStream.ts
@@ -159,6 +159,7 @@ export async function streamUiSubmission(options: {
   let buffer = "";
   let assistantText = "";
   let assistantMessageId: string | null = null;
+  let hasAssistantEvent = false;
 
   const ensureLiveAssistant = (messageId?: string) => {
     const nextMessageId = messageId || assistantMessageId || createLocalMessageId();
@@ -205,14 +206,17 @@ export async function streamUiSubmission(options: {
       if (code === UI_STREAM_ASSISTANT_MESSAGE_ID_CODE && typeof part?.messageId === "string" && part.messageId) {
         ensureLiveAssistant(part.messageId);
       } else if (code === UI_STREAM_TEXT_CHUNK_CODE && typeof part === "string") {
+        hasAssistantEvent = true;
         const messageId = ensureLiveAssistant();
         assistantText += part;
         setMessages((prev) => appendAssistantText(prev, messageId, part));
       } else if (code === UI_STREAM_REASONING_CHUNK_CODE && typeof part === "string") {
+        hasAssistantEvent = true;
         const messageId = ensureLiveAssistant();
         setStreamEvents((prev) => [...prev, { type: "reasoning", content: part }]);
         setMessages((prev) => appendAssistantReasoning(prev, messageId, part));
       } else if (code === UI_STREAM_TOOL_CALL_CODE) {
+        hasAssistantEvent = true;
         const messageId = ensureLiveAssistant();
         setStreamEvents((prev) => [
           ...prev,
@@ -234,6 +238,7 @@ export async function streamUiSubmission(options: {
           ),
         );
       } else if (code === UI_STREAM_TOOL_RESULT_CODE) {
+        hasAssistantEvent = true;
         const messageId = ensureLiveAssistant();
         setStreamEvents((prev) => [
           ...prev,
@@ -254,6 +259,7 @@ export async function streamUiSubmission(options: {
           ),
         );
       } else if (code === UI_STREAM_USAGE_CODE && part && typeof part === "object") {
+        hasAssistantEvent = true;
         const messageId = ensureLiveAssistant();
         setStreamEvents((prev) => [
           ...prev,
@@ -270,7 +276,7 @@ export async function streamUiSubmission(options: {
     }
   }
 
-  return { assistantText };
+  return { assistantText, hasAssistantEvent };
 }
 
 export async function streamSessionPartEvents(options: {
@@ -282,6 +288,7 @@ export async function streamSessionPartEvents(options: {
   const { events, setMessages, setStreamEvents, signal } = options;
   let assistantText = "";
   let assistantMessageId: string | null = null;
+  let hasAssistantEvent = false;
 
   const ensureLiveAssistant = (messageId?: string) => {
     const nextMessageId = messageId || assistantMessageId || createLocalMessageId();
@@ -320,21 +327,26 @@ export async function streamSessionPartEvents(options: {
     const messageId = ensureLiveAssistant(event?.messageId ?? event?.message_id);
 
     if (partType === SESSION_MESSAGE_PART_TYPE.TEXT || partType === "SESSION_MESSAGE_PART_TYPE_TEXT") {
+      hasAssistantEvent = true;
       assistantText += content;
       setMessages((prev) => appendAssistantText(prev, messageId, content));
     } else if (partType === SESSION_MESSAGE_PART_TYPE.REASONING || partType === "SESSION_MESSAGE_PART_TYPE_REASONING") {
+      hasAssistantEvent = true;
       setStreamEvents((prev) => [...prev, { type: "reasoning", content }]);
       setMessages((prev) => appendAssistantReasoning(prev, messageId, content));
     } else if (partType === SESSION_MESSAGE_PART_TYPE.TOOL_CALL || partType === "SESSION_MESSAGE_PART_TYPE_TOOL_CALL") {
+      hasAssistantEvent = true;
       const toolCallId = typeof payload?.tool_call_id === "string" ? payload.tool_call_id : part.id || `tool-${createLocalMessageId()}`;
       const toolName = typeof part.name === "string" && part.name ? part.name : "tool";
       setStreamEvents((prev) => [...prev, { type: "tool_call", content: toolName, name: toolName, payload }]);
       setMessages((prev) => applyToolInvocationToMessages(prev, toolCallId, toolName, payload?.input, undefined, messageId));
     } else if (partType === SESSION_MESSAGE_PART_TYPE.TOOL_RESULT || partType === "SESSION_MESSAGE_PART_TYPE_TOOL_RESULT") {
+      hasAssistantEvent = true;
       const toolCallId = typeof payload?.tool_call_id === "string" ? payload.tool_call_id : part.id || `tool-${createLocalMessageId()}`;
       setStreamEvents((prev) => [...prev, { type: "tool_result", content: toolCallId, payload }]);
       setMessages((prev) => applyToolInvocationToMessages(prev, toolCallId, "", undefined, payload?.output ?? content, messageId));
     } else if (partType === SESSION_MESSAGE_PART_TYPE.USAGE || partType === "SESSION_MESSAGE_PART_TYPE_USAGE") {
+      hasAssistantEvent = true;
       const usage = payload && typeof payload === "object" ? payload as UsageSummary : {};
       setStreamEvents((prev) => [...prev, { type: "usage", content: formatUsageSummary(usage), payload: usage }]);
       setMessages((prev) => applyUsageToMessages(prev, messageId, usage));
@@ -342,11 +354,12 @@ export async function streamSessionPartEvents(options: {
       const error = new Error(content || "Session stream error");
       throw error;
     } else if (partType === SESSION_MESSAGE_PART_TYPE.IMAGE || partType === "SESSION_MESSAGE_PART_TYPE_IMAGE") {
+      hasAssistantEvent = true;
       setMessages((prev) => appendAssistantPart(prev, messageId, part));
     }
   }
 
-  return { assistantText };
+  return { assistantText, hasAssistantEvent };
 }
 
 function parsePayload(value: unknown): any {

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -195,6 +195,9 @@ pub trait ExecutionSink: Send + Sync {
     async fn on_reasoning(&self, reasoning: &str);
     /// The agent chose to call a tool.
     async fn on_tool_call(&self, id: &str, name: &str, input: &Value);
+    /// The model has started emitting tool-call deltas. Implementations can
+    /// flush any buffered live output before the tool call is fully assembled.
+    async fn on_tool_call_stream_started(&self) {}
     /// The full completed LLM response reached a durable recovery boundary.
     async fn on_llm_response(&self, _: &crate::harness::llm::ChatResponse) -> Result<()> {
         Ok(())
@@ -569,6 +572,7 @@ impl AgentExecutor {
             let mut final_reply = String::new();
             let mut tool_calls_by_index: BTreeMap<usize, ToolCall> = BTreeMap::new();
             let mut final_usage: Option<ChatUsage> = None;
+            let mut saw_tool_call_delta = false;
             let thinking = resolve_model_profile(self.agent_spec.model_policy.as_ref())
                 .and_then(|model| model.thinking.clone());
             let usage_subject = self.usage_subject();
@@ -674,6 +678,10 @@ impl AgentExecutor {
                     ChatStreamEvent {
                         event: Some(chat_stream_event::Event::ToolCallDelta(delta)),
                     } => {
+                        if !saw_tool_call_delta {
+                            saw_tool_call_delta = true;
+                            sink.on_tool_call_stream_started().await;
+                        }
                         let entry = tool_calls_by_index
                             .entry(delta.index as usize)
                             .or_insert_with(|| ToolCall {

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1325,6 +1325,10 @@ impl ExecutionSink for PubSubSessionSink {
         .await;
     }
 
+    async fn on_tool_call_stream_started(&self) {
+        self.flush_active_stream_event_buffer().await;
+    }
+
     async fn on_tool_result_recorded(&self, id: &str, name: &str, result: &str) -> Result<()> {
         let part_id = self.next_part_id();
         let cas = CasStore::new(self.objects.clone());
@@ -2221,6 +2225,57 @@ mod tests {
         assert_eq!(
             reply_part_contents,
             vec!["drafting request", "Tool call", "final"]
+        );
+    }
+
+    #[tokio::test]
+    async fn token_buffer_flushes_when_tool_call_stream_starts() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let kv = Arc::new(MockKvStore::default());
+        let sink = PubSubSessionSink::new_with_token_publish_interval(
+            kv.clone(),
+            Arc::new(MockPubSub {
+                events: events.clone(),
+            }),
+            "conic",
+            "session-1",
+            "infra",
+            "reply-1",
+            reply_key(),
+            "submission-1",
+            "attempt-1",
+            Duration::from_secs(10),
+        );
+
+        let mut fanout = fanout_stream(&sink).await;
+        sink.on_token("drafting ").await;
+        sink.on_token("request").await;
+        sink.on_tool_call_stream_started().await;
+
+        let event = next_fanout_event(&mut fanout).await;
+        assert_eq!(
+            event_part(&event).part_type,
+            data_proto::SessionMessagePartType::Text as i32
+        );
+        assert_eq!(event_part(&event).content, "drafting request");
+
+        sink.on_tool_call("tool-1", "create_prompt", &json!({"content": "x"}))
+            .await;
+        let tool_event = next_fanout_event(&mut fanout).await;
+        assert_eq!(
+            event_part(&tool_event).part_type,
+            data_proto::SessionMessagePartType::ToolCall as i32
+        );
+
+        let projection = latest_reply_message(kv.as_ref()).await;
+        let projection_part_contents = projection
+            .parts
+            .iter()
+            .map(|part| part.content.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            projection_part_contents,
+            vec!["drafting request", "Tool call"]
         );
     }
 

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -1580,6 +1580,222 @@ describe('TalonCopilot', () => {
     });
   });
 
+  it('stops progress after a completed tool-only stream', async () => {
+    const createdAt = String(Date.now() * 1000);
+    const gatewayClient = {
+      sessions: {
+        create: jest.fn().mockResolvedValue({ sessionId: 'sess-tool-only' }),
+        listMessages: jest.fn().mockResolvedValue({
+          sessionId: 'sess-tool-only',
+          state: 'IDLE',
+          items: [
+            {
+              message: {
+                id: 'assistant-tool-only',
+                role: 'ROLE_ASSISTANT',
+                parts: [
+                  {
+                    partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                    id: 'call-tool-only',
+                    name: 'inspect_docs',
+                    payloadJson: JSON.stringify({
+                      tool_call_id: 'call-tool-only',
+                      input: { query: 'streaming' },
+                    }),
+                  },
+                  {
+                    partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                    id: 'call-tool-only',
+                    name: 'inspect_docs',
+                    payloadJson: JSON.stringify({
+                      tool_call_id: 'call-tool-only',
+                      output: 'done',
+                    }),
+                  },
+                  {
+                    partType: 'SESSION_MESSAGE_PART_TYPE_USAGE',
+                    payloadJson: JSON.stringify({ total_tokens: 18 }),
+                  },
+                ],
+                createdAt,
+              },
+              steps: [],
+            },
+          ],
+          hasMore: false,
+        }),
+        submitTurn: jest.fn(async function* () {
+          yield {
+            kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DELTA',
+            messageId: 'assistant-tool-only',
+            part: {
+              partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+              id: 'call-tool-only',
+              name: 'inspect_docs',
+              payloadJson: JSON.stringify({
+                tool_call_id: 'call-tool-only',
+                input: { query: 'streaming' },
+              }),
+            },
+          };
+          yield {
+            kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DELTA',
+            messageId: 'assistant-tool-only',
+            part: {
+              partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+              id: 'call-tool-only',
+              name: 'inspect_docs',
+              payloadJson: JSON.stringify({
+                tool_call_id: 'call-tool-only',
+                output: 'done',
+              }),
+            },
+          };
+          yield {
+            kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DELTA',
+            messageId: 'assistant-tool-only',
+            part: {
+              partType: 'SESSION_MESSAGE_PART_TYPE_USAGE',
+              payloadJson: JSON.stringify({ total_tokens: 18 }),
+            },
+          };
+          yield {
+            kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DONE',
+            messageId: 'assistant-tool-only',
+          };
+        }),
+        streamParts: jest.fn(async function* () {}),
+        stopGeneration: jest.fn(),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Ask Talon to perform a task...'), {
+      target: { value: 'inspect without final text' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    const workedButton = await screen.findByRole('button', { name: /Worked/ });
+    expect(screen.queryByText(/Working/)).not.toBeInTheDocument();
+    expect(gatewayClient.sessions.listMessages).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(workedButton);
+    expect(screen.getByText(/Called/)).toHaveTextContent('inspect_docs');
+    expect(screen.getByText('18 total')).toBeInTheDocument();
+  });
+
+  it('highlights a live tool call while it is running', async () => {
+    let finishTool!: () => void;
+    const toolFinished = new Promise<void>((resolve) => {
+      finishTool = resolve;
+    });
+    const createdAt = String(Date.now() * 1000);
+    const gatewayClient = {
+      sessions: {
+        create: jest.fn().mockResolvedValue({ sessionId: 'sess-running-tool' }),
+        listMessages: jest.fn().mockResolvedValue({
+          sessionId: 'sess-running-tool',
+          state: 'IDLE',
+          items: [
+            {
+              message: {
+                id: 'assistant-running-tool',
+                role: 'ROLE_ASSISTANT',
+                parts: [
+                  {
+                    partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                    id: 'call-running',
+                    name: 'long_flow',
+                    payloadJson: JSON.stringify({
+                      tool_call_id: 'call-running',
+                      input: { task: 'run' },
+                    }),
+                  },
+                  {
+                    partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                    id: 'call-running',
+                    name: 'long_flow',
+                    payloadJson: JSON.stringify({
+                      tool_call_id: 'call-running',
+                      output: 'complete',
+                    }),
+                  },
+                ],
+                createdAt,
+              },
+              steps: [],
+            },
+          ],
+          hasMore: false,
+        }),
+        submitTurn: jest.fn(async function* () {
+          yield {
+            kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DELTA',
+            messageId: 'assistant-running-tool',
+            part: {
+              partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+              id: 'call-running',
+              name: 'long_flow',
+              payloadJson: JSON.stringify({
+                tool_call_id: 'call-running',
+                input: { task: 'run' },
+              }),
+            },
+          };
+          await toolFinished;
+          yield {
+            kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DELTA',
+            messageId: 'assistant-running-tool',
+            part: {
+              partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+              id: 'call-running',
+              name: 'long_flow',
+              payloadJson: JSON.stringify({
+                tool_call_id: 'call-running',
+                output: 'complete',
+              }),
+            },
+          };
+          yield {
+            kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DONE',
+            messageId: 'assistant-running-tool',
+          };
+        }),
+        streamParts: jest.fn(async function* () {}),
+        stopGeneration: jest.fn(),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Ask Talon to perform a task...'), {
+      target: { value: 'run the long flow' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    expect(await screen.findByText('Running')).toBeInTheDocument();
+    expect(screen.getByText(/Called/)).toHaveTextContent('long_flow');
+
+    await act(async () => {
+      finishTool();
+      await toolFinished;
+    });
+    await waitFor(() => expect(screen.queryByText('Running')).not.toBeInTheDocument());
+  });
+
   it('loads older history pages when scrolled near the top', async () => {
     const gatewayClient = {
       createSession: jest.fn(),


### PR DESCRIPTION
## Summary

Fix Talon session streaming around tool-call boundaries.

- Flush buffered text as soon as the model starts emitting tool-call deltas, before the completed tool call is assembled.
- Treat tool calls, tool results, usage, reasoning, and images as assistant stream activity so tool-only streams do not fall back into canonical wait/progress behavior.
- Show a small `Running` badge for live tool rows that do not yet have a result.
- Add regression coverage for tool-only stream completion and live running-tool highlighting.

## Root Cause

The execution sink only flushed buffered text when `on_tool_call` fired after the tool call was fully assembled. During a long or blocked tool-call stream, the UI could have already received enough activity to show progress but not enough text to avoid the canonical wait path. Tool-only streams were also treated as if no assistant response had arrived because the UI keyed only on `assistantText`.

## Scope

This PR is intentionally scoped to streaming only. I rebased onto `origin/main`, stashed the broader dirty worktree, and re-applied only the streaming changes. Excluded files such as `build.rs`, proto/session journal files, and worker session changes are not required for these checks to pass.

The excluded mixed work is preserved locally in `stash@{0}` as `preserve-mixed-worktree-before-streaming-pr`.

## Validation

- `cargo test`
- pre-push hook: `cargo metadata --locked`, `cargo fmt --all --check`, `cargo build --locked --bins`, `cargo test --locked`
- `pnpm -C ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`
- `pnpm -C ui exec tsc -p tsconfig.json --noEmit`
- `git diff --check`

Note: the UI Jest run still prints existing React `act(...)` warnings, but the suite passes.