### PR TITLE
Fix release version detection for stacked pushes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Detect changed SDK versions
         id: detect


### PR DESCRIPTION
## Summary

- fetch the full Git history in the package-version detection job
- ensure the workflow can compare against `github.event.before` for stacked PR pushes

## Root cause

The detector checked out only two commits but compared versions to the push base SHA. For a stacked push, that base can be older than the shallow checkout, causing every package version to appear changed and triggering release jobs.

## Validation

- `git diff --check`
- YAML parse check