### PR TITLE
Continue replay after missing historical output

### DIFF
--- a/src/harness/executor/history.rs
+++ b/src/harness/executor/history.rs
@@ -80,23 +80,11 @@ pub async fn load(
                 let mut marker_tail = message;
                 marker_tail.parts = marker_tail.parts.split_off(marker_index + 1);
                 if !marker_tail.parts.is_empty() {
-                    messages.extend(
-                        session_message_to_loop_messages_with_context(
-                            &marker_tail,
-                            objects,
-                            session_id,
-                        )
-                        .await?,
-                    );
+                    messages.extend(session_message_to_loop_messages(&marker_tail, objects).await?);
                 }
                 later_messages.reverse();
                 for message in later_messages {
-                    messages.extend(
-                        session_message_to_loop_messages_with_context(
-                            &message, objects, session_id,
-                        )
-                        .await?,
-                    );
+                    messages.extend(session_message_to_loop_messages(&message, objects).await?);
                 }
                 return Ok(Loaded {
                     messages,
@@ -111,9 +99,7 @@ pub async fn load(
     later_messages.reverse();
     let mut messages = Vec::new();
     for message in later_messages {
-        messages.extend(
-            session_message_to_loop_messages_with_context(&message, objects, session_id).await?,
-        );
+        messages.extend(session_message_to_loop_messages(&message, objects).await?);
     }
 
     Ok(Loaded {
@@ -169,16 +155,8 @@ async fn session_message_to_loop_messages(
     message: &data_proto::SessionMessage,
     objects: &(dyn ObjectStore + Send + Sync),
 ) -> Result<Vec<LoopMessage>> {
-    session_message_to_loop_messages_with_context(message, objects, "").await
-}
-
-async fn session_message_to_loop_messages_with_context(
-    message: &data_proto::SessionMessage,
-    objects: &(dyn ObjectStore + Send + Sync),
-    session_id: &str,
-) -> Result<Vec<LoopMessage>> {
     if message.role == data_proto::MessageRole::RoleAssistant as i32 {
-        return assistant_session_message_to_loop_messages(message, objects, session_id).await;
+        return assistant_session_message_to_loop_messages(message, objects).await;
     }
 
     Ok(vec![LoopMessage {
@@ -279,7 +257,6 @@ async fn message_part_content_parts(
 async fn assistant_session_message_to_loop_messages(
     message: &data_proto::SessionMessage,
     objects: &(dyn ObjectStore + Send + Sync),
-    session_id: &str,
 ) -> Result<Vec<LoopMessage>> {
     let mut history = Vec::new();
     let mut content_parts = Vec::new();
@@ -313,10 +290,7 @@ async fn assistant_session_message_to_loop_messages(
             if tool_calls.is_empty() {
                 continue;
             }
-            if let Some(message) =
-                tool_result_message_from_part_with_context(part, objects, session_id, &message.id)
-                    .await?
-            {
+            if let Some(message) = tool_result_message_from_part(part, objects).await? {
                 let Some(tool_call_id) = message.tool_call_id.as_deref() else {
                     continue;
                 };
@@ -437,15 +411,6 @@ async fn tool_result_message_from_part(
     part: &data_proto::SessionMessagePart,
     objects: &(dyn ObjectStore + Send + Sync),
 ) -> Result<Option<LoopMessage>> {
-    tool_result_message_from_part_with_context(part, objects, "", "").await
-}
-
-async fn tool_result_message_from_part_with_context(
-    part: &data_proto::SessionMessagePart,
-    objects: &(dyn ObjectStore + Send + Sync),
-    session_id: &str,
-    message_id: &str,
-) -> Result<Option<LoopMessage>> {
     let payload: serde_json::Value =
         serde_json::from_str(&part.payload_json).unwrap_or(serde_json::Value::Null);
     let Some(tool_call_id) = payload.get("tool_call_id").and_then(|v| v.as_str()) else {
@@ -465,10 +430,6 @@ async fn tool_result_message_from_part_with_context(
             content_parts: materialize_tool_output_content_parts(
                 parsed.tool_output.content_parts(),
                 objects,
-                session_id,
-                message_id,
-                part,
-                &parsed.tool_call_id,
             )
             .await?,
             tool_calls: None,
@@ -484,16 +445,7 @@ async fn tool_result_message_from_part_with_context(
     let output = if let Some(object) = part.object.as_ref() {
         let mut object_ref = object.clone();
         let Some(metadata) = objects.head(&object_ref.key).await? else {
-            let mut message = LoopMessage::text(
-                "tool",
-                unavailable_historical_tool_output(
-                    session_id,
-                    message_id,
-                    part,
-                    tool_call_id,
-                    &object_ref.key,
-                ),
-            );
+            let mut message = LoopMessage::text("tool", unavailable_historical_tool_output());
             message.tool_call_id = Some(tool_call_id.to_string());
             return Ok(Some(message));
         };
@@ -553,16 +505,7 @@ async fn tool_result_message_from_part_with_context(
             return Ok(Some(message));
         }
         let Some(stored) = objects.get(&object.key).await? else {
-            let mut message = LoopMessage::text(
-                "tool",
-                unavailable_historical_tool_output(
-                    session_id,
-                    message_id,
-                    part,
-                    tool_call_id,
-                    &object.key,
-                ),
-            );
+            let mut message = LoopMessage::text("tool", unavailable_historical_tool_output());
             message.tool_call_id = Some(tool_call_id.to_string());
             return Ok(Some(message));
         };
@@ -587,10 +530,6 @@ async fn tool_result_message_from_part_with_context(
 async fn materialize_tool_output_content_parts(
     parts: Vec<ChatContentPart>,
     objects: &(dyn ObjectStore + Send + Sync),
-    session_id: &str,
-    message_id: &str,
-    tool_result_part: &data_proto::SessionMessagePart,
-    tool_call_id: &str,
 ) -> Result<Vec<ChatContentPart>> {
     let mut materialized = Vec::with_capacity(parts.len());
     for content_part in parts {
@@ -599,13 +538,7 @@ async fn materialize_tool_output_content_parts(
             continue;
         };
         let Some(metadata) = objects.head(&object_ref.key).await? else {
-            materialized.push(text_part(unavailable_historical_tool_output(
-                session_id,
-                message_id,
-                tool_result_part,
-                tool_call_id,
-                &object_ref.key,
-            )));
+            materialized.push(text_part(unavailable_historical_tool_output()));
             continue;
         };
         if object_ref.media_type.trim().is_empty() {
@@ -613,13 +546,7 @@ async fn materialize_tool_output_content_parts(
         }
         if tool_output::is_text_object_media_type(&object_ref.media_type) {
             let Some(stored) = objects.get(&object_ref.key).await? else {
-                materialized.push(text_part(unavailable_historical_tool_output(
-                    session_id,
-                    message_id,
-                    tool_result_part,
-                    tool_call_id,
-                    &object_ref.key,
-                )));
+                materialized.push(text_part(unavailable_historical_tool_output()));
                 continue;
             };
             let bytes = decode_stored_object_bytes(&stored, &object_ref.key)?;
@@ -631,22 +558,7 @@ async fn materialize_tool_output_content_parts(
     Ok(materialized)
 }
 
-fn unavailable_historical_tool_output(
-    session_id: &str,
-    message_id: &str,
-    part: &data_proto::SessionMessagePart,
-    tool_call_id: &str,
-    object_key: &str,
-) -> String {
-    tracing::warn!(
-        session_id,
-        message_id,
-        part_id = %part.id,
-        tool_name = %part.name,
-        tool_call_id,
-        object_key,
-        "historical tool output object is missing during replay"
-    );
+fn unavailable_historical_tool_output() -> String {
     "[Historical tool output is unavailable. Do not assume it reflects the current state.]"
         .to_string()
 }

--- a/src/harness/executor/history.rs
+++ b/src/harness/executor/history.rs
@@ -80,11 +80,23 @@ pub async fn load(
                 let mut marker_tail = message;
                 marker_tail.parts = marker_tail.parts.split_off(marker_index + 1);
                 if !marker_tail.parts.is_empty() {
-                    messages.extend(session_message_to_loop_messages(&marker_tail, objects).await?);
+                    messages.extend(
+                        session_message_to_loop_messages_with_context(
+                            &marker_tail,
+                            objects,
+                            session_id,
+                        )
+                        .await?,
+                    );
                 }
                 later_messages.reverse();
                 for message in later_messages {
-                    messages.extend(session_message_to_loop_messages(&message, objects).await?);
+                    messages.extend(
+                        session_message_to_loop_messages_with_context(
+                            &message, objects, session_id,
+                        )
+                        .await?,
+                    );
                 }
                 return Ok(Loaded {
                     messages,
@@ -99,7 +111,9 @@ pub async fn load(
     later_messages.reverse();
     let mut messages = Vec::new();
     for message in later_messages {
-        messages.extend(session_message_to_loop_messages(&message, objects).await?);
+        messages.extend(
+            session_message_to_loop_messages_with_context(&message, objects, session_id).await?,
+        );
     }
 
     Ok(Loaded {
@@ -155,8 +169,16 @@ async fn session_message_to_loop_messages(
     message: &data_proto::SessionMessage,
     objects: &(dyn ObjectStore + Send + Sync),
 ) -> Result<Vec<LoopMessage>> {
+    session_message_to_loop_messages_with_context(message, objects, "").await
+}
+
+async fn session_message_to_loop_messages_with_context(
+    message: &data_proto::SessionMessage,
+    objects: &(dyn ObjectStore + Send + Sync),
+    session_id: &str,
+) -> Result<Vec<LoopMessage>> {
     if message.role == data_proto::MessageRole::RoleAssistant as i32 {
-        return assistant_session_message_to_loop_messages(message, objects).await;
+        return assistant_session_message_to_loop_messages(message, objects, session_id).await;
     }
 
     Ok(vec![LoopMessage {
@@ -257,6 +279,7 @@ async fn message_part_content_parts(
 async fn assistant_session_message_to_loop_messages(
     message: &data_proto::SessionMessage,
     objects: &(dyn ObjectStore + Send + Sync),
+    session_id: &str,
 ) -> Result<Vec<LoopMessage>> {
     let mut history = Vec::new();
     let mut content_parts = Vec::new();
@@ -290,7 +313,10 @@ async fn assistant_session_message_to_loop_messages(
             if tool_calls.is_empty() {
                 continue;
             }
-            if let Some(message) = tool_result_message_from_part(part, objects).await? {
+            if let Some(message) =
+                tool_result_message_from_part_with_context(part, objects, session_id, &message.id)
+                    .await?
+            {
                 let Some(tool_call_id) = message.tool_call_id.as_deref() else {
                     continue;
                 };
@@ -411,6 +437,15 @@ async fn tool_result_message_from_part(
     part: &data_proto::SessionMessagePart,
     objects: &(dyn ObjectStore + Send + Sync),
 ) -> Result<Option<LoopMessage>> {
+    tool_result_message_from_part_with_context(part, objects, "", "").await
+}
+
+async fn tool_result_message_from_part_with_context(
+    part: &data_proto::SessionMessagePart,
+    objects: &(dyn ObjectStore + Send + Sync),
+    session_id: &str,
+    message_id: &str,
+) -> Result<Option<LoopMessage>> {
     let payload: serde_json::Value =
         serde_json::from_str(&part.payload_json).unwrap_or(serde_json::Value::Null);
     let Some(tool_call_id) = payload.get("tool_call_id").and_then(|v| v.as_str()) else {
@@ -430,6 +465,10 @@ async fn tool_result_message_from_part(
             content_parts: materialize_tool_output_content_parts(
                 parsed.tool_output.content_parts(),
                 objects,
+                session_id,
+                message_id,
+                part,
+                &parsed.tool_call_id,
             )
             .await?,
             tool_calls: None,
@@ -444,11 +483,21 @@ async fn tool_result_message_from_part(
         .unwrap_or_else(|| part.content.clone());
     let output = if let Some(object) = part.object.as_ref() {
         let mut object_ref = object.clone();
+        let Some(metadata) = objects.head(&object_ref.key).await? else {
+            let mut message = LoopMessage::text(
+                "tool",
+                unavailable_historical_tool_output(
+                    session_id,
+                    message_id,
+                    part,
+                    tool_call_id,
+                    &object_ref.key,
+                ),
+            );
+            message.tool_call_id = Some(tool_call_id.to_string());
+            return Ok(Some(message));
+        };
         if object_ref.media_type.trim().is_empty() {
-            let metadata = objects
-                .head(&object_ref.key)
-                .await?
-                .ok_or_else(|| anyhow!("tool result object '{}' is missing", object_ref.key))?;
             object_ref = object_ref_from_metadata(&object_ref.key, &metadata);
         }
         let mut media_type = object_ref.media_type.trim().to_string();
@@ -503,10 +552,20 @@ async fn tool_result_message_from_part(
             message.tool_call_id = Some(tool_call_id.to_string());
             return Ok(Some(message));
         }
-        let stored = objects
-            .get(&object.key)
-            .await?
-            .ok_or_else(|| anyhow!("tool result object '{}' is missing", object.key))?;
+        let Some(stored) = objects.get(&object.key).await? else {
+            let mut message = LoopMessage::text(
+                "tool",
+                unavailable_historical_tool_output(
+                    session_id,
+                    message_id,
+                    part,
+                    tool_call_id,
+                    &object.key,
+                ),
+            );
+            message.tool_call_id = Some(tool_call_id.to_string());
+            return Ok(Some(message));
+        };
         let bytes = decode_stored_object_bytes(&stored, &object.key)?;
         let output = String::from_utf8_lossy(&bytes).into_owned();
         let mut message = LoopMessage::text("tool", output);
@@ -522,29 +581,47 @@ async fn tool_result_message_from_part(
 
 /// Converts text objects in a persisted typed tool result back into text before
 /// the result is replayed into model context. Non-text objects remain references
-/// so provider adapters can hydrate them in their native representation.
+/// so provider adapters can hydrate them in their native representation. A
+/// missing historical object is represented explicitly so one deleted File
+/// revision cannot prevent the entire session from replaying.
 async fn materialize_tool_output_content_parts(
     parts: Vec<ChatContentPart>,
     objects: &(dyn ObjectStore + Send + Sync),
+    session_id: &str,
+    message_id: &str,
+    tool_result_part: &data_proto::SessionMessagePart,
+    tool_call_id: &str,
 ) -> Result<Vec<ChatContentPart>> {
     let mut materialized = Vec::with_capacity(parts.len());
-    for part in parts {
-        let Some(mut object_ref) = content_part_object_ref(&part).cloned() else {
-            materialized.push(part);
+    for content_part in parts {
+        let Some(mut object_ref) = content_part_object_ref(&content_part).cloned() else {
+            materialized.push(content_part);
+            continue;
+        };
+        let Some(metadata) = objects.head(&object_ref.key).await? else {
+            materialized.push(text_part(unavailable_historical_tool_output(
+                session_id,
+                message_id,
+                tool_result_part,
+                tool_call_id,
+                &object_ref.key,
+            )));
             continue;
         };
         if object_ref.media_type.trim().is_empty() {
-            let metadata = objects
-                .head(&object_ref.key)
-                .await?
-                .ok_or_else(|| anyhow!("tool result object '{}' is missing", object_ref.key))?;
             object_ref = object_ref_from_metadata(&object_ref.key, &metadata);
         }
         if tool_output::is_text_object_media_type(&object_ref.media_type) {
-            let stored = objects
-                .get(&object_ref.key)
-                .await?
-                .ok_or_else(|| anyhow!("tool result object '{}' is missing", object_ref.key))?;
+            let Some(stored) = objects.get(&object_ref.key).await? else {
+                materialized.push(text_part(unavailable_historical_tool_output(
+                    session_id,
+                    message_id,
+                    tool_result_part,
+                    tool_call_id,
+                    &object_ref.key,
+                )));
+                continue;
+            };
             let bytes = decode_stored_object_bytes(&stored, &object_ref.key)?;
             materialized.push(text_part(String::from_utf8_lossy(&bytes).into_owned()));
         } else {
@@ -552,6 +629,26 @@ async fn materialize_tool_output_content_parts(
         }
     }
     Ok(materialized)
+}
+
+fn unavailable_historical_tool_output(
+    session_id: &str,
+    message_id: &str,
+    part: &data_proto::SessionMessagePart,
+    tool_call_id: &str,
+    object_key: &str,
+) -> String {
+    tracing::warn!(
+        session_id,
+        message_id,
+        part_id = %part.id,
+        tool_name = %part.name,
+        tool_call_id,
+        object_key,
+        "historical tool output object is missing during replay"
+    );
+    "[Historical tool output is unavailable. Do not assume it reflects the current state.]"
+        .to_string()
 }
 
 #[cfg(test)]
@@ -705,6 +802,71 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn load_replays_after_a_replaced_file_object_is_missing() {
+        let kv = MockKvStore::new();
+        let objects = InMemoryObjectStore::default();
+        let old_file_object = objects
+            .put(
+                "cas/Tenant%3Aacme/files/schedule-italki/old-version",
+                b"# Previous iTalki booking instructions",
+                ObjectMetadata {
+                    media_type: "text/markdown".to_string(),
+                    filename: "schedule-italki-lesson.md".to_string(),
+                    ..ObjectMetadata::default()
+                },
+            )
+            .await
+            .unwrap();
+        let output = ToolOutput::from_content_parts(
+            vec![object_ref_part(old_file_object.clone())],
+            "[Object: schedule-italki-lesson.md]",
+        );
+        let assistant = data_proto::SessionMessage {
+            id: "assistant-1".to_string(),
+            role: data_proto::MessageRole::RoleAssistant as i32,
+            created_at: 0,
+            labels: HashMap::new(),
+            parts: vec![
+                tool_call_part(
+                    "read-file-1",
+                    "read_file",
+                    serde_json::json!({ "path": "/skills/schedule-italki-lesson.md" }),
+                ),
+                data_proto::SessionMessagePart {
+                    id: "result-read-file-1".to_string(),
+                    part_type: data_proto::SessionMessagePartType::ToolResult as i32,
+                    content: String::new(),
+                    name: "read_file".to_string(),
+                    payload_json: tool_output::tool_result_payload_json("read-file-1", &output)
+                        .unwrap(),
+                    created_at: 0,
+                    object: Some(old_file_object.clone()),
+                },
+                session_text_part("assistant-text", "I found the booking instructions."),
+            ],
+        };
+        kv.set(
+            &crate::control::keys::session_message("ns", "agent", "session", &assistant.id),
+            &assistant.encode_to_vec(),
+        )
+        .await
+        .unwrap();
+
+        // File updates replace the live object and remove this old revision today.
+        objects.delete(&old_file_object.key).await.unwrap();
+
+        let loaded = load(&kv, &objects, "ns", "agent", "session").await.unwrap();
+
+        assert!(loaded.messages.iter().any(|message|
+            message.text_content() == "[Historical tool output is unavailable. Do not assume it reflects the current state.]"
+        ));
+        assert!(loaded
+            .messages
+            .iter()
+            .any(|message| message.text_content() == "I found the booking instructions."));
+    }
+
     fn assistant_message(parts: Vec<data_proto::SessionMessagePart>) -> data_proto::SessionMessage {
         data_proto::SessionMessage {
             id: "assistant-1".to_string(),
@@ -802,15 +964,19 @@ mod tests {
     #[tokio::test]
     async fn tool_result_message_replays_typed_tool_output_content_parts() {
         let store = InMemoryObjectStore::default();
-        let object = data_proto::ObjectRef {
-            key: "cas/image.png".to_string(),
-            media_type: "image/png".to_string(),
-            size_bytes: 12,
-            sha256: "abc123".to_string(),
-            filename: "image.png".to_string(),
-            metadata: HashMap::new(),
-            content_encoding: String::new(),
-        };
+        let object = store
+            .put(
+                "cas/image.png",
+                b"image-bytes",
+                ObjectMetadata {
+                    media_type: "image/png".to_string(),
+                    size_bytes: 11,
+                    filename: "image.png".to_string(),
+                    ..ObjectMetadata::default()
+                },
+            )
+            .await
+            .unwrap();
         let output = ToolOutput::from_content_parts(
             vec![text_part("caption"), object_ref_part(object.clone())],
             "caption",
@@ -1030,7 +1196,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_result_message_errors_when_object_is_missing() {
+    async fn tool_result_message_marks_missing_legacy_object_output_as_unavailable() {
         let store = InMemoryObjectStore::default();
         let mut part = tool_result_part(
             String::new(),
@@ -1045,11 +1211,45 @@ mod tests {
             ..Default::default()
         });
 
-        let err = tool_result_message_from_part(&part, &store)
+        let message = tool_result_message_from_part(&part, &store)
             .await
-            .unwrap_err();
+            .unwrap()
+            .unwrap();
 
-        assert!(err.to_string().contains("missing"));
+        assert_eq!(message.tool_call_id.as_deref(), Some("tool-1"));
+        assert_eq!(
+            message.text_content(),
+            "[Historical tool output is unavailable. Do not assume it reflects the current state.]"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_result_message_marks_missing_typed_object_output_as_unavailable() {
+        let store = InMemoryObjectStore::default();
+        let output = ToolOutput::from_content_parts(
+            vec![object_ref_part(data_proto::ObjectRef {
+                key: "cas/Tenant%3Aacme/files/italki/old-version".to_string(),
+                media_type: "text/markdown".to_string(),
+                filename: "schedule-italki-lesson.md".to_string(),
+                ..Default::default()
+            })],
+            "[Object: schedule-italki-lesson.md]",
+        );
+        let part = tool_result_part(
+            String::new(),
+            tool_output::tool_result_payload_json("read-file-1", &output).unwrap(),
+        );
+
+        let message = tool_result_message_from_part(&part, &store)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(message.tool_call_id.as_deref(), Some("read-file-1"));
+        assert_eq!(
+            message.text_content(),
+            "[Historical tool output is unavailable. Do not assume it reflects the current state.]"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Treat only object-store not-found results as unavailable historical tool output during replay.
- Preserve real storage and authorization errors.
- Cover a File revision being deleted after its read result was persisted.

## Why
A session tool result can reference a prior immutable File CAS revision that File update/delete removes. Replay must keep the conversation usable without reading the current File revision and silently rewriting history.

## File-versioning follow-up (design only)
File writes already create immutable CAS revisions. The current File status should remain the latest revision while session results continue to reference prior revisions. Before changing deletion behavior, evaluate either a durable revision-reachability index or a periodic reachability scan with a conservative grace period. The chosen lifecycle must cover update/delete races, in-flight tool calls, session deletion cleanup, storage bounds, and the fact that `RETAINED` means retain only until update/delete—not version retention.

No File byte copies or File lifecycle changes are introduced here.

## Validation
- `cargo test harness::executor::history --lib`