### PR TITLE
Lazy-load session tool results

### DIFF
--- a/packages/talon-chat/README.md
+++ b/packages/talon-chat/README.md
@@ -46,6 +46,18 @@ Keep session state in your app when you want to control which transcript is show
 
 `TalonCopilot` is still exported as an alias for existing integrations.
 
+## Styling
+
+The chat text defaults to a 16px reading size. Hosts can tune the main message
+and composer sizes with CSS variables:
+
+```css
+:root {
+  --talon-chat-message-font-size: 1rem;
+  --talon-chat-composer-font-size: 1rem;
+}
+```
+
 ## Image uploads
 
 `TalonSession` can accept image attachments when you provide an `onImageUpload`

--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -669,7 +669,7 @@ export function TalonChannel({
                 const messageAuthorKind = message.authorKind || message.author_kind || "user";
                 const messageActions = renderMessageActions?.(message);
                 return (
-                  <div key={channelMessageKey(message, index)} style={{ borderRadius: 12, border: border("rgba(148,163,184,0.24)"), background: "var(--copilot-channel-message-bg, rgba(255,255,255,0.72))", color: "var(--copilot-channel-message-fg, inherit)", padding: "1rem" }}>
+                  <div key={channelMessageKey(message, index)} style={{ borderRadius: 12, border: border("rgba(148,163,184,0.24)"), background: "var(--copilot-channel-message-bg, rgba(255,255,255,0.72))", color: "var(--copilot-channel-message-fg, inherit)", padding: "1.1rem" }}>
                     <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8, fontSize: 12, opacity: 0.72 }}>
                       <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontWeight: 700, color: "inherit", opacity: 1 }}>
                         <Hash size="13" />

