### PR TITLE
Add Responses API mock and E2E coverage

### DIFF
--- a/tests/e2e/stack.py
+++ b/tests/e2e/stack.py
@@ -492,6 +492,8 @@ def _base_env(grpc_port: int, *, worker_port: int | None = None) -> dict[str, st
     load_repo_dotenv_into_env(env, keys={"OPENAI_API_KEY", "CODEX_API_KEY"})
     env["RUST_LOG"] = "info"
     env["NOVITA_API_KEY"] = "test-dummy-key"
+    env["OPENAI_API_KEY"] = "test-dummy-key"
+    env["OPENAI_BASE_URL"] = f"http://127.0.0.1:{MOCK_LLM_PORT}"
     env["GRPC_ADDR"] = f"127.0.0.1:{grpc_port}"
     env["TALON_JWT_PRIVATE_KEY_PEM"] = E2E_JWT_PRIVATE_KEY_PEM
     env["TALON_JWT_ISSUER"] = E2E_JWT_ISSUER
@@ -545,6 +547,13 @@ def start_postgres_pubsub_stack(
         config_path.write_text(
             f"""
 providers:
+  openai:
+    type: openai
+    model: minimax/m2.7
+    api: responses
+    apiKey:
+      source: env
+      key: OPENAI_API_KEY
   mock:
     type: openai_compatible
     name: mock
@@ -623,6 +632,13 @@ def start_sqlite_local_stack(
         config_path.write_text(
             f"""
 providers:
+  openai:
+    type: openai
+    model: minimax/m2.7
+    api: responses
+    apiKey:
+      source: env
+      key: OPENAI_API_KEY
   mock:
     type: openai_compatible
     name: mock
@@ -782,6 +798,13 @@ def start_rocksdb_local_stack(
         config_path.write_text(
             f"""
 providers:
+  openai:
+    type: openai
+    model: minimax/m2.7
+    api: responses
+    apiKey:
+      source: env
+      key: OPENAI_API_KEY
   mock:
     type: openai_compatible
     name: mock
@@ -903,6 +926,13 @@ def start_aws_local_stack(
         config_path.write_text(
             f"""
 providers:
+  openai:
+    type: openai
+    model: minimax/m2.7
+    api: responses
+    apiKey:
+      source: env
+      key: OPENAI_API_KEY
   mock:
     type: openai_compatible
     name: mock

--- a/tests/mock_llm.py
+++ b/tests/mock_llm.py
@@ -56,7 +56,9 @@ CONTROL_STATE = {
     "mcp_tool_blocked": False,
     "mcp_tool_unblocked": False,
     "mcp_tool_call_count": 0,
+    "response_sequence": 0,
     "chat_requests": [],
+    "responses_requests": [],
 }
 
 
@@ -87,7 +89,9 @@ def reset_control_state():
             "mcp_tool_blocked": False,
             "mcp_tool_unblocked": False,
             "mcp_tool_call_count": 0,
+            "response_sequence": 0,
             "chat_requests": [],
+            "responses_requests": [],
         }
     )
 
@@ -814,6 +818,197 @@ async def chat_completions(request: Request):
         }
     }
     return JSONResponse(content=response_json)
+
+
+def responses_input_to_chat_messages(items):
+    messages = []
+    for item in items or []:
+        if item.get("type") == "function_call_output":
+            output = item.get("output", "")
+            if isinstance(output, list):
+                output = "\n".join(
+                    part.get("text", "") for part in output if isinstance(part, dict)
+                )
+            messages.append({
+                "role": "tool",
+                "tool_call_id": item.get("call_id", ""),
+                "content": str(output),
+            })
+            continue
+        if item.get("type") == "reasoning":
+            continue
+        if item.get("type") == "function_call":
+            messages.append({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": item.get("call_id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": item.get("name", ""),
+                        "arguments": item.get("arguments", "{}"),
+                    },
+                }],
+            })
+            continue
+        content = item.get("content", "")
+        if isinstance(content, list):
+            content = "\n".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and isinstance(part.get("text"), str)
+            )
+        messages.append({"role": item.get("role", "user"), "content": content})
+    return messages
+
+
+def responses_tools_to_chat_tools(tools):
+    return [
+        {"type": "function", "function": {"name": tool.get("name", "")}}
+        for tool in tools or []
+        if tool.get("type") == "function"
+    ]
+
+
+def responses_payload(model, *, content="", tool_call=None, response_id):
+    output = [{
+        "type": "reasoning",
+        "id": "rs_mock_1",
+        "summary": [{"type": "summary_text", "text": "Inspecting the request."}],
+    }]
+    if content:
+        output.append({
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": content}],
+        })
+    if tool_call is not None:
+        output.append({
+            "type": "function_call",
+            "call_id": tool_call[0],
+            "name": tool_call[1],
+            "arguments": json.dumps(tool_call[2]),
+        })
+    return {
+        "id": response_id,
+        "object": "response",
+        "status": "completed",
+        "model": model,
+        "output": output,
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 10,
+            "output_tokens_details": {"reasoning_tokens": 6},
+            "total_tokens": 26,
+        },
+    }
+
+
+async def stream_responses_payload(response, *, tool_call=None):
+    yield (
+        "event: response.created\n"
+        f"data: {json.dumps({'type': 'response.created', 'response': {'id': response['id'], 'model': response['model']}})}\n\n"
+    )
+    for reasoning in DEFAULT_REASONING:
+        yield (
+            "event: response.reasoning_summary_text.delta\n"
+            f"data: {json.dumps({'type': 'response.reasoning_summary_text.delta', 'delta': reasoning + ' '})}\n\n"
+        )
+        await asyncio.sleep(0.02)
+
+    message = next(
+        (item for item in response.get("output", []) if item.get("type") == "message"),
+        {},
+    )
+    text = ""
+    if message.get("type") == "message":
+        text = message.get("content", [{}])[0].get("text", "")
+    if text:
+        for word in text.split():
+            yield (
+                "event: response.output_text.delta\n"
+                f"data: {json.dumps({'type': 'response.output_text.delta', 'delta': word + ' '})}\n\n"
+            )
+            await asyncio.sleep(0.02)
+
+    if tool_call is not None:
+        call_id, tool_name, arguments = tool_call
+        yield (
+            "event: response.output_item.added\n"
+            f"data: {json.dumps({'type': 'response.output_item.added', 'output_index': 2, 'item': {'type': 'function_call', 'call_id': call_id, 'name': tool_name, 'arguments': ''}})}\n\n"
+        )
+        argument_text = json.dumps(arguments)
+        yield (
+            "event: response.function_call_arguments.delta\n"
+            f"data: {json.dumps({'type': 'response.function_call_arguments.delta', 'output_index': 2, 'call_id': call_id, 'name': tool_name, 'delta': argument_text})}\n\n"
+        )
+        yield (
+            "event: response.function_call_arguments.done\n"
+            f"data: {json.dumps({'type': 'response.function_call_arguments.done', 'output_index': 2, 'call_id': call_id, 'name': tool_name, 'arguments': argument_text})}\n\n"
+        )
+
+    yield (
+        "event: response.completed\n"
+        f"data: {json.dumps({'type': 'response.completed', 'response': response})}\n\n"
+    )
+
+
+@app.post("/responses")
+async def responses(request: Request):
+    data = await request.json()
+    CONTROL_STATE["request_count"] += 1
+    messages = responses_input_to_chat_messages(data.get("input", []))
+    tools = responses_tools_to_chat_tools(data.get("tools", []))
+    model = data.get("model", "mock-model")
+    CONTROL_STATE["responses_requests"].append({
+        "input": data.get("input", []),
+        "stream": bool(data.get("stream", False)),
+        "previousResponseId": data.get("previous_response_id"),
+        "toolNames": [tool.get("function", {}).get("name") for tool in tools],
+    })
+
+    last_text = last_message_text(messages)
+    scenario_response = scenario_response_for(messages, tools)
+    tool_call = None
+    if scenario_response is not None and scenario_response.get("type") == "tool_call":
+        tool_call = (
+            scenario_response["tool_call_id"],
+            scenario_response["tool_name"],
+            scenario_response.get("arguments", {}),
+        )
+        reply = scenario_response.get("content", TOOL_PREFACE)
+    elif should_emit_blocking_tool_call(messages, tools):
+        query = "super-large-docs.example.com" if "super large" in last_text.lower() else "docs.example.com"
+        tool_call = (BLOCKING_TOOL_CALL_ID, BLOCKING_TOOL_NAME, {"query": query})
+        reply = TOOL_PREFACE
+    elif should_emit_delegate_task_call(messages, tools):
+        tool_call = (DELEGATE_TASK_CALL_ID, DELEGATE_TASK_NAME, delegate_task_arguments(last_text))
+        reply = TOOL_PREFACE
+    elif should_emit_tool_call(messages, tools):
+        tool_call = (TOOL_CALL_ID, TOOL_NAME, {"query": "docs.example.com"})
+        reply = TOOL_PREFACE
+    elif is_tool_followup(messages):
+        reply = "I checked the requested tool result."
+    elif "square root of 144" in last_text.lower():
+        reply = "The square root of 144 is 12."
+    elif "hello" in last_text.lower():
+        reply = "Hello! I am a mock LLM. How can I assist you today?"
+    else:
+        reply = "I received your message: " + last_text
+
+    CONTROL_STATE["response_sequence"] += 1
+    response = responses_payload(
+        model,
+        content=reply,
+        tool_call=tool_call,
+        response_id=f"resp_mock_{CONTROL_STATE['response_sequence']}",
+    )
+    if data.get("stream", False):
+        return StreamingResponse(
+            stream_responses_payload(response, tool_call=tool_call),
+            media_type="text/event-stream",
+        )
+    return JSONResponse(content=response)
 
 
 @app.post("/__control/reset")

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -160,6 +160,89 @@ def test_single_turn_chat(
     assert "12" in message_text(agent_message)
 
 
+def test_native_openai_responses_api_handles_reasoning_and_tools(
+    stack: E2EStack,
+    client: TalonClient,
+) -> None:
+    namespace = f"talon-responses-{stack.name}-{uuid.uuid4().hex[:8]}"
+    ensure_namespace(client, namespace)
+    agent_name = "responses-api-agent"
+    create_agent_resource(
+        client,
+        namespace,
+        agent_name,
+        AgentSpec(
+            model_policy={
+                "profiles": [
+                    {
+                        "name": "default",
+                        "model": Model(
+                            provider="openai",
+                            name="minimax/m2.7",
+                            temperature=0.0,
+                            thinking={
+                                "enabled": True,
+                                "budget_tokens": 2048,
+                                "effort": "high",
+                            },
+                        ),
+                    }
+                ]
+            },
+            system_prompt="Use tools when needed.",
+        ),
+    )
+    mock_control("POST", "/__control/reset")
+    session_id = client.sessions.Create(
+        CreateSessionRequest(agent=agent_name, ns=namespace)
+    ).session_id
+    client.sessions.SendMessage(
+        SendMessageRequest(
+            agent=agent_name,
+            session_id=session_id,
+            ns=namespace,
+            message="lookup docs.example.com",
+        )
+    )
+
+    for _ in range(30):
+        time.sleep(1)
+        session = client.sessions.Get(
+            GetSessionRequest(agent=agent_name, session_id=session_id, ns=namespace)
+        )
+        assistant = last_assistant_message(session.messages)
+        if session.state == "IDLE" and assistant is not None:
+            break
+    else:
+        raise AssertionError("Responses API agent did not complete")
+
+    state = mock_control("GET", "/__control/state")
+    assert state["responses_requests"]
+    assert state["responses_requests"][0]["toolNames"]
+    assert not state["chat_requests"]
+    assert state["responses_requests"][0]["previousResponseId"] is None
+    assert state["responses_requests"][0]["input"]
+    assert state["responses_requests"][0]["input"][-1]["role"] == "user"
+    assert len(state["responses_requests"]) >= 2
+    assert state["responses_requests"][1]["previousResponseId"] == "resp_mock_1"
+    assert any(
+        item.get("type") == "function_call_output"
+        for request in state["responses_requests"]
+        for item in request["input"]
+    )
+    assert all(
+        "encrypted_content" not in json.dumps(request)
+        for request in state["responses_requests"]
+    )
+    assert assistant is not None
+    assert "checked" in message_text(assistant).lower()
+    assert session.context_tokens.provider_request_id == "resp_mock_2"
+    assert any(
+        part.part_type == PART_TYPE_REASONING and part.content
+        for part in assistant.parts
+    )
+
+
 def test_stop_generation_cancels_an_inflight_worker_stream(
     stack: E2EStack,
     client: TalonClient,

--- a/tests/test_mock_llm.py
+++ b/tests/test_mock_llm.py
@@ -162,5 +162,46 @@ async def test_mock_llm_chat_completions_endpoint_covers_json_and_streaming_path
         assert "data:" in stream.text
 
 
+@pytest.mark.anyio
+async def test_mock_llm_responses_endpoint_covers_json_and_streaming_paths() -> None:
+    transport = httpx.ASGITransport(app=mock_llm.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        standard = await client.post(
+            "/responses",
+            json={
+                "model": "mock-model",
+                "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            },
+        )
+        assert standard.status_code == 200
+        assert standard.json()["output"][0]["type"] == "reasoning"
+        assert "encrypted_content" not in standard.text
+        assert standard.json()["output"][1]["content"][0]["text"].startswith("Hello!")
+
+        tool = await client.post(
+            "/responses",
+            json={
+                "model": "mock-model",
+                "input": [{"role": "user", "content": [{"type": "input_text", "text": "lookup docs.example.com"}]}],
+                "tools": [{"type": "function", "name": mock_llm.TOOL_NAME}],
+            },
+        )
+        assert tool.status_code == 200
+        assert tool.json()["output"][2]["name"] == mock_llm.TOOL_NAME
+
+        stream = await client.post(
+            "/responses",
+            json={
+                "model": "mock-model",
+                "stream": True,
+                "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            },
+        )
+        assert stream.status_code == 200
+        assert "response.created" in stream.text
+        assert "response.output_text.delta" in stream.text
+        assert "response.completed" in stream.text
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What changed

- Extend the Python mock LLM server with `POST /responses`.
- Support deterministic JSON and SSE Responses payloads for reasoning, text, function calls, and usage.
- Record Responses requests separately from Chat Completions requests.
- Add mock-server unit coverage and native OpenAI E2E coverage for the Responses tool loop.
- Keep compatible-provider E2E configuration on the existing Chat Completions path.

## Assertions

- Native OpenAI uses `/responses`.
- Reasoning and tool calls reach the executor.
- Tool output returns in Responses input format.
- Final text, reasoning, and usage reach the client.
- `/chat/completions` is not used for the native provider.

This PR is stacked on #189.