### PR TITLE
Add Sightline Secret resource editing

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -13,6 +13,7 @@ import { ConnectionConfigScreen } from '../screens/ConnectionConfigScreen';
 import { MainHeader } from '../components/MainPanel/MainHeader';
 import { MainPanel } from '../components/MainPanel/MainPanel';
 import { ResourceInspector } from '../components/MainPanel/ResourceInspector';
+import { SecretInspector } from '../components/MainPanel/SecretInspector';
 import { YamlEditor } from '../components/MainPanel/YamlEditor';
 import {
   getDefaultGatewayUrl,
@@ -34,6 +35,8 @@ import {
   channelSubscriptionDocumentFromResource,
   type ResourceEnvelope,
 } from '../lib/talon/resourceMappers';
+import { createResource } from '../lib/talon/client';
+import { talonQueryKeys } from '../lib/talon/queryKeys';
 import { useResourceDocument } from '../hooks/useResourceDocument';
 
 const CONNECT_TIMEOUT_MS = 8000;
@@ -791,6 +794,19 @@ function DebuggerPageContent() {
       : 'Failed to load resource'
     : null;
 
+  const saveSecret = useCallback(async (manifest: any) => {
+    if (!selectedNamespace || selectedNamespace.type !== 'secret') {
+      throw new Error('No Secret is selected.');
+    }
+    await createResource(selectedNamespace.ns, manifest);
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: talonQueryKeys.resources(queryScope, selectedNamespace.ns, 'Secret') }),
+      queryClient.invalidateQueries({
+        queryKey: talonQueryKeys.resource(queryScope, selectedNamespace.ns, 'Secret', selectedNamespace.resourceName || ''),
+      }),
+    ]);
+  }, [queryClient, queryScope, selectedNamespace]);
+
   const handleSelectionChange = useCallback(
     (selection: Selection | null, historyMode: 'push' | 'replace' = 'push') => {
       nextHistoryModeRef.current = historyMode;
@@ -1468,8 +1484,14 @@ function DebuggerPageContent() {
               error={resourceError}
               document={resourceDocument}
               yaml={resourceYaml}
+              preferInspector={selectedNamespace?.type === 'secret'}
               dedicatedInspector={
-                selectedNamespace?.type === 'schedule' && resourceDocument ? (
+                selectedNamespace?.type === 'secret' && resourceDocument ? (
+                  <SecretInspector
+                    secret={resourceDocument as any}
+                    onSave={saveSecret}
+                  />
+                ) : selectedNamespace?.type === 'schedule' && resourceDocument ? (
                   <ScheduleInspector
                     schedule={resourceDocument as ScheduleDocument}
                     resourceYaml={resourceYaml}

--- a/ui/components/Explorer/Explorer.tsx
+++ b/ui/components/Explorer/Explorer.tsx
@@ -11,6 +11,7 @@ import {
   FolderOpen,
   FolderSimple,
   Hash,
+  Key,
   Plug,
   Robot,
   ShieldCheck,
@@ -80,6 +81,7 @@ const LEAF_TYPES: SelectionType[] = [
   'sandbox-class',
   'sandbox-policy',
   'sandbox',
+  'secret',
 ];
 const LIST_PREVIEW_LIMIT = 10;
 
@@ -110,6 +112,7 @@ function NodeIcon({ type, selected, expanded }: { type: SelectionType; selected:
     sandbox: Cube,
     'mcp-server': Plug,
     file: FileText,
+    secret: Key,
   };
   const colorByType: Partial<Record<SelectionType, string>> = {
     namespace: selected ? 'text-slate-900 dark:text-slate-50' : 'text-slate-500',
@@ -127,6 +130,7 @@ function NodeIcon({ type, selected, expanded }: { type: SelectionType; selected:
     sandbox: 'text-orange-500',
     'mcp-server': 'text-blue-600',
     file: 'text-violet-500',
+    secret: 'text-amber-600',
   };
   const IconComponent = iconByType[type] || Cube;
   return (

--- a/ui/components/Explorer/explorerModel.ts
+++ b/ui/components/Explorer/explorerModel.ts
@@ -286,7 +286,7 @@ export function buildNamespaceContents({
     }
   }
 
-  for (const title of ['Deployments', 'Connectors', 'Sandboxes', 'Templates', 'MCP Servers']) {
+  for (const title of ['Deployments', 'Connectors', 'Sandboxes', 'Secrets', 'Templates', 'MCP Servers']) {
     const nodes = (descriptorGroups.get(title) || []).sort(compareByName);
     if (nodes.length > 0) {
       groups.push({ id: title.toLowerCase().replace(/\s+/g, '-'), title, nodes });

--- a/ui/components/MainPanel/ResourceInspector.tsx
+++ b/ui/components/MainPanel/ResourceInspector.tsx
@@ -16,6 +16,7 @@ type ResourceInspectorProps = {
   document?: any;
   yaml: string;
   dedicatedInspector?: ReactNode;
+  preferInspector?: boolean;
 };
 
 type InspectorMode = 'yaml' | 'inspector';
@@ -299,12 +300,17 @@ export function ResourceInspector({
   document,
   yaml,
   dedicatedInspector,
+  preferInspector = false,
 }: ResourceInspectorProps) {
   const [mode, setMode] = useState<InspectorMode>('yaml');
 
   useEffect(() => {
     setMode('yaml');
   }, [selectedNode?.fullPath]);
+
+  useEffect(() => {
+    if (preferInspector) setMode('inspector');
+  }, [preferInspector, selectedNode?.fullPath]);
 
   const fileInspectorDescriptor = selectedNode?.type === 'file' && document ? fileDescriptor(document) : null;
   const inspector =

--- a/ui/components/MainPanel/SecretInspector.test.tsx
+++ b/ui/components/MainPanel/SecretInspector.test.tsx
@@ -34,4 +34,35 @@ describe('SecretInspector helpers', () => {
       stringData: { token: 'changed', region: 'us-west-2' },
     });
   });
+
+  it('preserves newlines in edited values', () => {
+    const secret = {
+      apiVersion: 'talon.impalasys.com/v1',
+      kind: 'Secret',
+      metadata: { name: 'certificate', namespace: 'demo' },
+      spec: { type: 'Opaque', data: { pem: 'bGluZTEKbGluZTI=' } },
+    };
+    const entries = secretEntriesFromResource(secret).map((entry) => ({
+      ...entry,
+      value: 'updated line 1\nupdated line 2',
+    }));
+
+    expect(secretManifestFromEntries(secret, 'Opaque', entries).spec.stringData).toEqual({
+      pem: 'updated line 1\nupdated line 2',
+    });
+  });
+
+  it('rejects Secrets without a name or namespace', () => {
+    const secret = {
+      apiVersion: 'talon.impalasys.com/v1',
+      kind: 'Secret',
+      metadata: { name: '', namespace: 'demo' },
+      spec: { type: 'Opaque', data: {} },
+    };
+
+    expect(() => secretManifestFromEntries(secret, 'Opaque', [])).toThrow('Secret metadata.name is required.');
+    expect(() => secretManifestFromEntries({ ...secret, metadata: { name: 'credentials', namespace: '' } }, 'Opaque', [])).toThrow(
+      'Secret metadata.namespace is required.',
+    );
+  });
 });

--- a/ui/components/MainPanel/SecretInspector.test.tsx
+++ b/ui/components/MainPanel/SecretInspector.test.tsx
@@ -1,0 +1,37 @@
+import { secretEntriesFromResource, secretManifestFromEntries } from './SecretInspector';
+
+describe('SecretInspector helpers', () => {
+  it('decodes existing data for editing and preserves unchanged encoding', () => {
+    const secret = {
+      apiVersion: 'talon.impalasys.com/v1',
+      kind: 'Secret',
+      metadata: { name: 'credentials', namespace: 'demo' },
+      spec: { kind: { case: 'secret', value: { type: 'Opaque', data: { token: 'dG9rZW4=' } } } },
+    };
+    const entries = secretEntriesFromResource(secret);
+
+    expect(entries[0]).toMatchObject({ key: 'token', value: 'token', originalEncoded: 'dG9rZW4=' });
+    expect(secretManifestFromEntries(secret, 'Opaque', entries).spec).toEqual({
+      type: 'Opaque',
+      data: { token: 'dG9rZW4=' },
+      stringData: {},
+    });
+  });
+
+  it('uses stringData for changed and new values', () => {
+    const secret = {
+      apiVersion: 'talon.impalasys.com/v1',
+      kind: 'Secret',
+      metadata: { name: 'credentials', namespace: 'demo' },
+      spec: { type: 'Opaque', data: { token: 'dG9rZW4=' } },
+    };
+    const entries = secretEntriesFromResource(secret).map((entry) => ({ ...entry, value: 'changed' }));
+    entries.push({ id: 2, key: 'region', value: 'us-west-2' });
+
+    expect(secretManifestFromEntries(secret, 'Opaque', entries).spec).toEqual({
+      type: 'Opaque',
+      data: {},
+      stringData: { token: 'changed', region: 'us-west-2' },
+    });
+  });
+});

--- a/ui/components/MainPanel/SecretInspector.tsx
+++ b/ui/components/MainPanel/SecretInspector.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useState } from 'react';
+import { Eye, EyeOff, Plus, Save, Trash2 } from 'lucide-react';
+
+type SecretResource = {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec?: {
+    kind?: {
+      case?: string;
+      value?: {
+        type?: string;
+        data?: Record<string, string>;
+      };
+    };
+    type?: string;
+    data?: Record<string, string>;
+  };
+};
+
+type SecretEntry = {
+  id: number;
+  key: string;
+  value: string;
+  originalValue?: string;
+  originalEncoded?: string;
+};
+
+function decodeBase64(value: string) {
+  try {
+    const binary = window.atob(value);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return '';
+  }
+}
+
+export function secretEntriesFromResource(resource: SecretResource): SecretEntry[] {
+  const data = resource.spec?.kind?.case === 'secret'
+    ? resource.spec.kind.value?.data || {}
+    : resource.spec?.data || {};
+  return Object.entries(data)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, encoded], index) => {
+      const value = decodeBase64(encoded);
+      return {
+        id: index + 1,
+        key,
+        value,
+        originalValue: value,
+        originalEncoded: encoded,
+      };
+    });
+}
+
+export function secretManifestFromEntries(resource: SecretResource, type: string, entries: SecretEntry[]) {
+  const data: Record<string, string> = {};
+  const stringData: Record<string, string> = {};
+  const keys = new Set<string>();
+
+  for (const entry of entries) {
+    const key = entry.key.trim();
+    if (!key) throw new Error('Secret keys cannot be empty.');
+    if (keys.has(key)) throw new Error(`Secret key '${key}' is duplicated.`);
+    keys.add(key);
+
+    if (entry.originalEncoded !== undefined && entry.value === entry.originalValue) {
+      data[key] = entry.originalEncoded;
+    } else {
+      stringData[key] = entry.value;
+    }
+  }
+
+  const metadata = resource.metadata || {};
+  return {
+    apiVersion: resource.apiVersion || 'talon.impalasys.com/v1',
+    kind: 'Secret',
+    metadata: {
+      name: metadata.name || '',
+      namespace: metadata.namespace || '',
+      labels: metadata.labels || {},
+      annotations: metadata.annotations || {},
+    },
+    spec: {
+      type: type.trim() || 'Opaque',
+      data,
+      stringData,
+    },
+  };
+}
+
+export function SecretInspector({
+  secret,
+  onSave,
+}: {
+  secret: SecretResource;
+  onSave: (manifest: ReturnType<typeof secretManifestFromEntries>) => Promise<void>;
+}) {
+  const [type, setType] = useState('Opaque');
+  const [entries, setEntries] = useState<SecretEntry[]>([]);
+  const [visible, setVisible] = useState<Set<number>>(new Set());
+  const [nextId, setNextId] = useState(1);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    const spec = secret.spec?.kind?.case === 'secret' ? secret.spec.kind.value || {} : secret.spec || {};
+    const nextEntries = secretEntriesFromResource(secret);
+    setType(spec.type || 'Opaque');
+    setEntries(nextEntries);
+    setNextId(nextEntries.length + 1);
+    setVisible(new Set());
+    setError(null);
+    setSaved(false);
+  }, [secret]);
+
+  const updateEntry = (id: number, update: Partial<SecretEntry>) => {
+    setEntries((current) => current.map((entry) => (entry.id === id ? { ...entry, ...update } : entry)));
+    setSaved(false);
+  };
+
+  const addEntry = () => {
+    const id = nextId;
+    setNextId((current) => current + 1);
+    setEntries((current) => [...current, { id, key: '', value: '' }]);
+    setSaved(false);
+  };
+
+  const removeEntry = (id: number) => {
+    setEntries((current) => current.filter((entry) => entry.id !== id));
+    setVisible((current) => {
+      const next = new Set(current);
+      next.delete(id);
+      return next;
+    });
+    setSaved(false);
+  };
+
+  const save = async () => {
+    setIsSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      await onSave(secretManifestFromEntries(secret, type, entries));
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save Secret');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-muted/20">
+      <div className="flex flex-wrap items-center gap-3 border-b border-border px-4 py-3">
+        <div>
+          <div className="text-sm font-semibold text-foreground">Secret values</div>
+          <div className="mt-0.5 text-xs text-muted-foreground">{secret.metadata?.name || 'Secret'} · values are hidden by default</div>
+        </div>
+        <label className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+          Type
+          <input
+            className="h-8 w-32 rounded-md border border-border bg-background px-2 text-xs text-foreground outline-none focus:ring-2 focus:ring-ring"
+            value={type}
+            onChange={(event) => {
+              setType(event.target.value);
+              setSaved(false);
+            }}
+            aria-label="Secret type"
+          />
+        </label>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <div className="mb-3 rounded-lg border border-amber-300/50 bg-amber-50/70 p-3 text-xs text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-200">
+          Sightline sends new or changed values as cleartext <code>stringData</code>; unchanged values keep their existing base64 encoding.
+        </div>
+
+        <div className="space-y-2">
+          {entries.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+              This Secret has no data keys.
+            </div>
+          ) : entries.map((entry) => {
+            const isVisible = visible.has(entry.id);
+            return (
+              <div key={entry.id} className="grid gap-2 rounded-xl border border-border bg-background/70 p-3 md:grid-cols-[minmax(9rem,0.7fr)_minmax(0,1.5fr)_auto] md:items-center">
+                <input
+                  className="h-9 rounded-md border border-border bg-background px-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-ring"
+                  value={entry.key}
+                  onChange={(event) => updateEntry(entry.id, { key: event.target.value })}
+                  placeholder="Key"
+                  aria-label="Secret key"
+                />
+                <div className="flex gap-2">
+                  <input
+                    className="h-9 min-w-0 flex-1 rounded-md border border-border bg-background px-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-ring"
+                    type={isVisible ? 'text' : 'password'}
+                    value={entry.value}
+                    onChange={(event) => updateEntry(entry.id, { value: event.target.value })}
+                    placeholder="Value"
+                    aria-label={`Secret value for ${entry.key || 'new key'}`}
+                  />
+                  <button
+                    type="button"
+                    className="rounded-md border border-border px-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    onClick={() => setVisible((current) => {
+                      const next = new Set(current);
+                      if (next.has(entry.id)) next.delete(entry.id); else next.add(entry.id);
+                      return next;
+                    })}
+                    aria-label={isVisible ? `Hide ${entry.key || 'secret'} value` : `Show ${entry.key || 'secret'} value`}
+                  >
+                    {isVisible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  className="flex h-9 items-center justify-center rounded-md border border-red-200/70 px-2 text-red-600 hover:bg-red-50 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/30"
+                  onClick={() => removeEntry(entry.id)}
+                  aria-label={`Remove ${entry.key || 'secret'} key`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-xs font-semibold text-muted-foreground hover:bg-muted hover:text-foreground"
+          onClick={addEntry}
+        >
+          <Plus className="h-3.5 w-3.5" /> Add key
+        </button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 border-t border-border px-4 py-3">
+        {error ? <div className="text-xs text-red-600 dark:text-red-400">{error}</div> : null}
+        {saved ? <div className="text-xs text-emerald-600 dark:text-emerald-400">Secret saved.</div> : null}
+        <button
+          type="button"
+          className="ml-auto inline-flex items-center gap-1.5 rounded-md bg-foreground px-3 py-2 text-xs font-semibold text-background disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={save}
+          disabled={isSaving}
+        >
+          <Save className="h-3.5 w-3.5" /> {isSaving ? 'Saving…' : 'Save changes'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/MainPanel/SecretInspector.tsx
+++ b/ui/components/MainPanel/SecretInspector.tsx
@@ -78,12 +78,17 @@ export function secretManifestFromEntries(resource: SecretResource, type: string
   }
 
   const metadata = resource.metadata || {};
+  const name = metadata.name?.trim() || '';
+  const namespace = metadata.namespace?.trim() || '';
+  if (!name) throw new Error('Secret metadata.name is required.');
+  if (!namespace) throw new Error('Secret metadata.namespace is required.');
+
   return {
     apiVersion: resource.apiVersion || 'talon.impalasys.com/v1',
     kind: 'Secret',
     metadata: {
-      name: metadata.name || '',
-      namespace: metadata.namespace || '',
+      name,
+      namespace,
       labels: metadata.labels || {},
       annotations: metadata.annotations || {},
     },
@@ -200,14 +205,22 @@ export function SecretInspector({
                   aria-label="Secret key"
                 />
                 <div className="flex gap-2">
-                  <input
-                    className="h-9 min-w-0 flex-1 rounded-md border border-border bg-background px-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-ring"
-                    type={isVisible ? 'text' : 'password'}
-                    value={entry.value}
-                    onChange={(event) => updateEntry(entry.id, { value: event.target.value })}
-                    placeholder="Value"
-                    aria-label={`Secret value for ${entry.key || 'new key'}`}
-                  />
+                  {isVisible ? (
+                    <textarea
+                      className="min-h-20 min-w-0 flex-1 resize-y rounded-md border border-border bg-background px-2 py-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-ring"
+                      value={entry.value}
+                      onChange={(event) => updateEntry(entry.id, { value: event.target.value })}
+                      placeholder="Value"
+                      aria-label={`Secret value for ${entry.key || 'new key'}`}
+                    />
+                  ) : (
+                    <div
+                      className="flex min-h-9 min-w-0 flex-1 items-center rounded-md border border-border bg-background px-2 text-sm tracking-widest text-muted-foreground"
+                      aria-label={`Secret value for ${entry.key || 'new key'}`}
+                    >
+                      {'•'.repeat(Math.max(8, Math.min(24, entry.value.length || 8)))}
+                    </div>
+                  )}
                   <button
                     type="button"
                     className="rounded-md border border-border px-2 text-muted-foreground hover:bg-muted hover:text-foreground"

--- a/ui/lib/resourceManifest.test.ts
+++ b/ui/lib/resourceManifest.test.ts
@@ -2,6 +2,25 @@ import { dump } from 'js-yaml';
 import { resourceToManifestDocument } from './resourceManifest';
 
 describe('resourceToManifestDocument', () => {
+  it('renders Secret data in manifest form', () => {
+    expect(resourceToManifestDocument({
+      apiVersion: 'talon.impalasys.com/v1',
+      kind: 'Secret',
+      metadata: { name: 'credentials', namespace: 'demo' },
+      spec: {
+        kind: {
+          case: 'secret',
+          value: { type: 'Opaque', data: { token: 'dG9rZW4=' } },
+        },
+      },
+    } as any)).toEqual({
+      apiVersion: 'talon.impalasys.com/v1',
+      kind: 'Secret',
+      metadata: { name: 'credentials', namespace: 'demo', labels: {}, annotations: {} },
+      spec: { type: 'Opaque', data: { token: 'dG9rZW4=' } },
+    });
+  });
+
   it('renders File enum fields as symbolic YAML values', () => {
     const document = resourceToManifestDocument({
       apiVersion: 'talon.impalasys.com/v1',

--- a/ui/lib/resourceManifest.ts
+++ b/ui/lib/resourceManifest.ts
@@ -116,6 +116,11 @@ function manifestSpec(caseName: string | undefined, value: any) {
         classRef: resourceRef(spec.classRef),
         runtimeTemplate: runtimeTemplate(spec.runtimeTemplate),
       });
+    case 'secret':
+      return yamlSafeValue({
+        type: spec.type || '',
+        data: spec.data || {},
+      });
     case 'permissionRequest':
       return yamlSafeValue({
         agent: spec.agent || '',

--- a/ui/lib/selection.test.ts
+++ b/ui/lib/selection.test.ts
@@ -80,6 +80,7 @@ describe('selection helpers', () => {
       ['sandbox-class', { name: 'node' }, 'demo:sandbox-class:node'],
       ['sandbox-policy', { name: 'default' }, 'demo:sandbox-policy:default'],
       ['sandbox', { name: 'box' }, 'demo:sandbox:box'],
+      ['secret', { name: 'credentials' }, 'demo:secret:credentials'],
     ];
 
     for (const [type, extra, fullPath] of cases) {
@@ -163,6 +164,7 @@ describe('selection helpers', () => {
       [{ type: 'sandbox-class', ns: 'demo', resourceName: 'node', fullPath: 'demo:sandbox-class:node' }, 'node', 'demo / SandboxClass'],
       [{ type: 'sandbox-policy', ns: 'demo', resourceName: 'default', fullPath: 'demo:sandbox-policy:default' }, 'default', 'demo / SandboxPolicy'],
       [{ type: 'sandbox', ns: 'demo', resourceName: 'box', fullPath: 'demo:sandbox:box' }, 'box', 'demo / Sandbox'],
+      [{ type: 'secret', ns: 'demo', resourceName: 'credentials', fullPath: 'demo:secret:credentials' }, 'credentials', 'demo / Secret'],
     ];
 
     for (const [selection, title, subtitle] of selections) {

--- a/ui/lib/selection.ts
+++ b/ui/lib/selection.ts
@@ -16,6 +16,7 @@ export type SelectionType =
   | 'sandbox-class'
   | 'sandbox-policy'
   | 'sandbox'
+  | 'secret'
   | 'mcp-server'
   | 'file';
 
@@ -43,6 +44,7 @@ export const RESOURCE_KIND_BY_SELECTION: Partial<Record<SelectionType, string>> 
   'sandbox-class': 'SandboxClass',
   'sandbox-policy': 'SandboxPolicy',
   sandbox: 'Sandbox',
+  secret: 'Secret',
   'mcp-server': 'McpServer',
   file: 'File',
 };
@@ -184,7 +186,8 @@ export function selectionFromSearchParams(searchParams: URLSearchParams): Select
       type === 'connector' ||
       type === 'sandbox-class' ||
       type === 'sandbox-policy' ||
-      type === 'sandbox'
+      type === 'sandbox' ||
+      type === 'secret'
     ) &&
     resourceName
   ) {
@@ -262,5 +265,6 @@ export function getSelectionSubtitle(selection: Selection | null) {
   if (selection.type === 'sandbox-class') return `${selection.ns} / SandboxClass`;
   if (selection.type === 'sandbox-policy') return `${selection.ns} / SandboxPolicy`;
   if (selection.type === 'sandbox') return `${selection.ns} / Sandbox`;
+  if (selection.type === 'secret') return `${selection.ns} / Secret`;
   return 'Sys / MCPServer';
 }

--- a/ui/lib/talon/resourceDescriptors.test.ts
+++ b/ui/lib/talon/resourceDescriptors.test.ts
@@ -11,6 +11,7 @@ describe('resource descriptors', () => {
     expect(RESOURCE_DESCRIPTOR_BY_SELECTION.connector?.kind).toBe('Connector');
     expect(RESOURCE_DESCRIPTOR_BY_SELECTION.template?.kind).toBe('Template');
     expect(RESOURCE_DESCRIPTOR_BY_SELECTION.sandbox?.sortPrefix).toBe('sandbox');
+    expect(RESOURCE_DESCRIPTOR_BY_SELECTION.secret?.kind).toBe('Secret');
   });
 
   it('maps resource badges without rendering the explorer', () => {
@@ -39,5 +40,13 @@ describe('resource descriptors', () => {
         spec: { kind: { case: 'connector', value: { classRef: { name: 'slack' }, enabled: true } } },
       }),
     ).toBe('slack');
+
+    expect(
+      RESOURCE_DESCRIPTOR_BY_SELECTION.secret!.badge({
+        kind: 'Secret',
+        metadata: { name: 'credentials', namespace: 'demo' },
+        spec: { kind: { case: 'secret', value: { type: 'Opaque', data: { token: 'dG9rZW4=' } } } },
+      }),
+    ).toBe('1 key');
   });
 });

--- a/ui/lib/talon/resourceDescriptors.ts
+++ b/ui/lib/talon/resourceDescriptors.ts
@@ -10,6 +10,7 @@ export type ExplorerIconKey =
   | 'file'
   | 'folder'
   | 'hash'
+  | 'key'
   | 'layers'
   | 'message'
   | 'package'
@@ -127,6 +128,19 @@ export const RESOURCE_DESCRIPTORS: ResourceDescriptor[] = [
     badge: (resource) => {
       const status = resourceStatus(resource, 'sandbox');
       return status.lease?.ownerSessionId ? 'leased' : status.phase || 'sandbox';
+    },
+  },
+  {
+    kind: 'Secret',
+    selectionType: 'secret',
+    sortPrefix: 'secret',
+    sortWeight: 3,
+    icon: 'key',
+    appearsInTree: true,
+    badge: (resource) => {
+      const spec = resourceSpec(resource, 'secret') as { data?: Record<string, string> };
+      const count = Object.keys(spec.data || {}).length;
+      return `${count} ${count === 1 ? 'key' : 'keys'}`;
     },
   },
 ];


### PR DESCRIPTION
## What changed
- add Secret resources to the Sightline explorer and URL selection model
- render Secret manifests with type and base64 data in the YAML view
- add a masked Secret editor for adding, removing, revealing, and saving values
- preserve unchanged encoded data and submit changed values through `stringData`

## Validation
- `pnpm lint`
- `pnpm test:unit` (118 tests)
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing and managing Secret resources in the explorer and debugger.
  * Added a dedicated Secret inspector for editing keys, values, visibility, and resource type.
  * Added Secret resource grouping, navigation, icons, labels, and key-count badges.
  * Added validation for empty or duplicate keys when saving Secrets.

* **Bug Fixes**
  * Secret updates now refresh related resource views automatically.

* **Tests**
  * Added coverage for Secret editing, selection, manifest generation, and resource descriptors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->