### PR TITLE
Reconcile live Talon sessions after reload and busy submits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,10 @@ jobs:
       - name: Check Docker daemon
         run: docker info
 
+      - name: Run live session reconciliation E2E
+        working-directory: ui
+        run: pnpm test:e2e --grep "Live session reconciliation"
+
       - name: Capture Sightline E2E screenshots
         working-directory: ui
         run: pnpm test:e2e --grep @screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,13 +232,9 @@ jobs:
       - name: Check Docker daemon
         run: docker info
 
-      - name: Run live session reconciliation E2E
+      - name: Run live session reconciliation and screenshot E2E
         working-directory: ui
-        run: pnpm test:e2e --grep "Live session reconciliation"
-
-      - name: Capture Sightline E2E screenshots
-        working-directory: ui
-        run: pnpm test:e2e --grep @screenshots
+        run: pnpm test:e2e --grep "Live session reconciliation|@screenshots"
 
       - name: Upload Sightline screenshots
         id: upload

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -1089,6 +1089,7 @@ export function TalonSession({
   const bottomRef = useRef<HTMLDivElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const resumeAbortControllerRef = useRef<AbortController | null>(null);
+  const stopAbortControllerRef = useRef<AbortController | null>(null);
   const currentSessionRef = useRef<{ ns: string; agent: string; sessionId: string } | null>(null);
   const messagesRef = useRef<CopilotMessage[]>(emptyMessages);
   const imageAttachmentsRef = useRef<TalonSessionPendingImageAttachment[]>([]);
@@ -2206,6 +2207,9 @@ export function TalonSession({
   const loadInitialSessionPage = useCallback(
     async (target: { ns: string; agent: string; sessionId: string }) => {
       const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
+      if (!isSameSession(currentSessionRef.current, target)) {
+        return res;
+      }
       autoScrollPinnedRef.current = true;
       setMessages(res.messages);
       setHasMoreHistory(res.hasMore);
@@ -2335,9 +2339,15 @@ export function TalonSession({
   );
 
   const waitForSessionToStop = useCallback(
-    async (target: { ns: string; agent: string; sessionId: string }) => {
+    async (target: { ns: string; agent: string; sessionId: string }, signal?: AbortSignal) => {
       for (let attempt = 0; attempt < 40; attempt += 1) {
+        if (signal?.aborted || !isSameSession(currentSessionRef.current, target)) {
+          return null;
+        }
         const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
+        if (signal?.aborted || !isSameSession(currentSessionRef.current, target)) {
+          return null;
+        }
         setSessionState(res.state);
         if (res.state !== "PROCESSING") {
           return res;
@@ -2355,6 +2365,9 @@ export function TalonSession({
       if (currentSessionRef.current && currentSessionRef.current.ns === namespace && currentSessionRef.current.agent === agent) {
         return;
       }
+      stopAbortControllerRef.current?.abort();
+      stopAbortControllerRef.current = null;
+      currentSessionRef.current = null;
       setCurrentSession(null);
       setSessionState(null);
       isStoppingRef.current = false;
@@ -2378,6 +2391,9 @@ export function TalonSession({
     abortControllerRef.current = null;
     resumeAbortControllerRef.current?.abort();
     resumeAbortControllerRef.current = controller;
+    stopAbortControllerRef.current?.abort();
+    stopAbortControllerRef.current = null;
+    currentSessionRef.current = nextSession;
     invalidateToolResultHydration();
     setIsLoading(false);
     setIsResuming(false);
@@ -2402,8 +2418,53 @@ export function TalonSession({
     return () => {
       cancelled = true;
       controller.abort();
+      stopAbortControllerRef.current?.abort();
+      stopAbortControllerRef.current = null;
     };
   }, [agent, invalidateToolResultHydration, loadInitialSessionPage, namespace, resumeStream, sessionId]);
+
+  useEffect(() => {
+    const target = currentSession;
+    if (!target || isSessionLive) {
+      return;
+    }
+
+    let cancelled = false;
+    let requestInFlight = false;
+    const pollForExternalGeneration = async () => {
+      if (cancelled || requestInFlight || !isSameSession(currentSessionRef.current, target)) {
+        return;
+      }
+      requestInFlight = true;
+      try {
+        const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
+        if (cancelled || !isSameSession(currentSessionRef.current, target) || res.state !== "PROCESSING") {
+          return;
+        }
+        await refreshNewestSessionPage(target);
+        if (cancelled || !isSameSession(currentSessionRef.current, target)) {
+          return;
+        }
+        const controller = new AbortController();
+        resumeAbortControllerRef.current?.abort();
+        resumeAbortControllerRef.current = controller;
+        setIsResuming(true);
+        setLoadingStartedAt(sessionProcessingStartTime(res.messages) ?? Date.now());
+        setLoadingNow(Date.now());
+        void resumeStream(target, controller.signal);
+      } catch {
+        // The normal stream/error path reports actionable failures once work is live.
+      } finally {
+        requestInFlight = false;
+      }
+    };
+
+    const intervalId = window.setInterval(() => void pollForExternalGeneration(), 1000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [currentSession, getSessionMessagesPage, hydrateSessionHistoryPage, isSessionLive, refreshNewestSessionPage, resumeStream]);
 
   const waitForCanonicalAssistantUpdate = useCallback(
     async (session: { ns: string; agent: string; sessionId: string }, baselineSignature: string) => {
@@ -2426,6 +2487,8 @@ export function TalonSession({
     abortControllerRef.current = null;
     resumeAbortControllerRef.current?.abort();
     resumeAbortControllerRef.current = null;
+    stopAbortControllerRef.current?.abort();
+    stopAbortControllerRef.current = null;
     resourceAbortRef.current?.abort();
     resourceAbortRef.current = null;
     setMessages(emptyMessages);
@@ -2617,6 +2680,8 @@ export function TalonSession({
     let submitTurnStarted = false;
     let resumedAfterBusyFailure = false;
     let submittedUserMessageId: string | null = null;
+    let submittedSession: TalonSessionHandle | null = null;
+    let submitController: AbortController | null = null;
 
     const ensureSession = async (): Promise<TalonSessionHandle> => {
       let session = currentSessionRef.current;
@@ -2718,8 +2783,10 @@ export function TalonSession({
       );
 
       session = await ensureSession();
+      submittedSession = session;
 
       const controller = new AbortController();
+      submitController = controller;
       abortControllerRef.current = controller;
       const uploadedImages = await uploadQueuedImages(session, controller.signal);
       const imageParts = uploadedImages.map((attachment) => {
@@ -2791,7 +2858,12 @@ export function TalonSession({
       }
     } catch (err: any) {
       const nextError = err instanceof Error ? err : new Error(String(err));
-      const session = currentSessionRef.current;
+      const session = submittedSession && isSameSession(currentSessionRef.current, submittedSession)
+        ? submittedSession
+        : null;
+      if (submitController?.signal.aborted || (submittedSession && !session)) {
+        return;
+      }
       if (session && isSessionBusyError(nextError)) {
         if (submittedUserMessageId) {
           const optimisticMessageId = submittedUserMessageId;
@@ -2827,10 +2899,15 @@ export function TalonSession({
       }
       setError(nextError);
     } finally {
-      abortControllerRef.current = null;
-      setIsLoading(false);
-      if (!resumedAfterBusyFailure) {
-        setLoadingStartedAt(null);
+      if (submitController?.signal.aborted || (submittedSession && !isSameSession(currentSessionRef.current, submittedSession))) {
+        return;
+      }
+      if (!submitController || abortControllerRef.current === submitController) {
+        abortControllerRef.current = null;
+        setIsLoading(false);
+        if (!resumedAfterBusyFailure) {
+          setLoadingStartedAt(null);
+        }
       }
     }
   }, [agent, clearSession, createSession, disabled, gatewayClient, isLoading, isSessionLive, namespace, onSessionChange, refreshNewestSessionPage, resolvedCommands, resolvedHistoryPageSize, resumeStream, sessionId, uploadQueuedImages, waitForCanonicalAssistantUpdate]);
@@ -2839,6 +2916,9 @@ export function TalonSession({
     if (!currentSessionRef.current || !isSessionLive || isStopping) return;
 
     const session = currentSessionRef.current;
+    const stopController = new AbortController();
+    stopAbortControllerRef.current?.abort();
+    stopAbortControllerRef.current = stopController;
     isStoppingRef.current = true;
     setIsStopping(true);
     abortControllerRef.current?.abort();
@@ -2855,20 +2935,29 @@ export function TalonSession({
         throw new Error("TalonSession requires a Talon clientset with sessions.stopGeneration().");
       }
       await sessions.stopGeneration(session);
-      const stopped = await waitForSessionToStop(session);
+      const stopped = await waitForSessionToStop(session, stopController.signal);
+      if (stopController.signal.aborted || !isSameSession(currentSessionRef.current, session)) {
+        return;
+      }
       if (!stopped) {
+        stopAbortControllerRef.current = null;
         isStoppingRef.current = false;
         setIsStopping(false);
         setError(new Error("Stop was requested, but the session is still generating."));
         return;
       }
       await refreshNewestSessionPage(session);
+      stopAbortControllerRef.current = null;
       isStoppingRef.current = false;
       setIsStopping(false);
       setIsResuming(false);
       setLoadingStartedAt(null);
       setError(null);
     } catch (err) {
+      if (stopController.signal.aborted || !isSameSession(currentSessionRef.current, session)) {
+        return;
+      }
+      stopAbortControllerRef.current = null;
       isStoppingRef.current = false;
       setIsStopping(false);
       const stopError = err instanceof Error ? err : new Error(String(err));

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -384,6 +384,11 @@ function normalizeEpochToMilliseconds(value: unknown) {
   return null;
 }
 
+function sessionProcessingStartTime(messages: CopilotMessage[]) {
+  const latestUserMessage = [...messages].reverse().find((message) => message.role === "user");
+  return latestUserMessage ? normalizeEpochToMilliseconds(latestUserMessage.createdAt) : null;
+}
+
 function getAssistantSignature(messages: any[] | undefined) {
   if (!Array.isArray(messages)) return "";
   return messages
@@ -870,6 +875,11 @@ function formatWorkingDuration(start: unknown, now = Date.now()) {
   return seconds > 0 ? `Working for ${minutes}m ${seconds}s` : `Working for ${minutes}m`;
 }
 
+function isSessionBusyError(error: unknown) {
+  const candidate = error as { message?: unknown } | null;
+  return typeof candidate?.message === "string" && /session is currently generating|session is busy/i.test(candidate.message);
+}
+
 function messageWithEditedContent(message: CopilotMessage, nextContent: string): CopilotMessage {
   const nextMessage: CopilotMessage = { ...message, content: nextContent };
   if (Array.isArray(nextMessage.parts)) {
@@ -1049,6 +1059,9 @@ export function TalonSession({
   const [input, setInput] = useState("");
   const [imageAttachments, setImageAttachments] = useState<TalonSessionPendingImageAttachment[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [isResuming, setIsResuming] = useState(false);
+  const [sessionState, setSessionState] = useState<string | null>(null);
+  const [isStopping, setIsStopping] = useState(false);
   const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
   const [loadingNow, setLoadingNow] = useState(Date.now());
   const [error, setError] = useState<Error | null>(null);
@@ -1082,10 +1095,12 @@ export function TalonSession({
   const submittedPreviewUrlsRef = useRef<string[]>([]);
   const toolResultHydrationInFlightRef = useRef<Set<string>>(new Set());
   const toolResultHydrationGenerationRef = useRef(0);
+  const isStoppingRef = useRef(false);
   const skipNextAutoScrollRef = useRef(false);
   const autoScrollPinnedRef = useRef(true);
   const prependScrollRestoreRef = useRef<{ previousScrollTop: number; previousScrollHeight: number } | null>(null);
   const isLoadingOlderHistoryRef = useRef(false);
+  const isSessionLive = isLoading || isResuming || sessionState === "PROCESSING" || isStopping;
 
   const invalidateToolResultHydration = useCallback(() => {
     toolResultHydrationGenerationRef.current += 1;
@@ -1168,7 +1183,7 @@ export function TalonSession({
       updateTranscriptScrollThumb();
     });
     return () => window.cancelAnimationFrame(rafId);
-  }, [currentSession?.sessionId, messages, streamEvents, isLoading, error, scrollTranscriptToBottom, updateTranscriptScrollThumb]);
+  }, [currentSession?.sessionId, messages, streamEvents, isSessionLive, error, scrollTranscriptToBottom, updateTranscriptScrollThumb]);
 
   useEffect(() => {
     updateTranscriptScrollThumb();
@@ -1178,16 +1193,16 @@ export function TalonSession({
 
   useSafeLayoutEffect(() => {
     updateTranscriptScrollThumb();
-  }, [messages, expandedThinkingMessages, expandedToolItems, toolResultHydration, isLoading, error, streamEvents, updateTranscriptScrollThumb]);
+  }, [messages, expandedThinkingMessages, expandedToolItems, toolResultHydration, isSessionLive, error, streamEvents, updateTranscriptScrollThumb]);
 
   useEffect(() => {
-    if (!isLoading || loadingStartedAt === null) {
+    if (!isSessionLive || loadingStartedAt === null) {
       return;
     }
     setLoadingNow(Date.now());
     const intervalId = window.setInterval(() => setLoadingNow(Date.now()), 250);
     return () => window.clearInterval(intervalId);
-  }, [isLoading, loadingStartedAt]);
+  }, [isSessionLive, loadingStartedAt]);
 
   useEffect(() => {
     return () => {
@@ -1556,22 +1571,16 @@ export function TalonSession({
       const usageSummary = formatUsageSummary(usage);
       const isUserMessage = message.role === "user";
       const isLatestMessage = messageIndex === messages.length - 1;
-      const isLiveAssistantMessage = isLoading && isLatestMessage && message.role === "assistant";
+      const isLiveAssistantMessage = isSessionLive && isLatestMessage && message.role === "assistant";
       const isEditableMessage =
         (allowMessageEditing || enableDebugMessageEditing) &&
         (message.role === "user" || message.role === "assistant") &&
         !isLiveAssistantMessage;
       const isEditingMessage = editingMessageId === message.id;
       const messageActionTimestamp = isEditableMessage ? formatMessageActionTimestamp(message) : null;
-      const finalizedTimeline = isLiveAssistantMessage
-        ? { workTimeline: [], finalTimeline: timeline }
-        : splitFinalAssistantTimeline(timeline);
-      const visibleTimeline = isLiveAssistantMessage
-        ? timeline
-        : finalizedTimeline.finalTimeline;
-      const workTimeline = isLiveAssistantMessage
-        ? []
-        : finalizedTimeline.workTimeline;
+      const finalizedTimeline = splitFinalAssistantTimeline(timeline);
+      const visibleTimeline = finalizedTimeline.finalTimeline;
+      const workTimeline = finalizedTimeline.workTimeline;
       const workHasReasoning = workTimeline.some((item) => item.type === "reasoning");
       const workHasUsage = workTimeline.some((item) => item.type === "usage");
       const hasExpandedWorkDetails =
@@ -1591,7 +1600,7 @@ export function TalonSession({
       const workLabel = isLiveAssistantMessage
         ? formatWorkingDuration(loadingStartedAt, loadingNow)
         : formatWorkDuration(previousUserMessage?.createdAt, message.createdAt);
-      const isWorkExpanded = expandedThinkingMessages[message.id] ?? false;
+      const isWorkExpanded = isLiveAssistantMessage || (expandedThinkingMessages[message.id] ?? false);
       const deliveryStatus = message.labels?.[LABEL_CONNECTOR_DELIVERY_STATUS];
       const isPendingConnectorDelivery =
         enableDebugMessageEditing && deliveryStatus === CONNECTOR_DELIVERY_PENDING_REVIEW;
@@ -2150,7 +2159,7 @@ export function TalonSession({
         </React.Fragment>
       );
     });
-  }, [allowMessageEditing, cancelEditingMessage, copyMessageContent, editingMessageId, editingMessageValue, enableDebugMessageEditing, expandedThinkingMessages, expandedToolItems, handleResourceClick, hydrateToolResultForExpandedItem, isLoading, loadingNow, loadingStartedAt, messages, objectUrlForRef, reviewActionMessageId, saveEditingMessage, startEditingMessage, toggleThinkingMessage, toggleToolItem, toolResultHydration, updateConnectorDeliveryStatus]);
+  }, [allowMessageEditing, cancelEditingMessage, copyMessageContent, editingMessageId, editingMessageValue, enableDebugMessageEditing, expandedThinkingMessages, expandedToolItems, handleResourceClick, hydrateToolResultForExpandedItem, isLoading, isResuming, isSessionLive, isStopping, loadingNow, loadingStartedAt, messages, objectUrlForRef, reviewActionMessageId, saveEditingMessage, startEditingMessage, toggleThinkingMessage, toggleToolItem, toolResultHydration, updateConnectorDeliveryStatus]);
 
   const resolvedHistoryPageSize = Math.max(
     1,
@@ -2202,7 +2211,14 @@ export function TalonSession({
       setHasMoreHistory(res.hasMore);
       setNextBeforeMessageId(res.nextBeforeMessageId);
       setStreamEvents([]);
+      currentSessionRef.current = target;
       setCurrentSession(target);
+      setSessionState(res.state);
+      const isProcessing = res.state === "PROCESSING";
+      setIsLoading(false);
+      setIsResuming(isProcessing);
+      setLoadingStartedAt(isProcessing ? sessionProcessingStartTime(res.messages) ?? Date.now() : null);
+      setLoadingNow(Date.now());
       return res;
     },
     [getSessionMessagesPage, hydrateSessionHistoryPage],
@@ -2281,6 +2297,7 @@ export function TalonSession({
         setNextBeforeMessageId(res.nextBeforeMessageId);
       }
       setStreamEvents([]);
+      setSessionState(res.state);
       setCurrentSession(target);
       return res;
     },
@@ -2304,9 +2321,32 @@ export function TalonSession({
         if (!signal?.aborted) {
           setError(err instanceof Error ? err : new Error(String(err)));
         }
+      } finally {
+        if (!signal?.aborted && isSameSession(currentSessionRef.current, target)) {
+          const refreshed = await refreshNewestSessionPage(target).catch(() => null);
+          setIsResuming(false);
+          if (refreshed?.state !== "PROCESSING") {
+            setLoadingStartedAt(null);
+          }
+        }
       }
     },
-    [gatewayClient],
+    [gatewayClient, refreshNewestSessionPage],
+  );
+
+  const waitForSessionToStop = useCallback(
+    async (target: { ns: string; agent: string; sessionId: string }) => {
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
+        setSessionState(res.state);
+        if (res.state !== "PROCESSING") {
+          return res;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      return null;
+    },
+    [getSessionMessagesPage, hydrateSessionHistoryPage],
   );
 
   useEffect(() => {
@@ -2316,6 +2356,8 @@ export function TalonSession({
         return;
       }
       setCurrentSession(null);
+      setSessionState(null);
+      isStoppingRef.current = false;
       setMessages(emptyMessages);
       setHasMoreHistory(false);
       setNextBeforeMessageId(null);
@@ -2332,9 +2374,19 @@ export function TalonSession({
 
     let cancelled = false;
     const controller = new AbortController();
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
     resumeAbortControllerRef.current?.abort();
     resumeAbortControllerRef.current = controller;
     invalidateToolResultHydration();
+    setIsLoading(false);
+    setIsResuming(false);
+    setSessionState(null);
+    isStoppingRef.current = false;
+    setIsStopping(false);
+    setLoadingStartedAt(null);
+    setLoadingNow(Date.now());
+    setExpandedThinkingMessages({});
     loadInitialSessionPage(nextSession)
       .then((res) => {
         if (!cancelled && res.state === "PROCESSING") {
@@ -2372,6 +2424,8 @@ export function TalonSession({
   const clearLocalSession = useCallback(() => {
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
+    resumeAbortControllerRef.current?.abort();
+    resumeAbortControllerRef.current = null;
     resourceAbortRef.current?.abort();
     resourceAbortRef.current = null;
     setMessages(emptyMessages);
@@ -2381,6 +2435,10 @@ export function TalonSession({
     setHasMoreHistory(false);
     setNextBeforeMessageId(null);
     setIsLoading(false);
+    setIsResuming(false);
+    setSessionState(null);
+    isStoppingRef.current = false;
+    setIsStopping(false);
     setLoadingStartedAt(null);
     setExpandedThinkingMessages({});
     setExpandedToolItems({});
@@ -2555,8 +2613,10 @@ export function TalonSession({
     let text = submittedText.trim();
     const pendingAttachments = imageAttachmentsRef.current;
     const hasImages = pendingAttachments.length > 0;
-    if ((!text && !hasImages) || isLoading || disabled) return;
+    if ((!text && !hasImages) || isSessionLive || disabled) return;
     let submitTurnStarted = false;
+    let resumedAfterBusyFailure = false;
+    let submittedUserMessageId: string | null = null;
 
     const ensureSession = async (): Promise<TalonSessionHandle> => {
       let session = currentSessionRef.current;
@@ -2649,6 +2709,7 @@ export function TalonSession({
     setStreamEvents([]);
     resumeAbortControllerRef.current?.abort();
     resumeAbortControllerRef.current = null;
+    setIsResuming(false);
 
     try {
       let session = currentSessionRef.current;
@@ -2688,6 +2749,7 @@ export function TalonSession({
         parts: messageParts,
         createdAt: String(Date.now() * 1000),
       };
+      submittedUserMessageId = userMessage.id;
 
       setInput("");
       submittedPreviewUrlsRef.current.push(...uploadedImages.map((attachment) => attachment.previewUrl));
@@ -2730,7 +2792,30 @@ export function TalonSession({
     } catch (err: any) {
       const nextError = err instanceof Error ? err : new Error(String(err));
       const session = currentSessionRef.current;
-      if (session && submitTurnStarted) {
+      if (session && isSessionBusyError(nextError)) {
+        if (submittedUserMessageId) {
+          const optimisticMessageId = submittedUserMessageId;
+          messagesRef.current = messagesRef.current.filter((message) => message.id !== optimisticMessageId);
+          setMessages((prev) => prev.filter((message) => message.id !== optimisticMessageId));
+        }
+        const refreshed = await refreshNewestSessionPage(session).catch(() => null);
+        if (isStoppingRef.current) {
+          return;
+        }
+        if (refreshed?.state === "PROCESSING") {
+          const controller = new AbortController();
+          resumeAbortControllerRef.current?.abort();
+          resumeAbortControllerRef.current = controller;
+          resumedAfterBusyFailure = true;
+          setIsResuming(true);
+          setLoadingStartedAt(sessionProcessingStartTime(refreshed.messages) ?? Date.now());
+          setLoadingNow(Date.now());
+          setError(null);
+          void resumeStream(session, controller.signal);
+          return;
+        }
+      }
+      if (session && submitTurnStarted && !isSessionBusyError(nextError)) {
         const baselineAssistantSignature = getAssistantSignature(
           messagesRef.current.slice(-resolvedHistoryPageSize),
         );
@@ -2744,29 +2829,61 @@ export function TalonSession({
     } finally {
       abortControllerRef.current = null;
       setIsLoading(false);
-      setLoadingStartedAt(null);
+      if (!resumedAfterBusyFailure) {
+        setLoadingStartedAt(null);
+      }
     }
-  }, [agent, clearSession, createSession, disabled, gatewayClient, isLoading, namespace, onSessionChange, refreshNewestSessionPage, resolvedCommands, resolvedHistoryPageSize, sessionId, uploadQueuedImages, waitForCanonicalAssistantUpdate]);
+  }, [agent, clearSession, createSession, disabled, gatewayClient, isLoading, isSessionLive, namespace, onSessionChange, refreshNewestSessionPage, resolvedCommands, resolvedHistoryPageSize, resumeStream, sessionId, uploadQueuedImages, waitForCanonicalAssistantUpdate]);
 
   const stopGeneration = useCallback(async () => {
-    if (!currentSessionRef.current || !isLoading) return;
+    if (!currentSessionRef.current || !isSessionLive || isStopping) return;
 
+    const session = currentSessionRef.current;
+    isStoppingRef.current = true;
+    setIsStopping(true);
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
+    resumeAbortControllerRef.current?.abort();
+    resumeAbortControllerRef.current = null;
     setIsLoading(false);
+    setIsResuming(false);
     setLoadingStartedAt(null);
 
     try {
-      const session = currentSessionRef.current;
       const sessions = gatewayClient?.sessions;
       if (!sessions?.stopGeneration) {
         throw new Error("TalonSession requires a Talon clientset with sessions.stopGeneration().");
       }
       await sessions.stopGeneration(session);
+      const stopped = await waitForSessionToStop(session);
+      if (!stopped) {
+        isStoppingRef.current = false;
+        setIsStopping(false);
+        setError(new Error("Stop was requested, but the session is still generating."));
+        return;
+      }
+      await refreshNewestSessionPage(session);
+      isStoppingRef.current = false;
+      setIsStopping(false);
+      setIsResuming(false);
+      setLoadingStartedAt(null);
+      setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err : new Error(String(err)));
+      isStoppingRef.current = false;
+      setIsStopping(false);
+      const stopError = err instanceof Error ? err : new Error(String(err));
+      setError(stopError);
+      const refreshed = await refreshNewestSessionPage(session).catch(() => null);
+      if (refreshed?.state === "PROCESSING") {
+        const controller = new AbortController();
+        resumeAbortControllerRef.current = controller;
+        setIsResuming(true);
+        setLoadingStartedAt(sessionProcessingStartTime(refreshed.messages) ?? Date.now());
+        setLoadingNow(Date.now());
+        void resumeStream(session, controller.signal);
+      }
     }
-  }, [gatewayClient, isLoading, setError]);
+  }, [gatewayClient, isSessionLive, isStopping, refreshNewestSessionPage, resumeStream, setError, waitForSessionToStop]);
 
   const handleTranscriptScroll = useCallback(() => {
     updateTranscriptScrollThumb();
@@ -2889,7 +3006,7 @@ export function TalonSession({
               <div style={{ maxWidth: 896, margin: "0 auto", padding: "1.5rem", display: "flex", flexDirection: "column", gap: "2rem" }}>
               {renderedMessages}
 
-              {isLoading && messages[messages.length - 1]?.role === "user" ? (
+              {isSessionLive && messages[messages.length - 1]?.role === "user" ? (
                 <div style={{ width: "100%" }}>
                   <div style={{ fontSize: 13, fontWeight: 500, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
                     {formatWorkingDuration(loadingStartedAt, loadingNow)}
@@ -2957,9 +3074,9 @@ export function TalonSession({
                   variant={composerVariant}
                   autoFocus={autoFocus}
                   rows={inputRows}
-                  canSubmit={Boolean((input || "").trim() || imageAttachments.length > 0) && !isLoading}
-                  isGenerating={isLoading}
-                  canStop={Boolean(currentSession)}
+                  canSubmit={Boolean((input || "").trim() || imageAttachments.length > 0) && !isSessionLive}
+                  isGenerating={isSessionLive}
+                  canStop={Boolean(currentSession) && !isStopping}
                   commandMenuItems={commandMenuItems}
                   startAdornment={composerStartAdornment}
                   endAdornment={composerEndAdornment}

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -2276,8 +2276,11 @@ export function TalonSession({
   );
 
   const refreshNewestSessionPage = useCallback(
-    async (target: { ns: string; agent: string; sessionId: string }) => {
+    async (target: { ns: string; agent: string; sessionId: string }, signal?: AbortSignal) => {
       const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
+      if (signal?.aborted || !isSameSession(currentSessionRef.current, target)) {
+        return null;
+      }
       const newestPageIds = new Set(res.messages.map((message) => message.id));
       const oldestPageMessage = res.messages[0];
       const oldestPageId = oldestPageMessage?.id;
@@ -2328,8 +2331,20 @@ export function TalonSession({
       } finally {
         if (!signal?.aborted && isSameSession(currentSessionRef.current, target)) {
           const refreshed = await refreshNewestSessionPage(target).catch(() => null);
-          setIsResuming(false);
-          if (refreshed?.state !== "PROCESSING") {
+          if (refreshed?.state === "PROCESSING" && !isStoppingRef.current) {
+            const controller = new AbortController();
+            resumeAbortControllerRef.current?.abort();
+            resumeAbortControllerRef.current = controller;
+            setIsResuming(true);
+            setLoadingStartedAt(sessionProcessingStartTime(refreshed.messages) ?? Date.now());
+            setLoadingNow(Date.now());
+            window.setTimeout(() => {
+              if (!controller.signal.aborted && isSameSession(currentSessionRef.current, target) && !isStoppingRef.current) {
+                void resumeStream(target, controller.signal);
+              }
+            }, 250);
+          } else {
+            setIsResuming(false);
             setLoadingStartedAt(null);
           }
         }
@@ -2467,12 +2482,18 @@ export function TalonSession({
   }, [currentSession, getSessionMessagesPage, hydrateSessionHistoryPage, isSessionLive, refreshNewestSessionPage, resumeStream]);
 
   const waitForCanonicalAssistantUpdate = useCallback(
-    async (session: { ns: string; agent: string; sessionId: string }, baselineSignature: string) => {
+    async (session: { ns: string; agent: string; sessionId: string }, baselineSignature: string, signal?: AbortSignal) => {
       for (let attempt = 0; attempt < 40; attempt += 1) {
+        if (signal?.aborted || !isSameSession(currentSessionRef.current, session)) {
+          return false;
+        }
         const sessionState = await hydrateSessionHistoryPage(await getSessionMessagesPage(session));
+        if (signal?.aborted || !isSameSession(currentSessionRef.current, session)) {
+          return false;
+        }
         const nextSignature = getAssistantSignature(sessionState.messages);
         if (nextSignature && nextSignature !== baselineSignature) {
-          await refreshNewestSessionPage(session);
+          await refreshNewestSessionPage(session, signal);
           return true;
         }
         await new Promise((resolve) => setTimeout(resolve, 250));
@@ -2852,9 +2873,9 @@ export function TalonSession({
       });
 
       if (!hasAssistantEvent) {
-        await waitForCanonicalAssistantUpdate(session, baselineAssistantSignature);
+        await waitForCanonicalAssistantUpdate(session, baselineAssistantSignature, submitController?.signal);
       } else {
-        await refreshNewestSessionPage(session);
+        await refreshNewestSessionPage(session, submitController?.signal);
       }
     } catch (err: any) {
       const nextError = err instanceof Error ? err : new Error(String(err));
@@ -2869,8 +2890,16 @@ export function TalonSession({
           const optimisticMessageId = submittedUserMessageId;
           messagesRef.current = messagesRef.current.filter((message) => message.id !== optimisticMessageId);
           setMessages((prev) => prev.filter((message) => message.id !== optimisticMessageId));
+          setInput((current) => current || submittedText.trim());
+          if (imageAttachmentsRef.current.length === 0 && pendingAttachments.length > 0) {
+            imageAttachmentsRef.current = pendingAttachments;
+            setImageAttachments(pendingAttachments);
+          }
         }
-        const refreshed = await refreshNewestSessionPage(session).catch(() => null);
+        const refreshed = await refreshNewestSessionPage(session, submitController?.signal).catch(() => null);
+        if (submitController?.signal.aborted || !isSameSession(currentSessionRef.current, session)) {
+          return;
+        }
         if (isStoppingRef.current) {
           return;
         }
@@ -2891,7 +2920,7 @@ export function TalonSession({
         const baselineAssistantSignature = getAssistantSignature(
           messagesRef.current.slice(-resolvedHistoryPageSize),
         );
-        const recovered = await waitForCanonicalAssistantUpdate(session, baselineAssistantSignature).catch(() => false);
+        const recovered = await waitForCanonicalAssistantUpdate(session, baselineAssistantSignature, submitController?.signal).catch(() => false);
         if (recovered) {
           setError(null);
           return;
@@ -2940,16 +2969,10 @@ export function TalonSession({
         return;
       }
       if (!stopped) {
-        stopAbortControllerRef.current = null;
-        isStoppingRef.current = false;
-        setIsStopping(false);
         setError(new Error("Stop was requested, but the session is still generating."));
         return;
       }
-      await refreshNewestSessionPage(session);
-      stopAbortControllerRef.current = null;
-      isStoppingRef.current = false;
-      setIsStopping(false);
+      await refreshNewestSessionPage(session, stopController.signal);
       setIsResuming(false);
       setLoadingStartedAt(null);
       setError(null);
@@ -2957,12 +2980,9 @@ export function TalonSession({
       if (stopController.signal.aborted || !isSameSession(currentSessionRef.current, session)) {
         return;
       }
-      stopAbortControllerRef.current = null;
-      isStoppingRef.current = false;
-      setIsStopping(false);
       const stopError = err instanceof Error ? err : new Error(String(err));
       setError(stopError);
-      const refreshed = await refreshNewestSessionPage(session).catch(() => null);
+      const refreshed = await refreshNewestSessionPage(session, stopController.signal).catch(() => null);
       if (refreshed?.state === "PROCESSING") {
         const controller = new AbortController();
         resumeAbortControllerRef.current = controller;
@@ -2970,6 +2990,14 @@ export function TalonSession({
         setLoadingStartedAt(sessionProcessingStartTime(refreshed.messages) ?? Date.now());
         setLoadingNow(Date.now());
         void resumeStream(session, controller.signal);
+      }
+    } finally {
+      if (stopAbortControllerRef.current === stopController) {
+        stopAbortControllerRef.current = null;
+      }
+      if (!stopController.signal.aborted && isSameSession(currentSessionRef.current, session)) {
+        isStoppingRef.current = false;
+        setIsStopping(false);
       }
     }
   }, [gatewayClient, isSessionLive, isStopping, refreshNewestSessionPage, resumeStream, setError, waitForSessionToStop]);

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -2928,10 +2928,9 @@ export function TalonSession({
       }
       setError(nextError);
     } finally {
-      if (submitController?.signal.aborted || (submittedSession && !isSameSession(currentSessionRef.current, submittedSession))) {
-        return;
-      }
-      if (!submitController || abortControllerRef.current === submitController) {
+      const staleSession = submitController?.signal.aborted
+        || (submittedSession && !isSameSession(currentSessionRef.current, submittedSession));
+      if (!staleSession && (!submitController || abortControllerRef.current === submitController)) {
         abortControllerRef.current = null;
         setIsLoading(false);
         if (!resumedAfterBusyFailure) {
@@ -2958,18 +2957,33 @@ export function TalonSession({
     setIsResuming(false);
     setLoadingStartedAt(null);
 
+    const resumeIfStillProcessing = async () => {
+      const refreshed = await refreshNewestSessionPage(session, stopController.signal).catch(() => null);
+      if (refreshed?.state !== "PROCESSING") {
+        return;
+      }
+      const controller = new AbortController();
+      resumeAbortControllerRef.current?.abort();
+      resumeAbortControllerRef.current = controller;
+      setIsResuming(true);
+      setLoadingStartedAt(sessionProcessingStartTime(refreshed.messages) ?? Date.now());
+      setLoadingNow(Date.now());
+      void resumeStream(session, controller.signal);
+    };
+
     try {
       const sessions = gatewayClient?.sessions;
       if (!sessions?.stopGeneration) {
         throw new Error("TalonSession requires a Talon clientset with sessions.stopGeneration().");
       }
-      await sessions.stopGeneration(session);
+      await sessions.stopGeneration(session, { signal: stopController.signal });
       const stopped = await waitForSessionToStop(session, stopController.signal);
       if (stopController.signal.aborted || !isSameSession(currentSessionRef.current, session)) {
         return;
       }
       if (!stopped) {
         setError(new Error("Stop was requested, but the session is still generating."));
+        await resumeIfStillProcessing();
         return;
       }
       await refreshNewestSessionPage(session, stopController.signal);
@@ -2982,15 +2996,7 @@ export function TalonSession({
       }
       const stopError = err instanceof Error ? err : new Error(String(err));
       setError(stopError);
-      const refreshed = await refreshNewestSessionPage(session, stopController.signal).catch(() => null);
-      if (refreshed?.state === "PROCESSING") {
-        const controller = new AbortController();
-        resumeAbortControllerRef.current = controller;
-        setIsResuming(true);
-        setLoadingStartedAt(sessionProcessingStartTime(refreshed.messages) ?? Date.now());
-        setLoadingNow(Date.now());
-        void resumeStream(session, controller.signal);
-      }
+      await resumeIfStillProcessing();
     } finally {
       if (stopAbortControllerRef.current === stopController) {
         stopAbortControllerRef.current = null;

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -710,7 +710,6 @@ test.describe('Live session reconciliation', () => {
       message: 'square root of 144',
       labels: {},
     });
-    await waitForSessionState(client, target, 'PROCESSING');
     await waitForMockStreamBlocked();
 
     await chatInput.fill('a second request that must not be accepted');

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -152,7 +152,7 @@ async function resetMockLlm() {
 }
 
 async function waitForMockStreamBlocked() {
-  await expect.poll(async () => (await mockLlmControl('/__control/state')).blocked).toBe(true);
+  await expect.poll(async () => (await mockLlmControl('/__control/state')).blocked, { timeout: 60000 }).toBe(true);
 }
 
 async function unblockMockLlm() {
@@ -683,6 +683,8 @@ test.describe('Live session reconciliation', () => {
     await page.getByRole('button', { name: /Stop generation/i }).click();
     await waitForSessionState(client, target, 'IDLE');
     await expect(page.getByRole('button', { name: /Stop generation/i })).toHaveCount(0, { timeout: 15000 });
+    await expect(page.locator('body')).toContainText('The');
+    await expect(page.getByRole('button', { name: /Worked for/i })).toBeVisible();
     await expect(page.getByText(/System Incident/)).toHaveCount(0);
   });
 
@@ -712,12 +714,11 @@ test.describe('Live session reconciliation', () => {
     await waitForMockStreamBlocked();
 
     await chatInput.fill('a second request that must not be accepted');
-    await expect(sendButton).toBeEnabled();
     await sendButton.click();
 
     await expect.poll(() => submitTurnRequests.length).toBe(1);
     await expect(page.getByText(/Working for/)).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText('a second request that must not be accepted', { exact: true })).toHaveCount(0);
+    await expect(chatInput).toHaveValue('a second request that must not be accepted');
     await expect(page.getByText(/System Incident/)).toHaveCount(0);
 
     await page.getByRole('button', { name: /Stop generation/i }).click();

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -649,11 +649,13 @@ test.describe('Live session reconciliation', () => {
 
   test.afterEach(async () => {
     await unblockMockLlm();
+    await resetMockLlm();
   });
 
   test('reopens a processing session after reload and stops an externally started generation', async ({ page }) => {
     const { sessionId, gatewayUrl, client, testNs, testAgent } = await createTestSession();
     const target = { ns: testNs, agent: testAgent, sessionId };
+    const { chatInput } = await openSessionDirectly(page, target, gatewayUrl);
 
     await mockLlmControl('/__control/block_stream_after_chunks', {
       method: 'POST',
@@ -668,7 +670,6 @@ test.describe('Live session reconciliation', () => {
     await waitForSessionState(client, target, 'PROCESSING');
     await waitForMockStreamBlocked();
 
-    const { chatInput } = await openSessionDirectly(page, target, gatewayUrl);
     await expect(page.getByText(/Working for/)).toBeVisible({ timeout: 15000 });
     await expect(page.getByRole('button', { name: /Stop generation/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /Worked for/i })).toHaveCount(0);
@@ -688,6 +689,12 @@ test.describe('Live session reconciliation', () => {
   test('recovers from a busy UI submit while an external generation remains live', async ({ page }) => {
     const { sessionId, gatewayUrl, client, testNs, testAgent } = await createTestSession();
     const target = { ns: testNs, agent: testAgent, sessionId };
+    const submitTurnRequests: string[] = [];
+    page.on('request', request => {
+      if (request.url().includes('/SubmitTurn')) {
+        submitTurnRequests.push(request.url());
+      }
+    });
 
     await mockLlmControl('/__control/block_stream_after_chunks', {
       method: 'POST',
@@ -708,6 +715,7 @@ test.describe('Live session reconciliation', () => {
     await expect(sendButton).toBeEnabled();
     await sendButton.click();
 
+    await expect.poll(() => submitTurnRequests.length).toBe(1);
     await expect(page.getByText(/Working for/)).toBeVisible({ timeout: 15000 });
     await expect(page.getByText('a second request that must not be accepted', { exact: true })).toHaveCount(0);
     await expect(page.getByText(/System Incident/)).toHaveCount(0);

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -692,6 +692,7 @@ test.describe('Live session reconciliation', () => {
     const { sessionId, gatewayUrl, client, testNs, testAgent } = await createTestSession();
     const target = { ns: testNs, agent: testAgent, sessionId };
     const submitTurnRequests: string[] = [];
+    let externalGenerationStarted = false;
     page.on('request', request => {
       if (request.url().includes('/SubmitTurn')) {
         submitTurnRequests.push(request.url());
@@ -705,12 +706,21 @@ test.describe('Live session reconciliation', () => {
     });
     const { chatInput, sendButton } = await openSessionDirectly(page, target, gatewayUrl);
 
-    await client.sessions.sendMessage({
-      ...target,
-      message: 'square root of 144',
-      labels: {},
+    await page.route('**/SubmitTurn', async route => {
+      if (externalGenerationStarted) {
+        await route.continue();
+        return;
+      }
+      externalGenerationStarted = true;
+      const externalGeneration = client.sessions.sendMessage({
+        ...target,
+        message: 'square root of 144',
+        labels: {},
+      });
+      void externalGeneration.catch(() => undefined);
+      await waitForMockStreamBlocked();
+      await route.continue();
     });
-    await waitForMockStreamBlocked();
 
     await chatInput.fill('a second request that must not be accepted');
     await sendButton.click();

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -136,6 +136,53 @@ async function provisionMcpSession(page: Page) {
   return { chatInput, sendButton, sessionId, gatewayUrl, client, testNs, testAgent };
 }
 
+function mockLlmUrl(pathname: string) {
+  const port = process.env.MOCK_LLM_PORT || '8000';
+  return `http://127.0.0.1:${port}${pathname}`;
+}
+
+async function mockLlmControl(pathname: string, init?: RequestInit) {
+  const response = await fetch(mockLlmUrl(pathname), init);
+  expect(response.ok).toBeTruthy();
+  return response.json();
+}
+
+async function resetMockLlm() {
+  await mockLlmControl('/__control/reset', { method: 'POST' });
+}
+
+async function waitForMockStreamBlocked() {
+  await expect.poll(async () => (await mockLlmControl('/__control/state')).blocked).toBe(true);
+}
+
+async function unblockMockLlm() {
+  await mockLlmControl('/__control/unblock_stream', { method: 'POST' });
+}
+
+async function waitForSessionState(
+  client: any,
+  target: { ns: string; agent: string; sessionId: string },
+  expectedState: string,
+) {
+  await expect(async () => {
+    const history = await client.sessions.listMessages({
+      ...target,
+      pageSize: 50,
+    });
+    expect(history.state).toBe(expectedState);
+  }).toPass({ timeout: 60000 });
+}
+
+async function openSessionDirectly(page: Page, target: { ns: string; agent: string; sessionId: string }, gatewayUrl: string) {
+  await installBrowserAuth(page, gatewayUrl);
+  await page.goto(`/?connected=true&ns=${encodeURIComponent(target.ns)}&agent=${encodeURIComponent(target.agent)}&session=${encodeURIComponent(target.sessionId)}`);
+
+  const chatInput = page.locator('textarea[placeholder="Ask Talon to perform a task..."]');
+  const sendButton = page.locator('form').filter({ has: chatInput }).getByRole('button', { name: 'Send message' });
+  await expect(chatInput).toBeVisible({ timeout: 15000 });
+  return { chatInput, sendButton };
+}
+
 async function decodeCasText(response: any, data: Uint8Array): Promise<string> {
   const encoding = String(response?.contentEncoding || response?.metadata?.contentEncoding || '').toLowerCase();
   if (encoding === 'zstd') {
@@ -590,6 +637,88 @@ test.describe('Chat Streaming', () => {
     await toolToggle.click();
     await expect(page.locator('code').filter({ hasText: 'reference section 079' }).last()).toBeVisible({ timeout: 10000 });
     expect(browserCasObjectRequests).toHaveLength(1);
+  });
+});
+
+test.describe('Live session reconciliation', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(async () => {
+    await resetMockLlm();
+  });
+
+  test.afterEach(async () => {
+    await unblockMockLlm();
+  });
+
+  test('reopens a processing session after reload and stops an externally started generation', async ({ page }) => {
+    const { sessionId, gatewayUrl, client, testNs, testAgent } = await createTestSession();
+    const target = { ns: testNs, agent: testAgent, sessionId };
+
+    await mockLlmControl('/__control/block_stream_after_chunks', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chunks: 1 }),
+    });
+    await client.sessions.sendMessage({
+      ...target,
+      message: 'square root of 144',
+      labels: {},
+    });
+    await waitForSessionState(client, target, 'PROCESSING');
+    await waitForMockStreamBlocked();
+
+    const { chatInput } = await openSessionDirectly(page, target, gatewayUrl);
+    await expect(page.getByText(/Working for/)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: /Stop generation/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Worked for/i })).toHaveCount(0);
+
+    await page.reload();
+    await expect(chatInput).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/Working for/)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: /Stop generation/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Worked for/i })).toHaveCount(0);
+
+    await page.getByRole('button', { name: /Stop generation/i }).click();
+    await waitForSessionState(client, target, 'IDLE');
+    await expect(page.getByRole('button', { name: /Stop generation/i })).toHaveCount(0, { timeout: 15000 });
+    await expect(page.getByText(/System Incident/)).toHaveCount(0);
+  });
+
+  test('recovers from a busy UI submit while an external generation remains live', async ({ page }) => {
+    const { sessionId, gatewayUrl, client, testNs, testAgent } = await createTestSession();
+    const target = { ns: testNs, agent: testAgent, sessionId };
+
+    await mockLlmControl('/__control/block_stream_after_chunks', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chunks: 1 }),
+    });
+    const { chatInput, sendButton } = await openSessionDirectly(page, target, gatewayUrl);
+
+    await client.sessions.sendMessage({
+      ...target,
+      message: 'square root of 144',
+      labels: {},
+    });
+    await waitForSessionState(client, target, 'PROCESSING');
+    await waitForMockStreamBlocked();
+
+    await chatInput.fill('a second request that must not be accepted');
+    await expect(sendButton).toBeEnabled();
+    await sendButton.click();
+
+    await expect(page.getByText(/Working for/)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('a second request that must not be accepted', { exact: true })).toHaveCount(0);
+    await expect(page.getByText(/System Incident/)).toHaveCount(0);
+
+    await page.getByRole('button', { name: /Stop generation/i }).click();
+    await waitForSessionState(client, target, 'IDLE');
+    await expect(async () => {
+      const history = await client.sessions.listMessages({ ...target, pageSize: 50 });
+      const contents = (history.items ?? []).map((item: any) => sessionMessageText(item.message));
+      expect(contents).not.toContain('a second request that must not be accepted');
+    }).toPass({ timeout: 30000 });
   });
 });
 

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -2724,6 +2724,25 @@ describe('TalonCopilot', () => {
             },
           ],
           steps: [],
+        })
+        .mockResolvedValue({
+          sessionId: 'sess-busy-submit',
+          state: 'IDLE',
+          messages: [
+            {
+              id: 'user-existing-busy',
+              role: 'ROLE_USER',
+              content: 'Existing prompt',
+              createdAt: String(Date.now() * 1000),
+            },
+            {
+              id: 'assistant-existing-busy',
+              role: 'ROLE_ASSISTANT',
+              content: 'Canonical partial response',
+              createdAt: String(Date.now() * 1000),
+            },
+          ],
+          steps: [],
         }),
       submitTurn,
       streamParts: jest.fn(async function* () {
@@ -2749,7 +2768,7 @@ describe('TalonCopilot', () => {
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
 
     expect(await screen.findByText(/Working for/)).toBeInTheDocument();
-    expect(screen.queryByText('new request')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Ask Talon to perform a task...')).toHaveValue('new request');
     expect(screen.queryByText(/system incident/i)).not.toBeInTheDocument();
     expect(submitTurn).toHaveBeenCalledTimes(1);
 

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -2294,6 +2294,73 @@ describe('TalonCopilot', () => {
     expect(screen.getByText('18 total')).toBeInTheDocument();
   });
 
+  it('restores the open working state when reloading a processing session', async () => {
+    const streamStarted = deferred<void>();
+    const finishStream = deferred<void>();
+    const gatewayClient = {
+      sessions: {
+        create: jest.fn(),
+        listMessages: jest.fn().mockResolvedValueOnce({
+          sessionId: 'sess-reloaded-processing',
+          state: 'PROCESSING',
+          items: [
+            {
+              message: {
+                id: 'user-reloaded-processing',
+                role: 'ROLE_USER',
+                content: 'Continue the in-progress task',
+                createdAt: String(Date.now() * 1000),
+              },
+              steps: [],
+            },
+            {
+              message: {
+                id: 'assistant-reloaded-processing',
+                role: 'ROLE_ASSISTANT',
+                parts: [
+                  { type: 'reasoning', text: 'Still checking the latest records.' },
+                  { type: 'text', text: 'The current answer is not complete yet.' },
+                ],
+                createdAt: String(Date.now() * 1000),
+              },
+              steps: [],
+            },
+          ],
+          hasMore: false,
+        }).mockResolvedValue({
+          sessionId: 'sess-reloaded-processing',
+          state: 'IDLE',
+          items: [],
+          hasMore: false,
+        }),
+        submitTurn: jest.fn(async function* () {}),
+        streamParts: jest.fn(async function* () {
+          streamStarted.resolve();
+          await finishStream.promise;
+          yield { kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DONE', messageId: 'assistant-reloaded-processing' };
+        }),
+        stopGeneration: jest.fn(),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-reloaded-processing"
+      />,
+    );
+
+    expect(await screen.findByText(/Working for/)).toBeInTheDocument();
+    await waitFor(() => expect(streamStarted.promise).resolves.toBeUndefined());
+    expect(screen.queryByText(/Worked for/)).not.toBeInTheDocument();
+    expect(screen.getByText('Still checking the latest records.')).toBeInTheDocument();
+
+    finishStream.resolve();
+    await waitFor(() => expect(screen.queryByText(/Working for/)).not.toBeInTheDocument());
+  });
+
   it('highlights a live tool call while it is running', async () => {
     let finishTool!: () => void;
     const toolFinished = new Promise<void>((resolve) => {
@@ -2531,8 +2598,9 @@ describe('TalonCopilot', () => {
     expect(screen.queryByText(/system incident/i)).not.toBeInTheDocument();
   });
 
-  it('aborts an existing session resume stream before sending a new message', async () => {
+  it('exposes stop generation for an externally processing session', async () => {
     const resumeStream = makeControllableStreamResponse();
+    const stopGeneration = jest.fn(async () => ({ success: true }));
     const gatewayClient = {
       createSession: jest.fn(),
       listSessionMessages: jest
@@ -2570,6 +2638,7 @@ describe('TalonCopilot', () => {
           steps: [],
         }),
       getSession: jest.fn(),
+      stopGeneration,
     };
     const fetchMock = global.fetch as jest.Mock;
     fetchMock.mockReset();
@@ -2601,20 +2670,91 @@ describe('TalonCopilot', () => {
     });
     const resumeSignal = fetchMock.mock.calls[0][1].signal as AbortSignal;
 
+    fireEvent.click(screen.getByRole('button', { name: /stop generation/i }));
+
+    await waitFor(() => expect(resumeSignal.aborted).toBe(true));
+    await waitFor(() => expect(stopGeneration).toHaveBeenCalledWith({
+      ns: 'ops',
+      agent: 'copilot',
+      sessionId: 'sess-existing-processing',
+    }));
+    resumeStream.release(null);
+
+    expect(screen.queryByText('Sure')).not.toBeInTheDocument();
+    expect(gatewayClient.createSession).not.toHaveBeenCalled();
+  });
+
+  it('rolls back a busy submission and resumes the canonical session stream', async () => {
+    const resumeFinished = deferred<void>();
+    const submitTurn = jest.fn(async function* () {
+      throw Object.assign(new Error('Session is currently generating a response.'), { code: 8 });
+    });
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest
+        .fn()
+        .mockResolvedValueOnce({
+          sessionId: 'sess-busy-submit',
+          state: 'IDLE',
+          messages: [
+            {
+              id: 'user-existing-busy',
+              role: 'ROLE_USER',
+              content: 'Existing prompt',
+              createdAt: String(Date.now() * 1000),
+            },
+          ],
+          steps: [],
+        })
+        .mockResolvedValueOnce({
+          sessionId: 'sess-busy-submit',
+          state: 'PROCESSING',
+          messages: [
+            {
+              id: 'user-existing-busy',
+              role: 'ROLE_USER',
+              content: 'Existing prompt',
+              createdAt: String(Date.now() * 1000),
+            },
+            {
+              id: 'assistant-existing-busy',
+              role: 'ROLE_ASSISTANT',
+              content: 'Canonical partial response',
+              createdAt: String(Date.now() * 1000),
+            },
+          ],
+          steps: [],
+        }),
+      submitTurn,
+      streamParts: jest.fn(async function* () {
+        await resumeFinished.promise;
+        yield { kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DONE', messageId: 'assistant-existing-busy' };
+      }),
+      stopGeneration: jest.fn(),
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-busy-submit"
+      />,
+    );
+
+    await screen.findByText('Existing prompt');
     fireEvent.change(screen.getByPlaceholderText('Ask Talon to perform a task...'), {
       target: { value: 'new request' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
 
-    await waitFor(() => expect(resumeSignal.aborted).toBe(true));
-    resumeStream.release('f:{"messageId":"assistant-existing"}\n');
-    resumeStream.release('0:"Sure"\n');
-    resumeStream.release(null);
+    expect(await screen.findByText(/Working for/)).toBeInTheDocument();
+    expect(screen.queryByText('new request')).not.toBeInTheDocument();
+    expect(screen.queryByText(/system incident/i)).not.toBeInTheDocument();
+    expect(submitTurn).toHaveBeenCalledTimes(1);
 
-    expect(await screen.findByText('Sure')).toBeInTheDocument();
-    await waitFor(() => expect(gatewayClient.listSessionMessages).toHaveBeenCalledTimes(2));
-    expect(screen.queryByText('SureSure')).not.toBeInTheDocument();
-    expect(gatewayClient.createSession).not.toHaveBeenCalled();
+    resumeFinished.resolve();
+    await waitFor(() => expect(screen.queryByText(/Working for/)).not.toBeInTheDocument());
   });
 });
 

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -2673,11 +2673,14 @@ describe('TalonCopilot', () => {
     fireEvent.click(screen.getByRole('button', { name: /stop generation/i }));
 
     await waitFor(() => expect(resumeSignal.aborted).toBe(true));
-    await waitFor(() => expect(stopGeneration).toHaveBeenCalledWith({
-      ns: 'ops',
-      agent: 'copilot',
-      sessionId: 'sess-existing-processing',
-    }));
+    await waitFor(() => expect(stopGeneration).toHaveBeenCalledWith(
+      {
+        ns: 'ops',
+        agent: 'copilot',
+        sessionId: 'sess-existing-processing',
+      },
+      { signal: expect.any(AbortSignal) },
+    ));
     resumeStream.release(null);
 
     await waitFor(() => {

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -2680,8 +2680,10 @@ describe('TalonCopilot', () => {
     }));
     resumeStream.release(null);
 
-    expect(screen.queryByText('Sure')).not.toBeInTheDocument();
-    expect(gatewayClient.createSession).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByText('Sure')).not.toBeInTheDocument();
+      expect(gatewayClient.createSession).not.toHaveBeenCalled();
+    });
   });
 
   it('rolls back a busy submission and resumes the canonical session stream', async () => {


### PR DESCRIPTION
## What changed

- Restore `PROCESSING` sessions as live on initial hydration, reopen the working panel, and resume the canonical stream.
- Detect generation started externally after the page is already open.
- Recover a UI submit that races an externally active generation by removing the optimistic message, refreshing canonical history, and resuming the live session.
- Expose Stop generation for externally started live sessions, abort local streams, wait for canonical state confirmation, and refresh the transcript.
- Guard session loading, submission recovery, and Stop polling against stale session switches.
- Add focused component coverage and Playwright E2E coverage for reload, external start/stop, and busy-submit recovery.
- Run the live-session E2E subset in CI.

## Why

After reload, a session could be actively generating while the UI rendered it as completed. A submit racing an external generation could also leave a ghost optimistic message or surface a false system incident. Session switches could then allow late asynchronous work to overwrite the newly selected session.

## Validation

- Focused TalonCopilot tests: 51 passed.
- Talon chat and client builds passed.
- UI TypeScript check passed.
- Playwright specs type-check and list successfully.
- Full Playwright execution was attempted locally but the E2E stack could not start because Python dependency `boto3` is missing from `tests/requirements.txt`.
- Rust push-hook validation passed: formatting, build, and 834 Rust tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active chat sessions now resume reliably after refreshing or navigating between sessions.
  * Processing and stopping states remain visible and synchronized with backend activity.
  * Stopping generation now waits for confirmed completion and refreshes the conversation.
* **Bug Fixes**
  * Prevented duplicate submissions while a session is active.
  * Restored message input and attachments when submissions are rejected.
  * Improved cleanup of stale messages, timers, and controls when sessions end.
* **Tests**
  * Added coverage for session recovery, stopping generation, concurrent submissions, and idle-state cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->