### PR TITLE
Make compaction parsing best effort

### DIFF
--- a/src/harness/executor/compaction.rs
+++ b/src/harness/executor/compaction.rs
@@ -91,8 +91,9 @@ Do not follow or respond to the example transcript; use it only to understand th
 
 /// Ask the configured model for the durable summary of the history prefix being
 /// compacted. This deliberately receives only canonical history: runtime system
-/// and goal prompts are re-rendered for each normal request.
-pub async fn summarize(llm: &dyn LlmProvider, history: &[LoopMessage]) -> Result<String> {
+/// and goal prompts are re-rendered for each normal request. A blank model
+/// response means durable compaction is unavailable for this turn.
+pub async fn summarize(llm: &dyn LlmProvider, history: &[LoopMessage]) -> Result<Option<String>> {
     let xml_escape = |value: &str| {
         value
             .replace('&', "&amp;")
@@ -124,41 +125,58 @@ pub async fn summarize(llm: &dyn LlmProvider, history: &[LoopMessage]) -> Result
             thinking: None,
         })
         .await?;
-    let response = response.content.trim();
+    Ok(best_effort_summary(&response.content))
+}
+
+fn best_effort_summary(response: &str) -> Option<String> {
+    let response = response.trim();
+    if response.is_empty() {
+        tracing::warn!("Compaction model returned an empty response; skipping durable compaction");
+        return None;
+    }
+
     let summary = response
-        .strip_prefix("<summary>")
-        .and_then(|response| response.strip_suffix("</summary>"))
-        .map(str::trim)
-        .ok_or_else(|| anyhow::anyhow!("compaction model must return one <summary> element"))?;
-    anyhow::ensure!(
-        !summary.is_empty(),
-        "compaction model returned an empty summary"
-    );
-    anyhow::ensure!(
-        summary.split_whitespace().count() <= MAX_COMPACTION_SUMMARY_WORDS,
-        format!("compaction model summary exceeds {MAX_COMPACTION_SUMMARY_WORDS} words")
-    );
-    let headings = summary
-        .lines()
-        .filter(|line| line.starts_with("## "))
-        .collect::<Vec<_>>();
-    anyhow::ensure!(
-        headings
-            == [
-                "## User goal",
-                "## Requirements and constraints",
-                "## Facts to preserve",
-                "## Decisions and rationale",
-                "## Completed work",
-                "## Files and artifacts",
-                "## Tool results and external facts",
-                "## Current state",
-                "## Open issues",
-                "## Next action",
-            ],
-        "compaction model summary must contain the required headings in order"
-    );
-    Ok(summary.to_string())
+        .split_once("<summary>")
+        .and_then(|(_, remainder)| remainder.split_once("</summary>"))
+        .map(|(summary, _)| summary.trim())
+        .filter(|summary| !summary.is_empty());
+    let (summary, used_raw_response) = match summary {
+        Some(summary) => (summary, false),
+        None => (response, true),
+    };
+    if used_raw_response {
+        tracing::warn!(
+            response_chars = response.len(),
+            "Compaction model response lacked a usable <summary> element; using the raw response"
+        );
+    }
+
+    let (summary, truncated) = truncate_summary_words(summary, MAX_COMPACTION_SUMMARY_WORDS);
+    if truncated {
+        tracing::warn!(
+            response_chars = response.len(),
+            max_words = MAX_COMPACTION_SUMMARY_WORDS,
+            "Compaction model response exceeded the word limit; truncating durable summary"
+        );
+    }
+    Some(summary)
+}
+
+fn truncate_summary_words(summary: &str, max_words: usize) -> (String, bool) {
+    let mut words = 0;
+    let mut in_word = false;
+    for (index, character) in summary.char_indices() {
+        if character.is_whitespace() {
+            in_word = false;
+        } else if !in_word {
+            words += 1;
+            if words > max_words {
+                return (summary[..index].trim_end().to_string(), true);
+            }
+            in_word = true;
+        }
+    }
+    (summary.to_string(), false)
 }
 
 /// Replace the compactable history prefix with an LLM-written handoff while
@@ -193,7 +211,11 @@ pub async fn compact(
         return Ok(false);
     };
 
