### PR TITLE
refactor: extract session history and client

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -47,6 +47,16 @@ import {
   objectRefSizeBytes,
 } from "./session/objectRefs";
 import type { TalonChatObjectRef, TalonSessionHandle } from "./session/types";
+import {
+  canCompareCanonicalMessageIds,
+  historyMessageTimestamp,
+  isLocalMessageId,
+  mergeNewestCanonicalPage,
+  normalizeHistoryPage,
+  normalizeMessageLabels,
+  normalizeRawSessionMessage,
+  type SessionHistoryPage,
+} from "./session/history";
 
 const useSafeLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
@@ -394,43 +404,11 @@ function getAssistantSignature(messages: any[] | undefined) {
     .join("|");
 }
 
-type SessionHistoryPage = {
-  messages: CopilotMessage[];
-  state: string;
-  hasMore: boolean;
-  nextBeforeMessageId: string | null;
-};
-
 type ScrollThumbState = {
   visible: boolean;
   top: number;
   height: number;
 };
-
-function stableStringHash(value: string) {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
-  }
-  return hash.toString(36);
-}
-
-function stableHistoryMessageId(message: any, index: number) {
-  if (typeof message?.id === "string" && message.id.length > 0) {
-    return message.id;
-  }
-  const role = normalizeMessageRole(message?.role);
-  const createdAt = message?.createdAt ?? message?.created_at ?? "unknown";
-  const content = getMessageContent(message);
-  return `history-${role}-${createdAt}-${index}-${stableStringHash(content)}`;
-}
-
-function normalizeMessageLabels(labels: unknown): Record<string, string> | undefined {
-  if (!labels || typeof labels !== "object" || Array.isArray(labels)) return undefined;
-  const entries = Object.entries(labels as Record<string, unknown>)
-    .filter((entry): entry is [string, string] => typeof entry[1] === "string");
-  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
-}
 
 function replaceMessageTextPart(message: CopilotMessage, text: string) {
   const sourceParts = Array.isArray(message.parts) ? message.parts : [];
@@ -705,10 +683,6 @@ function isNearScrollBottom(container: HTMLElement) {
   return container.scrollHeight - container.scrollTop - container.clientHeight <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
 }
 
-function historyMessageTimestamp(message: Pick<CopilotMessage, "createdAt">) {
-  return normalizeEpochToMilliseconds(message.createdAt);
-}
-
 function formatMessageActionTimestamp(message: CopilotMessage) {
   const timestampMs = historyMessageTimestamp(message);
   if (timestampMs === null) {
@@ -795,107 +769,6 @@ function editableMessageContent(message: CopilotMessage) {
     }
   }
   return getMessageContent(message);
-}
-
-function isLocalMessageId(id: string) {
-  return id.startsWith("local-") || id.startsWith("msg-");
-}
-
-function canCompareCanonicalMessageIds(left: string, right: string) {
-  const isFallbackId = (id: string) => id.startsWith("history-") || isLocalMessageId(id);
-  return !isFallbackId(left) && !isFallbackId(right);
-}
-
-function historyItemsFromResponse(response: any) {
-  if (Array.isArray(response?.items)) {
-    return response.items as Array<{ message?: any; steps?: any[] }>;
-  }
-  if (Array.isArray(response?.messages)) {
-    const stepsByMessage = new Map<string, any[]>();
-    for (const step of response.steps || []) {
-      const messageId = step?.messageId ?? step?.message_id;
-      if (!messageId) continue;
-      const existing = stepsByMessage.get(messageId) ?? [];
-      existing.push(step);
-      stepsByMessage.set(messageId, existing);
-    }
-    return response.messages.map((message: any) => ({
-      message,
-      steps: stepsByMessage.get(message?.id) ?? [],
-    }));
-  }
-  return [];
-}
-
-function normalizeRawSessionMessage(message: any, index: number): CopilotMessage {
-  return {
-    id: stableHistoryMessageId(message, index),
-    role: normalizeMessageRole(message.role),
-    content: getMessageContent(message),
-    labels: normalizeMessageLabels(message.labels),
-    parts: Array.isArray(message.parts) ? message.parts : undefined,
-    createdAt: message.createdAt ?? message.created_at,
-  };
-}
-
-function normalizeHistoryPage(response: any): SessionHistoryPage {
-  const items = historyItemsFromResponse(response);
-  const rawMessages = items
-    .map((item) => item?.message)
-    .filter(Boolean)
-    .map((message: any, index: number) => normalizeRawSessionMessage(message, index));
-  const steps = items.flatMap((item) => item?.steps || []);
-  return {
-    messages: hydrateMessagesWithSteps(rawMessages, steps),
-    state: typeof response?.state === "string" ? response.state : "IDLE",
-    hasMore: Boolean(response?.hasMore ?? response?.has_more),
-    nextBeforeMessageId:
-      typeof response?.nextBeforeMessageId === "string"
-        ? response.nextBeforeMessageId
-        : typeof response?.next_before_message_id === "string"
-          ? response.next_before_message_id
-          : null,
-  };
-}
-
-function mergeNewestCanonicalPage(existingMessages: CopilotMessage[], newestPageMessages: CopilotMessage[]) {
-  if (newestPageMessages.length === 0) {
-    return existingMessages;
-  }
-  const newestIds = new Set(newestPageMessages.map((message) => message.id));
-  const oldestPageId = newestPageMessages[0]?.id;
-  const newestPageId = newestPageMessages[newestPageMessages.length - 1]?.id;
-  const oldestPageTimestamp = historyMessageTimestamp(newestPageMessages[0]);
-  const newestPageTimestamp = historyMessageTimestamp(newestPageMessages[newestPageMessages.length - 1]);
-  const preservedOlderMessages = existingMessages.filter((message) => {
-    if (message.id === "1") return true;
-    if (isLocalMessageId(message.id)) return false;
-    if (newestIds.has(message.id)) return false;
-    const messageTimestamp = historyMessageTimestamp(message);
-    if (messageTimestamp !== null && oldestPageTimestamp !== null) {
-      return messageTimestamp < oldestPageTimestamp;
-    }
-    // Only canonical backend IDs are sortable. Fallback IDs include content/index data and must not order pages.
-    return oldestPageId && canCompareCanonicalMessageIds(message.id, oldestPageId) ? message.id < oldestPageId : false;
-  });
-  const preservedNewerMessages = existingMessages.filter((message) => {
-    if (message.id === "1") return false;
-    if (isLocalMessageId(message.id)) return false;
-    if (newestIds.has(message.id)) return false;
-    const messageTimestamp = historyMessageTimestamp(message);
-    if (messageTimestamp !== null && newestPageTimestamp !== null) {
-      return messageTimestamp > newestPageTimestamp;
-    }
-    return newestPageId && canCompareCanonicalMessageIds(message.id, newestPageId) ? message.id > newestPageId : false;
-  });
-  const mergedMessages = [...preservedOlderMessages, ...newestPageMessages, ...preservedNewerMessages];
-  const dedupedMessages = new Map<string, CopilotMessage>();
-  for (const message of mergedMessages) {
-    if (!dedupedMessages.has(message.id)) {
-      dedupedMessages.set(message.id, message);
-    }
-  }
-  return Array.from(dedupedMessages.values());
 }
 
 export function TalonSession({
@@ -1217,7 +1090,7 @@ export function TalonSession({
         labels,
       });
       const updated = response?.message
-        ? { ...message, ...normalizeRawSessionMessage(response.message, 0) }
+        ? { ...message, ...normalizeRawSessionMessage(response.message) }
         : { ...message, parts, labels, content: getMessageContent({ ...message, parts }) };
       setMessages((current) => {
         const nextMessages = current.map((item) => item.id === message.id ? updated : item);

--- a/packages/talon-chat/src/session/client.test.ts
+++ b/packages/talon-chat/src/session/client.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createSessionClient } from "./client.ts";
+
+describe("session client adapter", () => {
+  it("provides typed list/create/clear/stop calls with normalized arguments", async () => {
+    let listRequest: any;
+    const source = {
+      listMessages: async (request: any) => {
+        listRequest = request;
+        return { items: [] };
+      },
+      create: async () => ({ sessionId: "created-session" }),
+      clear: async () => undefined,
+      stopGeneration: async (_target: any, options: any) => options,
+    };
+    const client = createSessionClient(source, (response) => ({
+      ...response,
+      messages: [],
+      state: "IDLE",
+      hasMore: false,
+      nextBeforeMessageId: null,
+      hasMoreOlder: false,
+      beforeMessageId: null,
+    }));
+    const target = { ns: "ops", agent: "copilot", sessionId: "sess-1" };
+    await client.listMessages(target, { beforeMessageId: "older", pageSize: 10 });
+    assert.deepEqual(listRequest, {
+      ns: "ops",
+      agent: "copilot",
+      sessionId: "sess-1",
+      pageSize: 10,
+      beforeMessageId: "older",
+    });
+    assert.deepEqual(await client.create({ ns: "ops", agent: "copilot" }), {
+      ns: "ops",
+      agent: "copilot",
+      sessionId: "created-session",
+    });
+    await client.clear(target);
+    const controller = new AbortController();
+    await client.stopGeneration(target, controller.signal);
+  });
+});

--- a/packages/talon-chat/src/session/client.ts
+++ b/packages/talon-chat/src/session/client.ts
@@ -1,0 +1,42 @@
+import type { SessionTarget } from "./types";
+import type { SessionHistoryPage } from "./history";
+
+export type SessionClient = {
+  listMessages(target: SessionTarget, options?: { beforeMessageId?: string | null; pageSize?: number; signal?: AbortSignal }): Promise<SessionHistoryPage>;
+  create(target: Omit<SessionTarget, "sessionId">): Promise<SessionTarget>;
+  clear(target: SessionTarget): Promise<void>;
+  stopGeneration(target: SessionTarget, signal?: AbortSignal): Promise<void>;
+};
+
+export type SessionClientSource = {
+  create?: (target: { ns: string; agent: string }) => Promise<{ sessionId: string }>;
+  clear?: (target: SessionTarget) => Promise<unknown>;
+  listMessages?: (request: { ns: string; agent: string; sessionId: string; pageSize?: number; beforeMessageId?: string }) => Promise<any>;
+  stopGeneration?: (target: SessionTarget, options?: { signal?: AbortSignal }) => Promise<unknown>;
+};
+
+export function createSessionClient(source: SessionClientSource, normalizePage: (response: any) => SessionHistoryPage, pageSize = 50): SessionClient {
+  return {
+    async listMessages(target, options) {
+      if (!source.listMessages) throw new Error("Session client does not expose listMessages().");
+      return normalizePage(await source.listMessages({
+        ...target,
+        pageSize: options?.pageSize ?? pageSize,
+        beforeMessageId: options?.beforeMessageId || undefined,
+      }));
+    },
+    async create(target) {
+      if (!source.create) throw new Error("Session client does not expose create().");
+      const result = await source.create(target);
+      return { ...target, sessionId: result.sessionId };
+    },
+    async clear(target) {
+      if (!source.clear) throw new Error("Session client does not expose clear().");
+      await source.clear(target);
+    },
+    async stopGeneration(target, signal) {
+      if (!source.stopGeneration) throw new Error("Session client does not expose stopGeneration().");
+      await source.stopGeneration(target, { signal });
+    },
+  };
+}

--- a/packages/talon-chat/src/session/history.test.ts
+++ b/packages/talon-chat/src/session/history.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  mergeNewestCanonicalPage,
+  normalizeHistoryPage,
+  stableHistoryMessageId,
+  validateCursorAdvances,
+} from "./history.ts";
+
+describe("session history", () => {
+  it("keeps fallback message IDs stable across repeated page loads", () => {
+    const message = {
+      role: "ROLE_ASSISTANT",
+      content: "same content",
+      createdAt: "1777755592000000",
+    };
+    assert.equal(stableHistoryMessageId(message), stableHistoryMessageId({ ...message }));
+  });
+
+  it("normalizes snake_case pagination fields and preserves canonical IDs", () => {
+    const page = normalizeHistoryPage({
+      state: "IDLE",
+      has_more: true,
+      next_before_message_id: "older-than-this",
+      messages: [{
+        id: "server-message-1",
+        role: "ROLE_USER",
+        content: "hello",
+        created_at: "1777755592000000",
+      }],
+    });
+    assert.equal(page.messages[0]?.id, "server-message-1");
+    assert.equal(page.hasMoreOlder, true);
+    assert.equal(page.beforeMessageId, "older-than-this");
+  });
+
+  it("replaces updated canonical messages while retaining optimistic local messages", () => {
+    const merged = mergeNewestCanonicalPage(
+      [
+        { id: "local-user-1", role: "user", content: "optimistic prompt" },
+        { id: "assistant-1", role: "assistant", content: "partial" },
+      ],
+      [{ id: "assistant-1", role: "assistant", content: "canonical final" }],
+      { preserveOptimistic: true },
+    );
+    assert.deepEqual(merged.map((message) => [message.id, message.content]), [
+      ["local-user-1", "optimistic prompt"],
+      ["assistant-1", "canonical final"],
+    ]);
+  });
+
+  it("rejects a non-advancing pagination cursor", () => {
+    assert.equal(validateCursorAdvances("cursor-1", "cursor-1"), false);
+    assert.equal(validateCursorAdvances("cursor-1", "cursor-2"), true);
+    assert.equal(validateCursorAdvances(null, "cursor-1"), true);
+  });
+});

--- a/packages/talon-chat/src/session/history.ts
+++ b/packages/talon-chat/src/session/history.ts
@@ -1,0 +1,158 @@
+// @ts-ignore The Node strip-types test runner requires explicit .ts resolution.
+import { getMessageContent, hydrateMessagesWithSteps, normalizeMessageRole, type CopilotMessage } from "../lib/chatTimeline.ts";
+
+export type HistoryState = {
+  messages: CopilotMessage[];
+  hasMoreOlder: boolean;
+  beforeMessageId: string | null;
+};
+
+export type SessionHistoryPage = HistoryState & {
+  state: string;
+  hasMore: boolean;
+  nextBeforeMessageId: string | null;
+};
+
+function stableStringHash(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+export function stableHistoryMessageId(message: any): string {
+  if (typeof message?.id === "string" && message.id.length > 0) return message.id;
+  const role = normalizeMessageRole(message?.role);
+  const createdAt = message?.createdAt ?? message?.created_at ?? "unknown";
+  const content = getMessageContent(message);
+  return `history-${role}-${createdAt}-${stableStringHash(content)}`;
+}
+
+export function normalizeMessageLabels(labels: unknown): Record<string, string> | undefined {
+  if (!labels || typeof labels !== "object" || Array.isArray(labels)) return undefined;
+  const entries = Object.entries(labels as Record<string, unknown>)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string");
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+export function historyMessageTimestamp(message: Pick<CopilotMessage, "createdAt"> | undefined): number | null {
+  const value = message?.createdAt;
+  if (value == null) return null;
+  const numeric = typeof value === "bigint" ? Number(value) : Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return null;
+  if (numeric >= 1e15) return Math.trunc(numeric / 1000);
+  if (numeric >= 1e12) return Math.trunc(numeric);
+  if (numeric >= 1e9) return Math.trunc(numeric * 1000);
+  return null;
+}
+
+export function isLocalMessageId(id: string): boolean {
+  return id.startsWith("local-") || id.startsWith("msg-");
+}
+
+export function canCompareCanonicalMessageIds(left: string, right: string): boolean {
+  const isFallbackId = (id: string) => id.startsWith("history-") || isLocalMessageId(id);
+  return !isFallbackId(left) && !isFallbackId(right);
+}
+
+export function historyItemsFromResponse(response: any): Array<{ message?: any; steps?: any[] }> {
+  if (Array.isArray(response?.items)) return response.items;
+  if (Array.isArray(response?.messages)) {
+    const stepsByMessage = new Map<string, any[]>();
+    for (const step of response.steps || []) {
+      const messageId = step?.messageId ?? step?.message_id;
+      if (!messageId) continue;
+      stepsByMessage.set(messageId, [...(stepsByMessage.get(messageId) ?? []), step]);
+    }
+    return response.messages.map((message: any) => ({
+      message,
+      steps: stepsByMessage.get(message?.id) ?? [],
+    }));
+  }
+  return [];
+}
+
+export function normalizeRawSessionMessage(message: any): CopilotMessage {
+  return {
+    id: stableHistoryMessageId(message),
+    role: normalizeMessageRole(message?.role),
+    content: getMessageContent(message),
+    labels: normalizeMessageLabels(message?.labels),
+    parts: Array.isArray(message?.parts) ? message.parts : undefined,
+    createdAt: message?.createdAt ?? message?.created_at,
+  };
+}
+
+export function normalizeHistoryPage(response: any): SessionHistoryPage {
+  const items = historyItemsFromResponse(response);
+  const rawMessages = items
+    .map((item) => item?.message)
+    .filter(Boolean)
+    .map((message: any) => normalizeRawSessionMessage(message));
+  const steps = items.flatMap((item) => item?.steps || []);
+  const messages = hydrateMessagesWithSteps(rawMessages, steps);
+  const nextBeforeMessageId = typeof response?.nextBeforeMessageId === "string"
+    ? response.nextBeforeMessageId
+    : typeof response?.next_before_message_id === "string"
+      ? response.next_before_message_id
+      : null;
+  const hasMoreOlder = Boolean(response?.hasMore ?? response?.has_more);
+  return {
+    messages,
+    state: typeof response?.state === "string" ? response.state : "IDLE",
+    hasMore: hasMoreOlder,
+    nextBeforeMessageId,
+    hasMoreOlder,
+    beforeMessageId: nextBeforeMessageId,
+  };
+}
+
+export function mergeNewestCanonicalPage(
+  existingMessages: CopilotMessage[],
+  newestPageMessages: CopilotMessage[],
+  options: { preserveOptimistic?: boolean } = {},
+): CopilotMessage[] {
+  if (newestPageMessages.length === 0) return existingMessages;
+  const newestIds = new Set(newestPageMessages.map((message) => message.id));
+  const oldestPageId = newestPageMessages[0]?.id;
+  const newestPageId = newestPageMessages[newestPageMessages.length - 1]?.id;
+  const oldestPageTimestamp = historyMessageTimestamp(newestPageMessages[0]);
+  const newestPageTimestamp = historyMessageTimestamp(newestPageMessages[newestPageMessages.length - 1]);
+  const optimisticMessages = options.preserveOptimistic
+    ? existingMessages.filter((message) => isLocalMessageId(message.id))
+    : [];
+  const preservedOlderMessages = existingMessages.filter((message) => {
+    if (message.id === "1") return true;
+    if (isLocalMessageId(message.id)) return false;
+    if (newestIds.has(message.id)) return false;
+    const messageTimestamp = historyMessageTimestamp(message);
+    if (messageTimestamp !== null && oldestPageTimestamp !== null) return messageTimestamp < oldestPageTimestamp;
+    return Boolean(oldestPageId && canCompareCanonicalMessageIds(message.id, oldestPageId) && message.id < oldestPageId);
+  });
+  const preservedNewerMessages = existingMessages.filter((message) => {
+    if (message.id === "1" || isLocalMessageId(message.id) || newestIds.has(message.id)) return false;
+    const messageTimestamp = historyMessageTimestamp(message);
+    if (messageTimestamp !== null && newestPageTimestamp !== null) return messageTimestamp > newestPageTimestamp;
+    return Boolean(newestPageId && canCompareCanonicalMessageIds(message.id, newestPageId) && message.id > newestPageId);
+  });
+  const dedupedMessages = new Map<string, CopilotMessage>();
+  for (const message of [...preservedOlderMessages, ...optimisticMessages, ...newestPageMessages, ...preservedNewerMessages]) {
+    dedupedMessages.set(message.id, message);
+  }
+  return Array.from(dedupedMessages.values());
+}
+
+export function validateCursorAdvances(previous: string | null, next: string | null): boolean {
+  if (!next) return false;
+  if (!previous) return true;
+  return next !== previous;
+}
+
+export function historyStateFromPage(page: SessionHistoryPage): HistoryState {
+  return {
+    messages: page.messages,
+    hasMoreOlder: page.hasMoreOlder,
+    beforeMessageId: page.beforeMessageId,
+  };
+}


### PR DESCRIPTION
## Summary
- move session history normalization, stable identity, canonical page merging, and pagination state into `src/session/history.ts`
- add a typed session client adapter for list/create/clear/stop calls
- add tests for stable IDs, snake/camel pagination, canonical replacement, optimistic preservation, cursor validation, and client argument normalization

## Validation
- pnpm --dir packages/talon-chat test
- pnpm --dir packages/talon-chat build
- pnpm --dir ui exec tsc -p tsconfig.json --noEmit
- pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --no-coverage