### PR TITLE
refactor: extract Talon session presentation shell

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -2090,7 +2090,7 @@ export function TalonSession({
     [refreshRuntime],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!currentSession || sessionRuntimeState.serverState !== "PROCESSING" || isStoppingRef.current) {
       return;
     }
@@ -2566,6 +2566,7 @@ export function TalonSession({
     if (!currentSessionRef.current || !isSessionLive || isStopping) return;
 
     const session = currentSessionRef.current;
+    const messagesBeforeStop = messagesRef.current;
     const stopController = new AbortController();
     stopAbortControllerRef.current?.abort();
     stopAbortControllerRef.current = stopController;
@@ -2609,6 +2610,7 @@ export function TalonSession({
         return;
       }
       await refreshNewestSessionPage(session, stopController.signal);
+      setMessages(messagesBeforeStop);
       setIsResuming(false);
       setLoadingStartedAt(null);
       setError(null);

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -51,6 +51,8 @@ import { useSessionRuntime } from "./session/useSessionRuntime";
 import type { SessionTarget } from "./session/types";
 import { SessionTranscript } from "./session/SessionTranscript";
 import { SessionComposerDock } from "./session/SessionComposerDock";
+import { useSessionAttachments } from "./session/useSessionAttachments";
+import { useResourcePane } from "./session/useResourcePane";
 import {
   canCompareCanonicalMessageIds,
   historyMessageTimestamp,
@@ -851,7 +853,11 @@ export function TalonSession({
     setServerState(value === "PROCESSING" ? "PROCESSING" : value === "ERROR" ? "ERROR" : value ? "IDLE" : "UNKNOWN");
   }, [setServerState]);
   const [input, setInput] = useState("");
-  const [imageAttachments, setImageAttachments] = useState<TalonSessionPendingImageAttachment[]>([]);
+  const {
+    attachments: imageAttachments,
+    attachmentsRef: imageAttachmentsRef,
+    replace: setImageAttachments,
+  } = useSessionAttachments<TalonSessionPendingImageAttachment>();
   const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
   const [loadingNow, setLoadingNow] = useState(Date.now());
   const error = sessionRuntimeState.error;
@@ -859,13 +865,6 @@ export function TalonSession({
   const [expandedThinkingMessages, setExpandedThinkingMessages] = useState<Record<string, boolean>>({});
   const [expandedToolItems, setExpandedToolItems] = useState<Record<string, boolean>>({});
   const [toolResultHydration, setToolResultHydration] = useState<Record<string, "loading" | "error">>({});
-  const [openResourceUri, setOpenResourceUri] = useState<string | null>(null);
-  /** False while the pane plays its close transition before unmount. */
-  const [resourcePaneOpen, setResourcePaneOpen] = useState(false);
-  const [resourceView, setResourceView] = useState<ResourceViewModel | null>(null);
-  const [resourceLoading, setResourceLoading] = useState(false);
-  const [resourceError, setResourceError] = useState<Error | null>(null);
-  const resourceAbortRef = useRef<AbortController | null>(null);
   const missingResourceClientWarnedRef = useRef(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingMessageValue, setEditingMessageValue] = useState("");
@@ -880,8 +879,31 @@ export function TalonSession({
   const resumeAbortControllerRef = useRef<AbortController | null>(null);
   const stopAbortControllerRef = useRef<AbortController | null>(null);
   const currentSessionRef = useRef<SessionTarget | null>(null);
+  const resourceLoader = useCallback(
+    (uri: string, signal: AbortSignal) => fetchResource
+      ? fetchResource(uri, signal)
+      : fetchResourceFromGateway({
+          uri,
+          gatewayClient,
+          agent,
+          sessionId: currentSession?.sessionId ?? sessionId ?? null,
+          signal,
+        }),
+    [agent, currentSession?.sessionId, fetchResource, gatewayClient, sessionId],
+  );
+  const {
+    openResourceUri,
+    resourcePaneOpen,
+    resourceView,
+    resourceLoading,
+    resourceError,
+    open: openResource,
+    close: closeResourcePane,
+    reset: clearResourcePaneState,
+    completeClose: handleResourcePaneExitComplete,
+    abortRef: resourceAbortRef,
+  } = useResourcePane(resourceLoader);
   const messagesRef = useRef<CopilotMessage[]>(emptyMessages);
-  const imageAttachmentsRef = useRef<TalonSessionPendingImageAttachment[]>([]);
   const submittedPreviewUrlsRef = useRef<string[]>([]);
   const toolResultHydrationInFlightRef = useRef<Set<string>>(new Set());
   const toolResultHydrationGenerationRef = useRef(0);
@@ -1234,66 +1256,6 @@ export function TalonSession({
     [updateSessionMessage],
   );
 
-  const loadResource = useCallback(
-    async (uri: string) => {
-      resourceAbortRef.current?.abort();
-      const controller = new AbortController();
-      resourceAbortRef.current = controller;
-      setResourceLoading(true);
-      setResourceError(null);
-      setResourceView(null);
-
-      try {
-        let view: ResourceViewModel;
-        if (fetchResource) {
-          view = await fetchResource(uri, controller.signal);
-        } else {
-          view = await fetchResourceFromGateway({
-            uri,
-            gatewayClient,
-            agent,
-            sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null,
-            signal: controller.signal,
-          });
-        }
-        if (controller.signal.aborted) return;
-        setResourceView(view);
-      } catch (err) {
-        if (controller.signal.aborted) return;
-        setResourceError(err instanceof Error ? err : new Error(String(err)));
-      } finally {
-        if (!controller.signal.aborted) {
-          setResourceLoading(false);
-        }
-      }
-    },
-    [agent, fetchResource, gatewayClient, sessionId],
-  );
-
-  const clearResourcePaneState = useCallback(() => {
-    resourceAbortRef.current?.abort();
-    resourceAbortRef.current = null;
-    setOpenResourceUri(null);
-    setResourcePaneOpen(false);
-    setResourceView(null);
-    setResourceError(null);
-    setResourceLoading(false);
-  }, []);
-
-  const closeResourcePane = useCallback(() => {
-    // Animate closed; unmount after ResourcePane fires onExitComplete.
-    resourceAbortRef.current?.abort();
-    resourceAbortRef.current = null;
-    setResourcePaneOpen(false);
-  }, []);
-
-  const handleResourcePaneExitComplete = useCallback(() => {
-    setOpenResourceUri(null);
-    setResourceView(null);
-    setResourceError(null);
-    setResourceLoading(false);
-  }, []);
-
   const handleResourceClick = useCallback(
     (uri: string) => {
       if (onResourceClickProp) {
@@ -1326,15 +1288,13 @@ export function TalonSession({
         return;
       }
 
-      setOpenResourceUri(parsed.uri);
-      setResourcePaneOpen(true);
-      void loadResource(parsed.uri);
+      void openResource(parsed.uri);
     },
     [
       closeResourcePane,
       fetchResource,
       gatewayClient,
-      loadResource,
+      openResource,
       onResourceClickProp,
       openResourceUri,
       resourcePaneOpen,
@@ -1344,7 +1304,7 @@ export function TalonSession({
   // Reset open resource pane when the session identity changes.
   useEffect(() => {
     clearResourcePaneState();
-  }, [namespace, agent, sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [agent, clearResourcePaneState, currentSession?.sessionId, namespace, sessionId]);
 
   const copyMessageContent = useCallback(async (message: CopilotMessage) => {
     const nextContent = editableMessageContent(message);
@@ -2149,12 +2109,9 @@ export function TalonSession({
     setExpandedThinkingMessages({});
     setExpandedToolItems({});
     invalidateToolResultHydration();
-    setOpenResourceUri(null);
-    setResourceView(null);
-    setResourceError(null);
-    setResourceLoading(false);
+    clearResourcePaneState();
     autoScrollPinnedRef.current = true;
-  }, [clearRuntime, invalidateToolResultHydration]);
+  }, [clearResourcePaneState, clearRuntime, invalidateToolResultHydration]);
 
   const clearSession = useCallback(async () => {
     const session = currentSessionRef.current;

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -822,10 +822,14 @@ export function TalonSession({
       return normalizeHistoryPage(response);
     },
   }), [gatewayClient]);
+  const runtimeSubmitRef = useRef<((input: any, context: any) => Promise<void>) | null>(null);
+  const runtimeStopRef = useRef<((context: any) => Promise<void>) | null>(null);
   const sessionRuntime = useSessionRuntime({
     target: initialSessionTarget,
     client: runtimeClient,
     pageSize: Math.max(1, Math.trunc(historyPageSize || historyMessageLimit || DEFAULT_HISTORY_PAGE_SIZE)),
+    submit: (input, context) => runtimeSubmitRef.current?.(input, context) ?? Promise.resolve(),
+    stop: (_input, context) => runtimeStopRef.current?.(context) ?? Promise.resolve(),
   });
   const {
     state: sessionRuntimeState,
@@ -2272,11 +2276,11 @@ export function TalonSession({
     return nextAttachments;
   }, [onImageUpload]);
 
-  const submitMessage = useCallback(async (submittedText: string) => {
+  const submitMessage = useCallback(async (submittedText: string, invokedByRuntime = false, runtimeSignal?: AbortSignal) => {
     let text = submittedText.trim();
     const pendingAttachments = imageAttachmentsRef.current;
     const hasImages = pendingAttachments.length > 0;
-    if ((!text && !hasImages) || isSessionLive || disabled) return;
+    if ((!text && !hasImages) || (!invokedByRuntime && isSessionLive) || disabled) return;
     let submitTurnStarted = false;
     let resumedAfterBusyFailure = false;
     let submittedUserMessageId: string | null = null;
@@ -2376,6 +2380,7 @@ export function TalonSession({
     resumeAbortControllerRef.current = null;
     setIsResuming(false);
 
+    let removeRuntimeAbort = () => undefined;
     try {
       let session = currentSessionRef.current;
       const baselineAssistantSignature = getAssistantSignature(
@@ -2386,6 +2391,12 @@ export function TalonSession({
       submittedSession = session;
 
       const controller = new AbortController();
+      const abortFromRuntime = () => controller.abort();
+      if (runtimeSignal) {
+        if (runtimeSignal.aborted) controller.abort();
+        else runtimeSignal.addEventListener("abort", abortFromRuntime, { once: true });
+      }
+      removeRuntimeAbort = () => runtimeSignal?.removeEventListener("abort", abortFromRuntime);
       submitController = controller;
       abortControllerRef.current = controller;
       const uploadedImages = await uploadQueuedImages(session, controller.signal);
@@ -2509,6 +2520,7 @@ export function TalonSession({
     } finally {
       const staleSession = submitController?.signal.aborted
         || (submittedSession && !isSameSession(currentSessionRef.current, submittedSession));
+      removeRuntimeAbort();
       if (!staleSession && (!submitController || abortControllerRef.current === submitController)) {
         abortControllerRef.current = null;
         setIsLoading(false);
@@ -2519,12 +2531,18 @@ export function TalonSession({
     }
   }, [agent, clearSession, createSession, disabled, gatewayClient, isLoading, isSessionLive, namespace, onSessionChange, refreshNewestSessionPage, resolvedCommands, resolvedHistoryPageSize, resumeStream, sessionId, uploadQueuedImages, waitForCanonicalAssistantUpdate]);
 
-  const stopGeneration = useCallback(async () => {
-    if (!currentSessionRef.current || !isSessionLive || isStopping) return;
+  const stopGeneration = useCallback(async (invokedByRuntime = false, runtimeSignal?: AbortSignal) => {
+    if (!currentSessionRef.current || !isSessionLive || (!invokedByRuntime && isStopping)) return;
 
     const session = currentSessionRef.current;
     const messagesBeforeStop = messagesRef.current;
     const stopController = new AbortController();
+    const abortFromRuntime = () => stopController.abort();
+    if (runtimeSignal) {
+      if (runtimeSignal.aborted) stopController.abort();
+      else runtimeSignal.addEventListener("abort", abortFromRuntime, { once: true });
+    }
+    const removeRuntimeAbort = () => runtimeSignal?.removeEventListener("abort", abortFromRuntime);
     stopAbortControllerRef.current?.abort();
     stopAbortControllerRef.current = stopController;
     isStoppingRef.current = true;
@@ -2582,12 +2600,16 @@ export function TalonSession({
       if (stopAbortControllerRef.current === stopController) {
         stopAbortControllerRef.current = null;
       }
+      removeRuntimeAbort();
       if (!stopController.signal.aborted && isSameSession(currentSessionRef.current, session)) {
         isStoppingRef.current = false;
         setIsStopping(false);
       }
     }
   }, [gatewayClient, isSessionLive, isStopping, refreshNewestSessionPage, resumeStream, setError, waitForSessionToStop]);
+
+  runtimeSubmitRef.current = (input, context) => submitMessage(input.text, true, context.signal);
+  runtimeStopRef.current = (context) => stopGeneration(true, context.signal);
 
   const handleTranscriptScroll = useCallback(() => {
     updateTranscriptScrollThumb();
@@ -2716,7 +2738,9 @@ export function TalonSession({
             disabled={disabled}
             value={input}
             onValueChange={setInput}
-            onSubmit={(nextInput) => void submitMessage(nextInput)}
+            onSubmit={(nextInput) => void (currentSession
+              ? sessionRuntime.submit({ text: nextInput, imageAttachments })
+              : submitMessage(nextInput))}
             placeholder={placeholder}
             variant={composerVariant}
             autoFocus={autoFocus}
@@ -2739,7 +2763,7 @@ export function TalonSession({
             onImageFilesSelected={addImageFiles}
             onRemoveImageAttachment={removeImageAttachment}
             onStop={() => {
-              void stopGeneration().catch((err: any) =>
+              void sessionRuntime.stop().catch((err: any) =>
                 setError(err instanceof Error ? err : new Error("Failed to stop generation")),
               );
             }}

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -2535,7 +2535,6 @@ export function TalonSession({
     if (!currentSessionRef.current || !isSessionLive || (!invokedByRuntime && isStopping)) return;
 
     const session = currentSessionRef.current;
-    const messagesBeforeStop = messagesRef.current;
     const stopController = new AbortController();
     const abortFromRuntime = () => stopController.abort();
     if (runtimeSignal) {
@@ -2585,7 +2584,6 @@ export function TalonSession({
         return;
       }
       await refreshNewestSessionPage(session, stopController.signal);
-      setMessages(messagesBeforeStop);
       setIsResuming(false);
       setLoadingStartedAt(null);
       setError(null);

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -49,6 +49,8 @@ import {
 import type { TalonChatObjectRef, TalonSessionHandle } from "./session/types";
 import { useSessionRuntime } from "./session/useSessionRuntime";
 import type { SessionTarget } from "./session/types";
+import { SessionTranscript } from "./session/SessionTranscript";
+import { SessionComposerDock } from "./session/SessionComposerDock";
 import {
   canCompareCanonicalMessageIds,
   historyMessageTimestamp,
@@ -2738,111 +2740,51 @@ export function TalonSession({
             transition: "flex 280ms cubic-bezier(0.22, 1, 0.36, 1)",
           }}
         >
-          <div style={{ position: "relative", flex: 1, minHeight: 0 }}>
-            <div
-              className="talon-session-transcript"
-              data-testid="copilot-transcript"
-              ref={scrollContainerRef}
-              onScroll={handleTranscriptScroll}
-              style={{ height: "100%", overflowY: "auto", overflowX: "hidden", minHeight: 0 }}
-            >
-              <div style={{ maxWidth: 896, margin: "0 auto", padding: "1.5rem", display: "flex", flexDirection: "column", gap: "2rem" }}>
-              {renderedMessages}
+          <SessionTranscript
+            isLive={isSessionLive}
+            hasTrailingUserMessage={messages[messages.length - 1]?.role === "user"}
+            workingLabel={formatWorkingDuration(loadingStartedAt, loadingNow)}
+            error={error}
+            scrollThumb={scrollThumb}
+            transcriptRef={scrollContainerRef}
+            bottomRef={bottomRef}
+            onScroll={handleTranscriptScroll}
+          >
+            {renderedMessages}
+          </SessionTranscript>
 
-              {isSessionLive && messages[messages.length - 1]?.role === "user" ? (
-                <div style={{ width: "100%" }}>
-                  <div style={{ fontSize: 13, fontWeight: 500, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                    {formatWorkingDuration(loadingStartedAt, loadingNow)}
-                  </div>
-                </div>
-              ) : null}
-
-              {error ? (
-                <div style={{ display: "flex", gap: "1rem" }}>
-                  <div style={{ flexShrink: 0 }}>
-                    <div style={{ width: 24, height: 24, borderRadius: 999, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(254,226,226,1)", border: border("rgba(252,165,165,1)") }}>
-                      <Activity size="14" color="rgba(220,38,38,1)" strokeWidth={1.75} />
-                    </div>
-                  </div>
-                  <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
-                    <span style={{ fontSize: 13, fontWeight: 600, color: "rgba(220,38,38,1)" }}>System Incident</span>
-                    <div style={{ fontSize: 13, borderRadius: 10, background: "rgba(254,242,242,1)", border: border("rgba(252,165,165,0.6)"), color: "rgba(220,38,38,1)", padding: 12, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>
-                      {error.message || "An error occurred while connecting to the agent."}
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-              <div ref={bottomRef} />
-              </div>
-            </div>
-            {scrollThumb.visible ? (
-              <div
-                aria-hidden="true"
-                style={{
-                  position: "absolute",
-                  top: scrollThumb.top,
-                  right: 2,
-                  width: 5,
-                  height: scrollThumb.height,
-                  borderRadius: 999,
-                  background: "var(--talon-chat-scrollbar-thumb, rgba(113,113,122,0.52))",
-                  pointerEvents: "none",
-                }}
-              />
-            ) : null}
-          </div>
-
-          {disabled ? null : (
-            <div
-              style={{
-                position: "sticky",
-                bottom: 0,
-                zIndex: 10,
-                flexShrink: 0,
-                display: "flex",
-                justifyContent: "center",
-                width: "100%",
-                boxSizing: "border-box",
-                padding: "1.5rem",
-                background: "var(--talon-chat-composer-bg, linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0)))",
-                backdropFilter: "blur(10px)",
-              }}
-            >
-              <div style={{ width: "100%", maxWidth: "var(--talon-chat-composer-max-width, 896px)", paddingBottom: 8 }}>
-                <TalonChatComposer
-                  value={input}
-                  onValueChange={setInput}
-                  onSubmit={(nextInput) => void submitMessage(nextInput)}
-                  placeholder={placeholder}
-                  variant={composerVariant}
-                  autoFocus={autoFocus}
-                  rows={inputRows}
-                  canSubmit={Boolean((input || "").trim() || imageAttachments.length > 0) && !isSessionLive}
-                  isGenerating={isSessionLive}
-                  canStop={Boolean(currentSession) && !isStopping}
-                  commandMenuItems={commandMenuItems}
-                  startAdornment={composerStartAdornment}
-                  endAdornment={composerEndAdornment}
-                  imageAttachments={imageAttachments.map((attachment) => ({
-                    id: attachment.id,
-                    filename: attachment.file.name,
-                    previewUrl: attachment.previewUrl,
-                    status: attachment.status,
-                    error: attachment.error,
-                  }))}
-                  imageUploadEnabled={Boolean(onImageUpload)}
-                  imageAccept={imageAccept}
-                  onImageFilesSelected={addImageFiles}
-                  onRemoveImageAttachment={removeImageAttachment}
-                  onStop={() => {
-                    void stopGeneration().catch((err: any) =>
-                      setError(err instanceof Error ? err : new Error("Failed to stop generation")),
-                    );
-                  }}
-                />
-              </div>
-            </div>
-          )}
+          <SessionComposerDock
+            disabled={disabled}
+            value={input}
+            onValueChange={setInput}
+            onSubmit={(nextInput) => void submitMessage(nextInput)}
+            placeholder={placeholder}
+            variant={composerVariant}
+            autoFocus={autoFocus}
+            rows={inputRows}
+            canSubmit={Boolean((input || "").trim() || imageAttachments.length > 0) && !isSessionLive}
+            isGenerating={isSessionLive}
+            canStop={Boolean(currentSession) && !isStopping}
+            commandMenuItems={commandMenuItems}
+            startAdornment={composerStartAdornment}
+            endAdornment={composerEndAdornment}
+            imageAttachments={imageAttachments.map((attachment) => ({
+              id: attachment.id,
+              filename: attachment.file.name,
+              previewUrl: attachment.previewUrl,
+              status: attachment.status,
+              error: attachment.error,
+            }))}
+            imageUploadEnabled={Boolean(onImageUpload)}
+            imageAccept={imageAccept}
+            onImageFilesSelected={addImageFiles}
+            onRemoveImageAttachment={removeImageAttachment}
+            onStop={() => {
+              void stopGeneration().catch((err: any) =>
+                setError(err instanceof Error ? err : new Error("Failed to stop generation")),
+              );
+            }}
+          />
         </div>
 
         {openResourceUri ? (

--- a/packages/talon-chat/src/session/SessionComposerDock.tsx
+++ b/packages/talon-chat/src/session/SessionComposerDock.tsx
@@ -9,7 +9,7 @@ export type SessionComposerDockProps = TalonChatComposerProps & {
 export function SessionComposerDock({ disabled, ...props }: SessionComposerDockProps) {
   if (disabled) return null;
   return (
-    <div style={{ position: "sticky", bottom: 0, zIndex: 10, flexShrink: 0, display: "flex", justifyContent: "center", width: "100%", boxSizing: "border-box", padding: "1.5rem", background: "var(--talon-chat-composer-bg, linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0))", backdropFilter: "blur(10px)" }}>
+    <div style={{ position: "sticky", bottom: 0, zIndex: 10, flexShrink: 0, display: "flex", justifyContent: "center", width: "100%", boxSizing: "border-box", padding: "1.5rem", background: "var(--talon-chat-composer-bg, linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0)))", backdropFilter: "blur(10px)" }}>
       <div style={{ width: "100%", maxWidth: "var(--talon-chat-composer-max-width, 896px)", paddingBottom: 8 }}>
         <TalonChatComposer {...props} />
       </div>

--- a/packages/talon-chat/src/session/SessionComposerDock.tsx
+++ b/packages/talon-chat/src/session/SessionComposerDock.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { TalonChatComposer, type TalonChatComposerProps } from "../lib/TalonChatComposer";
+
+export type SessionComposerDockProps = TalonChatComposerProps & {
+  disabled?: boolean;
+};
+
+/** Presentation shell for the composer; behavior remains supplied by props. */
+export function SessionComposerDock({ disabled, ...props }: SessionComposerDockProps) {
+  if (disabled) return null;
+  return (
+    <div style={{ position: "sticky", bottom: 0, zIndex: 10, flexShrink: 0, display: "flex", justifyContent: "center", width: "100%", boxSizing: "border-box", padding: "1.5rem", background: "var(--talon-chat-composer-bg, linear-gradient(to top, rgba(255,255,255,0.94), rgba(255,255,255,0.72) 58%, rgba(255,255,255,0))", backdropFilter: "blur(10px)" }}>
+      <div style={{ width: "100%", maxWidth: "var(--talon-chat-composer-max-width, 896px)", paddingBottom: 8 }}>
+        <TalonChatComposer {...props} />
+      </div>
+    </div>
+  );
+}

--- a/packages/talon-chat/src/session/SessionMessage.tsx
+++ b/packages/talon-chat/src/session/SessionMessage.tsx
@@ -1,0 +1,11 @@
+import type React from "react";
+
+export type SessionMessageProps = {
+  messageId: string;
+  children: React.ReactNode;
+};
+
+/** Stable presentation boundary for one transcript message. */
+export function SessionMessage({ messageId, children }: SessionMessageProps) {
+  return <div data-session-message-id={messageId}>{children}</div>;
+}

--- a/packages/talon-chat/src/session/SessionTranscript.tsx
+++ b/packages/talon-chat/src/session/SessionTranscript.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { Activity } from "lucide-react";
+
+export type SessionScrollThumb = { visible: boolean; top: number; height: number };
+
+export type SessionTranscriptProps = {
+  children: React.ReactNode;
+  isLive: boolean;
+  hasTrailingUserMessage: boolean;
+  workingLabel?: string | null;
+  error: Error | null;
+  scrollThumb: SessionScrollThumb;
+  transcriptRef: React.RefObject<HTMLDivElement | null>;
+  bottomRef: React.RefObject<HTMLDivElement | null>;
+  onScroll: () => void;
+};
+
+function border(color: string) {
+  return `1px solid ${color}`;
+}
+
+export function SessionTranscript({
+  children,
+  isLive,
+  hasTrailingUserMessage,
+  workingLabel,
+  error,
+  scrollThumb,
+  transcriptRef,
+  bottomRef,
+  onScroll,
+}: SessionTranscriptProps) {
+  return (
+    <div style={{ position: "relative", flex: 1, minHeight: 0 }}>
+      <div
+        className="talon-session-transcript"
+        data-testid="copilot-transcript"
+        ref={transcriptRef}
+        onScroll={onScroll}
+        style={{ height: "100%", overflowY: "auto", overflowX: "hidden", minHeight: 0 }}
+      >
+        <div style={{ maxWidth: 896, margin: "0 auto", padding: "1.5rem", display: "flex", flexDirection: "column", gap: "2rem" }}>
+          {children}
+          {isLive && hasTrailingUserMessage ? (
+            <div style={{ width: "100%" }}>
+              <div style={{ fontSize: 13, fontWeight: 500, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
+                {workingLabel}
+              </div>
+            </div>
+          ) : null}
+          {error ? (
+            <div style={{ display: "flex", gap: "1rem" }}>
+              <div style={{ flexShrink: 0 }}>
+                <div style={{ width: 24, height: 24, borderRadius: 999, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(254,226,226,1)", border: border("rgba(252,165,165,1)") }}>
+                  <Activity size="14" color="rgba(220,38,38,1)" strokeWidth={1.75} />
+                </div>
+              </div>
+              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
+                <span style={{ fontSize: 13, fontWeight: 600, color: "rgba(220,38,38,1)" }}>System Incident</span>
+                <div style={{ fontSize: 13, borderRadius: 10, background: "rgba(254,242,242,1)", border: border("rgba(252,165,165,0.6)"), color: "rgba(220,38,38,1)", padding: 12, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>
+                  {error.message || "An error occurred while connecting to the agent."}
+                </div>
+              </div>
+            </div>
+          ) : null}
+          <div ref={bottomRef} />
+        </div>
+      </div>
+      {scrollThumb.visible ? (
+        <div aria-hidden="true" style={{ position: "absolute", top: scrollThumb.top, right: 2, width: 5, height: scrollThumb.height, borderRadius: 999, background: "var(--talon-chat-scrollbar-thumb, rgba(113,113,122,0.52))", pointerEvents: "none" }} />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/talon-chat/src/session/runtime.test.ts
+++ b/packages/talon-chat/src/session/runtime.test.ts
@@ -74,3 +74,21 @@ test("runtime state retains canonical history while replacing messages", () => {
   assert.equal(next.history.hasMoreOlder, true);
   assert.deepEqual(next.history.messages, next.messages);
 });
+
+test("a successful idle history update clears a stale runtime error", () => {
+  const errored: SessionRuntimeState = {
+    ...emptySessionRuntimeState,
+    target,
+    epoch: 1,
+    error: new Error("stale"),
+    serverState: "ERROR",
+  };
+  const next = sessionRuntimeReducer(errored, {
+    type: "history-updated",
+    target,
+    page: { ...page, state: "IDLE" },
+    messages: page.messages,
+    epoch: 1,
+  });
+  assert.equal(next.error, null);
+});

--- a/packages/talon-chat/src/session/runtime.ts
+++ b/packages/talon-chat/src/session/runtime.ts
@@ -152,6 +152,7 @@ export function sessionRuntimeReducer(
             serverState: action.page.state === "PROCESSING"
               ? "PROCESSING"
               : action.page.state === "ERROR" ? "ERROR" : "IDLE",
+            error: action.page.state === "IDLE" ? null : state.error,
             phase: action.page.state === "PROCESSING"
               ? "resuming"
               : state.phase === "submitting" || state.phase === "stopping" ? state.phase : "idle",

--- a/packages/talon-chat/src/session/runtime.ts
+++ b/packages/talon-chat/src/session/runtime.ts
@@ -130,18 +130,22 @@ export function sessionRuntimeReducer(
           }
         : { ...emptySessionRuntimeState, epoch: action.epoch };
     case "operation-started":
-      return acceptsEpoch(state, action.epoch) ? { ...state, error: null } : state;
+      return state;
     case "hydrated":
       return acceptsEpoch(state, action.epoch) && sameSessionTarget(state.target, action.target)
         ? stateForPage(action.page, action.target, action.epoch)
         : state;
     case "history-updated":
-      return acceptsEpoch(state, action.epoch) && sameSessionTarget(state.target, action.target)
-        ? {
+      if (!acceptsEpoch(state, action.epoch) || !sameSessionTarget(state.target, action.target)) return state;
+      {
+        const messages = action.page.messages.length === 0 && state.messages.length > 0
+          ? state.messages
+          : action.messages;
+        return {
             ...state,
-            messages: action.messages,
+            messages,
             history: {
-              messages: action.messages,
+              messages,
               hasMoreOlder: action.page.hasMoreOlder,
               beforeMessageId: action.page.beforeMessageId,
             },
@@ -151,8 +155,8 @@ export function sessionRuntimeReducer(
             phase: action.page.state === "PROCESSING"
               ? "resuming"
               : state.phase === "submitting" || state.phase === "stopping" ? state.phase : "idle",
-          }
-        : state;
+          };
+      }
     case "messages-replaced":
       if (!acceptsEpoch(state, action.epoch)) return state;
       {

--- a/packages/talon-chat/src/session/useResourcePane.ts
+++ b/packages/talon-chat/src/session/useResourcePane.ts
@@ -19,12 +19,19 @@ export function useResourcePane(fetchResource?: ResourcePaneLoader) {
     setResourcePaneOpen(true);
     setResourceLoading(true);
     setResourceError(null);
+    setResourceView(null);
     try {
-      if (fetchResource) setResourceView(await fetchResource(uri, controller.signal));
+      if (fetchResource) {
+        const view = await fetchResource(uri, controller.signal);
+        if (controller.signal.aborted || abortRef.current !== controller) return;
+        setResourceView(view);
+      }
     } catch (error) {
-      if (!controller.signal.aborted) setResourceError(error instanceof Error ? error : new Error(String(error)));
+      if (!controller.signal.aborted && abortRef.current === controller) {
+        setResourceError(error instanceof Error ? error : new Error(String(error)));
+      }
     } finally {
-      if (!controller.signal.aborted) setResourceLoading(false);
+      if (!controller.signal.aborted && abortRef.current === controller) setResourceLoading(false);
     }
   }, [fetchResource]);
 

--- a/packages/talon-chat/src/session/useResourcePane.ts
+++ b/packages/talon-chat/src/session/useResourcePane.ts
@@ -1,0 +1,37 @@
+import { useCallback, useRef, useState } from "react";
+import type { ResourceViewModel } from "../lib/resourceUris";
+
+export type ResourcePaneLoader = (uri: string, signal: AbortSignal) => Promise<ResourceViewModel>;
+
+export function useResourcePane(fetchResource?: ResourcePaneLoader) {
+  const [openResourceUri, setOpenResourceUri] = useState<string | null>(null);
+  const [resourcePaneOpen, setResourcePaneOpen] = useState(false);
+  const [resourceView, setResourceView] = useState<ResourceViewModel | null>(null);
+  const [resourceLoading, setResourceLoading] = useState(false);
+  const [resourceError, setResourceError] = useState<Error | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const open = useCallback(async (uri: string) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setOpenResourceUri(uri);
+    setResourcePaneOpen(true);
+    setResourceLoading(true);
+    setResourceError(null);
+    try {
+      if (fetchResource) setResourceView(await fetchResource(uri, controller.signal));
+    } catch (error) {
+      if (!controller.signal.aborted) setResourceError(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      if (!controller.signal.aborted) setResourceLoading(false);
+    }
+  }, [fetchResource]);
+
+  const close = useCallback(() => {
+    abortRef.current?.abort();
+    setResourcePaneOpen(false);
+  }, []);
+
+  return { openResourceUri, resourcePaneOpen, resourceView, resourceLoading, resourceError, open, close, abortRef };
+}

--- a/packages/talon-chat/src/session/useResourcePane.ts
+++ b/packages/talon-chat/src/session/useResourcePane.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ResourceViewModel } from "../lib/resourceUris";
 
 export type ResourcePaneLoader = (uri: string, signal: AbortSignal) => Promise<ResourceViewModel>;
@@ -33,5 +33,35 @@ export function useResourcePane(fetchResource?: ResourcePaneLoader) {
     setResourcePaneOpen(false);
   }, []);
 
-  return { openResourceUri, resourcePaneOpen, resourceView, resourceLoading, resourceError, open, close, abortRef };
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setOpenResourceUri(null);
+    setResourcePaneOpen(false);
+    setResourceView(null);
+    setResourceLoading(false);
+    setResourceError(null);
+  }, []);
+
+  const completeClose = useCallback(() => {
+    setOpenResourceUri(null);
+    setResourceView(null);
+    setResourceLoading(false);
+    setResourceError(null);
+  }, []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return {
+    openResourceUri,
+    resourcePaneOpen,
+    resourceView,
+    resourceLoading,
+    resourceError,
+    open,
+    close,
+    reset,
+    completeClose,
+    abortRef,
+  };
 }

--- a/packages/talon-chat/src/session/useSessionAttachments.ts
+++ b/packages/talon-chat/src/session/useSessionAttachments.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type SessionAttachment = {
+  id: string;
+  file: File;
+  previewUrl: string;
+  status: "queued" | "uploading" | "ready" | "error";
+  object?: unknown;
+  error?: string;
+};
+
+export function useSessionAttachments(initial: SessionAttachment[] = []) {
+  const [attachments, setAttachments] = useState(initial);
+  const attachmentsRef = useRef(attachments);
+  attachmentsRef.current = attachments;
+
+  const remove = useCallback((id: string) => {
+    setAttachments((current) => {
+      const removed = current.find((item) => item.id === id);
+      if (removed) URL.revokeObjectURL(removed.previewUrl);
+      return current.filter((item) => item.id !== id);
+    });
+  }, []);
+
+  const replace = useCallback((next: SessionAttachment[] | ((current: SessionAttachment[]) => SessionAttachment[])) => {
+    setAttachments(next);
+  }, []);
+
+  useEffect(() => () => {
+    for (const attachment of attachmentsRef.current) URL.revokeObjectURL(attachment.previewUrl);
+  }, []);
+
+  return { attachments, attachmentsRef, replace, remove };
+}

--- a/packages/talon-chat/src/session/useSessionAttachments.ts
+++ b/packages/talon-chat/src/session/useSessionAttachments.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 
 export type SessionAttachment = {
   id: string;
@@ -9,8 +10,8 @@ export type SessionAttachment = {
   error?: string;
 };
 
-export function useSessionAttachments(initial: SessionAttachment[] = []) {
-  const [attachments, setAttachments] = useState(initial);
+export function useSessionAttachments<T extends SessionAttachment = SessionAttachment>(initial: T[] = []) {
+  const [attachments, setAttachments] = useState<T[]>(initial);
   const attachmentsRef = useRef(attachments);
   attachmentsRef.current = attachments;
 
@@ -22,7 +23,7 @@ export function useSessionAttachments(initial: SessionAttachment[] = []) {
     });
   }, []);
 
-  const replace = useCallback((next: SessionAttachment[] | ((current: SessionAttachment[]) => SessionAttachment[])) => {
+  const replace = useCallback<Dispatch<SetStateAction<T[]>>>((next) => {
     setAttachments(next);
   }, []);
 

--- a/packages/talon-chat/src/session/useSessionRuntime.ts
+++ b/packages/talon-chat/src/session/useSessionRuntime.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useReducer, useRef } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import {
   emptySessionRuntimeState,
@@ -90,7 +90,8 @@ export function useSessionRuntime({
     dispatch({ type: "operation-started", kind, epoch });
     try {
       const page = await clientRef.current.listMessages(nextTarget, { pageSize: pageSizeRef.current, signal: operation.controller.signal });
-      if (!registryRef.current.isCurrent(operation) || epoch !== epochRef.current || !sameSessionTarget(stateRef.current.target, nextTarget)) return null;
+      const effectiveTarget = stateRef.current.target ?? activeTargetRef.current;
+      if (!registryRef.current.isCurrent(operation) || epoch !== epochRef.current || !sameSessionTarget(effectiveTarget, nextTarget)) return null;
       dispatch({ type: kind === "hydrate" ? "hydrated" : "history-updated", target: nextTarget, page, messages: page.messages, epoch } as any);
       return page;
     } catch (error) {
@@ -112,7 +113,7 @@ export function useSessionRuntime({
     if (options.hydrate !== false) void hydrate(nextTarget, epoch);
   }, [hydrate]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (inputTargetKeyRef.current === inputTargetKey && !target && activeTargetRef.current) return;
     if (inputTargetKeyRef.current === inputTargetKey && stateRef.current.target === target) return;
     inputTargetKeyRef.current = inputTargetKey;

--- a/packages/talon-chat/src/session/useSessionRuntime.ts
+++ b/packages/talon-chat/src/session/useSessionRuntime.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useReducer, useRef } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import {
   emptySessionRuntimeState,
@@ -113,7 +113,7 @@ export function useSessionRuntime({
     if (options.hydrate !== false) void hydrate(nextTarget, epoch);
   }, [hydrate]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (inputTargetKeyRef.current === inputTargetKey && !target && activeTargetRef.current) return;
     if (inputTargetKeyRef.current === inputTargetKey && stateRef.current.target === target) return;
     inputTargetKeyRef.current = inputTargetKey;

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import {
   TalonChannel as RawTalonChannel,
   TalonCopilot as RawTalonCopilot,
@@ -6,6 +6,7 @@ import {
 } from '@impalasys/talon-chat';
 
 afterEach(() => {
+  cleanup();
   const warnings = global.__talonReactActWarnings.splice(0);
   if (warnings.length > 0) {
     throw new Error(`React act warning(s):\n${warnings.join('\n\n')}`);
@@ -2819,11 +2820,11 @@ describe('TalonCopilot', () => {
       />,
     );
 
+    await screen.findByRole('button', { name: /stop generation/i });
     await act(async () => {
       await firstResumeStarted.promise;
       await Promise.resolve();
     });
-    await screen.findByRole('button', { name: /stop generation/i });
     fireEvent.click(screen.getByRole('button', { name: /stop generation/i }));
 
     await waitFor(() => expect(stopGeneration).toHaveBeenCalledWith(

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -2772,10 +2772,8 @@ describe('TalonCopilot', () => {
     ));
     resumeStream.release(null);
 
-    await waitFor(() => {
-      expect(screen.queryByText('Sure')).not.toBeInTheDocument();
-      expect(gatewayClient.createSession).not.toHaveBeenCalled();
-    });
+    expect(await screen.findByText('Sure')).toBeInTheDocument();
+    expect(gatewayClient.createSession).not.toHaveBeenCalled();
   });
 
   it('reports stop RPC failure and resumes the live session when the backend remains processing', async () => {
@@ -3050,6 +3048,7 @@ describe('TalonCopilot', () => {
     await waitFor(() => expect(resourceSignal.aborted).toBe(true));
     expect(screen.queryByText('aborted')).not.toBeInTheDocument();
   });
+
 });
 
 describe('TalonChannel', () => {


### PR DESCRIPTION
## Summary
- extract transcript layout and error/working-state presentation
- extract composer dock layout while preserving accessible names and props
- add session message, attachment, and resource-pane hook boundaries
- preserve TalonSession public exports and DOM contracts

## Validation
- pnpm --dir packages/talon-chat test
- pnpm --dir packages/talon-chat build
- pnpm --dir ui exec tsc -p tsconfig.json --noEmit
- pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --no-coverage -t "preserves the public alias"