### PR TITLE
Fix tool output CAS hydration in chat UI

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -545,26 +545,21 @@ function objectRefFromPart(part: any): TalonChatObjectRef | undefined {
 }
 
 function objectRefFromValue(value: unknown): TalonChatObjectRef | undefined {
-  if (typeof value === "string") {
-    try {
-      return objectRefFromValue(JSON.parse(value));
-    } catch {
-      return undefined;
-    }
-  }
   if (!value || typeof value !== "object") return undefined;
 
   const candidate = value as Record<string, unknown>;
-  if (typeof candidate.key === "string" && candidate.key.length > 0) {
-    return candidate as TalonChatObjectRef;
+  for (const key of ["object", "objectRef", "object_ref"]) {
+    const nested = candidate[key];
+    if (nested && typeof nested === "object" && typeof (nested as TalonChatObjectRef).key === "string") {
+      return nested as TalonChatObjectRef;
+    }
   }
 
-  for (const key of ["object", "objectRef", "object_ref", "tool_output", "toolOutput", "output"]) {
-    const nested = objectRefFromValue(candidate[key]);
-    if (nested) return nested;
-  }
-
-  const contentParts = candidate.content_parts ?? candidate.contentParts;
+  const toolOutput = candidate.tool_output ?? candidate.toolOutput;
+  const output = toolOutput && typeof toolOutput === "object"
+    ? toolOutput as Record<string, unknown>
+    : candidate;
+  const contentParts = output.content_parts ?? output.contentParts;
   if (Array.isArray(contentParts)) {
     for (const part of contentParts) {
       const nested = objectRefFromValue(part);

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -540,7 +540,38 @@ function parsePayloadJson(payloadJson: unknown): Record<string, unknown> {
 
 function objectRefFromPart(part: any): TalonChatObjectRef | undefined {
   const object = part?.object ?? part?.objectRef ?? part?.object_ref;
-  return object && typeof object === "object" ? object as TalonChatObjectRef : undefined;
+  if (object && typeof object === "object") return object as TalonChatObjectRef;
+  return objectRefFromValue(parsePayloadJson(part?.payloadJson ?? part?.payload_json));
+}
+
+function objectRefFromValue(value: unknown): TalonChatObjectRef | undefined {
+  if (typeof value === "string") {
+    try {
+      return objectRefFromValue(JSON.parse(value));
+    } catch {
+      return undefined;
+    }
+  }
+  if (!value || typeof value !== "object") return undefined;
+
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.key === "string" && candidate.key.length > 0) {
+    return candidate as TalonChatObjectRef;
+  }
+
+  for (const key of ["object", "objectRef", "object_ref", "tool_output", "toolOutput", "output"]) {
+    const nested = objectRefFromValue(candidate[key]);
+    if (nested) return nested;
+  }
+
+  const contentParts = candidate.content_parts ?? candidate.contentParts;
+  if (Array.isArray(contentParts)) {
+    for (const part of contentParts) {
+      const nested = objectRefFromValue(part);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
 }
 
 function objectRefKey(object: TalonChatObjectRef | undefined): string {
@@ -560,10 +591,31 @@ function isToolResultPart(part: any) {
   return type === SESSION_MESSAGE_PART_TYPE.TOOL_RESULT || type === "SESSION_MESSAGE_PART_TYPE_TOOL_RESULT";
 }
 
-function withToolResultContent(part: any, output: string) {
+function withToolResultContent(part: any, output: string, objectKey?: string) {
   const nextPart = { ...part, content: output };
   const payload = parsePayloadJson(part?.payloadJson ?? part?.payload_json);
   const nextPayload = { ...payload, output };
+  const toolOutputKey = "tool_output" in payload ? "tool_output" : "toolOutput";
+  const toolOutput = payload[toolOutputKey];
+  const toolOutputRecord = toolOutput && typeof toolOutput === "object"
+    ? toolOutput as Record<string, unknown>
+    : undefined;
+  if (toolOutputRecord) {
+    const outputPartsKey = "content_parts" in toolOutputRecord ? "content_parts" : "contentParts";
+    const outputParts = toolOutputRecord[outputPartsKey];
+    if (Array.isArray(outputParts)) {
+      nextPayload[toolOutputKey] = {
+        ...toolOutputRecord,
+        summary: output,
+        [outputPartsKey]: outputParts.map((outputPart) => {
+          const object = objectRefFromValue(outputPart);
+          return object && (!objectKey || object.key === objectKey)
+            ? { type: "text", text: output }
+            : outputPart;
+        }),
+      };
+    }
+  }
   if ("payload_json" in nextPart && !("payloadJson" in nextPart)) {
     nextPart.payload_json = JSON.stringify(nextPayload);
   } else {
@@ -636,7 +688,7 @@ function toolCallIdFromToolResultPart(part: any): string {
 function findHydratableToolResultPart(
   parts: unknown,
   toolCallId: string,
-): { part: any; index: number; key: string } | null {
+): { part: any; index: number; key: string; object: TalonChatObjectRef } | null {
   if (!Array.isArray(parts)) return null;
   for (let index = 0; index < parts.length; index += 1) {
     const part = parts[index] as any;
@@ -646,7 +698,9 @@ function findHydratableToolResultPart(
     if (!key) continue;
     const partToolCallId = toolCallIdFromToolResultPart(part);
     if (toolCallId && partToolCallId !== toolCallId) continue;
-    return { part, index, key };
+    const object = objectRefFromPart(part);
+    if (!object) continue;
+    return { part, index, key, object };
   }
   return null;
 }
@@ -1152,8 +1206,12 @@ export function TalonSession({
   }, []);
 
   const hydrateToolResultForExpandedItem = useCallback(
-    async (message: CopilotMessage, toolCallId: string, toolKey: string) => {
-      const match = findHydratableToolResultPart(message.parts, toolCallId);
+    async (message: CopilotMessage, toolCallId: string, toolKey: string, result?: unknown) => {
+      const partMatch = findHydratableToolResultPart(message.parts, toolCallId);
+      const resultObject = partMatch ? undefined : objectRefFromValue(result);
+      const match = partMatch ?? (resultObject
+        ? { part: undefined, index: -1, key: resultObject.key, object: resultObject }
+        : null);
       const cas = gatewayClient?.cas;
       if (!match || !cas?.getObject) return;
       if (toolResultHydrationInFlightRef.current.has(toolKey)) return;
@@ -1167,7 +1225,7 @@ export function TalonSession({
 
       try {
         const response = await cas.getObject({ key: match.key });
-        const data = await toolResultObjectData(response, objectRefFromPart(match.part));
+        const data = await toolResultObjectData(response, match.object);
         const output = new TextDecoder().decode(data);
         if (toolResultHydrationGenerationRef.current !== generation) return;
 
@@ -1176,23 +1234,32 @@ export function TalonSession({
           const nextMessages = current.map((candidate) => {
             if (candidate.id !== message.id) return candidate;
             const currentMatch = findHydratableToolResultPart(candidate.parts, toolCallId);
-            if (!currentMatch || currentMatch.key !== match.key || !Array.isArray(candidate.parts)) {
-              return candidate;
+            if (currentMatch && currentMatch.key === match.key && Array.isArray(candidate.parts)) {
+              const parts = [...candidate.parts];
+              parts[currentMatch.index] = withToolResultContent(currentMatch.part, output, match.key);
+              const timelineSource = {
+                role: candidate.role,
+                content: candidate.content,
+                parts,
+                reasoningContent: candidate.reasoningContent,
+                usage: candidate.usage,
+              };
+              return {
+                ...candidate,
+                parts,
+                content: getMessageContent(timelineSource),
+                timeline: getMessageAssistantTimeline(timelineSource),
+              };
             }
-            const parts = [...candidate.parts];
-            parts[currentMatch.index] = withToolResultContent(currentMatch.part, output);
-            const timelineSource = {
-              role: candidate.role,
-              content: candidate.content,
-              parts,
-              reasoningContent: candidate.reasoningContent,
-              usage: candidate.usage,
-            };
+
+            const timeline = getMessageAssistantTimeline(candidate).map((item) =>
+              item.type === "tool" && item.toolCallId === toolCallId
+                ? { ...item, result: output }
+                : item,
+            );
             return {
               ...candidate,
-              parts,
-              content: getMessageContent(timelineSource),
-              timeline: getMessageAssistantTimeline(timelineSource),
+              timeline,
             };
           });
           messagesRef.current = nextMessages;
@@ -1617,7 +1684,7 @@ export function TalonSession({
                             onClick={() => {
                               toggleToolItem(toolKey);
                               if (!isToolExpanded) {
-                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey);
+                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey, item.result);
                               }
                             }}
                             style={{
@@ -1857,7 +1924,7 @@ export function TalonSession({
                             onClick={() => {
                               toggleToolItem(toolKey);
                               if (!isToolExpanded) {
-                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey);
+                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey, item.result);
                               }
                             }}
                             style={{

--- a/packages/talon-chat/src/lib/uiStream.ts
+++ b/packages/talon-chat/src/lib/uiStream.ts
@@ -344,7 +344,8 @@ export async function streamSessionPartEvents(options: {
       hasAssistantEvent = true;
       const toolCallId = typeof payload?.tool_call_id === "string" ? payload.tool_call_id : part.id || `tool-${createLocalMessageId()}`;
       setStreamEvents((prev) => [...prev, { type: "tool_result", content: toolCallId, payload }]);
-      setMessages((prev) => applyToolInvocationToMessages(prev, toolCallId, "", undefined, payload?.output ?? content, messageId));
+      const result = payload?.output ?? payload?.tool_output ?? payload?.toolOutput ?? content;
+      setMessages((prev) => applyToolInvocationToMessages(prev, toolCallId, "", undefined, result, messageId));
     } else if (partType === SESSION_MESSAGE_PART_TYPE.USAGE || partType === "SESSION_MESSAGE_PART_TYPE_USAGE") {
       hasAssistantEvent = true;
       const usage = payload && typeof payload === "object" ? payload as UsageSummary : {};

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -505,6 +505,80 @@ describe('TalonCopilot', () => {
     expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
   });
 
+  it('hydrates object refs nested in typed tool_output payloads', async () => {
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest.fn().mockResolvedValue({
+        sessionId: 'sess-nested-tool-output',
+        state: 'IDLE',
+        items: [
+          {
+            message: {
+              id: 'assistant-nested-tool-output',
+              role: 'ROLE_ASSISTANT',
+              parts: [
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                  toolName: 'read_file',
+                  payloadJson: JSON.stringify({
+                    tool_call_id: 'call-nested-tool-output',
+                    input: { uri: 'file://ops/docs/report.md' },
+                  }),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                  toolName: 'read_file',
+                  content: '',
+                  payloadJson: JSON.stringify({
+                    tool_call_id: 'call-nested-tool-output',
+                    tool_output: {
+                      summary: '[Object: report.md (text/markdown, 42 bytes)]',
+                      content_parts: [{
+                        type: 'object_ref',
+                        object_ref: {
+                          key: 'cas/ops/files/report.md',
+                          media_type: 'text/markdown',
+                        },
+                      }],
+                    },
+                  }),
+                },
+                {
+                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                  content: 'Done after reading the file.',
+                },
+              ],
+              createdAt: String(Date.now() * 1000),
+            },
+            steps: [],
+          },
+        ],
+        hasMore: false,
+      }),
+      cas: {
+        getObject: jest.fn().mockResolvedValue({
+          data: new TextEncoder().encode('# Hydrated report'),
+        }),
+      },
+    };
+
+    render(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-nested-tool-output"
+      />,
+    );
+
+    expect(await screen.findByText('Done after reading the file.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /Called\s+read_file/ }));
+
+    expect(await screen.findByText('# Hydrated report')).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).toHaveBeenCalledWith({ key: 'cas/ops/files/report.md' });
+  });
+
   it('does not start duplicate lazy CAS hydration while a tool result is already loading', async () => {
     const hydration = deferred<any>();
     const gatewayClient = {

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -579,6 +579,62 @@ describe('TalonCopilot', () => {
     expect(gatewayClient.cas.getObject).toHaveBeenCalledWith({ key: 'cas/ops/files/report.md' });
   });
 
+  it('does not hydrate ordinary streamed JSON results that contain a key field', async () => {
+    const gatewayClient = {
+      sessions: {
+        create: jest.fn().mockResolvedValue({ sessionId: 'sess-json-result' }),
+        listMessages: jest.fn().mockResolvedValue({
+          sessionId: 'sess-json-result',
+          state: 'IDLE',
+          items: [],
+          hasMore: false,
+        }),
+        submitTurn: jest.fn(async function* () {
+          yield {
+            kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DELTA',
+            messageId: 'assistant-json-result',
+            part: {
+              partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+              id: 'call-json-result',
+              name: 'search',
+              payloadJson: JSON.stringify({ tool_call_id: 'call-json-result', input: { query: 'docs' } }),
+            },
+          };
+          yield {
+            kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DELTA',
+            messageId: 'assistant-json-result',
+            part: {
+              partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+              id: 'call-json-result',
+              name: 'search',
+              payloadJson: JSON.stringify({
+                tool_call_id: 'call-json-result',
+                output: { key: 'search-result-42', title: 'Docs' },
+              }),
+            },
+          };
+          yield { kind: 'SESSION_MESSAGE_PART_EVENT_KIND_DONE', messageId: 'assistant-json-result' };
+        }),
+        streamParts: jest.fn(async function* () {}),
+        stopGeneration: jest.fn(),
+      },
+      cas: { getObject: jest.fn() },
+    };
+
+    render(<TalonCopilot namespace="ops" agent="copilot" gatewayClient={gatewayClient} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Ask Talon to perform a task...'), {
+      target: { value: 'search docs' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    fireEvent.click(await screen.findByRole('button', { name: /Worked/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /Called\s+search/ }));
+
+    expect(await screen.findByText(/search-result-42/)).toBeInTheDocument();
+    expect(gatewayClient.cas.getObject).not.toHaveBeenCalled();
+  });
+
   it('does not start duplicate lazy CAS hydration while a tool result is already loading', async () => {
     const hydration = deferred<any>();
     const gatewayClient = {


### PR DESCRIPTION
## Summary

- Hydrate CAS-backed object references nested in typed tool-output payloads.
- Preserve the typed `read_file` return contract while rendering decoded CAS text in the chat UI.

## Root cause

The chat UI only recognized top-level object references, while typed tool outputs store the reference in `tool_output.content_parts[].object_ref`.

## Validation

- `pnpm --dir ui test:unit`
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @impalasys/talon-client build`