### PR TITLE
Add previous_response_id Responses continuation

### DIFF
--- a/src/harness/llm/openai.rs
+++ b/src/harness/llm/openai.rs
@@ -2680,6 +2680,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn responses_input_without_previous_id_keeps_full_history() {
+        let provider = test_provider();
+        let input = provider
+            .serialize_responses_input(
+                vec![
+                    chat_message_text("system", "system instructions"),
+                    chat_message_text("user", "old question"),
+                    chat_message_text("assistant", "old answer"),
+                    chat_message_text("user", "new question"),
+                ],
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(input.len(), 4);
+        assert!(input
+            .iter()
+            .any(|item| item.to_string().contains("old question")));
+        assert!(input
+            .iter()
+            .any(|item| item.to_string().contains("old answer")));
+    }
+
+    #[tokio::test]
     async fn responses_input_with_previous_id_contains_instructions_and_new_suffix_only() {
         let provider = test_provider();
         let messages = vec![


### PR DESCRIPTION
## Summary

- Continue native OpenAI Responses requests with the persisted `TokenCounter.provider_request_id`.
- Send repeated system/developer instructions plus only the post-assistant suffix when a compatible response ID exists.
- Clear the continuation ID after compaction and retry stale IDs once with full normalized history.
- Preserve response IDs from streamed Responses even when usage is absent.

## Validation

- `cargo test` (876 tests)
- Responses provider tests (36)
- `tests/test_mock_llm.py` (6)

PR191 remains closed; this is the replacement continuation PR.