### PR TITLE
Preserve agent thinking configuration in YAML manifests

### DIFF
--- a/src/control/manifest/agent.rs
+++ b/src/control/manifest/agent.rs
@@ -52,6 +52,15 @@ struct ModelManifest {
     provider: String,
     name: String,
     temperature: f32,
+    thinking: Option<ThinkingConfigManifest>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase", default)]
+struct ThinkingConfigManifest {
+    enabled: bool,
+    budget_tokens: Option<u32>,
+    effort: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/control/manifest/agent_impls.rs
+++ b/src/control/manifest/agent_impls.rs
@@ -180,7 +180,11 @@ impl ModelManifest {
             provider: self.provider,
             name: self.name,
             temperature: self.temperature,
-            thinking: None,
+            thinking: self.thinking.map(|thinking| manifests::ThinkingConfig {
+                enabled: thinking.enabled,
+                budget_tokens: thinking.budget_tokens,
+                effort: thinking.effort,
+            }),
         }
     }
 
@@ -189,6 +193,13 @@ impl ModelManifest {
             provider: model.provider.clone(),
             name: model.name.clone(),
             temperature: model.temperature,
+            thinking: model.thinking.as_ref().map(|thinking| {
+                ThinkingConfigManifest {
+                    enabled: thinking.enabled,
+                    budget_tokens: thinking.budget_tokens,
+                    effort: thinking.effort.clone(),
+                }
+            }),
         }
     }
 }
@@ -212,6 +223,7 @@ impl ModelProfileManifest {
                     provider: String::new(),
                     name: String::new(),
                     temperature: 0.0,
+                    thinking: None,
                 }),
         }
     }

--- a/src/control/manifest/tests.rs
+++ b/src/control/manifest/tests.rs
@@ -359,6 +359,43 @@ spec:
     }
 
     #[test]
+    fn agent_manifest_round_trips_thinking_policy() {
+        let manifest = parse_resource_manifest(
+            r#"
+apiVersion: talon.impalasys.com/v1
+kind: Agent
+metadata:
+  name: reasoning-agent
+  namespace: customers
+spec:
+  modelPolicy:
+    profiles:
+      - name: default
+        model:
+          provider: openai
+          name: gpt-5.6-luna
+          temperature: 0.2
+          thinking:
+            enabled: true
+            budgetTokens: 2048
+            effort: high
+"#,
+        )
+        .expect("agent manifest parses");
+
+        let Some(resource_spec::Kind::Agent(spec)) = manifest.spec.and_then(|spec| spec.kind)
+        else {
+            panic!("expected Agent spec");
+        };
+        let policy = spec.model_policy.unwrap();
+        let model = policy.profiles[0].model.as_ref().unwrap();
+        let thinking = model.thinking.as_ref().expect("thinking policy");
+        assert!(thinking.enabled);
+        assert_eq!(thinking.budget_tokens, Some(2048));
+        assert_eq!(thinking.effort, "high");
+    }
+
+    #[test]
     fn sandbox_policy_manifest_accepts_and_renders_template_spec_shape() {
         let manifest = parse_resource_manifest(
             r#"


### PR DESCRIPTION
## What changed

Preserve the agent model `thinking` configuration when parsing and rendering YAML manifests, including `enabled`, `budgetTokens`, and `effort`.

## Why

This keeps agent model policy configuration durable through YAML manifest round trips while keeping provider API selection isolated in the preceding PR.

## Checks

- `cargo fmt --all --check`
- Focused manifest tests will run in CI.