### PR TITLE
Handle missing historical tool output

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -868,7 +868,7 @@ export function TalonSession({
   const [streamEvents, setStreamEvents] = useState<StreamEventItem[]>([]);
   const [expandedThinkingMessages, setExpandedThinkingMessages] = useState<Record<string, boolean>>({});
   const [expandedToolItems, setExpandedToolItems] = useState<Record<string, boolean>>({});
-  const [toolResultHydration, setToolResultHydration] = useState<Record<string, "loading" | "error">>({});
+  const [toolResultHydration, setToolResultHydration] = useState<Record<string, "loading" | { objectKey: string }>>({});
   const missingResourceClientWarnedRef = useRef(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingMessageValue, setEditingMessageValue] = useState("");
@@ -1150,7 +1150,7 @@ export function TalonSession({
         console.warn("Could not hydrate CAS tool-result object", match.key, err);
         setToolResultHydration((prev) => ({
           ...prev,
-          [toolKey]: "error",
+          [toolKey]: { objectKey: match.key },
         }));
       } finally {
         toolResultHydrationInFlightRef.current.delete(toolKey);
@@ -1545,7 +1545,15 @@ export function TalonSession({
                               </div>
                               {toolHydrationState ? (
                                 <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                  {toolHydrationState === "loading" ? "Loading output..." : "Could not load output."}
+                                  {toolHydrationState === "loading" ? "Loading output..." : (
+                                    <>
+                                      Historical output is unavailable.
+                                      <details style={{ marginTop: 4 }}>
+                                        <summary>Developer details</summary>
+                                        <code style={{ overflowWrap: "anywhere" }}>{toolHydrationState.objectKey}</code>
+                                      </details>
+                                    </>
+                                  )}
                                 </div>
                               ) : item.result !== undefined ? (
                                 <div>
@@ -1794,7 +1802,15 @@ export function TalonSession({
                               </div>
                               {toolHydrationState ? (
                                 <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                  {toolHydrationState === "loading" ? "Loading output..." : "Could not load output."}
+                                  {toolHydrationState === "loading" ? "Loading output..." : (
+                                    <>
+                                      Historical output is unavailable.
+                                      <details style={{ marginTop: 4 }}>
+                                        <summary>Developer details</summary>
+                                        <code style={{ overflowWrap: "anywhere" }}>{toolHydrationState.objectKey}</code>
+                                      </details>
+                                    </>
+                                  )}
                                 </div>
                               ) : item.result !== undefined ? (
                                 <div>
@@ -2724,6 +2740,9 @@ export function TalonSession({
             hasTrailingUserMessage={messages[messages.length - 1]?.role === "user"}
             workingLabel={formatWorkingDuration(loadingStartedAt, loadingNow)}
             error={error}
+            incident={sessionState === "ERROR" && !error
+              ? "This session previously encountered an error. You can continue, but any unavailable historical output will be marked in the transcript."
+              : null}
             scrollThumb={scrollThumb}
             transcriptRef={scrollContainerRef}
             bottomRef={bottomRef}

--- a/packages/talon-chat/src/session/SessionTranscript.tsx
+++ b/packages/talon-chat/src/session/SessionTranscript.tsx
@@ -9,6 +9,7 @@ export type SessionTranscriptProps = {
   hasTrailingUserMessage: boolean;
   workingLabel?: string | null;
   error: Error | null;
+  incident?: string | null;
   scrollThumb: SessionScrollThumb;
   transcriptRef: React.RefObject<HTMLDivElement | null>;
   bottomRef: React.RefObject<HTMLDivElement | null>;
@@ -25,6 +26,7 @@ export function SessionTranscript({
   hasTrailingUserMessage,
   workingLabel,
   error,
+  incident,
   scrollThumb,
   transcriptRef,
   bottomRef,
@@ -48,7 +50,7 @@ export function SessionTranscript({
               </div>
             </div>
           ) : null}
-          {error ? (
+          {error || incident ? (
             <div style={{ display: "flex", gap: "1rem" }}>
               <div style={{ flexShrink: 0 }}>
                 <div style={{ width: 24, height: 24, borderRadius: 999, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(254,226,226,1)", border: border("rgba(252,165,165,1)") }}>
@@ -56,9 +58,9 @@ export function SessionTranscript({
                 </div>
               </div>
               <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
-                <span style={{ fontSize: 13, fontWeight: 600, color: "rgba(220,38,38,1)" }}>System Incident</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: "rgba(220,38,38,1)" }}>Session Incident</span>
                 <div style={{ fontSize: 13, borderRadius: 10, background: "rgba(254,242,242,1)", border: border("rgba(252,165,165,0.6)"), color: "rgba(220,38,38,1)", padding: 12, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>
-                  {error.message || "An error occurred while connecting to the agent."}
+                  {error?.message || incident || "An error occurred while connecting to the agent."}
                 </div>
               </div>
             </div>

--- a/src/harness/executor/history.rs
+++ b/src/harness/executor/history.rs
@@ -80,11 +80,23 @@ pub async fn load(
                 let mut marker_tail = message;
                 marker_tail.parts = marker_tail.parts.split_off(marker_index + 1);
                 if !marker_tail.parts.is_empty() {
-                    messages.extend(session_message_to_loop_messages(&marker_tail, objects).await?);
+                    messages.extend(
+                        session_message_to_loop_messages_with_context(
+                            &marker_tail,
+                            objects,
+                            session_id,
+                        )
+                        .await?,
+                    );
                 }
                 later_messages.reverse();
                 for message in later_messages {
-                    messages.extend(session_message_to_loop_messages(&message, objects).await?);
+                    messages.extend(
+                        session_message_to_loop_messages_with_context(
+                            &message, objects, session_id,
+                        )
+                        .await?,
+                    );
                 }
                 return Ok(Loaded {
                     messages,
@@ -99,7 +111,9 @@ pub async fn load(
     later_messages.reverse();
     let mut messages = Vec::new();
     for message in later_messages {
-        messages.extend(session_message_to_loop_messages(&message, objects).await?);
+        messages.extend(
+            session_message_to_loop_messages_with_context(&message, objects, session_id).await?,
+        );
     }
 
     Ok(Loaded {
@@ -155,8 +169,16 @@ async fn session_message_to_loop_messages(
     message: &data_proto::SessionMessage,
     objects: &(dyn ObjectStore + Send + Sync),
 ) -> Result<Vec<LoopMessage>> {
+    session_message_to_loop_messages_with_context(message, objects, "").await
+}
+
+async fn session_message_to_loop_messages_with_context(
+    message: &data_proto::SessionMessage,
+    objects: &(dyn ObjectStore + Send + Sync),
+    session_id: &str,
+) -> Result<Vec<LoopMessage>> {
     if message.role == data_proto::MessageRole::RoleAssistant as i32 {
-        return assistant_session_message_to_loop_messages(message, objects).await;
+        return assistant_session_message_to_loop_messages(message, objects, session_id).await;
     }
 
     Ok(vec![LoopMessage {
@@ -257,6 +279,7 @@ async fn message_part_content_parts(
 async fn assistant_session_message_to_loop_messages(
     message: &data_proto::SessionMessage,
     objects: &(dyn ObjectStore + Send + Sync),
+    session_id: &str,
 ) -> Result<Vec<LoopMessage>> {
     let mut history = Vec::new();
     let mut content_parts = Vec::new();
@@ -290,7 +313,10 @@ async fn assistant_session_message_to_loop_messages(
             if tool_calls.is_empty() {
                 continue;
             }
-            if let Some(message) = tool_result_message_from_part(part, objects).await? {
+            if let Some(message) =
+                tool_result_message_from_part_with_context(part, objects, session_id, &message.id)
+                    .await?
+            {
                 let Some(tool_call_id) = message.tool_call_id.as_deref() else {
                     continue;
                 };
@@ -411,6 +437,15 @@ async fn tool_result_message_from_part(
     part: &data_proto::SessionMessagePart,
     objects: &(dyn ObjectStore + Send + Sync),
 ) -> Result<Option<LoopMessage>> {
+    tool_result_message_from_part_with_context(part, objects, "", "").await
+}
+
+async fn tool_result_message_from_part_with_context(
+    part: &data_proto::SessionMessagePart,
+    objects: &(dyn ObjectStore + Send + Sync),
+    session_id: &str,
+    message_id: &str,
+) -> Result<Option<LoopMessage>> {
     let payload: serde_json::Value =
         serde_json::from_str(&part.payload_json).unwrap_or(serde_json::Value::Null);
     let Some(tool_call_id) = payload.get("tool_call_id").and_then(|v| v.as_str()) else {
@@ -430,6 +465,10 @@ async fn tool_result_message_from_part(
             content_parts: materialize_tool_output_content_parts(
                 parsed.tool_output.content_parts(),
                 objects,
+                session_id,
+                message_id,
+                part,
+                &parsed.tool_call_id,
             )
             .await?,
             tool_calls: None,
@@ -444,11 +483,21 @@ async fn tool_result_message_from_part(
         .unwrap_or_else(|| part.content.clone());
     let output = if let Some(object) = part.object.as_ref() {
         let mut object_ref = object.clone();
+        let Some(metadata) = objects.head(&object_ref.key).await? else {
+            let mut message = LoopMessage::text(
+                "tool",
+                unavailable_historical_tool_output(
+                    session_id,
+                    message_id,
+                    part,
+                    tool_call_id,
+                    &object_ref.key,
+                ),
+            );
+            message.tool_call_id = Some(tool_call_id.to_string());
+            return Ok(Some(message));
+        };
         if object_ref.media_type.trim().is_empty() {
-            let metadata = objects
-                .head(&object_ref.key)
-                .await?
-                .ok_or_else(|| anyhow!("tool result object '{}' is missing", object_ref.key))?;
             object_ref = object_ref_from_metadata(&object_ref.key, &metadata);
         }
         let mut media_type = object_ref.media_type.trim().to_string();
@@ -503,10 +552,20 @@ async fn tool_result_message_from_part(
             message.tool_call_id = Some(tool_call_id.to_string());
             return Ok(Some(message));
         }
-        let stored = objects
-            .get(&object.key)
-            .await?
-            .ok_or_else(|| anyhow!("tool result object '{}' is missing", object.key))?;
+        let Some(stored) = objects.get(&object.key).await? else {
+            let mut message = LoopMessage::text(
+                "tool",
+                unavailable_historical_tool_output(
+                    session_id,
+                    message_id,
+                    part,
+                    tool_call_id,
+                    &object.key,
+                ),
+            );
+            message.tool_call_id = Some(tool_call_id.to_string());
+            return Ok(Some(message));
+        };
         let bytes = decode_stored_object_bytes(&stored, &object.key)?;
         let output = String::from_utf8_lossy(&bytes).into_owned();
         let mut message = LoopMessage::text("tool", output);
@@ -522,29 +581,47 @@ async fn tool_result_message_from_part(
 
 /// Converts text objects in a persisted typed tool result back into text before
 /// the result is replayed into model context. Non-text objects remain references
-/// so provider adapters can hydrate them in their native representation.
+/// so provider adapters can hydrate them in their native representation. A
+/// missing historical object is represented explicitly so one deleted File
+/// revision cannot prevent the entire session from replaying.
 async fn materialize_tool_output_content_parts(
     parts: Vec<ChatContentPart>,
     objects: &(dyn ObjectStore + Send + Sync),
+    session_id: &str,
+    message_id: &str,
+    tool_result_part: &data_proto::SessionMessagePart,
+    tool_call_id: &str,
 ) -> Result<Vec<ChatContentPart>> {
     let mut materialized = Vec::with_capacity(parts.len());
-    for part in parts {
-        let Some(mut object_ref) = content_part_object_ref(&part).cloned() else {
-            materialized.push(part);
+    for content_part in parts {
+        let Some(mut object_ref) = content_part_object_ref(&content_part).cloned() else {
+            materialized.push(content_part);
+            continue;
+        };
+        let Some(metadata) = objects.head(&object_ref.key).await? else {
+            materialized.push(text_part(unavailable_historical_tool_output(
+                session_id,
+                message_id,
+                tool_result_part,
+                tool_call_id,
+                &object_ref.key,
+            )));
             continue;
         };
         if object_ref.media_type.trim().is_empty() {
-            let metadata = objects
-                .head(&object_ref.key)
-                .await?
-                .ok_or_else(|| anyhow!("tool result object '{}' is missing", object_ref.key))?;
             object_ref = object_ref_from_metadata(&object_ref.key, &metadata);
         }
         if tool_output::is_text_object_media_type(&object_ref.media_type) {
-            let stored = objects
-                .get(&object_ref.key)
-                .await?
-                .ok_or_else(|| anyhow!("tool result object '{}' is missing", object_ref.key))?;
+            let Some(stored) = objects.get(&object_ref.key).await? else {
+                materialized.push(text_part(unavailable_historical_tool_output(
+                    session_id,
+                    message_id,
+                    tool_result_part,
+                    tool_call_id,
+                    &object_ref.key,
+                )));
+                continue;
+            };
             let bytes = decode_stored_object_bytes(&stored, &object_ref.key)?;
             materialized.push(text_part(String::from_utf8_lossy(&bytes).into_owned()));
         } else {
@@ -552,6 +629,26 @@ async fn materialize_tool_output_content_parts(
         }
     }
     Ok(materialized)
+}
+
+fn unavailable_historical_tool_output(
+    session_id: &str,
+    message_id: &str,
+    part: &data_proto::SessionMessagePart,
+    tool_call_id: &str,
+    object_key: &str,
+) -> String {
+    tracing::warn!(
+        session_id,
+        message_id,
+        part_id = %part.id,
+        tool_name = %part.name,
+        tool_call_id,
+        object_key,
+        "historical tool output object is missing during replay"
+    );
+    "[Historical tool output is unavailable. Do not assume it reflects the current state.]"
+        .to_string()
 }
 
 #[cfg(test)]
@@ -705,6 +802,71 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn load_replays_after_a_replaced_file_object_is_missing() {
+        let kv = MockKvStore::new();
+        let objects = InMemoryObjectStore::default();
+        let old_file_object = objects
+            .put(
+                "cas/Tenant%3Aacme/files/schedule-italki/old-version",
+                b"# Previous iTalki booking instructions",
+                ObjectMetadata {
+                    media_type: "text/markdown".to_string(),
+                    filename: "schedule-italki-lesson.md".to_string(),
+                    ..ObjectMetadata::default()
+                },
+            )
+            .await
+            .unwrap();
+        let output = ToolOutput::from_content_parts(
+            vec![object_ref_part(old_file_object.clone())],
+            "[Object: schedule-italki-lesson.md]",
+        );
+        let assistant = data_proto::SessionMessage {
+            id: "assistant-1".to_string(),
+            role: data_proto::MessageRole::RoleAssistant as i32,
+            created_at: 0,
+            labels: HashMap::new(),
+            parts: vec![
+                tool_call_part(
+                    "read-file-1",
+                    "read_file",
+                    serde_json::json!({ "path": "/skills/schedule-italki-lesson.md" }),
+                ),
+                data_proto::SessionMessagePart {
+                    id: "result-read-file-1".to_string(),
+                    part_type: data_proto::SessionMessagePartType::ToolResult as i32,
+                    content: String::new(),
+                    name: "read_file".to_string(),
+                    payload_json: tool_output::tool_result_payload_json("read-file-1", &output)
+                        .unwrap(),
+                    created_at: 0,
+                    object: Some(old_file_object.clone()),
+                },
+                session_text_part("assistant-text", "I found the booking instructions."),
+            ],
+        };
+        kv.set(
+            &crate::control::keys::session_message("ns", "agent", "session", &assistant.id),
+            &assistant.encode_to_vec(),
+        )
+        .await
+        .unwrap();
+
+        // File updates replace the live object and remove this old revision today.
+        objects.delete(&old_file_object.key).await.unwrap();
+
+        let loaded = load(&kv, &objects, "ns", "agent", "session").await.unwrap();
+
+        assert!(loaded.messages.iter().any(|message|
+            message.text_content() == "[Historical tool output is unavailable. Do not assume it reflects the current state.]"
+        ));
+        assert!(loaded
+            .messages
+            .iter()
+            .any(|message| message.text_content() == "I found the booking instructions."));
+    }
+
     fn assistant_message(parts: Vec<data_proto::SessionMessagePart>) -> data_proto::SessionMessage {
         data_proto::SessionMessage {
             id: "assistant-1".to_string(),
@@ -802,15 +964,19 @@ mod tests {
     #[tokio::test]
     async fn tool_result_message_replays_typed_tool_output_content_parts() {
         let store = InMemoryObjectStore::default();
-        let object = data_proto::ObjectRef {
-            key: "cas/image.png".to_string(),
-            media_type: "image/png".to_string(),
-            size_bytes: 12,
-            sha256: "abc123".to_string(),
-            filename: "image.png".to_string(),
-            metadata: HashMap::new(),
-            content_encoding: String::new(),
-        };
+        let object = store
+            .put(
+                "cas/image.png",
+                b"image-bytes",
+                ObjectMetadata {
+                    media_type: "image/png".to_string(),
+                    size_bytes: 11,
+                    filename: "image.png".to_string(),
+                    ..ObjectMetadata::default()
+                },
+            )
+            .await
+            .unwrap();
         let output = ToolOutput::from_content_parts(
             vec![text_part("caption"), object_ref_part(object.clone())],
             "caption",
@@ -1030,7 +1196,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_result_message_errors_when_object_is_missing() {
+    async fn tool_result_message_marks_missing_legacy_object_output_as_unavailable() {
         let store = InMemoryObjectStore::default();
         let mut part = tool_result_part(
             String::new(),
@@ -1045,11 +1211,45 @@ mod tests {
             ..Default::default()
         });
 
-        let err = tool_result_message_from_part(&part, &store)
+        let message = tool_result_message_from_part(&part, &store)
             .await
-            .unwrap_err();
+            .unwrap()
+            .unwrap();
 
-        assert!(err.to_string().contains("missing"));
+        assert_eq!(message.tool_call_id.as_deref(), Some("tool-1"));
+        assert_eq!(
+            message.text_content(),
+            "[Historical tool output is unavailable. Do not assume it reflects the current state.]"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_result_message_marks_missing_typed_object_output_as_unavailable() {
+        let store = InMemoryObjectStore::default();
+        let output = ToolOutput::from_content_parts(
+            vec![object_ref_part(data_proto::ObjectRef {
+                key: "cas/Tenant%3Aacme/files/italki/old-version".to_string(),
+                media_type: "text/markdown".to_string(),
+                filename: "schedule-italki-lesson.md".to_string(),
+                ..Default::default()
+            })],
+            "[Object: schedule-italki-lesson.md]",
+        );
+        let part = tool_result_part(
+            String::new(),
+            tool_output::tool_result_payload_json("read-file-1", &output).unwrap(),
+        );
+
+        let message = tool_result_message_from_part(&part, &store)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(message.tool_call_id.as_deref(), Some("read-file-1"));
+        assert_eq!(
+            message.text_content(),
+            "[Historical tool output is unavailable. Do not assume it reflects the current state.]"
+        );
     }
 
     #[tokio::test]

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -881,13 +881,13 @@ describe('TalonCopilot', () => {
     warnSpy.mockRestore();
   });
 
-  it('shows an inline error when lazy CAS tool result hydration fails', async () => {
+  it('keeps an errored session visible when historical output hydration fails', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     const gatewayClient = {
       createSession: jest.fn(),
       listSessionMessages: jest.fn().mockResolvedValue({
         sessionId: 'sess-cas-fail',
-        state: 'IDLE',
+        state: 'ERROR',
         items: [
           {
             message: {
@@ -937,11 +937,15 @@ describe('TalonCopilot', () => {
     );
 
     expect(await screen.findByText('Done after failed hydrate.')).toBeInTheDocument();
+    expect(screen.getByText('Session Incident')).toBeInTheDocument();
+    expect(screen.getByText(/This session previously encountered an error/)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Ask Talon to perform a task...')).toBeInTheDocument();
     expect(gatewayClient.cas.getObject).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
     fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
 
-    expect(await screen.findByText('Could not load output.')).toBeInTheDocument();
+    expect(await screen.findByText('Historical output is unavailable.')).toBeInTheDocument();
+    expect(screen.getByText('Developer details')).toBeInTheDocument();
     expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
       'Could not hydrate CAS tool-result object',


### PR DESCRIPTION
## Summary
- Preserve historical tool-call shells when a referenced object is gone.
- Replay a clear unavailable-history marker rather than substituting the current File revision.
- Keep errored Sightline sessions and the composer visible, with degraded output and developer details.

## Validation
- `cargo test harness::executor::history --lib`
- `pnpm --dir ui test:unit`
- `git diff --check`