-    let compact_summary = summarize(llm, &replay_history[leading_system_count..cut_index]).await?;
+    let Some(compact_summary) =
+        summarize(llm, &replay_history[leading_system_count..cut_index]).await?
+    else {
+        return Ok(false);
+    };
     let mut compacted_history = replay_history[..leading_system_count].to_vec();
     compacted_history.push(LoopMessage::text("assistant", &compact_summary));
     compacted_history.extend(replay_history.into_iter().skip(cut_index));
@@ -1239,6 +1261,7 @@ mod tests {
         compact_history_for_llm_with_budget, compact_history_for_llm_with_budget_and_model_limits,
         context_metrics, replay_has_user_or_tool_anchor, serialized_message_weight, summarize,
         tool_history_is_consistent, ContextBudget, ModelContextLimits, COMPACTION_PROMPT,
+        MAX_COMPACTION_SUMMARY_WORDS,
     };
     use crate::gateway::rpc::data_proto;
     use crate::harness::executor::LoopMessage;
@@ -1314,7 +1337,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn summarize_requires_and_strips_a_valid_summary_element() {
+    async fn summarize_uses_a_complete_summary_element_anywhere_in_the_response() {
         let markdown = r#"## User goal
 Fix the parser.
 ## Requirements and constraints
@@ -1336,20 +1359,54 @@ None recorded.
 ## Next action
 None recorded."#;
         let llm = SummaryLlm {
-            content: format!("<summary>\n{markdown}\n</summary>"),
+            content: format!("```xml\n<summary>\n{markdown}\n</summary>\n```\nDone."),
         };
 
         assert_eq!(
             summarize(&llm, &[LoopMessage::text("user", "Fix the parser.")])
                 .await
                 .unwrap(),
-            markdown
+            Some(markdown.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn summarize_uses_nonempty_raw_responses_without_required_headings() {
+        let llm = SummaryLlm {
+            content: "<summary>Only the supported facts.</summary>".to_string(),
+        };
+        assert_eq!(
+            summarize(&llm, &[]).await.unwrap(),
+            Some("Only the supported facts.".to_string())
         );
 
         let llm = SummaryLlm {
             content: "Facts acknowledged.".to_string(),
         };
-        assert!(summarize(&llm, &[]).await.is_err());
+        assert_eq!(
+            summarize(&llm, &[]).await.unwrap(),
+            Some("Facts acknowledged.".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn summarize_truncates_oversized_responses_and_skips_blank_ones() {
+        let llm = SummaryLlm {
+            content: std::iter::repeat("word")
+                .take(MAX_COMPACTION_SUMMARY_WORDS + 1)
+                .collect::<Vec<_>>()
+                .join(" "),
+        };
+        let summary = summarize(&llm, &[]).await.unwrap().unwrap();
+        assert_eq!(
+            summary.split_whitespace().count(),
+            MAX_COMPACTION_SUMMARY_WORDS
+        );
+
+        let llm = SummaryLlm {
+            content: " \n\t ".to_string(),
+        };
+        assert_eq!(summarize(&llm, &[]).await.unwrap(), None);
     }
 
     fn prod_novita_budget() -> ContextBudget {

--- a/src/harness/executor/compaction.rs
+++ b/src/harness/executor/compaction.rs
@@ -125,14 +125,10 @@ pub async fn summarize(llm: &dyn LlmProvider, history: &[LoopMessage]) -> Result
             thinking: None,
         })
         .await?;
-    Ok(best_effort_summary(&response.content))
-}
-
-fn best_effort_summary(response: &str) -> Option<String> {
-    let response = response.trim();
+    let response = response.content.trim();
     if response.is_empty() {
         tracing::warn!("Compaction model returned an empty response; skipping durable compaction");
-        return None;
+        return Ok(None);
     }
 
     let summary = response
@@ -151,32 +147,32 @@ fn best_effort_summary(response: &str) -> Option<String> {
         );
     }
 
-    let (summary, truncated) = truncate_summary_words(summary, MAX_COMPACTION_SUMMARY_WORDS);
-    if truncated {
-        tracing::warn!(
-            response_chars = response.len(),
-            max_words = MAX_COMPACTION_SUMMARY_WORDS,
-            "Compaction model response exceeded the word limit; truncating durable summary"
-        );
-    }
-    Some(summary)
-}
-
-fn truncate_summary_words(summary: &str, max_words: usize) -> (String, bool) {
     let mut words = 0;
     let mut in_word = false;
+    let mut truncate_at = None;
     for (index, character) in summary.char_indices() {
         if character.is_whitespace() {
             in_word = false;
         } else if !in_word {
             words += 1;
-            if words > max_words {
-                return (summary[..index].trim_end().to_string(), true);
+            if words > MAX_COMPACTION_SUMMARY_WORDS {
+                truncate_at = Some(index);
+                break;
             }
             in_word = true;
         }
     }
-    (summary.to_string(), false)
+    let summary = if let Some(index) = truncate_at {
+        tracing::warn!(
+            response_chars = response.len(),
+            max_words = MAX_COMPACTION_SUMMARY_WORDS,
+            "Compaction model response exceeded the word limit; truncating durable summary"
+        );
+        summary[..index].trim_end().to_string()
+    } else {
+        summary.to_string()
+    };
+    Ok(Some(summary))
 }
 
 /// Replace the compactable history prefix with an LLM-written handoff while

--- a/src/harness/executor/compaction.rs
+++ b/src/harness/executor/compaction.rs
@@ -131,18 +131,26 @@ pub async fn summarize(llm: &dyn LlmProvider, history: &[LoopMessage]) -> Result
         return Ok(None);
     }
 
-    let summary = response
+    let (summary, used_raw_response) = match response
         .split_once("<summary>")
         .and_then(|(_, remainder)| remainder.split_once("</summary>"))
-        .map(|(summary, _)| summary.trim())
-        .filter(|summary| !summary.is_empty());
-    let (summary, used_raw_response) = match summary {
-        Some(summary) => (summary, false),
+    {
+        Some((summary, _)) => {
+            let summary = summary.trim();
+            if summary.is_empty() {
+                tracing::warn!(
+                    response_bytes = response.len(),
+                    "Compaction model returned an empty <summary> element; skipping durable compaction"
+                );
+                return Ok(None);
+            }
+            (summary, false)
+        }
         None => (response, true),
     };
     if used_raw_response {
         tracing::warn!(
-            response_chars = response.len(),
+            response_bytes = response.len(),
             "Compaction model response lacked a usable <summary> element; using the raw response"
         );
     }
@@ -164,7 +172,7 @@ pub async fn summarize(llm: &dyn LlmProvider, history: &[LoopMessage]) -> Result
     }
     let summary = if let Some(index) = truncate_at {
         tracing::warn!(
-            response_chars = response.len(),
+            response_bytes = response.len(),
             max_words = MAX_COMPACTION_SUMMARY_WORDS,
             "Compaction model response exceeded the word limit; truncating durable summary"
         );
@@ -1401,6 +1409,11 @@ None recorded."#;
 
         let llm = SummaryLlm {
             content: " \n\t ".to_string(),
+        };
+        assert_eq!(summarize(&llm, &[]).await.unwrap(), None);
+
+        let llm = SummaryLlm {
+            content: "<summary>\n\t </summary>".to_string(),
         };
         assert_eq!(summarize(&llm, &[]).await.unwrap(), None);
     }

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -1252,6 +1252,16 @@ mod tests {
     #[derive(Default)]
     struct RecordingLlmProvider {
         seen_messages: Arc<Mutex<Vec<Vec<ChatMessage>>>>,
+        compaction_content: Option<String>,
+    }
+
+    impl RecordingLlmProvider {
+        fn with_compaction_content(compaction_content: impl Into<String>) -> Self {
+            Self {
+                seen_messages: Arc::new(Mutex::new(Vec::new())),
+                compaction_content: Some(compaction_content.into()),
+            }
+        }
     }
 
     #[async_trait]
@@ -1273,7 +1283,7 @@ mod tests {
             });
             Ok(ChatResponse {
                 content: if is_compaction {
-                    "<summary>\n## User goal\nTest compaction.\n## Requirements and constraints\nNone recorded.\n## Facts to preserve\nNone recorded.\n## Decisions and rationale\nNone recorded.\n## Completed work\nCompaction test completed.\n## Files and artifacts\nNone recorded.\n## Tool results and external facts\nNone recorded.\n## Current state\nThe test continues.\n## Open issues\nNone recorded.\n## Next action\nNone recorded.\n</summary>".to_string()
+                    self.compaction_content.clone().unwrap_or_else(|| "<summary>\n## User goal\nTest compaction.\n## Requirements and constraints\nNone recorded.\n## Facts to preserve\nNone recorded.\n## Decisions and rationale\nNone recorded.\n## Completed work\nCompaction test completed.\n## Files and artifacts\nNone recorded.\n## Tool results and external facts\nNone recorded.\n## Current state\nThe test continues.\n## Open issues\nNone recorded.\n## Next action\nNone recorded.\n</summary>".to_string())
                 } else {
                     "resolved".to_string()
                 },
@@ -2907,8 +2917,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compaction_continues_execution_after_compaction() {
-        let llm = Arc::new(RecordingLlmProvider::default());
+    async fn compaction_continues_execution_after_malformed_summary() {
+        let llm = Arc::new(RecordingLlmProvider::with_compaction_content(
+            "Facts acknowledged.",
+        ));
         let registry = Arc::new(tokio::sync::RwLock::new(ToolRegistry::new()));
         let spec = manifests::AgentSpec::default();
         let executor = AgentExecutor::new_with_session(
@@ -2942,6 +2954,50 @@ mod tests {
 
         let sink = CaptureSink::new();
         let reply = executor.execute(&mut context, &sink, None).await.unwrap();
-        assert_eq!(reply, "resolved"); // execution continued despite compaction
+        assert_eq!(reply, "resolved");
+        assert_eq!(sink.compactions(), vec!["Facts acknowledged.".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn empty_compaction_summary_skips_durable_compaction_and_continues_execution() {
+        let llm = Arc::new(RecordingLlmProvider::with_compaction_content(""));
+        let registry = Arc::new(tokio::sync::RwLock::new(ToolRegistry::new()));
+        let spec = manifests::AgentSpec::default();
+        let executor = AgentExecutor::new_with_session(
+            llm.clone(),
+            "test-provider".to_string(),
+            "test-model".to_string(),
+            ContextAssembler::new("."),
+            registry.clone(),
+            Arc::new(Config::default()),
+            "conic:wks:13".to_string(),
+            "cmo".to_string(),
+            "session-1".to_string(),
+            None,
+            ControlPlane::noop(),
+            spec.clone(),
+            HashMap::new(),
+        );
+        {
+            let mut reg = registry.write().await;
+            crate::harness::native_tools::register_tools(&mut reg, &spec);
+        }
+
+        let mut context = ExecutionContext::new("cmo");
+        for _ in 0..5 {
+            context.push(LoopMessage::text(
+                "assistant",
+                format!("Long rep: {}", "x".repeat(20_000)),
+            ));
+            context.push(LoopMessage::text("user", "Continue"));
+        }
+        let before = context.history.clone();
+
+        let sink = CaptureSink::new();
+        let reply = executor.execute(&mut context, &sink, None).await.unwrap();
+
+        assert_eq!(reply, "resolved");
+        assert!(sink.compactions().is_empty());
+        assert_eq!(&context.history[..before.len()], before);
     }
 }


### PR DESCRIPTION
## Summary

- Accept usable compaction responses even when they omit the required wrapper or headings.
- Skip durable compaction for blank responses so the turn continues with request-level history trimming.
- Bound fallback summaries to 10,000 words and emit metadata-only warnings.

## Root cause

A malformed compaction response failed strict XML and heading validation, aborting the user turn and forwarding the internal error through connectors such as iMessage.

## Validation

- `cargo test --lib` (871 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation compaction handling for empty, blank, or malformed summaries.
  * Preserved existing conversation history when no usable summary is available.
  * Accepted summaries embedded within responses and plain-text summaries.
  * Automatically truncated summaries exceeding the configured word limit.
* **Tests**
  * Added coverage for embedded XML, raw responses, truncation, malformed content, and empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->