### PR TITLE
refactor: extract session protocol codecs

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -29,14 +29,26 @@ import {
   type ResourceViewModel,
 } from "./lib/resourceUris";
 import { streamSessionPartEvents, type StreamEventItem } from "./lib/uiStream";
+import {
+  SESSION_MESSAGE_PART_TYPE,
+  messagePartsForSessionUpdate,
+  parsePayloadJson,
+  protoSessionPartsFromChatParts,
+  isSessionTextPart,
+} from "./session/protocol";
+import {
+  normalizeImageUploadResult,
+  normalizeObjectRefForJson,
+  objectRefContentEncoding,
+  objectRefFromPart,
+  objectRefFromValue,
+  objectRefKey,
+  objectRefMediaType,
+  objectRefSizeBytes,
+} from "./session/objectRefs";
+import type { TalonChatObjectRef, TalonSessionHandle } from "./session/types";
 
 const useSafeLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
-
-const SESSION_MESSAGE_PART_TYPE = {
-  TEXT: (data.SessionMessagePartType?.TEXT ?? "SESSION_MESSAGE_PART_TYPE_TEXT") as data.SessionMessagePartType,
-  TOOL_RESULT: (data.SessionMessagePartType?.TOOL_RESULT ?? "SESSION_MESSAGE_PART_TYPE_TOOL_RESULT") as data.SessionMessagePartType,
-  IMAGE: (data.SessionMessagePartType?.IMAGE ?? "SESSION_MESSAGE_PART_TYPE_IMAGE") as data.SessionMessagePartType,
-};
 
 export type SessionServiceClientLike = {
   sessions: Pick<
@@ -75,16 +87,7 @@ export type TalonSessionCommandTarget = {
 
 export type TalonSessionCommand = TalonChatCommand<TalonSessionCommandTarget, CopilotMessage>;
 
-export type TalonChatObjectRef = {
-  key: string;
-  mediaType?: string;
-  media_type?: string;
-  sizeBytes?: number | bigint | string;
-  size_bytes?: number | bigint | string;
-  sha256?: string;
-  filename?: string;
-  metadata?: Record<string, string>;
-};
+export type { TalonChatObjectRef } from "./session/types";
 
 export type TalonImageUploadContext = {
   file: File;
@@ -97,12 +100,6 @@ export type TalonImageUploadContext = {
 export type TalonImageUploadResult = TalonChatObjectRef | {
   object: TalonChatObjectRef;
   url?: string;
-};
-
-type TalonSessionHandle = {
-  ns: string;
-  agent: string;
-  sessionId: string;
 };
 
 export type TalonSessionPendingImageAttachment = {
@@ -435,65 +432,6 @@ function normalizeMessageLabels(labels: unknown): Record<string, string> | undef
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
-function objectRefMediaType(object: TalonChatObjectRef | undefined) {
-  return object?.mediaType || object?.media_type || "";
-}
-
-function objectRefSizeBytes(object: TalonChatObjectRef): number {
-  const value = object.sizeBytes ?? object.size_bytes ?? 0;
-  if (typeof value === "bigint") return Number(value);
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-  }
-  return Number.isFinite(value) ? value : 0;
-}
-
-function normalizeObjectRefForJson(object: TalonChatObjectRef) {
-  return {
-    key: object.key,
-    mediaType: object.mediaType ?? object.media_type ?? "",
-    sizeBytes: objectRefSizeBytes(object),
-    sha256: object.sha256 ?? "",
-    filename: object.filename ?? "",
-    metadata: object.metadata ?? {},
-  };
-}
-
-function normalizeImageUploadResult(result: TalonImageUploadResult) {
-  return "object" in result ? result.object : result;
-}
-
-function serializableMessageParts(parts: unknown) {
-  if (!Array.isArray(parts)) return [];
-  return parts.map((part: any) => {
-    if (!part || typeof part !== "object") return part;
-    const { previewUrl: _previewUrl, ...serializablePart } = part;
-    return serializablePart;
-  });
-}
-
-function protoSessionPartsFromChatParts(parts: unknown) {
-  return (serializableMessageParts(parts) || []).map((part: any) => {
-    if (part?.type === "image") {
-      return {
-        partType: SESSION_MESSAGE_PART_TYPE.IMAGE,
-        payloadJson: part.payloadJson ?? part.payload_json ?? "",
-        object: part.object,
-      };
-    }
-    return {
-      partType: SESSION_MESSAGE_PART_TYPE.TEXT,
-      content: String(part?.text ?? part?.content ?? ""),
-    };
-  });
-}
-
-function isSessionTextPart(part: any) {
-  const type = part?.type ?? part?.partType ?? part?.part_type;
-  return type === "text" || type === SESSION_MESSAGE_PART_TYPE.TEXT || type === "SESSION_MESSAGE_PART_TYPE_TEXT";
-}
-
 function replaceMessageTextPart(message: CopilotMessage, text: string) {
   const sourceParts = Array.isArray(message.parts) ? message.parts : [];
   const parts = sourceParts.map((part: any) => part && typeof part === "object" ? { ...part } : part);
@@ -520,70 +458,6 @@ function replaceMessageTextPart(message: CopilotMessage, text: string) {
       content: text,
     },
   ];
-}
-
-function messagePartsForSessionUpdate(message: CopilotMessage) {
-  return Array.isArray(message.parts) && message.parts.length > 0
-    ? message.parts
-    : [
-        {
-          partType: SESSION_MESSAGE_PART_TYPE.TEXT,
-          content: getMessageContent(message),
-        },
-      ];
-}
-
-function parsePayloadJson(payloadJson: unknown): Record<string, unknown> {
-  if (typeof payloadJson !== "string" || payloadJson.length === 0) return {};
-  try {
-    const value = JSON.parse(payloadJson);
-    return value && typeof value === "object" ? value as Record<string, unknown> : {};
-  } catch {
-    return {};
-  }
-}
-
-function objectRefFromPart(part: any): TalonChatObjectRef | undefined {
-  const object = part?.object ?? part?.objectRef ?? part?.object_ref;
-  if (object && typeof object === "object") return object as TalonChatObjectRef;
-  return objectRefFromValue(parsePayloadJson(part?.payloadJson ?? part?.payload_json));
-}
-
-function objectRefFromValue(value: unknown): TalonChatObjectRef | undefined {
-  if (!value || typeof value !== "object") return undefined;
-
-  const candidate = value as Record<string, unknown>;
-  for (const key of ["object", "objectRef", "object_ref"]) {
-    const nested = candidate[key];
-    if (nested && typeof nested === "object" && typeof (nested as TalonChatObjectRef).key === "string") {
-      return nested as TalonChatObjectRef;
-    }
-  }
-
-  const toolOutput = candidate.tool_output ?? candidate.toolOutput;
-  const output = toolOutput && typeof toolOutput === "object"
-    ? toolOutput as Record<string, unknown>
-    : candidate;
-  const contentParts = output.content_parts ?? output.contentParts;
-  if (Array.isArray(contentParts)) {
-    for (const part of contentParts) {
-      const nested = objectRefFromValue(part);
-      if (nested) return nested;
-    }
-  }
-  return undefined;
-}
-
-function objectRefKey(object: TalonChatObjectRef | undefined): string {
-  return typeof object?.key === "string" ? object.key : "";
-}
-
-function objectRefContentEncoding(object: TalonChatObjectRef | undefined): string {
-  return (object as any)?.contentEncoding
-    ?? (object as any)?.content_encoding
-    ?? object?.metadata?.content_encoding
-    ?? object?.metadata?.contentEncoding
-    ?? "";
 }
 
 function isToolResultPart(part: any) {

--- a/packages/talon-chat/src/session/objectRefs.test.ts
+++ b/packages/talon-chat/src/session/objectRefs.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  normalizeObjectRef,
+  objectRefContentEncoding,
+  objectRefFromPart,
+  objectRefFromValue,
+  objectRefSizeBytes,
+} from "./objectRefs.ts";
+
+describe("session object references", () => {
+  it("normalizes snake_case and bigint metadata without losing the key", () => {
+    const ref = normalizeObjectRef({
+      key: "cas/demo/result.txt",
+      media_type: "text/plain",
+      size_bytes: 12n,
+      content_encoding: "gzip",
+    });
+
+    assert.deepEqual(ref, {
+      key: "cas/demo/result.txt",
+      mediaType: "text/plain",
+      sizeBytes: 12,
+      sha256: "",
+      filename: "",
+      metadata: {},
+    });
+    assert.equal(objectRefSizeBytes({ key: ref.key, sizeBytes: "bad" }), 0);
+    assert.equal(objectRefContentEncoding({ key: ref.key, content_encoding: "gzip" }), "gzip");
+  });
+
+  it("finds direct, nested, and tool-output content-part references", () => {
+    const ref = { key: "cas/demo/nested.json", mediaType: "application/json" };
+    assert.deepEqual(objectRefFromValue({ object_ref: ref }), ref);
+    assert.deepEqual(objectRefFromValue({
+      tool_output: {
+        content_parts: [{ type: "text", text: "preview" }, { object: ref }],
+      },
+    }), ref);
+    assert.deepEqual(objectRefFromPart({
+      payloadJson: JSON.stringify({ tool_output: { contentParts: [{ objectRef: ref }] } }),
+    }), ref);
+  });
+});

--- a/packages/talon-chat/src/session/objectRefs.ts
+++ b/packages/talon-chat/src/session/objectRefs.ts
@@ -1,0 +1,92 @@
+import type { TalonChatObjectRef, TalonImageUploadResult } from "../TalonSession";
+
+export function objectRefMediaType(object: TalonChatObjectRef | undefined): string {
+  return object?.mediaType || object?.media_type || "";
+}
+
+export function objectRefSizeBytes(object: TalonChatObjectRef): number {
+  const value = object.sizeBytes ?? object.size_bytes ?? 0;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return Number.isFinite(value) ? value : 0;
+}
+
+export function normalizeObjectRef(object: TalonChatObjectRef): TalonChatObjectRef {
+  return {
+    key: object.key,
+    mediaType: object.mediaType ?? object.media_type ?? "",
+    sizeBytes: objectRefSizeBytes(object),
+    sha256: object.sha256 ?? "",
+    filename: object.filename ?? "",
+    metadata: object.metadata ?? {},
+  };
+}
+
+export function normalizeImageUploadResult(result: TalonImageUploadResult): TalonChatObjectRef {
+  return "object" in result ? result.object : result;
+}
+
+export function objectRefFromValue(value: unknown): TalonChatObjectRef | undefined {
+  if (!value || typeof value !== "object") return undefined;
+
+  const candidate = value as Record<string, unknown>;
+  for (const key of ["object", "objectRef", "object_ref"]) {
+    const nested = candidate[key];
+    if (nested && typeof nested === "object" && typeof (nested as TalonChatObjectRef).key === "string") {
+      return nested as TalonChatObjectRef;
+    }
+  }
+
+  const toolOutput = candidate.tool_output ?? candidate.toolOutput;
+  const output = toolOutput && typeof toolOutput === "object"
+    ? toolOutput as Record<string, unknown>
+    : candidate;
+  const contentParts = output.content_parts ?? output.contentParts;
+  if (Array.isArray(contentParts)) {
+    for (const part of contentParts) {
+      const nested = objectRefFromValue(part);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
+}
+
+export function normalizeObjectRefForJson(object: TalonChatObjectRef): TalonChatObjectRef {
+  return normalizeObjectRef(object);
+}
+
+function parsePayload(value: unknown): Record<string, unknown> {
+  if (typeof value !== "string" || value.length === 0) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+export function objectRefFromPart(
+  part: unknown,
+  parsePayloadJson: (value: unknown) => Record<string, unknown> = parsePayload,
+): TalonChatObjectRef | undefined {
+  const candidate = part as Record<string, unknown> | null;
+  if (!candidate || typeof candidate !== "object") return undefined;
+  const object = candidate.object ?? candidate.objectRef ?? candidate.object_ref;
+  if (object && typeof object === "object") return object as TalonChatObjectRef;
+  return objectRefFromValue(parsePayloadJson(candidate.payloadJson ?? candidate.payload_json));
+}
+
+export function objectRefKey(object: TalonChatObjectRef | undefined): string {
+  return typeof object?.key === "string" ? object.key : "";
+}
+
+export function objectRefContentEncoding(object: TalonChatObjectRef | undefined): string {
+  return object?.contentEncoding
+    ?? object?.content_encoding
+    ?? object?.metadata?.content_encoding
+    ?? object?.metadata?.contentEncoding
+    ?? "";
+}

--- a/packages/talon-chat/src/session/protocol.test.ts
+++ b/packages/talon-chat/src/session/protocol.test.ts
@@ -7,6 +7,7 @@ import {
   parseToolResultPayload,
   protoSessionPartsFromChatParts,
   SESSION_MESSAGE_PART_TYPE,
+  toolResultObjectRef,
   wireMessageToChatMessage,
 } from "./protocol.ts";
 
@@ -15,6 +16,16 @@ describe("session protocol codecs", () => {
     assert.deepEqual(parseToolResultPayload("not-json"), {});
     assert.deepEqual(parseToolResultPayload(JSON.stringify(["not an object"])), {});
     assert.deepEqual(parseToolResultPayload(undefined), {});
+  });
+
+  it("does not recurse when a tool result has no object reference payload", () => {
+    assert.doesNotThrow(() => toolResultObjectRef({ type: "tool-result" }));
+    assert.equal(toolResultObjectRef({ type: "tool-result" }), undefined);
+    assert.equal(toolResultObjectRef({ payloadJson: "{}" }), undefined);
+    assert.deepEqual(
+      toolResultObjectRef({ payloadJson: JSON.stringify({ object: { key: "cas/result" } }) }),
+      { key: "cas/result" },
+    );
   });
 
   it("keeps image object refs while removing UI-only preview URLs from RPC parts", () => {

--- a/packages/talon-chat/src/session/protocol.test.ts
+++ b/packages/talon-chat/src/session/protocol.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  chatMessageToWireMessage,
+  chatPartToWirePart,
+  messagePartsForSessionUpdate,
+  parseToolResultPayload,
+  protoSessionPartsFromChatParts,
+  SESSION_MESSAGE_PART_TYPE,
+  wireMessageToChatMessage,
+} from "./protocol.ts";
+
+describe("session protocol codecs", () => {
+  it("accepts malformed payloads without throwing", () => {
+    assert.deepEqual(parseToolResultPayload("not-json"), {});
+    assert.deepEqual(parseToolResultPayload(JSON.stringify(["not an object"])), {});
+    assert.deepEqual(parseToolResultPayload(undefined), {});
+  });
+
+  it("keeps image object refs while removing UI-only preview URLs from RPC parts", () => {
+    const parts = protoSessionPartsFromChatParts([
+      { type: "text", text: "inspect this" },
+      {
+        type: "image",
+        previewUrl: "blob:local-preview",
+        payloadJson: JSON.stringify({ filename: "photo.png" }),
+        object: { key: "uploads/photo.png", mediaType: "image/png" },
+      },
+    ]);
+
+    assert.equal(parts.length, 2);
+    assert.equal("previewUrl" in parts[1], false);
+    assert.deepEqual(parts[1].object, { key: "uploads/photo.png", mediaType: "image/png" });
+  });
+
+  it("round-trips chat message parts without exposing preview URLs", () => {
+    const message = {
+      id: "assistant-1",
+      role: "assistant" as const,
+      content: "done",
+      parts: [{ type: "text", text: "done", previewUrl: "blob:ignored" }],
+    };
+    const wire = chatMessageToWireMessage(message);
+    assert.equal("previewUrl" in (wire.parts as any[])[0], false);
+    assert.deepEqual(messagePartsForSessionUpdate(message), wire.parts);
+
+    const chat = wireMessageToChatMessage({
+      id: "assistant-1",
+      role: "ROLE_ASSISTANT",
+      parts: [{ partType: "SESSION_MESSAGE_PART_TYPE_TEXT", content: "done" }],
+    });
+    assert.equal(chat.id, "assistant-1");
+    assert.equal(chat.role, "assistant");
+    assert.deepEqual(chat.parts, [{ partType: "SESSION_MESSAGE_PART_TYPE_TEXT", content: "done" }]);
+  });
+
+  it("converts scalar parts to explicit text wire parts", () => {
+    assert.deepEqual(chatPartToWirePart("hello"), {
+      partType: SESSION_MESSAGE_PART_TYPE.TEXT,
+      content: "hello",
+    });
+  });
+});

--- a/packages/talon-chat/src/session/protocol.ts
+++ b/packages/talon-chat/src/session/protocol.ts
@@ -1,0 +1,110 @@
+import { data } from "@impalasys/talon-client";
+import type { CopilotMessage } from "../lib/chatTimeline";
+import type { TalonChatObjectRef, WireMessagePart } from "./types";
+
+export const SESSION_MESSAGE_PART_TYPE = {
+  TEXT: (data.SessionMessagePartType?.TEXT ?? "SESSION_MESSAGE_PART_TYPE_TEXT") as data.SessionMessagePartType,
+  TOOL_RESULT: (data.SessionMessagePartType?.TOOL_RESULT ?? "SESSION_MESSAGE_PART_TYPE_TOOL_RESULT") as data.SessionMessagePartType,
+  IMAGE: (data.SessionMessagePartType?.IMAGE ?? "SESSION_MESSAGE_PART_TYPE_IMAGE") as data.SessionMessagePartType,
+};
+
+export function parseToolResultPayload(payloadJson: unknown): Record<string, unknown> {
+  if (typeof payloadJson !== "string" || payloadJson.length === 0) return {};
+  try {
+    const value = JSON.parse(payloadJson);
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export const parsePayloadJson = parseToolResultPayload;
+
+function getMessageContent(message: CopilotMessage): string {
+  return typeof message.content === "string" ? message.content : "";
+}
+
+export function serializableMessageParts(parts: unknown): unknown[] {
+  if (!Array.isArray(parts)) return [];
+  return parts.map((part: unknown) => {
+    if (!part || typeof part !== "object") return part;
+    const { previewUrl: _previewUrl, ...serializablePart } = part as Record<string, unknown>;
+    return serializablePart;
+  });
+}
+
+export function wirePartToChatPart(part: unknown): Record<string, unknown> {
+  return part && typeof part === "object" ? { ...(part as Record<string, unknown>) } : { content: String(part ?? "") };
+}
+
+export function chatPartToWirePart(part: unknown): WireMessagePart {
+  if (part && typeof part === "object") {
+    const { previewUrl: _previewUrl, ...wirePart } = part as Record<string, unknown>;
+    return wirePart as WireMessagePart;
+  }
+  return {
+    partType: SESSION_MESSAGE_PART_TYPE.TEXT,
+    content: String(part ?? ""),
+  };
+}
+
+export function protoSessionPartsFromChatParts(parts: unknown): any[] {
+  return serializableMessageParts(parts).map((part: any) => {
+    if (part?.type === "image") {
+      return {
+        partType: SESSION_MESSAGE_PART_TYPE.IMAGE,
+        payloadJson: part.payloadJson ?? part.payload_json ?? "",
+        object: part.object,
+      };
+    }
+    return {
+      partType: SESSION_MESSAGE_PART_TYPE.TEXT,
+      content: String(part?.text ?? part?.content ?? ""),
+    };
+  });
+}
+
+export function chatMessageToWireMessage(message: CopilotMessage): Record<string, unknown> {
+  return {
+    id: message.id,
+    role: message.role,
+    parts: Array.isArray(message.parts)
+      ? message.parts.map(chatPartToWirePart)
+      : [{ partType: SESSION_MESSAGE_PART_TYPE.TEXT, content: getMessageContent(message) }],
+  };
+}
+
+export function wireMessageToChatMessage(message: any): CopilotMessage {
+  return {
+    id: String(message?.id ?? ""),
+    role: message?.role === "ROLE_USER" || message?.role === 1 || message?.role === "user" ? "user" : "assistant",
+    content: typeof message?.content === "string" ? message.content : "",
+    createdAt: message?.createdAt ?? message?.created_at,
+    parts: Array.isArray(message?.parts) ? message.parts.map(wirePartToChatPart) : undefined,
+  };
+}
+
+export function isSessionTextPart(part: unknown): boolean {
+  const value = part as Record<string, unknown> | null;
+  const type = value?.type ?? value?.partType ?? value?.part_type;
+  return type === "text" || type === SESSION_MESSAGE_PART_TYPE.TEXT || type === "SESSION_MESSAGE_PART_TYPE_TEXT";
+}
+
+export function messagePartsForSessionUpdate(message: CopilotMessage): any[] {
+  return Array.isArray(message.parts) && message.parts.length > 0
+    ? message.parts.map(chatPartToWirePart)
+    : [{ partType: SESSION_MESSAGE_PART_TYPE.TEXT, content: getMessageContent(message) }];
+}
+
+export function toolResultObjectRef(value: unknown, parsePayload = parseToolResultPayload): TalonChatObjectRef | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const candidate = value as Record<string, unknown>;
+  const direct = candidate.object ?? candidate.objectRef ?? candidate.object_ref;
+  if (direct && typeof direct === "object" && typeof (direct as TalonChatObjectRef).key === "string") {
+    return direct as TalonChatObjectRef;
+  }
+  const payload = parsePayload(candidate.payloadJson ?? candidate.payload_json);
+  return toolResultObjectRef(payload, parsePayload);
+}

--- a/packages/talon-chat/src/session/protocol.ts
+++ b/packages/talon-chat/src/session/protocol.ts
@@ -105,6 +105,9 @@ export function toolResultObjectRef(value: unknown, parsePayload = parseToolResu
   if (direct && typeof direct === "object" && typeof (direct as TalonChatObjectRef).key === "string") {
     return direct as TalonChatObjectRef;
   }
-  const payload = parsePayload(candidate.payloadJson ?? candidate.payload_json);
+  const payloadJson = candidate.payloadJson ?? candidate.payload_json;
+  if (typeof payloadJson !== "string" || payloadJson.length === 0) return undefined;
+  const payload = parsePayload(payloadJson);
+  if (Object.keys(payload).length === 0) return undefined;
   return toolResultObjectRef(payload, parsePayload);
 }

--- a/packages/talon-chat/src/session/types.ts
+++ b/packages/talon-chat/src/session/types.ts
@@ -1,0 +1,52 @@
+import type { CopilotMessage } from "../lib/chatTimeline";
+import type { data } from "@impalasys/talon-client";
+
+export type SessionTarget = {
+  ns: string;
+  agent: string;
+  sessionId: string;
+};
+
+export type TalonChatObjectRef = {
+  key: string;
+  mediaType?: string;
+  media_type?: string;
+  sizeBytes?: number | bigint | string;
+  size_bytes?: number | bigint | string;
+  sha256?: string;
+  filename?: string;
+  metadata?: Record<string, string>;
+  contentEncoding?: string;
+  content_encoding?: string;
+};
+
+export type TalonSessionHandle = SessionTarget;
+
+export type ChatMessagePart = Record<string, unknown> & {
+  type?: string;
+  partType?: unknown;
+  part_type?: unknown;
+  text?: string;
+  content?: string;
+  previewUrl?: string;
+};
+
+export type WireMessagePart = Record<string, unknown> & {
+  partType?: data.SessionMessagePartType;
+  part_type?: unknown;
+  content?: string;
+  payloadJson?: string;
+  payload_json?: string;
+  object?: TalonChatObjectRef;
+};
+
+export type WireSessionMessage = Record<string, unknown> & {
+  id?: string;
+  role?: unknown;
+  parts?: unknown;
+};
+
+export type SessionMessageUpdate = {
+  message: CopilotMessage;
+  parts: WireMessagePart[];
+};


### PR DESCRIPTION
## Summary
- extract session targets, object references, wire/UI part codecs, and payload parsing under `src/session/`
- keep `TalonSession` public exports compatible while consuming the extracted codecs
- add protocol and object-reference tests for enum forms, malformed payloads, nested refs, and preview stripping

## Validation
- pnpm --dir packages/talon-chat test
- pnpm --dir packages/talon-chat build
- pnpm --dir ui exec tsc -p tsconfig.json --noEmit
- pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --no-coverage