### PR TITLE
refactor: require canonical history message ids

### DIFF
--- a/packages/talon-chat/src/session/history.test.ts
+++ b/packages/talon-chat/src/session/history.test.ts
@@ -3,18 +3,15 @@ import { describe, it } from "node:test";
 import {
   mergeNewestCanonicalPage,
   normalizeHistoryPage,
-  stableHistoryMessageId,
   validateCursorAdvances,
 } from "./history.ts";
 
 describe("session history", () => {
-  it("keeps fallback message IDs stable across repeated page loads", () => {
-    const message = {
-      role: "ROLE_ASSISTANT",
-      content: "same content",
-      createdAt: "1777755592000000",
-    };
-    assert.equal(stableHistoryMessageId(message), stableHistoryMessageId({ ...message }));
+  it("requires canonical server message IDs", () => {
+    assert.throws(
+      () => normalizeHistoryPage({ messages: [{ role: "ROLE_ASSISTANT", content: "missing id" }] }),
+      /canonical id/,
+    );
   });
 
   it("normalizes snake_case pagination fields and preserves canonical IDs", () => {

--- a/packages/talon-chat/src/session/history.ts
+++ b/packages/talon-chat/src/session/history.ts
@@ -13,22 +13,6 @@ export type SessionHistoryPage = HistoryState & {
   nextBeforeMessageId: string | null;
 };
 
-function stableStringHash(value: string): string {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
-  }
-  return hash.toString(36);
-}
-
-export function stableHistoryMessageId(message: any): string {
-  if (typeof message?.id === "string" && message.id.length > 0) return message.id;
-  const role = normalizeMessageRole(message?.role);
-  const createdAt = message?.createdAt ?? message?.created_at ?? "unknown";
-  const content = getMessageContent(message);
-  return `history-${role}-${createdAt}-${stableStringHash(content)}`;
-}
-
 export function normalizeMessageLabels(labels: unknown): Record<string, string> | undefined {
   if (!labels || typeof labels !== "object" || Array.isArray(labels)) return undefined;
   const entries = Object.entries(labels as Record<string, unknown>)
@@ -52,8 +36,7 @@ export function isLocalMessageId(id: string): boolean {
 }
 
 export function canCompareCanonicalMessageIds(left: string, right: string): boolean {
-  const isFallbackId = (id: string) => id.startsWith("history-") || isLocalMessageId(id);
-  return !isFallbackId(left) && !isFallbackId(right);
+  return !isLocalMessageId(left) && !isLocalMessageId(right);
 }
 
 export function historyItemsFromResponse(response: any): Array<{ message?: any; steps?: any[] }> {
@@ -74,8 +57,11 @@ export function historyItemsFromResponse(response: any): Array<{ message?: any; 
 }
 
 export function normalizeRawSessionMessage(message: any): CopilotMessage {
+  if (typeof message?.id !== "string" || message.id.length === 0) {
+    throw new Error("Session history messages must include a canonical id.");
+  }
   return {
-    id: stableHistoryMessageId(message),
+    id: message.id,
     role: normalizeMessageRole(message?.role),
     content: getMessageContent(message),
     labels: normalizeMessageLabels(message?.labels),


### PR DESCRIPTION
## Summary
- remove the deterministic fallback history message ID generator
- require persisted session history messages to carry canonical server IDs
- retain local optimistic IDs and reconciliation behavior
- add regression coverage for missing canonical IDs

Stack layer: PR8, on top of PR7.

## Verification
- pnpm --dir packages/talon-chat test
- pnpm --dir packages/talon-chat build
- pnpm --dir ui exec tsc -p tsconfig.json --noEmit
- pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --no-coverage