### PR TITLE
Keep errored Sightline sessions visible

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -868,7 +868,7 @@ export function TalonSession({
   const [streamEvents, setStreamEvents] = useState<StreamEventItem[]>([]);
   const [expandedThinkingMessages, setExpandedThinkingMessages] = useState<Record<string, boolean>>({});
   const [expandedToolItems, setExpandedToolItems] = useState<Record<string, boolean>>({});
-  const [toolResultHydration, setToolResultHydration] = useState<Record<string, "loading" | "error">>({});
+  const [toolResultHydration, setToolResultHydration] = useState<Record<string, "loading" | { objectKey: string }>>({});
   const missingResourceClientWarnedRef = useRef(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingMessageValue, setEditingMessageValue] = useState("");
@@ -1150,7 +1150,7 @@ export function TalonSession({
         console.warn("Could not hydrate CAS tool-result object", match.key, err);
         setToolResultHydration((prev) => ({
           ...prev,
-          [toolKey]: "error",
+          [toolKey]: { objectKey: match.key },
         }));
       } finally {
         toolResultHydrationInFlightRef.current.delete(toolKey);
@@ -1545,7 +1545,15 @@ export function TalonSession({
                               </div>
                               {toolHydrationState ? (
                                 <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                  {toolHydrationState === "loading" ? "Loading output..." : "Could not load output."}
+                                  {toolHydrationState === "loading" ? "Loading output..." : (
+                                    <>
+                                      Historical output is unavailable.
+                                      <details style={{ marginTop: 4 }}>
+                                        <summary>Developer details</summary>
+                                        <code style={{ overflowWrap: "anywhere" }}>{toolHydrationState.objectKey}</code>
+                                      </details>
+                                    </>
+                                  )}
                                 </div>
                               ) : item.result !== undefined ? (
                                 <div>
@@ -1794,7 +1802,15 @@ export function TalonSession({
                               </div>
                               {toolHydrationState ? (
                                 <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                  {toolHydrationState === "loading" ? "Loading output..." : "Could not load output."}
+                                  {toolHydrationState === "loading" ? "Loading output..." : (
+                                    <>
+                                      Historical output is unavailable.
+                                      <details style={{ marginTop: 4 }}>
+                                        <summary>Developer details</summary>
+                                        <code style={{ overflowWrap: "anywhere" }}>{toolHydrationState.objectKey}</code>
+                                      </details>
+                                    </>
+                                  )}
                                 </div>
                               ) : item.result !== undefined ? (
                                 <div>
@@ -2724,6 +2740,9 @@ export function TalonSession({
             hasTrailingUserMessage={messages[messages.length - 1]?.role === "user"}
             workingLabel={formatWorkingDuration(loadingStartedAt, loadingNow)}
             error={error}
+            incident={sessionState === "ERROR" && !error
+              ? "This session previously encountered an error. You can continue, but any unavailable historical output will be marked in the transcript."
+              : null}
             scrollThumb={scrollThumb}
             transcriptRef={scrollContainerRef}
             bottomRef={bottomRef}

--- a/packages/talon-chat/src/session/SessionTranscript.tsx
+++ b/packages/talon-chat/src/session/SessionTranscript.tsx
@@ -9,6 +9,7 @@ export type SessionTranscriptProps = {
   hasTrailingUserMessage: boolean;
   workingLabel?: string | null;
   error: Error | null;
+  incident?: string | null;
   scrollThumb: SessionScrollThumb;
   transcriptRef: React.RefObject<HTMLDivElement | null>;
   bottomRef: React.RefObject<HTMLDivElement | null>;
@@ -25,6 +26,7 @@ export function SessionTranscript({
   hasTrailingUserMessage,
   workingLabel,
   error,
+  incident,
   scrollThumb,
   transcriptRef,
   bottomRef,
@@ -48,7 +50,7 @@ export function SessionTranscript({
               </div>
             </div>
           ) : null}
-          {error ? (
+          {error || incident ? (
             <div style={{ display: "flex", gap: "1rem" }}>
               <div style={{ flexShrink: 0 }}>
                 <div style={{ width: 24, height: 24, borderRadius: 999, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(254,226,226,1)", border: border("rgba(252,165,165,1)") }}>
@@ -56,9 +58,9 @@ export function SessionTranscript({
                 </div>
               </div>
               <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
-                <span style={{ fontSize: 13, fontWeight: 600, color: "rgba(220,38,38,1)" }}>System Incident</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: "rgba(220,38,38,1)" }}>Session Incident</span>
                 <div style={{ fontSize: 13, borderRadius: 10, background: "rgba(254,242,242,1)", border: border("rgba(252,165,165,0.6)"), color: "rgba(220,38,38,1)", padding: 12, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>
-                  {error.message || "An error occurred while connecting to the agent."}
+                  {error?.message || incident || "An error occurred while connecting to the agent."}
                 </div>
               </div>
             </div>

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -881,13 +881,13 @@ describe('TalonCopilot', () => {
     warnSpy.mockRestore();
   });
 
-  it('shows an inline error when lazy CAS tool result hydration fails', async () => {
+  it('keeps an errored session visible when historical output hydration fails', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     const gatewayClient = {
       createSession: jest.fn(),
       listSessionMessages: jest.fn().mockResolvedValue({
         sessionId: 'sess-cas-fail',
-        state: 'IDLE',
+        state: 'ERROR',
         items: [
           {
             message: {
@@ -937,11 +937,15 @@ describe('TalonCopilot', () => {
     );
 
     expect(await screen.findByText('Done after failed hydrate.')).toBeInTheDocument();
+    expect(screen.getByText('Session Incident')).toBeInTheDocument();
+    expect(screen.getByText(/This session previously encountered an error/)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Ask Talon to perform a task...')).toBeInTheDocument();
     expect(gatewayClient.cas.getObject).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
     fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
 
-    expect(await screen.findByText('Could not load output.')).toBeInTheDocument();
+    expect(await screen.findByText('Historical output is unavailable.')).toBeInTheDocument();
+    expect(screen.getByText('Developer details')).toBeInTheDocument();
     expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
       'Could not hydrate CAS tool-result object',


### PR DESCRIPTION
## Summary
- Keep the existing transcript and composer visible when a persisted session is in `ERROR`.
- Render unavailable historical tool output as a clear degraded state, with the object key confined to developer details.
- Cover an errored-session reload with failed historical-output hydration.

## Why
A missing historical object previously left Sightline blank after reload, hiding the usable transcript and preventing recovery.

## Validation
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable historical tool outputs so sessions retain useful diagnostic information instead of showing a generic error.
  * Added clearer “historical output unavailable” messaging with developer details when past output cannot be loaded.
  * Session incident messages now remain visible for sessions in an error state, alongside the composer and other relevant session controls.
* **Tests**
  * Expanded coverage for error-state sessions and deferred loading of historical tool output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->