### PR TITLE
Cancel in-flight tool calls when stopping sessions

### DIFF
--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -1094,10 +1094,28 @@ impl AgentExecutor {
                     )
                     .await?;
                     sink.on_tool_call(&tool.id, &tool.name, &input).await;
-                    let executed = self
-                        .execute_tool_call_result(tool)
-                        .instrument(tool_span.clone())
-                        .await;
+                    let executed = if let Some(token) = cancellation_token {
+                        tokio::select! {
+                            biased;
+                            _ = token.cancelled() => {
+                                tracing::info!(
+                                    agent_id = %context.agent_id,
+                                    tool = %tool.name,
+                                    tool_call_id = %tool.id,
+                                    "Tool call interrupted by user"
+                                );
+                                sink.on_done().await;
+                                return Ok(final_reply);
+                            }
+                            executed = self
+                                .execute_tool_call_result(tool)
+                                .instrument(tool_span.clone()) => executed,
+                        }
+                    } else {
+                        self.execute_tool_call_result(tool)
+                            .instrument(tool_span.clone())
+                            .await
+                    };
                     let stop_after_result = executed.stop_after_result;
                     let result = executed.result;
                     let result_text = result.summary();

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -313,6 +313,29 @@ def test_stop_generation_cancels_an_inflight_mcp_tool_call(
         state = mock_control("GET", "/__control/state")
         assert state["mcp_tool_blocked"] is True
         assert state["mcp_tool_unblocked"] is False
+
+        client.sessions.SendMessage(
+            SendMessageRequest(
+                agent=agent,
+                session_id=session_id,
+                ns=namespace,
+                message="hello after stop",
+            )
+        )
+        for _ in range(100):
+            session = client.sessions.Get(
+                GetSessionRequest(agent=agent, session_id=session_id, ns=namespace)
+            )
+            assistant = last_assistant_message(session.messages)
+            if (
+                session.state == "IDLE"
+                and assistant is not None
+                and "Hello!" in message_text(assistant)
+            ):
+                break
+            time.sleep(0.1)
+        else:
+            raise AssertionError("session did not accept a message after stopping")
     finally:
         mock_control("POST", "/__control/unblock_mcp_tool")
         mock_control("POST", "/__control/reset")

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -60,6 +60,16 @@ def wait_for_mock_stream_blocked(*, attempts: int = 100, delay: float = 0.1) -> 
     raise AssertionError("mock LLM did not block its stream")
 
 
+def wait_for_mock_mcp_tool_blocked(
+    *, attempts: int = 100, delay: float = 0.1
+) -> None:
+    for _ in range(attempts):
+        if mock_control("GET", "/__control/state").get("mcp_tool_blocked"):
+            return
+        time.sleep(delay)
+    raise AssertionError("mock MCP tool did not block")
+
+
 def _cas_response_bytes(response) -> bytes:
     if response.signed_url:
         downloaded = requests.get(response.signed_url, timeout=30)
@@ -224,6 +234,88 @@ def test_stop_generation_cancels_an_inflight_worker_stream(
         mock_control("POST", "/__control/unblock_stream")
         mock_control("POST", "/__control/reset")
 
+
+def test_stop_generation_cancels_an_inflight_mcp_tool_call(
+    stack: E2EStack,
+    client: TalonClient,
+) -> None:
+    """StopGeneration releases a session blocked on a remote MCP tool call."""
+    namespace = f"talon-stop-mcp-{stack.name}-{uuid.uuid4().hex[:8]}"
+    agent = "stop-mcp-tool-agent"
+    mcp_server = "durable-slow"
+    ensure_namespace(client, namespace)
+    create_resource(
+        client,
+        namespace,
+        "McpServer",
+        mcp_server,
+        ResourceSpec(
+            mcp_server=McpServerSpec(
+                transport="http",
+                target=f"http://127.0.0.1:{MOCK_LLM_PORT}/mcp",
+            )
+        ),
+    )
+    create_agent_resource(
+        client,
+        namespace,
+        agent,
+        AgentSpec(
+            mcp_server_refs=[mcp_server],
+            model_policy={
+                "profiles": [
+                    {
+                        "name": "default",
+                        "model": Model(
+                            provider="mock",
+                            name="minimax-m2.7",
+                            temperature=0.7,
+                        ),
+                    }
+                ]
+            },
+            system_prompt="Use the MCP lookup tool when asked.",
+        ),
+    )
+    session_id = client.sessions.Create(
+        CreateSessionRequest(agent=agent, ns=namespace)
+    ).session_id
+
+    mock_control("POST", "/__control/reset")
+    mock_control("POST", "/__control/block_mcp_tool")
+    try:
+        client.sessions.SendMessage(
+            SendMessageRequest(
+                agent=agent,
+                session_id=session_id,
+                ns=namespace,
+                message="Please run a blocking lookup docs.example.com.",
+            )
+        )
+        wait_for_mock_mcp_tool_blocked()
+
+        response = client.sessions.StopGeneration(
+            StopSessionGenerationRequest(agent=agent, session_id=session_id, ns=namespace),
+            timeout=10,
+        )
+        assert response.success
+
+        for _ in range(100):
+            session = client.sessions.Get(
+                GetSessionRequest(agent=agent, session_id=session_id, ns=namespace)
+            )
+            if session.state == "IDLE":
+                break
+            time.sleep(0.1)
+        else:
+            raise AssertionError("session did not become idle after stopping an MCP tool call")
+
+        state = mock_control("GET", "/__control/state")
+        assert state["mcp_tool_blocked"] is True
+        assert state["mcp_tool_unblocked"] is False
+    finally:
+        mock_control("POST", "/__control/unblock_mcp_tool")
+        mock_control("POST", "/__control/reset")
 
 
 def test_streaming_chat(

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -155,8 +155,13 @@ async function waitForMockStreamBlocked() {
   await expect.poll(async () => (await mockLlmControl('/__control/state')).blocked, { timeout: 60000 }).toBe(true);
 }
 
+async function waitForMockMcpToolBlocked() {
+  await expect.poll(async () => (await mockLlmControl('/__control/state')).mcp_tool_blocked, { timeout: 60000 }).toBe(true);
+}
+
 async function unblockMockLlm() {
   await mockLlmControl('/__control/unblock_stream', { method: 'POST' });
+  await mockLlmControl('/__control/unblock_mcp_tool', { method: 'POST' });
 }
 
 async function waitForSessionState(
@@ -685,6 +690,28 @@ test.describe('Live session reconciliation', () => {
     await expect(page.getByRole('button', { name: /Stop generation/i })).toHaveCount(0, { timeout: 15000 });
     await expect(page.locator('body')).toContainText('The');
     await expect(page.getByRole('button', { name: /Worked for/i })).toBeVisible();
+    await expect(page.getByText(/System Incident/)).toHaveCount(0);
+  });
+
+  test('stops an in-flight MCP tool call and accepts the next message', async ({ page }) => {
+    const { sessionId, gatewayUrl, client, testNs, testAgent } = await createMcpTestSession();
+    const target = { ns: testNs, agent: testAgent, sessionId };
+    const { chatInput, sendButton } = await openSessionDirectly(page, target, gatewayUrl);
+
+    await mockLlmControl('/__control/block_mcp_tool', { method: 'POST' });
+    await chatInput.fill('Please run a blocking lookup docs.example.com.');
+    await sendButton.click();
+    await waitForMockMcpToolBlocked();
+
+    await expect(page.getByRole('button', { name: /Stop generation/i })).toBeVisible();
+    await page.getByRole('button', { name: /Stop generation/i }).click();
+    await waitForSessionState(client, target, 'IDLE');
+    await expect(page.getByRole('button', { name: /Stop generation/i })).toHaveCount(0, { timeout: 15000 });
+
+    await chatInput.fill('hello after stop');
+    await sendButton.click();
+    await waitForSessionText(client, target, 'Hello! I am a mock LLM. How can I assist you today?');
+    await expect(page.getByText('Hello! I am a mock LLM. How can I assist you today?').last()).toBeVisible({ timeout: 15000 });
     await expect(page.getByText(/System Incident/)).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary
- race in-flight tool execution against the existing session cancellation token
- finish the partial response and release the session lock when stop wins
- prove the recovered session can accept and complete the next message
- add API-level and Sightline browser regressions using a synthetic MCP tool that never finishes

## Root cause
`StopGeneration` already reaches the worker that owns the active attempt, but the executor only observed the cancellation token while streaming model output. Once the model entered an MCP tool call, the worker awaited that tool future without observing cancellation, so Sightline reported success while the session remained busy indefinitely.

## User impact
The Sightline stop button now releases sessions blocked on remote tool calls. The same session can immediately accept another message, allowing connector traffic such as iMessage/Photon to resume after a stop.

## Validation
- `cargo +1.93.1 metadata --locked`
- `cargo +1.93.1 fmt --all --check`
- `cargo +1.93.1 build --locked --bins`
- `cargo +1.93.1 test --locked` (871 library tests and every binary/integration target passed; zero failures)
- local SQLite stop regressions (blocked provider stream and blocked MCP tool): 2 passed
- blocked-MCP cancellation and follow-up-message scenario: 10 consecutive local passes
- OrbStack/Postgres Sightline Chromium regression: 2 consecutive passes
- Sightline unit suite: 127 passed
- Sightline production build passed
- resource proto oneof check passed

## GitHub checks
The upstream workflows are marked `action_required` because fork workflows need maintainer approval before GitHub Actions can execute. The local validation above is complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for stopping an in-progress tool call.
  - Interrupted requests now return the partial response and restore the session for new messages.

- **Bug Fixes**
  - Prevented interrupted tool results from being recorded or charged.
  - Improved handling of cancellation while external tools are running.
  - Ensured stopping generation does not create a system incident.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->