### PR TITLE
Fix managed agent OpenAI replay payloads

### DIFF
--- a/src/harness/executor/history.rs
+++ b/src/harness/executor/history.rs
@@ -264,8 +264,17 @@ fn tool_call_from_part(part: &data_proto::SessionMessagePart) -> Option<ToolCall
     Some(ToolCall {
         id: tool_call_id.to_string(),
         name: part.name.clone(),
-        arguments: serde_json::to_string(&input).unwrap_or_else(|_| "null".to_string()),
+        arguments: tool_arguments_json(input),
     })
+}
+
+fn tool_arguments_json(input: serde_json::Value) -> String {
+    match input {
+        serde_json::Value::Object(_) => {
+            serde_json::to_string(&input).unwrap_or_else(|_| "{}".to_string())
+        }
+        _ => "{}".to_string(),
+    }
 }
 
 async fn tool_result_message_from_part(
@@ -726,6 +735,34 @@ mod tests {
         assert_eq!(calls[0].id, "call-ok");
         assert_eq!(history[1].tool_call_id.as_deref(), Some("call-ok"));
         assert_eq!(history[1].text_content(), "first-result");
+    }
+
+    #[tokio::test]
+    async fn assistant_session_message_replays_missing_tool_input_as_empty_object() {
+        let store = InMemoryObjectStore::default();
+        let call = data_proto::SessionMessagePart {
+            id: "000001".to_string(),
+            part_type: data_proto::SessionMessagePartType::ToolCall as i32,
+            content: "Tool call".to_string(),
+            name: "list_links".to_string(),
+            payload_json: serde_json::json!({
+                "tool_call_id": "call-empty",
+            })
+            .to_string(),
+            created_at: 0,
+            object: None,
+        };
+        let message = assistant_message(vec![
+            call,
+            tool_result_part_for_call("call-empty", "list_links", "[]"),
+        ]);
+
+        let history = session_message_to_loop_messages(&message, &store)
+            .await
+            .unwrap();
+
+        let calls = history[0].tool_calls.as_ref().unwrap();
+        assert_eq!(calls[0].arguments, "{}");
     }
 
     #[tokio::test]

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -512,9 +512,7 @@ impl AgentExecutor {
             prefix_latest_user_message(&mut history, post_history_prompt);
         }
 
-        let mut compacted = compact_history_for_llm(&history);
-        preserve_user_anchor(&history, &mut compacted);
-        compacted
+        compact_history_for_llm(&history)
             .iter()
             .map(|m| ChatMessage {
                 role: m.role.clone(),
@@ -874,33 +872,6 @@ fn normalize_tool_call_arguments(mut tool: ToolCall) -> ToolCall {
         _ => "{}".to_string(),
     };
     tool
-}
-
-fn preserve_user_anchor(original: &[LoopMessage], compacted: &mut Vec<LoopMessage>) {
-    if compacted
-        .iter()
-        .any(|message| message.role == "user" || message.role == "tool")
-    {
-        return;
-    }
-
-    let Some(anchor) = original
-        .iter()
-        .rev()
-        .find(|message| message.role == "user")
-        .cloned()
-    else {
-        return;
-    };
-    let insert_at = if compacted
-        .first()
-        .is_some_and(|message| message.role == "system")
-    {
-        1
-    } else {
-        0
-    };
-    compacted.insert(insert_at, anchor);
 }
 
 pub fn tool_result_loop_message(tool_call_id: &str, result: &str) -> LoopMessage {
@@ -1392,24 +1363,6 @@ mod tests {
 
         assert_eq!(empty.arguments, "{}");
         assert_eq!(null.arguments, "{}");
-    }
-
-    #[test]
-    fn preserve_user_anchor_when_compaction_left_only_system_and_assistant() {
-        let original = vec![
-            LoopMessage::text("system", "system prompt"),
-            LoopMessage::text("user", "scheduled prompt"),
-            LoopMessage::text("assistant", "large prior summary"),
-        ];
-        let mut compacted = vec![
-            LoopMessage::text("system", "system prompt"),
-            LoopMessage::text("assistant", "large prior summary"),
-        ];
-
-        super::preserve_user_anchor(&original, &mut compacted);
-
-        assert_eq!(compacted[1].role, "user");
-        assert_eq!(compacted[1].text_content(), "scheduled prompt");
     }
 
     #[tokio::test]

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -512,7 +512,9 @@ impl AgentExecutor {
             prefix_latest_user_message(&mut history, post_history_prompt);
         }
 
-        compact_history_for_llm(&history)
+        let mut compacted = compact_history_for_llm(&history);
+        preserve_user_anchor(&history, &mut compacted);
+        compacted
             .iter()
             .map(|m| ChatMessage {
                 role: m.role.clone(),
@@ -704,6 +706,7 @@ impl AgentExecutor {
             let tool_calls: Vec<ToolCall> = tool_calls_by_index
                 .into_values()
                 .filter(|tool| !tool.name.is_empty())
+                .map(normalize_tool_call_arguments)
                 .collect();
 
             let llm_response = ChatResponse {
@@ -805,7 +808,7 @@ impl AgentExecutor {
     }
 
     pub fn tool_call_input(tool: &ToolCall) -> Value {
-        serde_json::from_str(&tool.arguments).unwrap_or(Value::Null)
+        serde_json::from_str(&tool.arguments).unwrap_or_else(|_| serde_json::json!({}))
     }
 
     async fn tool_type(&self, name: &str) -> &'static str {
@@ -863,6 +866,41 @@ impl AgentExecutor {
         }
         Ok(format!("Tool '{}' not found.", name))
     }
+}
+
+fn normalize_tool_call_arguments(mut tool: ToolCall) -> ToolCall {
+    tool.arguments = match serde_json::from_str::<Value>(&tool.arguments) {
+        Ok(Value::Object(_)) => tool.arguments,
+        _ => "{}".to_string(),
+    };
+    tool
+}
+
+fn preserve_user_anchor(original: &[LoopMessage], compacted: &mut Vec<LoopMessage>) {
+    if compacted
+        .iter()
+        .any(|message| message.role == "user" || message.role == "tool")
+    {
+        return;
+    }
+
+    let Some(anchor) = original
+        .iter()
+        .rev()
+        .find(|message| message.role == "user")
+        .cloned()
+    else {
+        return;
+    };
+    let insert_at = if compacted
+        .first()
+        .is_some_and(|message| message.role == "system")
+    {
+        1
+    } else {
+        0
+    };
+    compacted.insert(insert_at, anchor);
 }
 
 pub fn tool_result_loop_message(tool_call_id: &str, result: &str) -> LoopMessage {
@@ -1324,6 +1362,54 @@ mod tests {
         assert_eq!(input["offset"], 0);
         assert!(input["limit"].is_number());
         assert!(!input["limit"].is_string());
+    }
+
+    #[test]
+    fn tool_call_input_defaults_invalid_arguments_to_empty_object() {
+        let tool = crate::harness::llm::ToolCall {
+            id: "call_1".to_string(),
+            name: "mcp_conic_list_links".to_string(),
+            arguments: String::new(),
+        };
+
+        let input = AgentExecutor::tool_call_input(&tool);
+
+        assert_eq!(input, json!({}));
+    }
+
+    #[test]
+    fn normalize_tool_call_arguments_defaults_empty_or_non_object_to_empty_object() {
+        let empty = super::normalize_tool_call_arguments(crate::harness::llm::ToolCall {
+            id: "call_1".to_string(),
+            name: "mcp_conic_list_links".to_string(),
+            arguments: String::new(),
+        });
+        let null = super::normalize_tool_call_arguments(crate::harness::llm::ToolCall {
+            id: "call_2".to_string(),
+            name: "mcp_conic_list_links".to_string(),
+            arguments: "null".to_string(),
+        });
+
+        assert_eq!(empty.arguments, "{}");
+        assert_eq!(null.arguments, "{}");
+    }
+
+    #[test]
+    fn preserve_user_anchor_when_compaction_left_only_system_and_assistant() {
+        let original = vec![
+            LoopMessage::text("system", "system prompt"),
+            LoopMessage::text("user", "scheduled prompt"),
+            LoopMessage::text("assistant", "large prior summary"),
+        ];
+        let mut compacted = vec![
+            LoopMessage::text("system", "system prompt"),
+            LoopMessage::text("assistant", "large prior summary"),
+        ];
+
+        super::preserve_user_anchor(&original, &mut compacted);
+
+        assert_eq!(compacted[1].role, "user");
+        assert_eq!(compacted[1].text_content(), "scheduled prompt");
     }
 
     #[tokio::test]

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -704,7 +704,6 @@ impl AgentExecutor {
             let tool_calls: Vec<ToolCall> = tool_calls_by_index
                 .into_values()
                 .filter(|tool| !tool.name.is_empty())
-                .map(normalize_tool_call_arguments)
                 .collect();
 
             let llm_response = ChatResponse {
@@ -806,7 +805,7 @@ impl AgentExecutor {
     }
 
     pub fn tool_call_input(tool: &ToolCall) -> Value {
-        serde_json::from_str(&tool.arguments).unwrap_or_else(|_| serde_json::json!({}))
+        serde_json::from_str(&tool.arguments).unwrap_or(Value::Null)
     }
 
     async fn tool_type(&self, name: &str) -> &'static str {
@@ -864,14 +863,6 @@ impl AgentExecutor {
         }
         Ok(format!("Tool '{}' not found.", name))
     }
-}
-
-fn normalize_tool_call_arguments(mut tool: ToolCall) -> ToolCall {
-    tool.arguments = match serde_json::from_str::<Value>(&tool.arguments) {
-        Ok(Value::Object(_)) => tool.arguments,
-        _ => "{}".to_string(),
-    };
-    tool
 }
 
 pub fn tool_result_loop_message(tool_call_id: &str, result: &str) -> LoopMessage {
@@ -1333,36 +1324,6 @@ mod tests {
         assert_eq!(input["offset"], 0);
         assert!(input["limit"].is_number());
         assert!(!input["limit"].is_string());
-    }
-
-    #[test]
-    fn tool_call_input_defaults_invalid_arguments_to_empty_object() {
-        let tool = crate::harness::llm::ToolCall {
-            id: "call_1".to_string(),
-            name: "mcp_conic_list_links".to_string(),
-            arguments: String::new(),
-        };
-
-        let input = AgentExecutor::tool_call_input(&tool);
-
-        assert_eq!(input, json!({}));
-    }
-
-    #[test]
-    fn normalize_tool_call_arguments_defaults_empty_or_non_object_to_empty_object() {
-        let empty = super::normalize_tool_call_arguments(crate::harness::llm::ToolCall {
-            id: "call_1".to_string(),
-            name: "mcp_conic_list_links".to_string(),
-            arguments: String::new(),
-        });
-        let null = super::normalize_tool_call_arguments(crate::harness::llm::ToolCall {
-            id: "call_2".to_string(),
-            name: "mcp_conic_list_links".to_string(),
-            arguments: "null".to_string(),
-        });
-
-        assert_eq!(empty.arguments, "{}");
-        assert_eq!(null.arguments, "{}");
     }
 
     #[tokio::test]

--- a/src/harness/llm/openai.rs
+++ b/src/harness/llm/openai.rs
@@ -114,12 +114,13 @@ impl OpenAiCompatibleProvider {
                         .tool_calls
                         .into_iter()
                         .map(|tool| {
+                            let arguments = Self::openai_tool_arguments(&tool.arguments);
                             serde_json::json!({
                                 "id": tool.id,
                                 "type": "function",
                                 "function": {
                                     "name": tool.name,
-                                    "arguments": tool.arguments,
+                                    "arguments": arguments,
                                 }
                             })
                         })
@@ -134,6 +135,13 @@ impl OpenAiCompatibleProvider {
                 json
             })
             .collect()
+    }
+
+    fn openai_tool_arguments(arguments: &str) -> String {
+        match serde_json::from_str::<Value>(arguments) {
+            Ok(Value::Object(_)) => arguments.to_string(),
+            _ => "{}".to_string(),
+        }
     }
 
     fn supports_tool_retry_without_tools(
@@ -906,6 +914,18 @@ mod tests {
             "mcp_conic_create_github_pr"
         );
         assert_eq!(serialized[1]["tool_call_id"], "call_1");
+    }
+
+    #[test]
+    fn serialize_messages_normalizes_invalid_tool_arguments() {
+        let messages = vec![assistant_tool_call_message("mcp_conic_list_links", "")];
+
+        let serialized = OpenAiCompatibleProvider::serialize_messages(messages);
+
+        assert_eq!(
+            serialized[0]["tool_calls"][0]["function"]["arguments"],
+            "{}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes managed-agent replay payloads that could produce OpenAI invalid request errors when replaying tool calls during scheduled/retry runs.

## Root cause

Talon could replay persisted tool-call arguments as `null` when historical session parts had no object-shaped `input`. OpenAI expects function-call `arguments` to be a JSON object string, so replaying `null` or malformed arguments can produce an invalid request.

## Changes

- Normalize missing or non-object persisted tool-call `input` to `{}` during session history reconstruction.
- Add a final OpenAI adapter guard so serialized tool-call arguments are object-shaped before sending an OpenAI-compatible payload.
- Add regression coverage for missing persisted tool input and OpenAI payload serialization.

## Validation

- `cargo fmt`
- `cargo test -q harness::executor::history::tests::`
- `cargo test -q harness::llm::openai::tests::`
- Push hook: `cargo fmt --all --check`
- Push hook: `cargo build --locked --bins`
- Push hook: `cargo test --locked`