### PR TITLE
refactor: extract Talon session stream adapter

### DIFF
--- a/packages/talon-chat/src/lib/uiStream.ts
+++ b/packages/talon-chat/src/lib/uiStream.ts
@@ -11,6 +11,9 @@ import {
   type CopilotMessage,
   type UsageSummary,
 } from "./chatTimeline";
+import {
+  streamSessionPartEvents as parseSessionPartEvents,
+} from "../session/stream";
 
 export type StreamEventItem = {
   type: "status" | "tool_call" | "tool_result" | "reasoning" | "usage" | "error";
@@ -308,23 +311,35 @@ export async function streamSessionPartEvents(options: {
     return nextMessageId;
   };
 
-  for await (const event of events) {
-    if (signal?.aborted) break;
-    const kind = event?.kind;
-    if (kind === 3 || kind === "SESSION_MESSAGE_PART_EVENT_KIND_ERROR") {
-      const error = new Error(event?.part?.content || "Session stream error");
-      throw error;
+  for await (const event of parseSessionPartEvents(events, signal)) {
+    if (event.type === "stream-failed") {
+      throw event.error;
     }
-    if (kind === 2 || kind === "SESSION_MESSAGE_PART_EVENT_KIND_DONE") {
+    if (event.type === "stream-completed") {
       break;
     }
+    if (event.type === "tool-started" || event.type === "tool-result") {
+      // The assistant-part event carries the complete part and is the single
+      // source used to update the UI. These events remain available to the
+      // runtime for lifecycle bookkeeping.
+      continue;
+    }
+    if (event.type === "usage") {
+      hasAssistantEvent = true;
+      const messageId = ensureLiveAssistant(event.messageId);
+      setStreamEvents((prev) => [
+        ...prev,
+        { type: "usage", content: formatUsageSummary(event.usage), payload: event.usage },
+      ]);
+      setMessages((prev) => applyUsageToMessages(prev, messageId, event.usage));
+      continue;
+    }
 
-    const part = event?.part;
-    if (!part) continue;
+    const { part } = event;
     const partType = part.partType ?? part.part_type;
     const content = String(part.content ?? "");
     const payload = parsePayload(part.payloadJson ?? part.payload_json);
-    const messageId = ensureLiveAssistant(event?.messageId ?? event?.message_id);
+    const messageId = ensureLiveAssistant(event.messageId);
 
     if (partType === SESSION_MESSAGE_PART_TYPE.TEXT || partType === "SESSION_MESSAGE_PART_TYPE_TEXT") {
       hasAssistantEvent = true;
@@ -346,14 +361,6 @@ export async function streamSessionPartEvents(options: {
       setStreamEvents((prev) => [...prev, { type: "tool_result", content: toolCallId, payload }]);
       const result = payload?.output ?? payload?.tool_output ?? payload?.toolOutput ?? content;
       setMessages((prev) => applyToolInvocationToMessages(prev, toolCallId, "", undefined, result, messageId));
-    } else if (partType === SESSION_MESSAGE_PART_TYPE.USAGE || partType === "SESSION_MESSAGE_PART_TYPE_USAGE") {
-      hasAssistantEvent = true;
-      const usage = payload && typeof payload === "object" ? payload as UsageSummary : {};
-      setStreamEvents((prev) => [...prev, { type: "usage", content: formatUsageSummary(usage), payload: usage }]);
-      setMessages((prev) => applyUsageToMessages(prev, messageId, usage));
-    } else if (partType === SESSION_MESSAGE_PART_TYPE.ERROR || partType === "SESSION_MESSAGE_PART_TYPE_ERROR") {
-      const error = new Error(content || "Session stream error");
-      throw error;
     } else if (partType === SESSION_MESSAGE_PART_TYPE.IMAGE || partType === "SESSION_MESSAGE_PART_TYPE_IMAGE") {
       hasAssistantEvent = true;
       setMessages((prev) => appendAssistantPart(prev, messageId, part));

--- a/packages/talon-chat/src/session/stream.test.ts
+++ b/packages/talon-chat/src/session/stream.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { streamSessionPartEvents } from "./stream.ts";
+
+async function collect(events: AsyncIterable<any>, signal?: AbortSignal) {
+  const result = [];
+  for await (const event of streamSessionPartEvents(events, signal)) result.push(event);
+  return result;
+}
+
+describe("session stream adapter", () => {
+  it("classifies numeric and string event kinds while preserving ordering", async () => {
+    const events = collect((async function* () {
+      yield {
+        kind: "SESSION_MESSAGE_PART_EVENT_KIND_DELTA",
+        messageId: "assistant-1",
+        part: { partType: "SESSION_MESSAGE_PART_TYPE_TOOL_CALL", id: "call-1", name: "search", payloadJson: JSON.stringify({ input: { q: "x" } }) },
+      };
+      yield {
+        kind: "SESSION_MESSAGE_PART_EVENT_KIND_DELTA",
+        messageId: "assistant-1",
+        part: { partType: 4, id: "call-1", payloadJson: JSON.stringify({ output: "done", tool_call_id: "call-1" }) },
+      };
+      yield {
+        kind: "SESSION_MESSAGE_PART_EVENT_KIND_DELTA",
+        messageId: "assistant-1",
+        part: { partType: "SESSION_MESSAGE_PART_TYPE_USAGE", payloadJson: JSON.stringify({ total_tokens: 9 }) },
+      };
+      yield { kind: "SESSION_MESSAGE_PART_EVENT_KIND_DONE", messageId: "assistant-1" };
+    })());
+    assert.deepEqual((await events).map((event) => event.type), [
+      "assistant-part", "tool-started", "assistant-part", "tool-result", "assistant-part", "usage", "stream-completed",
+    ]);
+  });
+
+  it("reports empty stream completion and preserves reasoning/image parts", async () => {
+    assert.deepEqual(await collect((async function* () {})()), [{ type: "stream-completed" }]);
+    const events = await collect((async function* () {
+      yield { kind: 1, messageId: "assistant-2", part: { partType: 2, content: "thinking" } };
+      yield { kind: 1, messageId: "assistant-2", part: { partType: "SESSION_MESSAGE_PART_TYPE_IMAGE", object: { key: "image" } } };
+    })());
+    assert.deepEqual(events.map((event) => event.type), ["assistant-part", "assistant-part", "stream-completed"]);
+  });
+
+  it("classifies stream failures and stops promptly on abort", async () => {
+    const failure = await collect((async function* () {
+      yield { kind: 3, part: { content: "gateway failed" } };
+    })());
+    assert.equal(failure[0]?.type, "stream-failed");
+    assert.equal((failure[0] as any).error.message, "gateway failed");
+
+    const controller = new AbortController();
+    controller.abort();
+    assert.deepEqual(await collect((async function* () {
+      yield { kind: "SESSION_MESSAGE_PART_EVENT_KIND_DONE" };
+    })(), controller.signal), []);
+  });
+});

--- a/packages/talon-chat/src/session/stream.ts
+++ b/packages/talon-chat/src/session/stream.ts
@@ -1,0 +1,119 @@
+import { data } from "@impalasys/talon-client";
+import type { UsageSummary } from "../lib/chatTimeline";
+
+export type ChatPart = Record<string, unknown> & {
+  partType?: data.SessionMessagePartType | string;
+  part_type?: data.SessionMessagePartType | string;
+  id?: string;
+  name?: string;
+  toolCallId?: string;
+  tool_call_id?: string;
+  content?: string;
+  payloadJson?: string;
+  payload_json?: string;
+};
+
+export type ToolResult = unknown;
+
+export type SessionRuntimeEvent =
+  | { type: "assistant-part"; messageId: string; part: ChatPart }
+  | { type: "tool-started"; toolCallId: string }
+  | { type: "tool-result"; toolCallId: string; result: ToolResult }
+  | { type: "usage"; messageId: string; usage: UsageSummary }
+  | { type: "stream-completed" }
+  | { type: "stream-failed"; error: Error };
+
+const SESSION_MESSAGE_PART_TYPE = {
+  TEXT: data.SessionMessagePartType?.TEXT ?? "SESSION_MESSAGE_PART_TYPE_TEXT",
+  REASONING: data.SessionMessagePartType?.REASONING ?? "SESSION_MESSAGE_PART_TYPE_REASONING",
+  TOOL_CALL: data.SessionMessagePartType?.TOOL_CALL ?? "SESSION_MESSAGE_PART_TYPE_TOOL_CALL",
+  TOOL_RESULT: data.SessionMessagePartType?.TOOL_RESULT ?? "SESSION_MESSAGE_PART_TYPE_TOOL_RESULT",
+  USAGE: data.SessionMessagePartType?.USAGE ?? "SESSION_MESSAGE_PART_TYPE_USAGE",
+  ERROR: data.SessionMessagePartType?.ERROR ?? "SESSION_MESSAGE_PART_TYPE_ERROR",
+  IMAGE: data.SessionMessagePartType?.IMAGE ?? "SESSION_MESSAGE_PART_TYPE_IMAGE",
+};
+
+function payload(value: unknown): Record<string, unknown> {
+  if (typeof value !== "string" || value.length === 0) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function toolCallId(part: ChatPart, parsedPayload: Record<string, unknown>): string {
+  const direct = part.toolCallId ?? part.tool_call_id ?? part.id;
+  if (typeof direct === "string" && direct.length > 0) return direct;
+  const nested = parsedPayload.tool_call_id ?? parsedPayload.toolCallId;
+  return typeof nested === "string" ? nested : "";
+}
+
+function eventKind(value: unknown): string | number | undefined {
+  if (typeof value === "number" || typeof value === "string") return value;
+  return undefined;
+}
+
+function isKind(value: unknown, numeric: number, named: string): boolean {
+  return value === numeric || value === named;
+}
+
+export async function* streamSessionPartEvents(
+  events: AsyncIterable<any>,
+  signal?: AbortSignal,
+): AsyncGenerator<SessionRuntimeEvent> {
+  try {
+    for await (const event of events) {
+      if (signal?.aborted) return;
+      const kind = eventKind(event?.kind);
+      if (isKind(kind, 3, "SESSION_MESSAGE_PART_EVENT_KIND_ERROR")) {
+        yield {
+          type: "stream-failed",
+          error: new Error(event?.part?.content || "Session stream error"),
+        };
+        return;
+      }
+      if (isKind(kind, 2, "SESSION_MESSAGE_PART_EVENT_KIND_DONE")) {
+        yield { type: "stream-completed" };
+        return;
+      }
+
+      const part = event?.part as ChatPart | undefined;
+      if (!part) continue;
+      const messageId = String(event?.messageId ?? event?.message_id ?? "");
+      const partType = part.partType ?? part.part_type;
+      const parsedPayload = payload(part.payloadJson ?? part.payload_json);
+
+      if (partType === SESSION_MESSAGE_PART_TYPE.ERROR || partType === "SESSION_MESSAGE_PART_TYPE_ERROR") {
+        yield { type: "stream-failed", error: new Error(String(part.content || "Session stream error")) };
+        return;
+      }
+
+      yield { type: "assistant-part", messageId, part };
+
+      if (partType === SESSION_MESSAGE_PART_TYPE.TOOL_CALL || partType === "SESSION_MESSAGE_PART_TYPE_TOOL_CALL") {
+        const id = toolCallId(part, parsedPayload);
+        if (id) yield { type: "tool-started", toolCallId: id };
+      } else if (partType === SESSION_MESSAGE_PART_TYPE.TOOL_RESULT || partType === "SESSION_MESSAGE_PART_TYPE_TOOL_RESULT") {
+        const id = toolCallId(part, parsedPayload);
+        if (id) {
+          yield {
+            type: "tool-result",
+            toolCallId: id,
+            result: parsedPayload.output ?? parsedPayload.tool_output ?? parsedPayload.toolOutput ?? part.content,
+          };
+        }
+      } else if (partType === SESSION_MESSAGE_PART_TYPE.USAGE || partType === "SESSION_MESSAGE_PART_TYPE_USAGE") {
+        yield { type: "usage", messageId, usage: parsedPayload as UsageSummary };
+      }
+    }
+    if (!signal?.aborted) yield { type: "stream-completed" };
+  } catch (error) {
+    if (!signal?.aborted) {
+      yield { type: "stream-failed", error: error instanceof Error ? error : new Error(String(error)) };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a typed, React-independent session stream adapter
- preserve numeric and string protocol event handling for text, reasoning, tools, usage, images, errors, completion, and aborts
- route the existing UI stream consumer through the adapter
- add adapter characterization tests

## Validation
- pnpm --dir packages/talon-chat test
- pnpm --dir packages/talon-chat build
- pnpm --dir ui exec tsc -p tsconfig.json --noEmit
- pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --no-coverage