### PR TITLE
refactor: introduce Talon session runtime

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -47,6 +47,8 @@ import {
   objectRefSizeBytes,
 } from "./session/objectRefs";
 import type { TalonChatObjectRef, TalonSessionHandle } from "./session/types";
+import { useSessionRuntime } from "./session/useSessionRuntime";
+import type { SessionTarget } from "./session/types";
 import {
   canCompareCanonicalMessageIds,
   historyMessageTimestamp,
@@ -802,16 +804,55 @@ export function TalonSession({
   onResourceClick: onResourceClickProp,
   fetchResource,
 }: TalonSessionProps) {
-  const [messages, setMessages] = useState<CopilotMessage[]>(emptyMessages);
+  const initialSessionTarget = useMemo<SessionTarget | null>(
+    () => sessionId ? { ns: namespace, agent, sessionId } : null,
+    [agent, namespace, sessionId],
+  );
+  const runtimeClient = useMemo(() => ({
+    listMessages: async (target: SessionTarget, options?: { beforeMessageId?: string | null; pageSize?: number; signal?: AbortSignal }) => {
+      const response = await gatewayClient.sessions.listMessages({
+        ...target,
+        pageSize: options?.pageSize,
+        beforeMessageId: options?.beforeMessageId || undefined,
+      });
+      return normalizeHistoryPage(response);
+    },
+  }), [gatewayClient]);
+  const sessionRuntime = useSessionRuntime({
+    target: initialSessionTarget,
+    client: runtimeClient,
+    pageSize: Math.max(1, Math.trunc(historyPageSize || historyMessageLimit || DEFAULT_HISTORY_PAGE_SIZE)),
+  });
+  const {
+    state: sessionRuntimeState,
+    isLive: runtimeIsLive,
+    setMessages,
+    setPhase,
+    setServerState,
+    setError,
+    refresh: refreshRuntime,
+    loadOlder: loadOlderRuntime,
+    clear: clearRuntime,
+    activateTarget,
+  } = sessionRuntime;
+  const messages = sessionRuntimeState.messages;
+  const currentSession = sessionRuntimeState.target;
+  const isLoading = sessionRuntimeState.phase === "submitting";
+  const isResuming = sessionRuntimeState.phase === "resuming";
+  const isStopping = sessionRuntimeState.phase === "stopping";
+  const sessionState = sessionRuntimeState.serverState === "UNKNOWN" ? null : sessionRuntimeState.serverState;
+  const isSessionLive = runtimeIsLive;
+  const setIsLoading = useCallback((value: boolean) => setPhase(value ? "submitting" : "idle"), [setPhase]);
+  const setIsResuming = useCallback((value: boolean) => setPhase(value ? "resuming" : "idle"), [setPhase]);
+  const setIsStopping = useCallback((value: boolean) => setPhase(value ? "stopping" : "idle"), [setPhase]);
+  const setSessionState = useCallback((value: string | null) => {
+    setServerState(value === "PROCESSING" ? "PROCESSING" : value === "ERROR" ? "ERROR" : value ? "IDLE" : "UNKNOWN");
+  }, [setServerState]);
   const [input, setInput] = useState("");
   const [imageAttachments, setImageAttachments] = useState<TalonSessionPendingImageAttachment[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isResuming, setIsResuming] = useState(false);
-  const [sessionState, setSessionState] = useState<string | null>(null);
-  const [isStopping, setIsStopping] = useState(false);
   const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
   const [loadingNow, setLoadingNow] = useState(Date.now());
-  const [error, setError] = useState<Error | null>(null);
+  const error = sessionRuntimeState.error;
   const [streamEvents, setStreamEvents] = useState<StreamEventItem[]>([]);
   const [expandedThinkingMessages, setExpandedThinkingMessages] = useState<Record<string, boolean>>({});
   const [expandedToolItems, setExpandedToolItems] = useState<Record<string, boolean>>({});
@@ -827,9 +868,8 @@ export function TalonSession({
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingMessageValue, setEditingMessageValue] = useState("");
   const [reviewActionMessageId, setReviewActionMessageId] = useState<string | null>(null);
-  const [currentSession, setCurrentSession] = useState<{ ns: string; agent: string; sessionId: string } | null>(null);
-  const [hasMoreHistory, setHasMoreHistory] = useState(false);
-  const [nextBeforeMessageId, setNextBeforeMessageId] = useState<string | null>(null);
+  const hasMoreHistory = sessionRuntimeState.history.hasMoreOlder;
+  const nextBeforeMessageId = sessionRuntimeState.history.beforeMessageId;
   const [isLoadingOlderHistory, setIsLoadingOlderHistory] = useState(false);
   const [scrollThumb, setScrollThumb] = useState<ScrollThumbState>({ visible: false, top: 0, height: 0 });
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -837,7 +877,7 @@ export function TalonSession({
   const abortControllerRef = useRef<AbortController | null>(null);
   const resumeAbortControllerRef = useRef<AbortController | null>(null);
   const stopAbortControllerRef = useRef<AbortController | null>(null);
-  const currentSessionRef = useRef<{ ns: string; agent: string; sessionId: string } | null>(null);
+  const currentSessionRef = useRef<SessionTarget | null>(null);
   const messagesRef = useRef<CopilotMessage[]>(emptyMessages);
   const imageAttachmentsRef = useRef<TalonSessionPendingImageAttachment[]>([]);
   const submittedPreviewUrlsRef = useRef<string[]>([]);
@@ -848,7 +888,6 @@ export function TalonSession({
   const autoScrollPinnedRef = useRef(true);
   const prependScrollRestoreRef = useRef<{ previousScrollTop: number; previousScrollHeight: number } | null>(null);
   const isLoadingOlderHistoryRef = useRef(false);
-  const isSessionLive = isLoading || isResuming || sessionState === "PROCESSING" || isStopping;
 
   const invalidateToolResultHydration = useCallback(() => {
     toolResultHydrationGenerationRef.current += 1;
@@ -894,6 +933,27 @@ export function TalonSession({
   useEffect(() => {
     currentSessionRef.current = currentSession;
   }, [currentSession]);
+
+  const previousSessionTargetRef = useRef<SessionTarget | null>(null);
+  useEffect(() => {
+    const previousTarget = previousSessionTargetRef.current;
+    previousSessionTargetRef.current = currentSession;
+    if (!previousTarget || !currentSession || isSameSession(previousTarget, currentSession)) return;
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    resumeAbortControllerRef.current?.abort();
+    resumeAbortControllerRef.current = null;
+    stopAbortControllerRef.current?.abort();
+    stopAbortControllerRef.current = null;
+    isStoppingRef.current = false;
+    setIsStopping(false);
+    setIsLoading(false);
+    setIsResuming(false);
+    setLoadingStartedAt(null);
+    setStreamEvents([]);
+    setExpandedThinkingMessages({});
+    invalidateToolResultHydration();
+  }, [currentSession?.agent, currentSession?.ns, currentSession?.sessionId, invalidateToolResultHydration, setIsLoading, setIsResuming, setIsStopping]);
 
   const scrollTranscriptToBottom = useCallback((behavior: ScrollBehavior) => {
     autoScrollPinnedRef.current = true;
@@ -1914,22 +1974,6 @@ export function TalonSession({
     Math.trunc(historyPageSize || historyMessageLimit || DEFAULT_HISTORY_PAGE_SIZE),
   );
 
-  const getSessionMessagesPage = useCallback(
-    async (target: { ns: string; agent: string; sessionId: string }, beforeMessageId?: string | null) => {
-      const sessions = gatewayClient?.sessions;
-      if (sessions?.listMessages) {
-        return sessions.listMessages({
-          ...target,
-          pageSize: resolvedHistoryPageSize,
-          beforeMessageId: beforeMessageId || undefined,
-        });
-      }
-
-      throw new Error("TalonSession requires a Talon clientset with sessions.listMessages().");
-    },
-    [gatewayClient, resolvedHistoryPageSize],
-  );
-
   const createSession = useCallback(
     async (target: { ns: string; agent: string }) => {
       const sessions = gatewayClient?.sessions;
@@ -1940,39 +1984,6 @@ export function TalonSession({
       throw new Error("TalonSession requires a Talon clientset with sessions.create().");
     },
     [gatewayClient],
-  );
-
-  const hydrateSessionHistoryPage = useCallback(
-    async (
-      response: any,
-    ): Promise<SessionHistoryPage> => {
-      return normalizeHistoryPage(response);
-    },
-    [],
-  );
-
-  const loadInitialSessionPage = useCallback(
-    async (target: { ns: string; agent: string; sessionId: string }) => {
-      const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
-      if (!isSameSession(currentSessionRef.current, target)) {
-        return res;
-      }
-      autoScrollPinnedRef.current = true;
-      setMessages(res.messages);
-      setHasMoreHistory(res.hasMore);
-      setNextBeforeMessageId(res.nextBeforeMessageId);
-      setStreamEvents([]);
-      currentSessionRef.current = target;
-      setCurrentSession(target);
-      setSessionState(res.state);
-      const isProcessing = res.state === "PROCESSING";
-      setIsLoading(false);
-      setIsResuming(isProcessing);
-      setLoadingStartedAt(isProcessing ? sessionProcessingStartTime(res.messages) ?? Date.now() : null);
-      setLoadingNow(Date.now());
-      return res;
-    },
-    [getSessionMessagesPage, hydrateSessionHistoryPage],
   );
 
   const loadOlderHistoryPage = useCallback(
@@ -1990,26 +2001,11 @@ export function TalonSession({
       isLoadingOlderHistoryRef.current = true;
       setIsLoadingOlderHistory(true);
       try {
-        const res = await hydrateSessionHistoryPage(
-          await getSessionMessagesPage(target, nextBeforeMessageId),
-        );
-        const existingIds = new Set(messagesRef.current.map((message) => message.id));
-        const olderMessages = res.messages.filter((message) => !existingIds.has(message.id));
-        if (olderMessages.length === 0) {
+        const res = await loadOlderRuntime(target);
+        if (!res) {
           prependScrollRestoreRef.current = null;
           skipNextAutoScrollRef.current = false;
-        } else {
-          setMessages((prev) => {
-            const currentIds = new Set(prev.map((message) => message.id));
-            const filteredOlderMessages = olderMessages.filter((message) => !currentIds.has(message.id));
-            if (filteredOlderMessages.length === 0) {
-              return prev;
-            }
-            return [...filteredOlderMessages, ...prev];
-          });
         }
-        setHasMoreHistory(res.hasMore);
-        setNextBeforeMessageId(res.nextBeforeMessageId);
       } catch (err) {
         prependScrollRestoreRef.current = null;
         skipNextAutoScrollRef.current = false;
@@ -2019,43 +2015,15 @@ export function TalonSession({
         setIsLoadingOlderHistory(false);
       }
     },
-    [getSessionMessagesPage, hydrateSessionHistoryPage, nextBeforeMessageId],
+    [loadOlderRuntime, nextBeforeMessageId],
   );
 
   const refreshNewestSessionPage = useCallback(
     async (target: { ns: string; agent: string; sessionId: string }, signal?: AbortSignal) => {
-      const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
-      if (signal?.aborted || !isSameSession(currentSessionRef.current, target)) {
-        return null;
-      }
-      const newestPageIds = new Set(res.messages.map((message) => message.id));
-      const oldestPageMessage = res.messages[0];
-      const oldestPageId = oldestPageMessage?.id;
-      const oldestPageTimestamp = oldestPageMessage ? historyMessageTimestamp(oldestPageMessage) : null;
-      const hasLoadedOlderHistory = messagesRef.current.some((message) => {
-        if (message.id === "1") return false;
-        if (isLocalMessageId(message.id)) return false;
-        if (newestPageIds.has(message.id)) return false;
-        const messageTimestamp = historyMessageTimestamp(message);
-        if (messageTimestamp !== null && oldestPageTimestamp !== null) {
-          return messageTimestamp < oldestPageTimestamp;
-        }
-        return oldestPageId && canCompareCanonicalMessageIds(message.id, oldestPageId) ? message.id < oldestPageId : false;
-      });
-      setMessages((prev) => {
-        const merged = mergeNewestCanonicalPage(prev, res.messages);
-        return merged;
-      });
-      if (!hasLoadedOlderHistory) {
-        setHasMoreHistory(res.hasMore);
-        setNextBeforeMessageId(res.nextBeforeMessageId);
-      }
       setStreamEvents([]);
-      setSessionState(res.state);
-      setCurrentSession(target);
-      return res;
+      return refreshRuntime(target, signal);
     },
-    [getSessionMessagesPage, hydrateSessionHistoryPage],
+    [refreshRuntime],
   );
 
   const resumeStream = useCallback(
@@ -2106,127 +2074,33 @@ export function TalonSession({
         if (signal?.aborted || !isSameSession(currentSessionRef.current, target)) {
           return null;
         }
-        const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
+        const res = await refreshRuntime(target, signal);
         if (signal?.aborted || !isSameSession(currentSessionRef.current, target)) {
           return null;
         }
-        setSessionState(res.state);
-        if (res.state !== "PROCESSING") {
+        if (res?.state !== "PROCESSING") {
           return res;
         }
         await new Promise((resolve) => setTimeout(resolve, 250));
       }
       return null;
     },
-    [getSessionMessagesPage, hydrateSessionHistoryPage],
+    [refreshRuntime],
   );
 
   useEffect(() => {
-    const nextSession = sessionId ? { ns: namespace, agent, sessionId } : null;
-    if (!nextSession) {
-      if (currentSessionRef.current && currentSessionRef.current.ns === namespace && currentSessionRef.current.agent === agent) {
-        return;
-      }
-      stopAbortControllerRef.current?.abort();
-      stopAbortControllerRef.current = null;
-      currentSessionRef.current = null;
-      setCurrentSession(null);
-      setSessionState(null);
-      isStoppingRef.current = false;
-      setMessages(emptyMessages);
-      setHasMoreHistory(false);
-      setNextBeforeMessageId(null);
-      setIsLoadingOlderHistory(false);
-      setStreamEvents([]);
-      invalidateToolResultHydration();
-      setError(null);
+    if (!currentSession || sessionRuntimeState.serverState !== "PROCESSING" || isStoppingRef.current) {
       return;
     }
-
-    if (isSameSession(currentSessionRef.current, nextSession)) {
-      return;
-    }
-
-    let cancelled = false;
+    if (resumeAbortControllerRef.current && !resumeAbortControllerRef.current.signal.aborted) return;
     const controller = new AbortController();
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = null;
-    resumeAbortControllerRef.current?.abort();
     resumeAbortControllerRef.current = controller;
-    stopAbortControllerRef.current?.abort();
-    stopAbortControllerRef.current = null;
-    currentSessionRef.current = nextSession;
-    invalidateToolResultHydration();
-    setIsLoading(false);
-    setIsResuming(false);
-    setSessionState(null);
-    isStoppingRef.current = false;
-    setIsStopping(false);
-    setLoadingStartedAt(null);
+    setIsResuming(true);
+    setLoadingStartedAt(sessionProcessingStartTime(messagesRef.current) ?? Date.now());
     setLoadingNow(Date.now());
-    setExpandedThinkingMessages({});
-    loadInitialSessionPage(nextSession)
-      .then((res) => {
-        if (!cancelled && res.state === "PROCESSING") {
-          void resumeStream(nextSession, controller.signal);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setMessages([{ id: "1", role: "system", content: `[Error loading session history: ${err.message}]` }]);
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      });
-    return () => {
-      cancelled = true;
-      controller.abort();
-      stopAbortControllerRef.current?.abort();
-      stopAbortControllerRef.current = null;
-    };
-  }, [agent, invalidateToolResultHydration, loadInitialSessionPage, namespace, resumeStream, sessionId]);
-
-  useEffect(() => {
-    const target = currentSession;
-    if (!target || isSessionLive) {
-      return;
-    }
-
-    let cancelled = false;
-    let requestInFlight = false;
-    const pollForExternalGeneration = async () => {
-      if (cancelled || requestInFlight || !isSameSession(currentSessionRef.current, target)) {
-        return;
-      }
-      requestInFlight = true;
-      try {
-        const res = await hydrateSessionHistoryPage(await getSessionMessagesPage(target));
-        if (cancelled || !isSameSession(currentSessionRef.current, target) || res.state !== "PROCESSING") {
-          return;
-        }
-        await refreshNewestSessionPage(target);
-        if (cancelled || !isSameSession(currentSessionRef.current, target)) {
-          return;
-        }
-        const controller = new AbortController();
-        resumeAbortControllerRef.current?.abort();
-        resumeAbortControllerRef.current = controller;
-        setIsResuming(true);
-        setLoadingStartedAt(sessionProcessingStartTime(res.messages) ?? Date.now());
-        setLoadingNow(Date.now());
-        void resumeStream(target, controller.signal);
-      } catch {
-        // The normal stream/error path reports actionable failures once work is live.
-      } finally {
-        requestInFlight = false;
-      }
-    };
-
-    const intervalId = window.setInterval(() => void pollForExternalGeneration(), 1000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-    };
-  }, [currentSession, getSessionMessagesPage, hydrateSessionHistoryPage, isSessionLive, refreshNewestSessionPage, resumeStream]);
+    void resumeStream(currentSession, controller.signal);
+    return () => controller.abort();
+  }, [currentSession, messagesRef, resumeStream, sessionRuntimeState.serverState, setIsResuming]);
 
   const waitForCanonicalAssistantUpdate = useCallback(
     async (session: { ns: string; agent: string; sessionId: string }, baselineSignature: string, signal?: AbortSignal) => {
@@ -2234,10 +2108,11 @@ export function TalonSession({
         if (signal?.aborted || !isSameSession(currentSessionRef.current, session)) {
           return false;
         }
-        const sessionState = await hydrateSessionHistoryPage(await getSessionMessagesPage(session));
+        const sessionState = await refreshRuntime(session, signal);
         if (signal?.aborted || !isSameSession(currentSessionRef.current, session)) {
           return false;
         }
+        if (!sessionState) return false;
         const nextSignature = getAssistantSignature(sessionState.messages);
         if (nextSignature && nextSignature !== baselineSignature) {
           await refreshNewestSessionPage(session, signal);
@@ -2247,7 +2122,7 @@ export function TalonSession({
       }
       return false;
     },
-    [getSessionMessagesPage, hydrateSessionHistoryPage, refreshNewestSessionPage],
+    [refreshNewestSessionPage, refreshRuntime],
   );
 
   const clearLocalSession = useCallback(() => {
@@ -2259,12 +2134,10 @@ export function TalonSession({
     stopAbortControllerRef.current = null;
     resourceAbortRef.current?.abort();
     resourceAbortRef.current = null;
-    setMessages(emptyMessages);
+    clearRuntime();
     messagesRef.current = emptyMessages;
     setStreamEvents([]);
     setError(null);
-    setHasMoreHistory(false);
-    setNextBeforeMessageId(null);
     setIsLoading(false);
     setIsResuming(false);
     setSessionState(null);
@@ -2279,7 +2152,7 @@ export function TalonSession({
     setResourceError(null);
     setResourceLoading(false);
     autoScrollPinnedRef.current = true;
-  }, [invalidateToolResultHydration]);
+  }, [clearRuntime, invalidateToolResultHydration]);
 
   const clearSession = useCallback(async () => {
     const session = currentSessionRef.current;
@@ -2457,12 +2330,12 @@ export function TalonSession({
         if (sessionId) {
           session = { ns: namespace, agent, sessionId };
           currentSessionRef.current = session;
-          setCurrentSession(session);
+          activateTarget(session, { hydrate: false });
         } else {
           const sessionRes = await createSession({ ns: namespace, agent });
           session = { ns: namespace, agent, sessionId: sessionRes.sessionId };
           currentSessionRef.current = session;
-          setCurrentSession(session);
+          activateTarget(session, { hydrate: false });
           onSessionChange?.(session.sessionId);
         }
       }

--- a/packages/talon-chat/src/session/runtime.test.ts
+++ b/packages/talon-chat/src/session/runtime.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  emptySessionRuntimeState,
+  SessionOperationRegistry,
+  sessionRuntimeReducer,
+  type SessionRuntimeState,
+} from "./runtime.ts";
+
+const target = { ns: "default", agent: "assistant", sessionId: "session-a" };
+const page = {
+  messages: [{ id: "m-1", role: "assistant", content: "hello" }],
+  state: "PROCESSING",
+  hasMore: false,
+  nextBeforeMessageId: null,
+  hasMoreOlder: false,
+  beforeMessageId: null,
+};
+
+test("runtime reducer makes processing hydration live and ignores stale epochs", () => {
+  const hydrating = sessionRuntimeReducer(emptySessionRuntimeState, {
+    type: "target-changed",
+    target,
+    epoch: 2,
+  });
+  const hydrated = sessionRuntimeReducer(hydrating, {
+    type: "hydrated",
+    target,
+    page,
+    epoch: 2,
+  });
+  assert.equal(hydrated.phase, "resuming");
+  assert.equal(hydrated.serverState, "PROCESSING");
+  assert.equal(hydrated.messages[0]?.id, "m-1");
+
+  const stale = sessionRuntimeReducer(hydrated, {
+    type: "messages-replaced",
+    messages: [{ id: "stale", role: "user", content: "wrong session" }],
+    epoch: 1,
+  });
+  assert.equal(stale, hydrated);
+});
+
+test("operation registry cancels replacement and all session work", () => {
+  const registry = new SessionOperationRegistry();
+  const first = registry.begin("hydrate", target, 1);
+  const replacement = registry.begin("hydrate", target, 1);
+  assert.equal(first.controller.signal.aborted, true);
+  assert.equal(registry.isCurrent(first), false);
+  assert.equal(registry.isCurrent(replacement), true);
+
+  registry.cancelAll();
+  assert.equal(replacement.controller.signal.aborted, true);
+  assert.equal(registry.isCurrent(replacement), false);
+});
+
+test("runtime state retains canonical history while replacing messages", () => {
+  const state: SessionRuntimeState = {
+    ...emptySessionRuntimeState,
+    target,
+    epoch: 1,
+    messages: [{ id: "local-1", role: "user", content: "optimistic" }],
+    history: {
+      messages: [{ id: "local-1", role: "user", content: "optimistic" }],
+      hasMoreOlder: true,
+      beforeMessageId: "m-0",
+    },
+  };
+  const next = sessionRuntimeReducer(state, {
+    type: "messages-replaced",
+    messages: [{ id: "m-1", role: "assistant", content: "canonical" }],
+    epoch: 1,
+  });
+  assert.equal(next.history.hasMoreOlder, true);
+  assert.deepEqual(next.history.messages, next.messages);
+});

--- a/packages/talon-chat/src/session/runtime.ts
+++ b/packages/talon-chat/src/session/runtime.ts
@@ -1,0 +1,198 @@
+// @ts-ignore The Node strip-types test runner requires explicit .ts resolution.
+import type { CopilotMessage } from "../lib/chatTimeline.ts";
+// @ts-ignore The Node strip-types test runner requires explicit .ts resolution.
+import type { SessionHistoryPage, HistoryState } from "./history.ts";
+import type { SessionTarget } from "./types";
+
+export type SessionPhase =
+  | "empty"
+  | "hydrating"
+  | "idle"
+  | "submitting"
+  | "resuming"
+  | "stopping";
+
+export type SessionServerState = "UNKNOWN" | "IDLE" | "PROCESSING" | "ERROR";
+
+export type SessionRuntimeState = {
+  target: SessionTarget | null;
+  phase: SessionPhase;
+  serverState: SessionServerState;
+  messages: CopilotMessage[];
+  history: HistoryState;
+  error: Error | null;
+  epoch: number;
+};
+
+export type RuntimeOperationKind =
+  | "hydrate"
+  | "paginate"
+  | "submit"
+  | "resume"
+  | "stop"
+  | "poll"
+  | "resource";
+
+export type RuntimeOperation = {
+  kind: RuntimeOperationKind;
+  target: SessionTarget;
+  epoch: number;
+  controller: AbortController;
+};
+
+export const emptyHistoryState: HistoryState = {
+  messages: [],
+  hasMoreOlder: false,
+  beforeMessageId: null,
+};
+
+export const emptySessionRuntimeState: SessionRuntimeState = {
+  target: null,
+  phase: "empty",
+  serverState: "UNKNOWN",
+  messages: [],
+  history: emptyHistoryState,
+  error: null,
+  epoch: 0,
+};
+
+export function sameSessionTarget(left: SessionTarget | null, right: SessionTarget | null): boolean {
+  return Boolean(
+    left && right
+      && left.ns === right.ns
+      && left.agent === right.agent
+      && left.sessionId === right.sessionId,
+  );
+}
+
+function stateForPage(page: SessionHistoryPage, target: SessionTarget, epoch: number): SessionRuntimeState {
+  const serverState: SessionServerState = page.state === "PROCESSING"
+    ? "PROCESSING"
+    : page.state === "ERROR"
+      ? "ERROR"
+      : "IDLE";
+  return {
+    target,
+    phase: serverState === "PROCESSING" ? "resuming" : "idle",
+    serverState,
+    messages: page.messages,
+    history: {
+      messages: page.messages,
+      hasMoreOlder: page.hasMoreOlder,
+      beforeMessageId: page.beforeMessageId,
+    },
+    error: null,
+    epoch,
+  };
+}
+
+export type SessionRuntimeAction =
+  | { type: "target-changed"; target: SessionTarget | null; epoch: number }
+  | { type: "operation-started"; kind: RuntimeOperationKind; epoch: number }
+  | { type: "hydrated"; target: SessionTarget; page: SessionHistoryPage; epoch: number }
+  | { type: "history-updated"; target: SessionTarget; page: SessionHistoryPage; messages: CopilotMessage[]; epoch: number }
+  | { type: "messages-replaced"; messages: CopilotMessage[] | ((previous: CopilotMessage[]) => CopilotMessage[]); epoch?: number }
+  | { type: "server-state"; serverState: SessionServerState; epoch?: number }
+  | { type: "phase"; phase: SessionPhase; epoch?: number }
+  | { type: "error"; error: Error | null; epoch?: number }
+  | { type: "cleared"; epoch?: number };
+
+function acceptsEpoch(state: SessionRuntimeState, epoch?: number): boolean {
+  return epoch == null || epoch === state.epoch;
+}
+
+export function sessionRuntimeReducer(
+  state: SessionRuntimeState,
+  action: SessionRuntimeAction,
+): SessionRuntimeState {
+  switch (action.type) {
+    case "target-changed":
+      return action.target
+        ? {
+            ...emptySessionRuntimeState,
+            target: action.target,
+            phase: "hydrating",
+            epoch: action.epoch,
+          }
+        : { ...emptySessionRuntimeState, epoch: action.epoch };
+    case "operation-started":
+      return acceptsEpoch(state, action.epoch) ? { ...state, error: null } : state;
+    case "hydrated":
+      return acceptsEpoch(state, action.epoch) && sameSessionTarget(state.target, action.target)
+        ? stateForPage(action.page, action.target, action.epoch)
+        : state;
+    case "history-updated":
+      return acceptsEpoch(state, action.epoch) && sameSessionTarget(state.target, action.target)
+        ? {
+            ...state,
+            messages: action.messages,
+            history: {
+              messages: action.messages,
+              hasMoreOlder: action.page.hasMoreOlder,
+              beforeMessageId: action.page.beforeMessageId,
+            },
+            serverState: action.page.state === "PROCESSING"
+              ? "PROCESSING"
+              : action.page.state === "ERROR" ? "ERROR" : "IDLE",
+            phase: action.page.state === "PROCESSING"
+              ? "resuming"
+              : state.phase === "submitting" || state.phase === "stopping" ? state.phase : "idle",
+          }
+        : state;
+    case "messages-replaced":
+      if (!acceptsEpoch(state, action.epoch)) return state;
+      {
+        const messages = typeof action.messages === "function" ? action.messages(state.messages) : action.messages;
+        return { ...state, messages, history: { ...state.history, messages } };
+      }
+    case "server-state":
+      return acceptsEpoch(state, action.epoch)
+        ? {
+            ...state,
+            serverState: action.serverState,
+            phase: action.serverState === "PROCESSING" ? "resuming" : state.phase,
+          }
+        : state;
+    case "phase":
+      return acceptsEpoch(state, action.epoch) ? { ...state, phase: action.phase } : state;
+    case "error":
+      return acceptsEpoch(state, action.epoch) ? { ...state, error: action.error, serverState: action.error ? "ERROR" : state.serverState } : state;
+    case "cleared":
+      return acceptsEpoch(state, action.epoch)
+        ? { ...emptySessionRuntimeState, epoch: state.epoch, target: state.target }
+        : state;
+    default:
+      return state;
+  }
+}
+
+export class SessionOperationRegistry {
+  private operations = new Map<RuntimeOperationKind, RuntimeOperation>();
+
+  begin(kind: RuntimeOperationKind, target: SessionTarget, epoch: number): RuntimeOperation {
+    this.operations.get(kind)?.controller.abort();
+    const operation = { kind, target, epoch, controller: new AbortController() };
+    this.operations.set(kind, operation);
+    return operation;
+  }
+
+  isCurrent(operation: RuntimeOperation): boolean {
+    return this.operations.get(operation.kind) === operation
+      && !operation.controller.signal.aborted;
+  }
+
+  finish(operation: RuntimeOperation): void {
+    if (this.operations.get(operation.kind) === operation) this.operations.delete(operation.kind);
+  }
+
+  cancel(kind: RuntimeOperationKind): void {
+    const operation = this.operations.get(kind);
+    operation?.controller.abort();
+    this.operations.delete(kind);
+  }
+
+  cancelAll(): void {
+    for (const operation of this.operations.values()) operation.controller.abort();
+    this.operations.clear();
+  }
+}

--- a/packages/talon-chat/src/session/stream.ts
+++ b/packages/talon-chat/src/session/stream.ts
@@ -57,6 +57,22 @@ function eventKind(value: unknown): string | number | undefined {
   return undefined;
 }
 
+function usageFromPayload(value: Record<string, unknown>): UsageSummary {
+  const numberValue = (...keys: string[]) => {
+    for (const key of keys) {
+      const candidate = value[key];
+      if (typeof candidate === "number" && Number.isFinite(candidate)) return candidate;
+    }
+    return undefined;
+  };
+  return {
+    inputTokens: numberValue("input_tokens", "inputTokens"),
+    outputTokens: numberValue("output_tokens", "outputTokens"),
+    reasoningTokens: numberValue("reasoning_tokens", "reasoningTokens"),
+    totalTokens: numberValue("total_tokens", "totalTokens"),
+  };
+}
+
 function isKind(value: unknown, numeric: number, named: string): boolean {
   return value === numeric || value === named;
 }
@@ -107,7 +123,7 @@ export async function* streamSessionPartEvents(
           };
         }
       } else if (partType === SESSION_MESSAGE_PART_TYPE.USAGE || partType === "SESSION_MESSAGE_PART_TYPE_USAGE") {
-        yield { type: "usage", messageId, usage: parsedPayload as UsageSummary };
+        yield { type: "usage", messageId, usage: usageFromPayload(parsedPayload) };
       }
     }
     if (!signal?.aborted) yield { type: "stream-completed" };

--- a/packages/talon-chat/src/session/useSessionRuntime.ts
+++ b/packages/talon-chat/src/session/useSessionRuntime.ts
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import {
+  emptySessionRuntimeState,
+  sameSessionTarget,
+  SessionOperationRegistry,
+  sessionRuntimeReducer,
+  type RuntimeOperationKind,
+  type SessionRuntimeState,
+} from "./runtime";
+import type { SessionHistoryPage } from "./history";
+import { mergeNewestCanonicalPage } from "./history";
+import type { SessionClient } from "./client";
+import type { SessionTarget } from "./types";
+import type { CopilotMessage } from "../lib/chatTimeline";
+
+export type UseSessionRuntimeOptions = {
+  target: SessionTarget | null;
+  client: Pick<SessionClient, "listMessages">;
+  pageSize: number;
+  pollIntervalMs?: number;
+};
+
+export type SessionRuntimeController = {
+  state: SessionRuntimeState;
+  isLive: boolean;
+  setMessages: Dispatch<SetStateAction<CopilotMessage[]>>;
+  setPhase: (phase: SessionRuntimeState["phase"]) => void;
+  setServerState: (state: SessionRuntimeState["serverState"]) => void;
+  setError: (error: Error | null) => void;
+  refresh: (target?: SessionTarget, signal?: AbortSignal) => Promise<SessionHistoryPage | null>;
+  loadOlder: (target?: SessionTarget, signal?: AbortSignal) => Promise<SessionHistoryPage | null>;
+  clear: () => void;
+  cancelAllOperations: () => void;
+  beginOperation: (kind: RuntimeOperationKind, target?: SessionTarget) => AbortSignal;
+  activateTarget: (target: SessionTarget, options?: { hydrate?: boolean }) => void;
+};
+
+function linkAbortSignal(source: AbortSignal | undefined, controller: AbortController): () => void {
+  if (!source) return () => undefined;
+  if (source.aborted) controller.abort();
+  const abort = () => controller.abort();
+  source.addEventListener("abort", abort, { once: true });
+  return () => source.removeEventListener("abort", abort);
+}
+
+export function useSessionRuntime({
+  target,
+  client,
+  pageSize,
+  pollIntervalMs = 1000,
+}: UseSessionRuntimeOptions): SessionRuntimeController {
+  const [state, dispatch] = useReducer(sessionRuntimeReducer, emptySessionRuntimeState);
+  const registryRef = useRef(new SessionOperationRegistry());
+  const epochRef = useRef(0);
+  const stateRef = useRef(state);
+  const activeTargetRef = useRef<SessionTarget | null>(target);
+  const inputTargetKey = target ? `${target.ns}\u0000${target.agent}\u0000${target.sessionId}` : null;
+  const inputTargetKeyRef = useRef<string | null>(inputTargetKey);
+  const clientRef = useRef(client);
+  const pageSizeRef = useRef(pageSize);
+  stateRef.current = state;
+  clientRef.current = client;
+  pageSizeRef.current = pageSize;
+
+  const beginOperation = useCallback((kind: RuntimeOperationKind, operationTarget?: SessionTarget) => {
+    const nextTarget = operationTarget ?? stateRef.current.target ?? target;
+    if (!nextTarget) {
+      const controller = new AbortController();
+      controller.abort();
+      return controller.signal;
+    }
+    return registryRef.current.begin(kind, nextTarget, epochRef.current).controller.signal;
+  }, [target]);
+
+  const hydrate = useCallback(async (nextTarget: SessionTarget, epoch: number, kind: "hydrate" | "poll" = "hydrate") => {
+    const operation = registryRef.current.begin(kind, nextTarget, epoch);
+    dispatch({ type: "operation-started", kind, epoch });
+    try {
+      const page = await clientRef.current.listMessages(nextTarget, { pageSize: pageSizeRef.current, signal: operation.controller.signal });
+      if (!registryRef.current.isCurrent(operation) || epoch !== epochRef.current || !sameSessionTarget(stateRef.current.target, nextTarget)) return null;
+      dispatch({ type: kind === "hydrate" ? "hydrated" : "history-updated", target: nextTarget, page, messages: page.messages, epoch } as any);
+      return page;
+    } catch (error) {
+      if (!operation.controller.signal.aborted && registryRef.current.isCurrent(operation)) {
+        dispatch({ type: "error", error: error instanceof Error ? error : new Error(String(error)), epoch });
+      }
+      return null;
+    } finally {
+      registryRef.current.finish(operation);
+    }
+  }, []);
+
+  const activateTarget = useCallback((nextTarget: SessionTarget, options: { hydrate?: boolean } = {}) => {
+    activeTargetRef.current = nextTarget;
+    const epoch = epochRef.current + 1;
+    epochRef.current = epoch;
+    registryRef.current.cancelAll();
+    dispatch({ type: "target-changed", target: nextTarget, epoch });
+    if (options.hydrate !== false) void hydrate(nextTarget, epoch);
+  }, [hydrate]);
+
+  useEffect(() => {
+    if (inputTargetKeyRef.current === inputTargetKey && !target && activeTargetRef.current) return;
+    if (inputTargetKeyRef.current === inputTargetKey && stateRef.current.target === target) return;
+    inputTargetKeyRef.current = inputTargetKey;
+    const epoch = epochRef.current + 1;
+    epochRef.current = epoch;
+    activeTargetRef.current = target;
+    registryRef.current.cancelAll();
+    dispatch({ type: "target-changed", target, epoch });
+    if (target) void hydrate(target, epoch);
+  }, [hydrate, inputTargetKey, target]);
+
+  useEffect(() => {
+    const pollingTarget = target ?? activeTargetRef.current;
+    if (!pollingTarget || state.target == null || state.phase !== "idle") return;
+    let disposed = false;
+    const poll = async () => {
+      if (disposed || stateRef.current.phase !== "idle" || stateRef.current.serverState === "PROCESSING") return;
+      const page = await hydrate(pollingTarget, epochRef.current, "poll");
+      if (disposed || !page || page.state !== "PROCESSING") return;
+    };
+    const intervalId = window.setInterval(() => void poll(), pollIntervalMs);
+    return () => {
+      disposed = true;
+      window.clearInterval(intervalId);
+      registryRef.current.cancel("poll");
+    };
+  }, [pollIntervalMs, state.phase, state.serverState, state.target, target, hydrate]);
+
+  useEffect(() => () => {
+    registryRef.current.cancelAll();
+  }, []);
+
+  const setMessages = useCallback<Dispatch<SetStateAction<CopilotMessage[]>>>((next) => {
+    dispatch({ type: "messages-replaced", messages: next, epoch: epochRef.current });
+  }, []);
+
+  const refresh = useCallback(async (refreshTarget = stateRef.current.target ?? undefined, signal?: AbortSignal) => {
+    if (!refreshTarget) return null;
+    const operation = registryRef.current.begin("poll", refreshTarget, epochRef.current);
+    const unlink = linkAbortSignal(signal, operation.controller);
+    dispatch({ type: "operation-started", kind: "poll", epoch: epochRef.current });
+    try {
+      const page = await clientRef.current.listMessages(refreshTarget, { pageSize: pageSizeRef.current, signal: operation.controller.signal });
+      const effectiveTarget = stateRef.current.target ?? activeTargetRef.current;
+      if (!registryRef.current.isCurrent(operation) || !sameSessionTarget(effectiveTarget, refreshTarget)) return null;
+      const merged = mergeNewestCanonicalPage(stateRef.current.messages, page.messages);
+      dispatch({ type: "history-updated", target: refreshTarget, page, messages: merged, epoch: epochRef.current });
+      return page;
+    } catch (error) {
+      if (!operation.controller.signal.aborted && registryRef.current.isCurrent(operation)) {
+        dispatch({ type: "error", error: error instanceof Error ? error : new Error(String(error)), epoch: epochRef.current });
+      }
+      return null;
+    } finally {
+      unlink();
+      registryRef.current.finish(operation);
+    }
+  }, []);
+
+  const loadOlder = useCallback(async (olderTarget = stateRef.current.target ?? undefined, signal?: AbortSignal) => {
+    if (!olderTarget || !stateRef.current.history.beforeMessageId) return null;
+    const operation = registryRef.current.begin("paginate", olderTarget, epochRef.current);
+    const unlink = linkAbortSignal(signal, operation.controller);
+    const beforeMessageId = stateRef.current.history.beforeMessageId;
+    try {
+      const page = await clientRef.current.listMessages(olderTarget, { pageSize: pageSizeRef.current, beforeMessageId, signal: operation.controller.signal });
+      if (!registryRef.current.isCurrent(operation) || !sameSessionTarget(stateRef.current.target, olderTarget)) return null;
+      const existingIds = new Set(stateRef.current.messages.map((message) => message.id));
+      const messages = [...page.messages.filter((message) => !existingIds.has(message.id)), ...stateRef.current.messages];
+      dispatch({ type: "history-updated", target: olderTarget, page, messages, epoch: epochRef.current });
+      return page;
+    } finally {
+      unlink();
+      registryRef.current.finish(operation);
+    }
+  }, []);
+
+  const setPhase = useCallback((phase: SessionRuntimeState["phase"]) => {
+    dispatch({ type: "phase", phase, epoch: epochRef.current });
+  }, []);
+  const setServerState = useCallback((serverState: SessionRuntimeState["serverState"]) => {
+    dispatch({ type: "server-state", serverState, epoch: epochRef.current });
+  }, []);
+  const setError = useCallback((error: Error | null) => {
+    dispatch({ type: "error", error, epoch: epochRef.current });
+  }, []);
+  const clear = useCallback(() => {
+    registryRef.current.cancelAll();
+    dispatch({ type: "cleared", epoch: epochRef.current });
+  }, []);
+  const cancelAllOperations = useCallback(() => registryRef.current.cancelAll(), []);
+
+  return {
+    state,
+    isLive: state.phase === "submitting" || state.phase === "resuming" || state.phase === "stopping" || state.serverState === "PROCESSING",
+    setMessages,
+    setPhase,
+    setServerState,
+    setError,
+    refresh,
+    loadOlder,
+    clear,
+    cancelAllOperations,
+    beginOperation,
+    activateTarget,
+  };
+}


### PR DESCRIPTION
## Summary
- add the authoritative session runtime reducer and operation registry
- guard hydration, pagination, refresh, polling, and session activation by target and epoch
- move session history state and error state behind useSessionRuntime
- reconcile processing sessions after reload and session replacement

## Validation
- pnpm --dir packages/talon-chat test
- pnpm --dir packages/talon-chat build
- pnpm --dir ui exec tsc -p tsconfig.json --noEmit
- targeted TalonSession characterization tests