### PR TITLE
Use Slack-style schedule mentions

### DIFF
--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -503,7 +503,7 @@ pub async fn dispatch_schedule(
 
 fn format_scheduled_message(schedule_name: &str, input_message: &str) -> String {
     format!(
-        "[Scheduled run: {}]\nThis is an automated scheduled execution. Execute the task below. Do not create, update, or delete schedules unless the task explicitly asks for that.\n\nTask:\n{}",
+        "<@schedule:{}>\nThis is an automated scheduled execution. Execute the task below. Do not create, update, or delete schedules unless the task explicitly asks for that.\n\nTask:\n{}",
         schedule_name,
         input_message.trim()
     )
@@ -1517,7 +1517,7 @@ mod tests {
     fn format_scheduled_message_includes_schedule_provenance() {
         assert_eq!(
             format_scheduled_message("hello-world-ping", "  Hello world!  "),
-            "[Scheduled run: hello-world-ping]\nThis is an automated scheduled execution. Execute the task below. Do not create, update, or delete schedules unless the task explicitly asks for that.\n\nTask:\nHello world!"
+            "<@schedule:hello-world-ping>\nThis is an automated scheduled execution. Execute the task below. Do not create, update, or delete schedules unless the task explicitly asks for that.\n\nTask:\nHello world!"
         );
     }
 

--- a/src/gateway/rpc/channels.rs
+++ b/src/gateway/rpc/channels.rs
@@ -107,13 +107,18 @@ fn contains_mention(content: &str, target: &str) -> bool {
         return false;
     }
 
+    let slack_needle = format!("<@{target}>");
+    if content.contains(&slack_needle) {
+        return true;
+    }
+
     let needle = format!("@{target}");
     let mut offset = 0;
     while let Some(match_offset) = content[offset..].find(&needle) {
         let start = offset + match_offset;
         let end = start + needle.len();
         let previous = content[..start].chars().next_back();
-        let start_ok = previous.map_or(true, |ch| ch != '@' && mention_boundary(ch));
+        let start_ok = previous.map_or(true, |ch| ch != '@' && ch != '<' && mention_boundary(ch));
         let end_ok = content[end..].chars().next().map_or(true, mention_boundary);
         if start_ok && end_ok {
             return true;
@@ -1088,4 +1093,42 @@ fn format_channel_prompt(
         message.content,
         context_section
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contains_mention;
+
+    #[test]
+    fn contains_mention_accepts_slack_style_mentions() {
+        assert!(contains_mention(
+            "Please check this <@assistant>.",
+            "assistant"
+        ));
+        assert!(contains_mention(
+            "<@support.bot:primary> can you help?",
+            "support.bot:primary"
+        ));
+        assert!(!contains_mention(
+            "<@assistant-extra> is different",
+            "assistant"
+        ));
+        assert!(!contains_mention("<@assistant", "assistant"));
+    }
+
+    #[test]
+    fn contains_mention_keeps_legacy_at_mentions_for_compatibility() {
+        assert!(contains_mention(
+            "Please check this @assistant, thanks",
+            "assistant"
+        ));
+        assert!(!contains_mention(
+            "Please check this @assistant-extra.",
+            "assistant"
+        ));
+        assert!(!contains_mention(
+            "Please check this @@assistant.",
+            "assistant"
+        ));
+    }
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -856,7 +856,7 @@ mod tests {
         assert_eq!(event.direction, MessageDirection::Inbound as i32);
         assert_eq!(event.agent, "assistant");
         assert_eq!(event.session_id, "session-1");
-        assert!(event.message.contains("Scheduled run: nightly"));
+        assert!(event.message.contains("<@schedule:nightly>"));
     }
 
     #[tokio::test]
@@ -956,7 +956,7 @@ mod tests {
         assert_eq!(event.direction, MessageDirection::Inbound as i32);
         assert_eq!(event.agent, "assistant");
         assert_eq!(event.session_id, "session-1");
-        assert!(event.message.contains("Scheduled run: nightly"));
+        assert!(event.message.contains("<@schedule:nightly>"));
 
         drop(scheduler);
         server.abort();


### PR DESCRIPTION
## Summary

- Format scheduled run provenance as `<@schedule:name>` instead of bracketed text.
- Recognize Slack-style `<@agent>` channel mentions while keeping legacy `@agent` matching.
- Update scheduled dispatch assertions and add focused mention parser coverage.

## Why

Scheduled Cron messages should use the same mention-looking syntax as Slack/channel messages so downstream routing and readers can treat the schedule source consistently.

## Validation

- `cargo fmt`
- `cargo test --lib contains_mention`
- `cargo test --lib format_scheduled_message_includes_schedule_provenance`
- `cargo test --lib handle_schedule_wakeup_dispatches_message_and_updates_schedule`
- `cargo test --lib local_scheduler_runner_fires_schedule_through_worker_dispatch`
- pre-push hook: `cargo metadata --locked`, `cargo fmt --all --check`, `cargo build --locked --bins`, `cargo test --locked`