--- a/packages/talon-chat/src/TalonChannel.tsx
+++ b/packages/talon-chat/src/TalonChannel.tsx
@@ -16,6 +16,7 @@ function border(color: string) {
 
 const talonChatFontFamily =
   'var(--talon-chat-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)';
+const talonChatMessageFontSize = "var(--talon-chat-message-font-size, 1rem)";
 
 const CHANNEL_SCROLL_LOAD_THRESHOLD_PX = 64;
 const CHANNEL_SCROLL_BOTTOM_THRESHOLD_PX = 96;
@@ -677,7 +678,7 @@ export function TalonChannel({
                       <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{resolvedFormatTimestamp(message)}</span>
                       {messageActions ? <div style={{ marginLeft: "auto" }}>{messageActions}</div> : null}
                     </div>
-                    <div style={{ marginTop: 8, whiteSpace: "normal", overflowWrap: "anywhere", fontSize: 14, lineHeight: 1.6 }}>
+                    <div style={{ marginTop: 8, whiteSpace: "normal", overflowWrap: "anywhere", fontSize: talonChatMessageFontSize, lineHeight: 1.6 }}>
                       <MarkdownMessage onResourceClick={onResourceClick}>{message.content || ""}</MarkdownMessage>
                     </div>
                   </div>

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -623,39 +623,31 @@ async function toolResultObjectData(response: any, fallbackObject?: TalonChatObj
   return bytes;
 }
 
-async function hydrateCasToolResultObjects(
-  messages: CopilotMessage[],
-  cas?: CasServiceClientLike,
-): Promise<CopilotMessage[]> {
-  if (!cas?.getObject) return messages;
-  const decoder = new TextDecoder();
-  return Promise.all(messages.map(async (message) => {
-    if (!Array.isArray(message.parts)) return message;
-    let changed = false;
-    const parts = await Promise.all(message.parts.map(async (part: any) => {
-      if (!part || typeof part !== "object" || !isToolResultPart(part)) return part;
-      if (typeof part.content === "string" && part.content.length > 0) return part;
-      const key = objectRefKey(objectRefFromPart(part));
-      if (!key) return part;
-      try {
-        const response = await cas.getObject({ key });
-        const data = await toolResultObjectData(response, objectRefFromPart(part));
-        changed = true;
-        return withToolResultContent(part, decoder.decode(data));
-      } catch (err) {
-        console.warn("Could not hydrate CAS tool-result object", key, err);
-        return part;
-      }
-    }));
-    return changed
-      ? {
-          ...message,
-          parts,
-          content: getMessageContent({ ...message, parts }),
-          timeline: getMessageAssistantTimeline({ ...message, parts }),
-        }
-      : message;
-  }));
+function toolCallIdFromToolResultPart(part: any): string {
+  if (typeof part?.toolCallId === "string") return part.toolCallId;
+  if (typeof part?.tool_call_id === "string") return part.tool_call_id;
+  if (typeof part?.id === "string") return part.id;
+  const payload = parsePayloadJson(part?.payloadJson ?? part?.payload_json);
+  const payloadToolCallId = payload.tool_call_id ?? payload.toolCallId;
+  return typeof payloadToolCallId === "string" ? payloadToolCallId : "";
+}
+
+function findHydratableToolResultPart(
+  parts: unknown,
+  toolCallId: string,
+): { part: any; index: number; key: string } | null {
+  if (!Array.isArray(parts)) return null;
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index] as any;
+    if (!part || typeof part !== "object" || !isToolResultPart(part)) continue;
+    if (typeof part.content === "string" && part.content.length > 0) continue;
+    const key = objectRefKey(objectRefFromPart(part));
+    if (!key) continue;
+    const partToolCallId = toolCallIdFromToolResultPart(part);
+    if (toolCallId && partToolCallId && partToolCallId !== toolCallId) continue;
+    return { part, index, key };
+  }
+  return null;
 }
 
 function messageImageParts(
@@ -987,6 +979,7 @@ export function TalonSession({
   const [streamEvents, setStreamEvents] = useState<StreamEventItem[]>([]);
   const [expandedThinkingMessages, setExpandedThinkingMessages] = useState<Record<string, boolean>>({});
   const [expandedToolItems, setExpandedToolItems] = useState<Record<string, boolean>>({});
+  const [toolResultHydration, setToolResultHydration] = useState<Record<string, "loading" | "error">>({});
   const [openResourceUri, setOpenResourceUri] = useState<string | null>(null);
   /** False while the pane plays its close transition before unmount. */
   const [resourcePaneOpen, setResourcePaneOpen] = useState(false);
@@ -1101,7 +1094,7 @@ export function TalonSession({
 
   useSafeLayoutEffect(() => {
     updateTranscriptScrollThumb();
-  }, [messages, expandedThinkingMessages, expandedToolItems, isLoading, error, streamEvents, updateTranscriptScrollThumb]);
+  }, [messages, expandedThinkingMessages, expandedToolItems, toolResultHydration, isLoading, error, streamEvents, updateTranscriptScrollThumb]);
 
   useEffect(() => {
     if (!isLoading || loadingStartedAt === null) {
@@ -1148,6 +1141,66 @@ export function TalonSession({
       [toolKey]: !prev[toolKey],
     }));
   }, []);
+
+  const hydrateToolResultForExpandedItem = useCallback(
+    async (message: CopilotMessage, toolCallId: string, toolKey: string) => {
+      const match = findHydratableToolResultPart(message.parts, toolCallId);
+      const cas = gatewayClient?.cas;
+      if (!match || !cas?.getObject) return;
+
+      setToolResultHydration((prev) => ({
+        ...prev,
+        [toolKey]: "loading",
+      }));
+
+      try {
+        const response = await cas.getObject({ key: match.key });
+        const data = await toolResultObjectData(response, objectRefFromPart(match.part));
+        const output = new TextDecoder().decode(data);
+
+        setMessages((current) => {
+          const nextMessages = current.map((candidate) => {
+            if (candidate.id !== message.id) return candidate;
+            const currentMatch = findHydratableToolResultPart(candidate.parts, toolCallId);
+            if (!currentMatch || currentMatch.key !== match.key || !Array.isArray(candidate.parts)) {
+              return candidate;
+            }
+            const parts = [...candidate.parts];
+            parts[currentMatch.index] = withToolResultContent(currentMatch.part, output);
+            const timelineSource = {
+              role: candidate.role,
+              content: candidate.content,
+              parts,
+              reasoningContent: candidate.reasoningContent,
+              usage: candidate.usage,
+            };
+            return {
+              ...candidate,
+              parts,
+              content: getMessageContent(timelineSource),
+              timeline: getMessageAssistantTimeline(timelineSource),
+            };
+          });
+          messagesRef.current = nextMessages;
+          return nextMessages;
+        });
+
+        setToolResultHydration((prev) => {
+          if (!(toolKey in prev)) return prev;
+          const next = { ...prev };
+          delete next[toolKey];
+          return next;
+        });
+      } catch (err) {
+        console.warn("Could not hydrate CAS tool-result object", match.key, err);
+        setToolResultHydration((prev) => ({
+          ...prev,
+          [toolKey]: "error",
+        }));
+      }
+    },
+    [gatewayClient],
+  );
 
   const updateSessionMessage = useCallback(
     async (message: CopilotMessage, parts: unknown[], labels: Record<string, string>) => {
@@ -1537,12 +1590,18 @@ export function TalonSession({
                       const toolKey = `${message.id}-work-tool-${item.toolCallId || index}`;
                       const isToolExpanded = expandedToolItems[toolKey] ?? false;
                       const isRunningTool = isLiveAssistantMessage && item.result === undefined;
+                      const toolHydrationState = toolResultHydration[toolKey];
                       return (
                         <div key={toolKey}>
                           <button
                             className="talon-session-tool-row"
                             type="button"
-                            onClick={() => toggleToolItem(toolKey)}
+                            onClick={() => {
+                              toggleToolItem(toolKey);
+                              if (!isToolExpanded) {
+                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey);
+                              }
+                            }}
                             style={{
                               width: "auto",
                               maxWidth: "100%",
@@ -1586,7 +1645,11 @@ export function TalonSession({
                                   <code>{JSON.stringify(item.args ?? {}, null, 2)}</code>
                                 </pre>
                               </div>
-                              {item.result !== undefined ? (
+                              {toolHydrationState ? (
+                                <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                                  {toolHydrationState === "loading" ? "Loading output..." : "Could not load output."}
+                                </div>
+                              ) : item.result !== undefined ? (
                                 <div>
                                   <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
                                     Output
@@ -1766,12 +1829,18 @@ export function TalonSession({
                       const toolKey = `${message.id}-timeline-tool-${item.toolCallId || index}`;
                       const isToolExpanded = expandedToolItems[toolKey] ?? false;
                       const isRunningTool = isLiveAssistantMessage && item.result === undefined;
+                      const toolHydrationState = toolResultHydration[toolKey];
                       return (
                         <div key={toolKey}>
                           <button
                             className="talon-session-tool-row"
                             type="button"
-                            onClick={() => toggleToolItem(toolKey)}
+                            onClick={() => {
+                              toggleToolItem(toolKey);
+                              if (!isToolExpanded) {
+                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey);
+                              }
+                            }}
                             style={{
                               width: "auto",
                               maxWidth: "100%",
@@ -1815,7 +1884,11 @@ export function TalonSession({
                                   <code>{JSON.stringify(item.args ?? {}, null, 2)}</code>
                                 </pre>
                               </div>
-                              {item.result !== undefined ? (
+                              {toolHydrationState ? (
+                                <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                                  {toolHydrationState === "loading" ? "Loading output..." : "Could not load output."}
+                                </div>
+                              ) : item.result !== undefined ? (
                                 <div>
                                   <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
                                     Output
@@ -1951,7 +2024,7 @@ export function TalonSession({
         </div>
       );
     });
-  }, [allowMessageEditing, cancelEditingMessage, copyMessageContent, editingMessageId, editingMessageValue, enableDebugMessageEditing, expandedThinkingMessages, expandedToolItems, handleResourceClick, isLoading, loadingNow, loadingStartedAt, messages, objectUrlForRef, reviewActionMessageId, saveEditingMessage, startEditingMessage, toggleThinkingMessage, toggleToolItem, updateConnectorDeliveryStatus]);
+  }, [allowMessageEditing, cancelEditingMessage, copyMessageContent, editingMessageId, editingMessageValue, enableDebugMessageEditing, expandedThinkingMessages, expandedToolItems, handleResourceClick, hydrateToolResultForExpandedItem, isLoading, loadingNow, loadingStartedAt, messages, objectUrlForRef, reviewActionMessageId, saveEditingMessage, startEditingMessage, toggleThinkingMessage, toggleToolItem, toolResultHydration, updateConnectorDeliveryStatus]);
 
   const resolvedHistoryPageSize = Math.max(
     1,
@@ -1989,20 +2062,15 @@ export function TalonSession({
   const hydrateSessionHistoryPage = useCallback(
     async (
       response: any,
-      target: { ns: string; agent: string; sessionId: string },
     ): Promise<SessionHistoryPage> => {
-      const res = normalizeHistoryPage(response);
-      return {
-        ...res,
-        messages: await hydrateCasToolResultObjects(res.messages, gatewayClient?.cas),
-      };
+      return normalizeHistoryPage(response);
     },
-    [gatewayClient],
+    [],
   );
 
   const loadInitialSessionPage = useCallback(
     async (target: { ns: string; agent: string; sessionId: string }) => {
-      const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target), target);
+      const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
       autoScrollPinnedRef.current = true;
       setMessages(res.messages);
       setHasMoreHistory(res.hasMore);
@@ -2031,7 +2099,6 @@ export function TalonSession({
       try {
         const res = await hydrateSessionHistoryPage(
           await getSessionMessagesPage(target, nextBeforeMessageId),
-          target,
         );
         const existingIds = new Set(messagesRef.current.map((message) => message.id));
         const olderMessages = res.messages.filter((message) => !existingIds.has(message.id));
@@ -2064,7 +2131,7 @@ export function TalonSession({
 
   const refreshNewestSessionPage = useCallback(
     async (target: { ns: string; agent: string; sessionId: string }) => {
-      const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target), target);
+      const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
       const newestPageIds = new Set(res.messages.map((message) => message.id));
       const oldestPageMessage = res.messages[0];
       const oldestPageId = oldestPageMessage?.id;
@@ -2128,6 +2195,7 @@ export function TalonSession({
       setNextBeforeMessageId(null);
       setIsLoadingOlderHistory(false);
       setStreamEvents([]);
+      setToolResultHydration({});
       setError(null);
       return;
     }
@@ -2161,7 +2229,7 @@ export function TalonSession({
   const waitForCanonicalAssistantUpdate = useCallback(
     async (session: { ns: string; agent: string; sessionId: string }, baselineSignature: string) => {
       for (let attempt = 0; attempt < 40; attempt += 1) {
-        const sessionState = await hydrateSessionHistoryPage(await getSessionMessagesPage(session), session);
+        const sessionState = await hydrateSessionHistoryPage(await getSessionMessagesPage(session));
         const nextSignature = getAssistantSignature(sessionState.messages);
         if (nextSignature && nextSignature !== baselineSignature) {
           await refreshNewestSessionPage(session);
@@ -2189,6 +2257,7 @@ export function TalonSession({
     setLoadingStartedAt(null);
     setExpandedThinkingMessages({});
     setExpandedToolItems({});
+    setToolResultHydration({});
     setOpenResourceUri(null);
     setResourceView(null);
     setResourceError(null);

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -626,10 +626,10 @@ async function toolResultObjectData(response: any, fallbackObject?: TalonChatObj
 function toolCallIdFromToolResultPart(part: any): string {
   if (typeof part?.toolCallId === "string") return part.toolCallId;
   if (typeof part?.tool_call_id === "string") return part.tool_call_id;
-  if (typeof part?.id === "string") return part.id;
   const payload = parsePayloadJson(part?.payloadJson ?? part?.payload_json);
   const payloadToolCallId = payload.tool_call_id ?? payload.toolCallId;
-  return typeof payloadToolCallId === "string" ? payloadToolCallId : "";
+  if (typeof payloadToolCallId === "string") return payloadToolCallId;
+  return typeof part?.id === "string" ? part.id : "";
 }
 
 function findHydratableToolResultPart(
@@ -644,7 +644,7 @@ function findHydratableToolResultPart(
     const key = objectRefKey(objectRefFromPart(part));
     if (!key) continue;
     const partToolCallId = toolCallIdFromToolResultPart(part);
-    if (toolCallId && partToolCallId && partToolCallId !== toolCallId) continue;
+    if (toolCallId && partToolCallId !== toolCallId) continue;
     return { part, index, key };
   }
   return null;
@@ -1004,10 +1004,18 @@ export function TalonSession({
   const messagesRef = useRef<CopilotMessage[]>(emptyMessages);
   const imageAttachmentsRef = useRef<TalonSessionPendingImageAttachment[]>([]);
   const submittedPreviewUrlsRef = useRef<string[]>([]);
+  const toolResultHydrationInFlightRef = useRef<Set<string>>(new Set());
+  const toolResultHydrationGenerationRef = useRef(0);
   const skipNextAutoScrollRef = useRef(false);
   const autoScrollPinnedRef = useRef(true);
   const prependScrollRestoreRef = useRef<{ previousScrollTop: number; previousScrollHeight: number } | null>(null);
   const isLoadingOlderHistoryRef = useRef(false);
+
+  const invalidateToolResultHydration = useCallback(() => {
+    toolResultHydrationGenerationRef.current += 1;
+    toolResultHydrationInFlightRef.current.clear();
+    setToolResultHydration({});
+  }, []);
 
   const updateTranscriptScrollThumb = useCallback(() => {
     const container = scrollContainerRef.current;
@@ -1147,7 +1155,10 @@ export function TalonSession({
       const match = findHydratableToolResultPart(message.parts, toolCallId);
       const cas = gatewayClient?.cas;
       if (!match || !cas?.getObject) return;
+      if (toolResultHydrationInFlightRef.current.has(toolKey)) return;
 
+      toolResultHydrationInFlightRef.current.add(toolKey);
+      const generation = toolResultHydrationGenerationRef.current;
       setToolResultHydration((prev) => ({
         ...prev,
         [toolKey]: "loading",
@@ -1157,8 +1168,10 @@ export function TalonSession({
         const response = await cas.getObject({ key: match.key });
         const data = await toolResultObjectData(response, objectRefFromPart(match.part));
         const output = new TextDecoder().decode(data);
+        if (toolResultHydrationGenerationRef.current !== generation) return;
 
         setMessages((current) => {
+          if (toolResultHydrationGenerationRef.current !== generation) return current;
           const nextMessages = current.map((candidate) => {
             if (candidate.id !== message.id) return candidate;
             const currentMatch = findHydratableToolResultPart(candidate.parts, toolCallId);
@@ -1184,6 +1197,7 @@ export function TalonSession({
           messagesRef.current = nextMessages;
           return nextMessages;
         });
+        if (toolResultHydrationGenerationRef.current !== generation) return;
 
         setToolResultHydration((prev) => {
           if (!(toolKey in prev)) return prev;
@@ -1192,11 +1206,14 @@ export function TalonSession({
           return next;
         });
       } catch (err) {
+        if (toolResultHydrationGenerationRef.current !== generation) return;
         console.warn("Could not hydrate CAS tool-result object", match.key, err);
         setToolResultHydration((prev) => ({
           ...prev,
           [toolKey]: "error",
         }));
+      } finally {
+        toolResultHydrationInFlightRef.current.delete(toolKey);
       }
     },
     [gatewayClient],
@@ -2195,7 +2212,7 @@ export function TalonSession({
       setNextBeforeMessageId(null);
       setIsLoadingOlderHistory(false);
       setStreamEvents([]);
-      setToolResultHydration({});
+      invalidateToolResultHydration();
       setError(null);
       return;
     }
@@ -2208,6 +2225,7 @@ export function TalonSession({
     const controller = new AbortController();
     resumeAbortControllerRef.current?.abort();
     resumeAbortControllerRef.current = controller;
+    invalidateToolResultHydration();
     loadInitialSessionPage(nextSession)
       .then((res) => {
         if (!cancelled && res.state === "PROCESSING") {
@@ -2224,7 +2242,7 @@ export function TalonSession({
       cancelled = true;
       controller.abort();
     };
-  }, [agent, loadInitialSessionPage, namespace, resumeStream, sessionId]);
+  }, [agent, invalidateToolResultHydration, loadInitialSessionPage, namespace, resumeStream, sessionId]);
 
   const waitForCanonicalAssistantUpdate = useCallback(
     async (session: { ns: string; agent: string; sessionId: string }, baselineSignature: string) => {
@@ -2257,13 +2275,13 @@ export function TalonSession({
     setLoadingStartedAt(null);
     setExpandedThinkingMessages({});
     setExpandedToolItems({});
-    setToolResultHydration({});
+    invalidateToolResultHydration();
     setOpenResourceUri(null);
     setResourceView(null);
     setResourceError(null);
     setResourceLoading(false);
     autoScrollPinnedRef.current = true;
-  }, []);
+  }, [invalidateToolResultHydration]);
 
   const clearSession = useCallback(async () => {
     const session = currentSessionRef.current;

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -1533,7 +1533,7 @@ export function TalonSession({
                   ? "var(--talon-chat-user-bubble-bg, rgba(24,24,27,0.07))"
                   : "transparent",
                 color: isUserMessage ? "var(--talon-chat-user-bubble-fg, inherit)" : "inherit",
-                padding: isUserMessage ? "0.65rem 0.85rem" : 0,
+                padding: isUserMessage ? "0.75rem 1rem" : 0,
               }}
             >
               {hasWorkDetails ? (
@@ -1748,7 +1748,7 @@ export function TalonSession({
                     borderRadius: 8,
                     background: "var(--talon-chat-edit-bg, rgba(24,24,27,0.92))",
                     color: "var(--talon-chat-edit-fg, inherit)",
-                    padding: "0.55rem 0.65rem",
+                    padding: "0.65rem 0.8rem",
                     font: "inherit",
                     fontSize: talonChatMessageFontSize,
                     lineHeight: 1.55,

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -326,6 +326,7 @@ async function fetchResourceFromGateway(options: {
 
 const talonChatFontFamily =
   'var(--talon-chat-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)';
+const talonChatMessageFontSize = "var(--talon-chat-message-font-size, 1rem)";
 
 function cn(...parts: Array<string | false | null | undefined>) {
   return parts.filter(Boolean).join(" ");
@@ -1749,6 +1750,7 @@ export function TalonSession({
                     color: "var(--talon-chat-edit-fg, inherit)",
                     padding: "0.55rem 0.65rem",
                     font: "inherit",
+                    fontSize: talonChatMessageFontSize,
                     lineHeight: 1.55,
                     outline: "none",
                     boxShadow: "var(--talon-chat-edit-shadow, inset 0 0 0 1px rgba(255,255,255,0.02))",
@@ -1809,7 +1811,7 @@ export function TalonSession({
                   overflow: "hidden",
                   overflowWrap: "anywhere",
                   whiteSpace: message.role === "assistant" ? "normal" : "pre-wrap",
-                  fontSize: message.role === "system" ? 12 : 14,
+                  fontSize: message.role === "system" ? 12 : talonChatMessageFontSize,
                   lineHeight: 1.65,
                   opacity: message.role === "system" ? 0.72 : 0.94,
                   fontFamily: message.role === "system" ? "ui-monospace, SFMono-Regular, monospace" : undefined,

--- a/packages/talon-chat/src/lib/TalonChatComposer.tsx
+++ b/packages/talon-chat/src/lib/TalonChatComposer.tsx
@@ -15,7 +15,7 @@ function border(color: string) {
 const talonChatFontFamily =
   'var(--talon-chat-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)';
 
-const composerTextareaFontSize = 16;
+const composerTextareaFontSize = "var(--talon-chat-composer-font-size, 1rem)";
 const composerTextareaLineHeight = 20;
 const composerMutedForeground = "var(--copilot-composer-muted-fg, var(--copilot-input-placeholder, rgba(82,82,91,0.72)))";
 const composerVariantTransition =

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -565,14 +565,31 @@ test.describe('Chat Streaming', () => {
     expect(hydrated).toContain('blocking_lookup result for docs.example.com');
     expect(hydrated).toContain('reference section 079');
 
+    const browserCasObjectRequests: string[] = [];
+    page.on('request', request => {
+      const url = request.url();
+      if (url.includes('/talon.v1.CasService/GetObject')) {
+        browserCasObjectRequests.push(url);
+      }
+    });
+
     await page.reload();
     const workToggle = page.getByRole('button', { name: /Worked for \d+s/ }).last();
     await expect(workToggle).toBeVisible({ timeout: 30000 });
+    expect(browserCasObjectRequests).toHaveLength(0);
     await workToggle.click();
+    expect(browserCasObjectRequests).toHaveLength(0);
+
     const toolToggle = page.getByRole('button', { name: /Called\s+mcp_durable_slow_blocking_lookup/ }).last();
     await expect(toolToggle).toBeVisible({ timeout: 10000 });
     await toolToggle.click();
     await expect(page.locator('code').filter({ hasText: 'reference section 079' }).last()).toBeVisible({ timeout: 10000 });
+    expect(browserCasObjectRequests).toHaveLength(1);
+
+    await toolToggle.click();
+    await toolToggle.click();
+    await expect(page.locator('code').filter({ hasText: 'reference section 079' }).last()).toBeVisible({ timeout: 10000 });
+    expect(browserCasObjectRequests).toHaveLength(1);
   });
 });
 

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -37,6 +37,16 @@ function makeStreamResponse(lines: string[]) {
   } as any;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve, reject };
+}
+
 function makeControllableStreamResponse() {
   const encoder = new TextEncoder();
   let releaseNextRead: ((line: string | null) => void) | null = null;
@@ -429,6 +439,238 @@ describe('TalonCopilot', () => {
       global.DecompressionStream = originalDecompressionStream;
       warnSpy.mockRestore();
     }
+  });
+
+  it('matches lazy CAS tool results by payload tool call id before generic part id', async () => {
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-payload-id',
+        state: 'IDLE',
+        items: [
+          {
+            message: {
+              id: 'assistant-payload-id',
+              role: 'ROLE_ASSISTANT',
+              parts: [
+                {
+                  id: 'generic-call-part-id',
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                  toolName: 'knowledge_search',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-from-payload', input: { query: 'docs' } }),
+                },
+                {
+                  id: 'generic-result-part-id',
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                  toolName: 'knowledge_search',
+                  content: '',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-from-payload' }),
+                  object: {
+                    key: 'cas/ops/sessions/sess-payload-id/messages/assistant-payload-id/000001.txt',
+                  },
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                  content: 'Done after payload id hydrate.',
+                },
+              ],
+              createdAt: String(Date.now() * 1000),
+            },
+            steps: [],
+          },
+        ],
+        hasMore: false,
+      }),
+      cas: {
+        getObject: jest.fn().mockResolvedValue({
+          data: new TextEncoder().encode('payload id hydrated output'),
+        }),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-payload-id"
+      />,
+    );
+
+    expect(await screen.findByText('Done after payload id hydrate.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
+
+    expect(await screen.findByText('payload id hydrated output')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start duplicate lazy CAS hydration while a tool result is already loading', async () => {
+    const hydration = deferred<any>();
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-cas-inflight',
+        state: 'IDLE',
+        items: [
+          {
+            message: {
+              id: 'assistant-cas-inflight',
+              role: 'ROLE_ASSISTANT',
+              parts: [
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                  toolCallId: 'call-cas-inflight',
+                  toolName: 'knowledge_search',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-cas-inflight', input: { query: 'docs' } }),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                  toolCallId: 'call-cas-inflight',
+                  toolName: 'knowledge_search',
+                  content: '',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-cas-inflight' }),
+                  object: {
+                    key: 'cas/ops/sessions/sess-cas-inflight/messages/assistant-cas-inflight/000001.txt',
+                  },
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                  content: 'Done while hydration is pending.',
+                },
+              ],
+              createdAt: String(Date.now() * 1000),
+            },
+            steps: [],
+          },
+        ],
+        hasMore: false,
+      }),
+      cas: {
+        getObject: jest.fn().mockReturnValue(hydration.promise),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-cas-inflight"
+      />,
+    );
+
+    expect(await screen.findByText('Done while hydration is pending.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    const toolToggle = await screen.findByRole('button', { name: /Called\s+knowledge_search/ });
+    fireEvent.click(toolToggle);
+    expect(await screen.findByText('Loading output...')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(toolToggle);
+    fireEvent.click(toolToggle);
+    expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      hydration.resolve({
+        data: new TextEncoder().encode('single in-flight hydrated output'),
+      });
+      await hydration.promise;
+    });
+
+    expect(await screen.findByText('single in-flight hydrated output')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores stale lazy CAS hydration failures after switching sessions', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const oldHydration = deferred<any>();
+    const listSessionMessages = jest.fn(async (request: any) => ({
+      sessionId: request.sessionId,
+      state: 'IDLE',
+      items: [
+        {
+          message: {
+            id: 'assistant-shared',
+            role: 'ROLE_ASSISTANT',
+            parts: [
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                toolCallId: 'call-shared',
+                toolName: 'knowledge_search',
+                payloadJson: JSON.stringify({ tool_call_id: 'call-shared', input: { query: request.sessionId } }),
+              },
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                toolCallId: 'call-shared',
+                toolName: 'knowledge_search',
+                content: '',
+                payloadJson: JSON.stringify({ tool_call_id: 'call-shared' }),
+                object: {
+                  key: `cas/ops/sessions/${request.sessionId}/messages/assistant-shared/000001.txt`,
+                },
+              },
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                content: request.sessionId === 'sess-stale-old'
+                  ? 'Old session final answer.'
+                  : 'New session final answer.',
+              },
+            ],
+            createdAt: String(Date.now() * 1000),
+          },
+          steps: [],
+        },
+      ],
+      hasMore: false,
+    }));
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages,
+      cas: {
+        getObject: jest.fn().mockReturnValue(oldHydration.promise),
+      },
+    };
+
+    const { rerender } = render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-stale-old"
+      />,
+    );
+
+    expect(await screen.findByText('Old session final answer.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
+    expect(await screen.findByText('Loading output...')).toBeInTheDocument();
+
+    rerender(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-stale-new"
+      />,
+    );
+
+    expect(await screen.findByText('New session final answer.')).toBeInTheDocument();
+
+    await act(async () => {
+      oldHydration.reject(new Error('old CAS failed'));
+      await oldHydration.promise.catch(() => undefined);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Could not load output.')).not.toBeInTheDocument();
+    });
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      'Could not hydrate CAS tool-result object',
+      expect.stringContaining('sess-stale-old'),
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
   });
 
   it('shows an inline error when lazy CAS tool result hydration fails', async () => {

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -339,7 +339,7 @@ describe('TalonCopilot', () => {
     expect(await screen.findByText('Hello from history')).toBeInTheDocument();
   });
 
-  it('hydrates zstd CAS tool results with a library fallback when the browser stream rejects zstd', async () => {
+  it('lazily hydrates zstd CAS tool results with a library fallback when the browser stream rejects zstd', async () => {
     const decodedOutput = new TextEncoder().encode('zstd hydrated tool output');
     const decompressZstd = jest.requireMock('fzstd').decompress as jest.Mock;
     decompressZstd.mockReturnValueOnce(decodedOutput);
@@ -412,9 +412,13 @@ describe('TalonCopilot', () => {
       );
 
       expect(await screen.findByText('Done')).toBeInTheDocument();
+      expect(gatewayClient.cas.getObject).not.toHaveBeenCalled();
       fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
       fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
       expect(await screen.findByText('zstd hydrated tool output')).toBeInTheDocument();
+      expect(gatewayClient.cas.getObject).toHaveBeenCalledWith({
+        key: 'cas/ops/sessions/sess-zstd/messages/assistant-zstd/000001.txt',
+      });
       expect(decompressZstd).toHaveBeenCalledWith(new Uint8Array([0x28, 0xb5, 0x2f, 0xfd]));
       expect(warnSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('Could not hydrate CAS tool-result object'),
@@ -425,6 +429,233 @@ describe('TalonCopilot', () => {
       global.DecompressionStream = originalDecompressionStream;
       warnSpy.mockRestore();
     }
+  });
+
+  it('shows an inline error when lazy CAS tool result hydration fails', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-cas-fail',
+        state: 'IDLE',
+        items: [
+          {
+            message: {
+              id: 'assistant-cas-fail',
+              role: 'ROLE_ASSISTANT',
+              parts: [
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                  toolCallId: 'call-cas-fail',
+                  toolName: 'knowledge_search',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-cas-fail', input: { query: 'docs' } }),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                  toolCallId: 'call-cas-fail',
+                  toolName: 'knowledge_search',
+                  content: '',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-cas-fail' }),
+                  object: {
+                    key: 'cas/ops/sessions/sess-cas-fail/messages/assistant-cas-fail/000001.txt',
+                  },
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                  content: 'Done after failed hydrate.',
+                },
+              ],
+              createdAt: String(Date.now() * 1000),
+            },
+            steps: [],
+          },
+        ],
+        hasMore: false,
+      }),
+      cas: {
+        getObject: jest.fn().mockRejectedValue(new Error('CAS unavailable')),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-cas-fail"
+      />,
+    );
+
+    expect(await screen.findByText('Done after failed hydrate.')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
+
+    expect(await screen.findByText('Could not load output.')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Could not hydrate CAS tool-result object',
+      'cas/ops/sessions/sess-cas-fail/messages/assistant-cas-fail/000001.txt',
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('does not refetch a lazy CAS tool result after it has been hydrated once', async () => {
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-cas-cache',
+        state: 'IDLE',
+        items: [
+          {
+            message: {
+              id: 'assistant-cas-cache',
+              role: 'ROLE_ASSISTANT',
+              parts: [
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                  toolCallId: 'call-cas-cache',
+                  toolName: 'knowledge_search',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-cas-cache', input: { query: 'docs' } }),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                  toolCallId: 'call-cas-cache',
+                  toolName: 'knowledge_search',
+                  content: '',
+                  payloadJson: JSON.stringify({ tool_call_id: 'call-cas-cache' }),
+                  object: {
+                    key: 'cas/ops/sessions/sess-cas-cache/messages/assistant-cas-cache/000001.txt',
+                  },
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                  content: 'Done after cached hydrate.',
+                },
+              ],
+              createdAt: String(Date.now() * 1000),
+            },
+            steps: [],
+          },
+        ],
+        hasMore: false,
+      }),
+      cas: {
+        getObject: jest.fn().mockResolvedValue({
+          data: new TextEncoder().encode('cached hydrated output'),
+        }),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-cas-cache"
+      />,
+    );
+
+    expect(await screen.findByText('Done after cached hydrate.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    const toolToggle = await screen.findByRole('button', { name: /Called\s+knowledge_search/ });
+    fireEvent.click(toolToggle);
+    expect(await screen.findByText('cached hydrated output')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(toolToggle);
+    fireEvent.click(toolToggle);
+    expect(await screen.findByText('cached hydrated output')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not hydrate CAS tool results while loading initial or older history pages', async () => {
+    const listSessionMessages = jest.fn(async (request: any) => ({
+      sessionId: 'sess-cas-pages',
+      state: 'IDLE',
+      hasMore: !request.beforeMessageId,
+      nextBeforeMessageId: request.beforeMessageId ? undefined : 'assistant-latest',
+      items: [
+        {
+          message: {
+            id: request.beforeMessageId ? 'assistant-older' : 'assistant-latest',
+            role: 'ROLE_ASSISTANT',
+            parts: [
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                toolCallId: request.beforeMessageId ? 'call-older' : 'call-latest',
+                toolName: 'knowledge_search',
+                payloadJson: JSON.stringify({
+                  tool_call_id: request.beforeMessageId ? 'call-older' : 'call-latest',
+                  input: { query: request.beforeMessageId ? 'older' : 'latest' },
+                }),
+              },
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                toolCallId: request.beforeMessageId ? 'call-older' : 'call-latest',
+                toolName: 'knowledge_search',
+                content: '',
+                payloadJson: JSON.stringify({
+                  tool_call_id: request.beforeMessageId ? 'call-older' : 'call-latest',
+                }),
+                object: {
+                  key: request.beforeMessageId
+                    ? 'cas/ops/sessions/sess-cas-pages/messages/assistant-older/000001.txt'
+                    : 'cas/ops/sessions/sess-cas-pages/messages/assistant-latest/000001.txt',
+                },
+              },
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                content: request.beforeMessageId ? 'Older page final answer.' : 'Latest page final answer.',
+              },
+            ],
+            createdAt: request.beforeMessageId ? '1777755591000000' : '1777755592000000',
+          },
+          steps: [],
+        },
+      ],
+    }));
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages,
+      cas: {
+        getObject: jest.fn().mockResolvedValue({
+          data: new TextEncoder().encode('hydrated page output'),
+        }),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-cas-pages"
+        historyPageSize={1}
+      />,
+    );
+
+    expect(await screen.findByText('Latest page final answer.')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).not.toHaveBeenCalled();
+
+    fireEvent.scroll(screen.getByTestId('copilot-transcript'), { target: { scrollTop: 0 } });
+
+    expect(await screen.findByText('Older page final answer.')).toBeInTheDocument();
+    expect(listSessionMessages).toHaveBeenCalledWith({
+      ns: 'ops',
+      agent: 'copilot',
+      sessionId: 'sess-cas-pages',
+      pageSize: 1,
+      beforeMessageId: 'assistant-latest',
+    });
+    expect(gatewayClient.cas.getObject).not.toHaveBeenCalled();
+
+    const workToggles = screen.getAllByRole('button', { name: /Worked/ });
+    fireEvent.click(workToggles.at(-1)!);
+    fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
+    expect(await screen.findByText('hydrated page output')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
   });
 
   it('shows pending connector replies and requests delivery by updating message labels', async () => {


### PR DESCRIPTION
## Summary

- Keep `@impalasys/talon-chat` history replay lightweight by preserving paginated `ListMessages` hydration and deferring CAS-backed tool-result downloads until the matching tool row is expanded.
- Add inline loading/error states for lazy tool-result hydration and avoid refetching outputs once hydrated.
- Extend Jest and Playwright coverage for no eager CAS fetches, paged history loading, hydration failure, cached re-expansion, and browser-level CAS network assertions.

## Root Cause

Object-backed tool-result parts were being hydrated for every loaded session history page, so large tool outputs could be downloaded before the user opened collapsed tool details.

## Validation

- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`
- `pnpm --filter @impalasys/talon-chat test`
- `pnpm --filter @impalasys/talon-chat build`
- `pnpm --filter @impalasys/talon-client build && pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `git diff --check`
- Pre-push hook: `cargo metadata --locked`, `cargo fmt --all --check`, `cargo build --locked --bins`, `cargo test --locked`

Note: I did not run the Playwright e2e locally because the UI and gateway were not running, but the browser-level assertion is wired into the existing chat e2e.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Tool outputs are now loaded only when expanded, improving session history loading and navigation.
  - Previously viewed outputs remain available without repeated loading.

- **User Experience**
  - Expanded tool results display a loading indicator while content is retrieved.
  - A clear error message appears when an output cannot be loaded.
  - Behavior is consistent across work and timeline views, including paginated history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->