### PR TITLE
Use real tokenizers for context budgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1187,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
 ]
 
 [[package]]
@@ -1889,6 +1915,17 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5618,6 +5655,7 @@ dependencies = [
  "sse-stream",
  "talon-client",
  "tempfile",
+ "tiktoken-rs",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
@@ -5713,6 +5751,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -1045,6 +1046,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1248,6 +1255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1429,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +1583,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,13 +1694,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -1668,13 +1748,33 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1711,6 +1811,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -1878,6 +2009,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "etcetera"
@@ -3365,6 +3502,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "pastey",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,6 +3614,28 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3832,9 +4007,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem"
@@ -4381,6 +4556,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redb"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4666,7 +4872,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -5104,7 +5310,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5276,6 +5482,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -5486,6 +5704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "str_stack"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5658,6 +5882,7 @@ dependencies = [
  "tiktoken-rs",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
+ "tokenizers",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.20.1",
@@ -5854,6 +6079,39 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
+dependencies = [
+ "ahash",
+ "compact_str",
+ "daachorse",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "fancy-regex",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "tokio"
@@ -6493,16 +6751,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 sse-stream = "0.2"
 tiktoken-rs = "0.12"
+tokenizers = { version = "0.23", default-features = false, features = ["fancy-regex"] }
 urlencoding = "2.1"
 tokio = { version = "1.0", features = ["full"] }
 tokio-tungstenite = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 sse-stream = "0.2"
+tiktoken-rs = "0.12"
 urlencoding = "2.1"
 tokio = { version = "1.0", features = ["full"] }
 tokio-tungstenite = "0.20"

--- a/src/harness/executor/compaction.rs
+++ b/src/harness/executor/compaction.rs
@@ -21,6 +21,11 @@ use crate::control::tool_output::is_text_object_media_type;
 use crate::harness::llm::{chat_content_part, text_part, ChatContentPart};
 use serde_json::Value;
 
+/// Conservative fallback for models without a locally available tokenizer.
+/// Tool-call JSON and code are denser than ordinary prose, so this intentionally
+/// leaves more headroom than a four-characters-per-token estimate.
+pub const FALLBACK_CHARS_PER_TOKEN: usize = 3;
+
 pub fn compact_history_for_llm(history: &[LoopMessage]) -> Vec<LoopMessage> {
     compact_history_for_llm_with_budget(history, ContextBudget::default())
 }
@@ -39,7 +44,7 @@ pub fn compact_history_for_llm_with_budget(
 /// Model metadata that affects the amount of history Talon can send in one
 /// request. Context limits are token limits, while the compactor operates on
 /// character weights, so the effective input limit is conservatively estimated
-/// at four characters per token.
+/// at [`FALLBACK_CHARS_PER_TOKEN`] characters per token.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ModelContextLimits {
     pub context_window_tokens: Option<u64>,
@@ -81,8 +86,11 @@ impl ModelContextLimits {
     }
 
     pub fn effective_input_chars(self) -> Option<usize> {
-        self.effective_input_tokens()
-            .map(|tokens| tokens.min((usize::MAX / 4) as u64).saturating_mul(4) as usize)
+        self.effective_input_tokens().map(|tokens| {
+            tokens
+                .min((usize::MAX / FALLBACK_CHARS_PER_TOKEN) as u64)
+                .saturating_mul(FALLBACK_CHARS_PER_TOKEN as u64) as usize
+        })
     }
 }
 
@@ -1097,7 +1105,7 @@ mod tests {
         };
 
         assert_eq!(limits.effective_input_tokens(), Some(112_000));
-        assert_eq!(limits.effective_input_chars(), Some(448_000));
+        assert_eq!(limits.effective_input_chars(), Some(336_000));
     }
 
     #[test]
@@ -1126,8 +1134,8 @@ mod tests {
         .with_model_limits(limits)
         .with_tool_schema_chars(1_000);
 
-        assert_eq!(limits.effective_input_chars(), Some(3_400));
-        assert_eq!(budget.total_chars, 2_400);
+        assert_eq!(limits.effective_input_chars(), Some(2_550));
+        assert_eq!(budget.total_chars, 1_550);
     }
 
     #[test]

--- a/src/harness/executor/compaction.rs
+++ b/src/harness/executor/compaction.rs
@@ -18,6 +18,7 @@
 
 use super::runtime::LoopMessage;
 use crate::control::tool_output::is_text_object_media_type;
+use crate::harness::llm::tokenizer::Tokenizer;
 use crate::harness::llm::{chat_content_part, text_part, ChatContentPart};
 use serde_json::Value;
 
@@ -110,6 +111,79 @@ pub fn compact_history_for_llm_with_model_limits_and_tool_schema(
         .with_model_limits(model_limits)
         .with_tool_schema_chars(tool_schema_chars);
     compact_history_for_llm_with_budget_and_model_limits(history, budget, model_limits)
+}
+
+/// Compact with the cheap character budget first, then use a real tokenizer to
+/// tighten the result only if the candidate still exceeds the model input
+/// budget. This keeps tokenization off the hot path for ordinary turns while
+/// making near-limit requests safe for supported model families.
+pub fn compact_history_for_llm_with_model_limits_and_tokenizer(
+    history: &[LoopMessage],
+    model_limits: ModelContextLimits,
+    tool_schema_json: &str,
+    tokenizer: &Tokenizer,
+) -> Vec<LoopMessage> {
+    let budget = ContextBudget::default()
+        .with_model_limits(model_limits)
+        .with_tool_schema_chars(tool_schema_json.len());
+    let candidate =
+        compact_history_for_llm_with_budget_and_model_limits(history, budget, model_limits);
+    let Some(token_limit) = model_limits.effective_input_tokens() else {
+        return candidate;
+    };
+    if serialized_history_token_count(&candidate, tool_schema_json, tokenizer) <= token_limit {
+        return candidate;
+    }
+
+    let mut low = 0usize;
+    let mut high = budget.total_chars;
+    let mut best = candidate;
+    while low < high {
+        let mid = low.saturating_add(high.saturating_sub(low).saturating_add(1) / 2);
+        let mut candidate_budget = budget;
+        candidate_budget.total_chars = mid;
+        let candidate = compact_history_for_llm_with_budget_and_model_limits(
+            history,
+            candidate_budget,
+            model_limits,
+        );
+        if serialized_history_token_count(&candidate, tool_schema_json, tokenizer) <= token_limit {
+            low = mid;
+            best = candidate;
+        } else {
+            high = mid.saturating_sub(1);
+        }
+    }
+    best
+}
+
+fn serialized_history_token_count(
+    history: &[LoopMessage],
+    tool_schema_json: &str,
+    tokenizer: &Tokenizer,
+) -> u64 {
+    let mut serialized = String::new();
+    for message in history {
+        serialized.push_str(&message.role);
+        serialized.push('\n');
+        serialized.push_str(&message.text_content());
+        serialized.push('\n');
+        if let Some(tool_calls) = &message.tool_calls {
+            for call in tool_calls {
+                serialized.push_str(&call.id);
+                serialized.push('\n');
+                serialized.push_str(&call.name);
+                serialized.push('\n');
+                serialized.push_str(&call.arguments);
+                serialized.push('\n');
+            }
+        }
+        if let Some(tool_call_id) = &message.tool_call_id {
+            serialized.push_str(tool_call_id);
+            serialized.push('\n');
+        }
+    }
+    tokenizer.count_text(&serialized) as u64 + tokenizer.count_text(tool_schema_json) as u64
 }
 
 pub fn compact_history_for_llm_with_budget_and_model_limits(
@@ -1045,11 +1119,13 @@ fn env_usize(key: &str, default: usize) -> usize {
 mod tests {
     use super::{
         compact_history_for_llm_with_budget, compact_history_for_llm_with_budget_and_model_limits,
-        context_metrics, replay_has_user_or_tool_anchor, serialized_message_weight,
+        compact_history_for_llm_with_model_limits_and_tokenizer, context_metrics,
+        replay_has_user_or_tool_anchor, serialized_history_token_count, serialized_message_weight,
         tool_history_is_consistent, ContextBudget, ModelContextLimits,
     };
     use crate::gateway::rpc::data_proto;
     use crate::harness::executor::LoopMessage;
+    use crate::harness::llm::tokenizer::Tokenizer;
     use crate::harness::llm::{
         content_part_object_ref, object_ref_part, text_part, ChatContentPart, ToolCall,
     };
@@ -1136,6 +1212,23 @@ mod tests {
 
         assert_eq!(limits.effective_input_chars(), Some(2_550));
         assert_eq!(budget.total_chars, 1_550);
+    }
+
+    #[test]
+    fn real_tokenizer_tightens_a_candidate_that_exceeds_the_token_budget() {
+        let history = (0..12)
+            .map(|index| message("user", format!("message {index} {}", "x".repeat(1_000))))
+            .collect::<Vec<_>>();
+        let limits = ModelContextLimits {
+            context_window_tokens: Some(1_000),
+            max_output_tokens: Some(1_000),
+        };
+        let tokenizer = Tokenizer::for_model("gpt-4o").expect("gpt-4o tokenizer");
+        let compacted = compact_history_for_llm_with_model_limits_and_tokenizer(
+            &history, limits, "[]", &tokenizer,
+        );
+
+        assert!(serialized_history_token_count(&compacted, "[]", &tokenizer) <= 850);
     }
 
     #[test]

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -6,9 +6,10 @@ use crate::control::config::Config;
 use crate::control::tool_output::{self, is_text_object_media_type, ToolOutputExt};
 use crate::control::ControlPlane;
 use crate::harness::executor::compaction::{
-    compact_history_for_llm_with_model_limits_and_tool_schema, context_metrics, ContextMetrics,
+    compact_history_for_llm_with_model_limits_and_tokenizer, context_metrics, ContextMetrics,
 };
 use crate::harness::llm::resolver::{model_context_limits, resolve_model_profile};
+use crate::harness::llm::tokenizer::Tokenizer;
 use crate::harness::llm::ToolOutput;
 use crate::harness::llm::{
     chat_content_part, chat_stream_event, object_ref_part, text_part, ChatContentPart, ChatMessage,
@@ -524,7 +525,7 @@ impl AgentExecutor {
         &self,
         context: &ExecutionContext,
         prompts: &ExecutionPrompts,
-        tool_schema_chars: usize,
+        tool_schema_json: &str,
     ) -> Result<(Vec<ChatMessage>, ContextMetrics)> {
         let mut history = context.history.clone();
         if let Some(system_prompt) = prompts.system_prompt.as_deref() {
@@ -539,11 +540,23 @@ impl AgentExecutor {
             &self.llm_provider_key,
             &self.llm_model,
         );
-        let compacted_history = compact_history_for_llm_with_model_limits_and_tool_schema(
-            &history,
-            model_limits,
-            tool_schema_chars,
-        );
+        let tool_schema_chars = tool_schema_json.len();
+        let compacted_history = Tokenizer::for_model(&self.llm_model)
+            .map(|tokenizer| {
+                compact_history_for_llm_with_model_limits_and_tokenizer(
+                    &history,
+                    model_limits,
+                    tool_schema_json,
+                    &tokenizer,
+                )
+            })
+            .unwrap_or_else(|| {
+                crate::harness::executor::compaction::compact_history_for_llm_with_model_limits_and_tool_schema(
+                    &history,
+                    model_limits,
+                    tool_schema_chars,
+                )
+            });
         let metrics = context_metrics(&history, &compacted_history, tool_schema_chars);
         let mut messages = compacted_history
             .iter()
@@ -663,9 +676,9 @@ impl AgentExecutor {
                 let reg = self.registry.read().await;
                 reg.to_provider_tools()
             };
-            let tool_schema_chars = telemetry::serialize_tool_definitions_json(&tools).len();
+            let tool_schema_json = telemetry::serialize_tool_definitions_json(&tools);
             let (messages, context_metrics) = self
-                .messages_for_llm(context, &prompts, tool_schema_chars)
+                .messages_for_llm(context, &prompts, &tool_schema_json)
                 .await?;
 
             let mut final_reply = String::new();

--- a/src/harness/llm/mod.rs
+++ b/src/harness/llm/mod.rs
@@ -7,6 +7,7 @@ pub mod mock;
 pub mod openai;
 pub mod provider;
 pub mod resolver;
+pub mod tokenizer;
 
 pub use anthropic::AnthropicProvider;
 pub use mock::MockLlmProvider;

--- a/src/harness/llm/tokenizer.rs
+++ b/src/harness/llm/tokenizer.rs
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Fast, process-local token counting for model families with a known BPE.
+//!
+//! Unknown model families return `None` and continue using Talon's
+//! conservative character fallback. Provider-reported usage remains
+//! authoritative after a request.
+
+use tiktoken_rs::{bpe_for_model, CoreBPE};
+
+#[derive(Clone, Copy)]
+pub struct Tokenizer {
+    bpe: &'static CoreBPE,
+}
+
+impl Tokenizer {
+    pub fn for_model(model: &str) -> Option<Self> {
+        bpe_for_model(model).ok().map(|bpe| Self { bpe })
+    }
+
+    #[inline]
+    pub fn count_text(&self, text: &str) -> usize {
+        self.bpe.encode_ordinary(text).len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Tokenizer;
+
+    #[test]
+    fn recognizes_openai_model_families() {
+        let tokenizer = Tokenizer::for_model("gpt-4o").expect("gpt-4o tokenizer");
+        assert!(tokenizer.count_text("hello world") > 0);
+    }
+
+    #[test]
+    fn leaves_unknown_model_families_to_fallback() {
+        assert!(Tokenizer::for_model("accounts/fireworks/models/inkling").is_none());
+    }
+}

--- a/src/harness/llm/tokenizer.rs
+++ b/src/harness/llm/tokenizer.rs
@@ -7,27 +7,104 @@
 //! conservative character fallback. Provider-reported usage remains
 //! authoritative after a request.
 
-use tiktoken_rs::{bpe_for_model, CoreBPE};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, OnceLock},
+};
 
-#[derive(Clone, Copy)]
+use tiktoken_rs::{bpe_for_model, CoreBPE};
+use tokenizers::Tokenizer as HuggingFaceTokenizer;
+
+type HuggingFace = HuggingFaceTokenizer;
+
+#[derive(Clone)]
 pub struct Tokenizer {
-    bpe: &'static CoreBPE,
+    backend: Backend,
 }
+
+#[derive(Clone)]
+enum Backend {
+    Tiktoken(&'static CoreBPE),
+    HuggingFace(Arc<HuggingFace>),
+}
+
+static HUGGINGFACE_CACHE: OnceLock<Mutex<HashMap<PathBuf, Arc<HuggingFace>>>> = OnceLock::new();
 
 impl Tokenizer {
     pub fn for_model(model: &str) -> Option<Self> {
-        bpe_for_model(model).ok().map(|bpe| Self { bpe })
+        if let Ok(bpe) = bpe_for_model(model) {
+            return Some(Self {
+                backend: Backend::Tiktoken(bpe),
+            });
+        }
+
+        configured_huggingface_tokenizer(model).and_then(|path| Self::from_file(&path).ok())
+    }
+
+    /// Load a locally provisioned Hugging Face `tokenizer.json`.
+    ///
+    /// The file is cached by canonical path, so request handling never repeats
+    /// the relatively expensive JSON parse. Network downloads deliberately do
+    /// not happen here; tokenizer assets should be baked into the image or
+    /// mounted at startup.
+    pub fn from_file(path: &Path) -> Result<Self, String> {
+        let path = path
+            .canonicalize()
+            .map_err(|error| format!("canonicalize tokenizer {}: {error}", path.display()))?;
+        let cache = HUGGINGFACE_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        let mut cache = cache
+            .lock()
+            .map_err(|_| "tokenizer cache lock poisoned".to_owned())?;
+        let tokenizer = if let Some(tokenizer) = cache.get(&path) {
+            Arc::clone(tokenizer)
+        } else {
+            let tokenizer = Arc::new(
+                HuggingFaceTokenizer::from_file(&path)
+                    .map_err(|error| format!("load tokenizer {}: {error}", path.display()))?,
+            );
+            cache.insert(path, Arc::clone(&tokenizer));
+            tokenizer
+        };
+        Ok(Self {
+            backend: Backend::HuggingFace(tokenizer),
+        })
     }
 
     #[inline]
     pub fn count_text(&self, text: &str) -> usize {
-        self.bpe.encode_ordinary(text).len()
+        match &self.backend {
+            Backend::Tiktoken(bpe) => bpe.encode_ordinary(text).len(),
+            Backend::HuggingFace(tokenizer) => tokenizer
+                .encode(text, false)
+                .map(|encoding| encoding.len())
+                .unwrap_or_else(|_| text.len().div_ceil(3)),
+        }
     }
+}
+
+fn configured_huggingface_tokenizer(model: &str) -> Option<PathBuf> {
+    let root = std::env::var_os("TALON_TOKENIZER_DIR")?;
+    let root = PathBuf::from(root);
+    if root.is_file() {
+        return Some(root);
+    }
+
+    let model_name = model.rsplit('/').next().unwrap_or(model);
+    [
+        root.join(model_name).join("tokenizer.json"),
+        root.join(format!("{model_name}.json")),
+        root.join("tokenizer.json"),
+    ]
+    .into_iter()
+    .find(|path| path.is_file())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Tokenizer;
+    use std::sync::Arc;
+
+    use super::{Backend, HuggingFaceTokenizer, Tokenizer};
 
     #[test]
     fn recognizes_openai_model_families() {
@@ -38,5 +115,20 @@ mod tests {
     #[test]
     fn leaves_unknown_model_families_to_fallback() {
         assert!(Tokenizer::for_model("accounts/fireworks/models/inkling").is_none());
+    }
+
+    #[test]
+    fn counts_a_locally_loaded_huggingface_tokenizer() {
+        let tokenizer = HuggingFaceTokenizer::new(
+            tokenizers::models::wordlevel::WordLevel::builder()
+                .vocab([("[UNK]".to_owned(), 0), ("hello".to_owned(), 1)].into())
+                .unk_token("[UNK]".to_owned())
+                .build()
+                .expect("word-level tokenizer"),
+        );
+        let tokenizer = Tokenizer {
+            backend: Backend::HuggingFace(Arc::new(tokenizer)),
+        };
+        assert_eq!(tokenizer.count_text("hello"), 1);
     }
 }

--- a/src/harness/telemetry.rs
+++ b/src/harness/telemetry.rs
@@ -1,7 +1,9 @@
 // Copyright (C) 2026 Impala Systems, Inc.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::harness::executor::compaction::{ContextMetrics, ModelContextLimits};
+use crate::harness::executor::compaction::{
+    ContextMetrics, ModelContextLimits, FALLBACK_CHARS_PER_TOKEN,
+};
 use crate::harness::llm::{
     chat_content_part, ChatContentPart, ChatMessage, ChatRequest, ChatUsage, Tool, ToolCall,
 };
@@ -152,7 +154,7 @@ pub fn record_chat_operation_details(
         ),
         KeyValue::new(
             "talon.context.estimated_input_tokens",
-            (context_metrics.estimated_chars_after / 4) as i64,
+            (context_metrics.estimated_chars_after / FALLBACK_CHARS_PER_TOKEN) as i64,
         ),
         KeyValue::new(
             "talon.context.tool_schema_chars",


### PR DESCRIPTION
## Summary

Adds real local tokenization to the context-budget path, with a provider-aware fallback strategy.

### Runtime behavior

- Talon first performs the cheap character-based compaction pass.
- For recognized OpenAI-family models such as `gpt-4o`, it uses the native `tiktoken-rs` BPE.
- For unknown/open-weight models, it can load a locally provisioned Hugging Face `tokenizer.json` using `TALON_TOKENIZER_DIR`. Fireworks Inkling's published tokenizer asset is compatible with this path.
- Hugging Face tokenizers are parsed once and cached by canonical path. There are no network downloads or tokenizer JSON reloads in request handling.
- If the tokenizer is unavailable, Talon retains the conservative 3-characters-per-token fallback.
- If a near-limit candidate still exceeds the effective input-token budget, Talon binary-searches the compaction character budget until the locally tokenized candidate fits.
- Provider-reported usage remains authoritative for billing and post-request telemetry.

### Why this shape

Tokenization only runs on the near-limit path; ordinary turns keep the fast heuristic. The tokenizer asset is provisioned with the runtime image or mount rather than fetched during a request. This avoids latency, network dependence, and repeated model initialization.

The current count is still over Talon's provider-neutral transcript representation. A follow-up should move final counting after object-ref hydration and provider-specific serialization, because tool framing and multimodal inputs differ by provider.

### Follow-up provider plan

1. Add tokenizer kind/revision and tokenizer asset metadata to the model catalog instead of relying on `TALON_TOKENIZER_DIR`.
2. Add provider-native preflight counters for structured or multimodal requests: Anthropic `count_tokens`, Gemini `countTokens`, and any stable Fireworks equivalent.
3. Keep provider usage as the source of truth and record local counter kind, estimated tokens, exact preflight tokens, and provider-reported tokens separately.
4. Add Criterion benchmarks for cold/warm tokenizer loading, repeated tool schemas, growing transcripts, and concurrent tokenizer access.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo metadata --locked --no-deps`
- `cargo test -p talon --lib` — 851 passed
- Push hook: `cargo metadata --locked`, `cargo fmt --all --check`, `cargo build --locked --bins`, and `cargo test --locked` passed
