### PR TITLE
Use token snapshots for compaction thresholds

### DIFF
--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -461,6 +461,7 @@ pub struct AgentExecutor {
     pub namespace: String,
     pub agent_id: String,
     pub session_id: String,
+    pub prior_context_tokens: Option<TokenCounter>,
     pub control_plane: ControlPlane,
     pub agent_spec: crate::gateway::rpc::manifests::AgentSpec,
     pub mcp_tools: HashMap<String, RegisteredMcpTool>,
@@ -532,10 +533,16 @@ impl AgentExecutor {
             namespace,
             agent_id,
             session_id,
+            prior_context_tokens: None,
             control_plane,
             agent_spec,
             mcp_tools,
         }
+    }
+
+    pub fn with_prior_context_tokens(mut self, tokens: Option<TokenCounter>) -> Self {
+        self.prior_context_tokens = tokens;
+        self
     }
 
     pub async fn system_loop_message(&self) -> Result<LoopMessage> {
@@ -711,6 +718,36 @@ impl AgentExecutor {
         history_weight + prompt_weight + tool_weight
     }
 
+    fn estimate_context_input_tokens(
+        &self,
+        context: &ExecutionContext,
+        prior_context_tokens: Option<&TokenCounter>,
+        prior_request_history_len: Option<usize>,
+    ) -> Option<u64> {
+        let counter = prior_context_tokens.filter(|counter| {
+            counter.usage_available
+                && counter.provider == self.llm_provider_key
+                && counter.model == self.llm_model
+        })?;
+
+        let delta_start = prior_request_history_len.unwrap_or_else(|| {
+            context
+                .history
+                .iter()
+                .rposition(|message| message.role == "user")
+                .unwrap_or(context.history.len())
+        });
+        let delta_chars = context
+            .history
+            .get(delta_start..)
+            .unwrap_or_default()
+            .iter()
+            .map(serialized_message_weight)
+            .sum::<usize>();
+        let delta_tokens = (delta_chars as u64).saturating_add(3) / 4;
+        Some(counter.input_tokens.saturating_add(delta_tokens))
+    }
+
     /// Run the prepared execution context to completion, emitting events to
     /// `sink` along the way.
     /// Returns the final reply text.
@@ -741,6 +778,8 @@ impl AgentExecutor {
         let prompts = self.render_execution_prompts(context)?;
         let mut turn_limit = DEFAULT_EXECUTION_TURN_LIMIT;
         let mut compaction_disabled = false;
+        let mut prior_context_tokens = self.prior_context_tokens.clone();
+        let mut prior_request_history_len = None;
         loop {
             if turn_limit == 0 {
                 let msg = "Turn limit reached".to_string();
@@ -757,16 +796,29 @@ impl AgentExecutor {
             // Trigger durable compaction before preparing messages if the complete
             // request estimate exceeds the model's effective window. Compaction
             // is journaled before the in-memory history is replaced.
+            let model_limits = model_context_limits(
+                self.config.as_ref(),
+                &self.llm_provider_key,
+                &self.llm_model,
+            );
             let estimated_context_budget = self.estimate_context_budget(context, &prompts, &tools);
             let durable_budget = ContextBudget::default()
-                .with_model_limits(model_context_limits(
-                    self.config.as_ref(),
-                    &self.llm_provider_key,
-                    &self.llm_model,
-                ))
+                .with_model_limits(model_limits)
                 .with_tool_schema_chars(tool_schema_chars)
                 .total_chars;
-            let should_compact = !compaction_disabled && estimated_context_budget > durable_budget;
+            let estimated_context_tokens = self.estimate_context_input_tokens(
+                context,
+                prior_context_tokens.as_ref(),
+                prior_request_history_len,
+            );
+            let should_compact = !compaction_disabled
+                && match (
+                    estimated_context_tokens,
+                    model_limits.effective_input_tokens(),
+                ) {
+                    (Some(estimated_tokens), Some(input_budget)) => estimated_tokens > input_budget,
+                    _ => estimated_context_budget > durable_budget,
+                };
 
             if should_compact {
                 let prev_history_len = context.history.len();
@@ -817,6 +869,7 @@ impl AgentExecutor {
                 tools,
                 thinking,
             };
+            prior_request_history_len = Some(context.history.len());
             let reasoning_level = request
                 .thinking
                 .as_ref()
@@ -981,6 +1034,7 @@ impl AgentExecutor {
                         .unwrap_or_else(|| self.normalize_token_counter(TokenCounter::default())),
                 ),
             };
+            prior_context_tokens = llm_response.usage.clone();
             telemetry::record_chat_output(
                 &llm_span,
                 &llm_response.content,
@@ -1166,8 +1220,8 @@ pub fn tool_output_loop_message(tool_call_id: &str, result: &ToolOutput) -> Loop
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentEvent, AgentExecutor, CaptureSink, ContextAssembler, ExecutionContext, ExecutionSink,
-        LoopMessage,
+        serialized_message_weight, AgentEvent, AgentExecutor, CaptureSink, ContextAssembler,
+        ExecutionContext, ExecutionSink, LoopMessage,
     };
     use crate::control::config::Config;
     use crate::control::object_store::ObjectMetadata;
@@ -2655,6 +2709,91 @@ mod tests {
         assert_eq!(reply, "resolved");
         assert_eq!(sink.compactions().len(), 1);
         assert!(!sink.compactions()[0].trim().is_empty());
+    }
+
+    #[test]
+    fn provider_snapshot_estimate_adds_the_new_message() {
+        let executor = AgentExecutor::new(
+            Arc::new(RecordingLlmProvider::default()),
+            "test-provider".to_string(),
+            "test-model".to_string(),
+            ContextAssembler::new("."),
+            Arc::new(tokio::sync::RwLock::new(ToolRegistry::new())),
+            Arc::new(Config::default()),
+            "ns".to_string(),
+            "agent".to_string(),
+            ControlPlane::noop(),
+            manifests::AgentSpec::default(),
+            HashMap::new(),
+        );
+        let context = ExecutionContext::with_history(
+            "agent",
+            vec![
+                LoopMessage::text("assistant", "prior response"),
+                LoopMessage::text("user", "new message"),
+            ],
+        );
+        let counter = TokenCounter {
+            input_tokens: 100,
+            usage_available: true,
+            provider: "test-provider".to_string(),
+            model: "test-model".to_string(),
+            ..Default::default()
+        };
+        let delta_tokens = (serialized_message_weight(&context.history[1]) as u64 + 3) / 4;
+
+        assert_eq!(
+            executor.estimate_context_input_tokens(&context, Some(&counter), None),
+            Some(100 + delta_tokens)
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_snapshot_can_trigger_compaction_before_character_budget() {
+        let llm = Arc::new(RecordingLlmProvider::default());
+        let registry = Arc::new(tokio::sync::RwLock::new(ToolRegistry::new()));
+        let mut config = Config::default();
+        config.models.insert(
+            "test-model".to_string(),
+            crate::control::config::proto::ModelConfig {
+                context_window_tokens: Some(1_000),
+                ..Default::default()
+            },
+        );
+        let executor = AgentExecutor::new(
+            llm,
+            "test-provider".to_string(),
+            "test-model".to_string(),
+            ContextAssembler::new("."),
+            registry,
+            Arc::new(config),
+            "ns".to_string(),
+            "agent".to_string(),
+            ControlPlane::noop(),
+            manifests::AgentSpec::default(),
+            HashMap::new(),
+        )
+        .with_prior_context_tokens(Some(TokenCounter {
+            input_tokens: 900,
+            usage_available: true,
+            provider: "test-provider".to_string(),
+            model: "test-model".to_string(),
+            ..Default::default()
+        }));
+        let mut context = ExecutionContext::with_history(
+            "agent",
+            vec![
+                LoopMessage::text("system", "system"),
+                LoopMessage::text("user", "initial ".to_string() + &"x".repeat(2_000)),
+                LoopMessage::text("assistant", "prior response"),
+                LoopMessage::text("user", "new message"),
+            ],
+        );
+        let sink = CaptureSink::new();
+
+        executor.execute(&mut context, &sink, None).await.unwrap();
+
+        assert_eq!(sink.compactions().len(), 1);
     }
 
     #[tokio::test]

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -461,7 +461,7 @@ pub struct AgentExecutor {
     pub namespace: String,
     pub agent_id: String,
     pub session_id: String,
-    pub prior_context_tokens: Option<TokenCounter>,
+    pub context_tokens: Option<TokenCounter>,
     pub control_plane: ControlPlane,
     pub agent_spec: crate::gateway::rpc::manifests::AgentSpec,
     pub mcp_tools: HashMap<String, RegisteredMcpTool>,
@@ -520,7 +520,7 @@ impl AgentExecutor {
         namespace: String,
         agent_id: String,
         session_id: String,
-        prior_context_tokens: Option<TokenCounter>,
+        context_tokens: Option<TokenCounter>,
         control_plane: ControlPlane,
         agent_spec: crate::gateway::rpc::manifests::AgentSpec,
         mcp_tools: HashMap<String, RegisteredMcpTool>,
@@ -535,7 +535,7 @@ impl AgentExecutor {
             namespace,
             agent_id,
             session_id,
-            prior_context_tokens,
+            context_tokens,
             control_plane,
             agent_spec,
             mcp_tools,
@@ -718,10 +718,10 @@ impl AgentExecutor {
     fn estimate_context_input_tokens(
         &self,
         context: &ExecutionContext,
-        prior_context_tokens: Option<&TokenCounter>,
+        context_tokens: Option<&TokenCounter>,
         prior_request_history_len: Option<usize>,
     ) -> Option<u64> {
-        let counter = prior_context_tokens.filter(|counter| {
+        let counter = context_tokens.filter(|counter| {
             counter.usage_available
                 && counter.input_tokens > 0
                 && counter.provider == self.llm_provider_key
@@ -776,7 +776,7 @@ impl AgentExecutor {
         let prompts = self.render_execution_prompts(context)?;
         let mut turn_limit = DEFAULT_EXECUTION_TURN_LIMIT;
         let mut compaction_disabled = false;
-        let mut prior_context_tokens = self.prior_context_tokens.clone();
+        let mut context_tokens = self.context_tokens.clone();
         let mut prior_request_history_len = None;
         loop {
             if turn_limit == 0 {
@@ -806,7 +806,7 @@ impl AgentExecutor {
                 .total_chars;
             let estimated_context_tokens = self.estimate_context_input_tokens(
                 context,
-                prior_context_tokens.as_ref(),
+                context_tokens.as_ref(),
                 prior_request_history_len,
             );
             let should_compact = !compaction_disabled
@@ -1034,7 +1034,7 @@ impl AgentExecutor {
                         .unwrap_or_else(|| self.normalize_token_counter(TokenCounter::default())),
                 ),
             };
-            prior_context_tokens = llm_response.usage.clone();
+            context_tokens = llm_response.usage.clone();
             telemetry::record_chat_output(
                 &llm_span,
                 &llm_response.content,

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -726,6 +726,7 @@ impl AgentExecutor {
     ) -> Option<u64> {
         let counter = prior_context_tokens.filter(|counter| {
             counter.usage_available
+                && counter.input_tokens > 0
                 && counter.provider == self.llm_provider_key
                 && counter.model == self.llm_model
         })?;
@@ -816,7 +817,9 @@ impl AgentExecutor {
                     estimated_context_tokens,
                     model_limits.effective_input_tokens(),
                 ) {
-                    (Some(estimated_tokens), Some(input_budget)) => estimated_tokens > input_budget,
+                    (Some(estimated_tokens), Some(input_budget)) => {
+                        estimated_tokens > input_budget || estimated_context_budget > durable_budget
+                    }
                     _ => estimated_context_budget > durable_budget,
                 };
 
@@ -2745,6 +2748,36 @@ mod tests {
         assert_eq!(
             executor.estimate_context_input_tokens(&context, Some(&counter), None),
             Some(100 + delta_tokens)
+        );
+    }
+
+    #[test]
+    fn provider_snapshot_estimate_requires_reported_input_tokens() {
+        let executor = AgentExecutor::new(
+            Arc::new(RecordingLlmProvider::default()),
+            "test-provider".to_string(),
+            "test-model".to_string(),
+            ContextAssembler::new("."),
+            Arc::new(tokio::sync::RwLock::new(ToolRegistry::new())),
+            Arc::new(Config::default()),
+            "ns".to_string(),
+            "agent".to_string(),
+            ControlPlane::noop(),
+            manifests::AgentSpec::default(),
+            HashMap::new(),
+        );
+        let context =
+            ExecutionContext::with_history("agent", vec![LoopMessage::text("user", "new message")]);
+        let counter = TokenCounter {
+            usage_available: true,
+            provider: "test-provider".to_string(),
+            model: "test-model".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            executor.estimate_context_input_tokens(&context, Some(&counter), None),
+            None
         );
     }
 

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -503,6 +503,7 @@ impl AgentExecutor {
             namespace,
             agent_id,
             String::new(),
+            None,
             control_plane,
             agent_spec,
             mcp_tools,
@@ -519,6 +520,7 @@ impl AgentExecutor {
         namespace: String,
         agent_id: String,
         session_id: String,
+        prior_context_tokens: Option<TokenCounter>,
         control_plane: ControlPlane,
         agent_spec: crate::gateway::rpc::manifests::AgentSpec,
         mcp_tools: HashMap<String, RegisteredMcpTool>,
@@ -533,16 +535,11 @@ impl AgentExecutor {
             namespace,
             agent_id,
             session_id,
-            prior_context_tokens: None,
+            prior_context_tokens,
             control_plane,
             agent_spec,
             mcp_tools,
         }
-    }
-
-    pub fn with_prior_context_tokens(mut self, tokens: Option<TokenCounter>) -> Self {
-        self.prior_context_tokens = tokens;
-        self
     }
 
     pub async fn system_loop_message(&self) -> Result<LoopMessage> {
@@ -2360,6 +2357,7 @@ mod tests {
             "Tenant:acme:Workspace:main".to_string(),
             "writer".to_string(),
             "writer-session".to_string(),
+            None,
             control_plane_with_wire().await,
             spec.clone(),
             HashMap::new(),
@@ -2406,6 +2404,7 @@ mod tests {
             "Tenant:acme:Workspace:main".to_string(),
             "writer".to_string(),
             "writer-session".to_string(),
+            None,
             ControlPlane::noop(),
             spec.clone(),
             HashMap::new(),
@@ -2440,6 +2439,7 @@ mod tests {
             "Tenant:acme:Workspace:main".to_string(),
             "writer".to_string(),
             "writer-session".to_string(),
+            None,
             control_plane_with_wire().await,
             spec.clone(),
             HashMap::new(),
@@ -2685,6 +2685,7 @@ mod tests {
             "conic:wks:13".to_string(),
             "cmo".to_string(),
             "session-1".to_string(),
+            None,
             ControlPlane::noop(),
             spec.clone(),
             HashMap::new(),
@@ -2793,7 +2794,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let executor = AgentExecutor::new(
+        let executor = AgentExecutor::new_with_session(
             llm,
             "test-provider".to_string(),
             "test-model".to_string(),
@@ -2802,17 +2803,18 @@ mod tests {
             Arc::new(config),
             "ns".to_string(),
             "agent".to_string(),
+            String::new(),
+            Some(TokenCounter {
+                input_tokens: 900,
+                usage_available: true,
+                provider: "test-provider".to_string(),
+                model: "test-model".to_string(),
+                ..Default::default()
+            }),
             ControlPlane::noop(),
             manifests::AgentSpec::default(),
             HashMap::new(),
-        )
-        .with_prior_context_tokens(Some(TokenCounter {
-            input_tokens: 900,
-            usage_available: true,
-            provider: "test-provider".to_string(),
-            model: "test-model".to_string(),
-            ..Default::default()
-        }));
+        );
         let mut context = ExecutionContext::with_history(
             "agent",
             vec![
@@ -2884,6 +2886,7 @@ mod tests {
             "conic:wks:13".to_string(),
             "cmo".to_string(),
             "session-1".to_string(),
+            None,
             ControlPlane::noop(),
             spec.clone(),
             HashMap::new(),
@@ -2918,6 +2921,7 @@ mod tests {
             "conic:wks:13".to_string(),
             "cmo".to_string(),
             "session-1".to_string(),
+            None,
             ControlPlane::noop(),
             spec.clone(),
             HashMap::new(),

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -193,14 +193,12 @@ impl AgentRuntime {
             ns.to_string(),
             agent_id.to_string(),
             session_id.to_string(),
-            cp.clone(),
-            spec.clone(),
-            mcp_tools,
-        )
-        .with_prior_context_tokens(
             session
                 .as_ref()
                 .and_then(|session| session.context_tokens.clone()),
+            cp.clone(),
+            spec.clone(),
+            mcp_tools,
         );
 
         Ok(Self {

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -196,6 +196,11 @@ impl AgentRuntime {
             cp.clone(),
             spec.clone(),
             mcp_tools,
+        )
+        .with_prior_context_tokens(
+            session
+                .as_ref()
+                .and_then(|session| session.context_tokens.clone()),
         );
 
         Ok(Self {

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -4030,6 +4030,7 @@ mod tests {
                 "ns".to_string(),
                 "agent".to_string(),
                 "session-1".to_string(),
+                None,
                 cp.clone(),
                 manifests::AgentSpec::default(),
                 HashMap::new(),


### PR DESCRIPTION
## What changed

Uses the prior session `TokenCounter.input_tokens` when it is available for the same provider and model. Talon adds a conservative character-to-token estimate for the newly added message (or messages appended during a tool loop) and compares that estimate with the model effective input budget.

When no compatible provider snapshot is available, or the model has no configured token window, the existing character-based threshold remains the fallback.

## Validation

- `cargo fmt --all --check`
- `cargo metadata --locked`
- `cargo test -p talon --lib` (868 passed)
- `git diff --check`