### PR TITLE
Preserve hydrated CAS tool output

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -449,39 +449,6 @@ function isToolResultPart(part: any) {
   return type === SESSION_MESSAGE_PART_TYPE.TOOL_RESULT || type === "SESSION_MESSAGE_PART_TYPE_TOOL_RESULT";
 }
 
-function withToolResultContent(part: any, output: string, objectKey?: string) {
-  const nextPart = { ...part, content: output };
-  const payload = parsePayloadJson(part?.payloadJson ?? part?.payload_json);
-  const nextPayload = { ...payload, output };
-  const toolOutputKey = "tool_output" in payload ? "tool_output" : "toolOutput";
-  const toolOutput = payload[toolOutputKey];
-  const toolOutputRecord = toolOutput && typeof toolOutput === "object"
-    ? toolOutput as Record<string, unknown>
-    : undefined;
-  if (toolOutputRecord) {
-    const outputPartsKey = "content_parts" in toolOutputRecord ? "content_parts" : "contentParts";
-    const outputParts = toolOutputRecord[outputPartsKey];
-    if (Array.isArray(outputParts)) {
-      nextPayload[toolOutputKey] = {
-        ...toolOutputRecord,
-        summary: output,
-        [outputPartsKey]: outputParts.map((outputPart) => {
-          const object = objectRefFromValue(outputPart);
-          return object && (!objectKey || object.key === objectKey)
-            ? { type: "text", text: output }
-            : outputPart;
-        }),
-      };
-    }
-  }
-  if ("payload_json" in nextPart && !("payloadJson" in nextPart)) {
-    nextPart.payload_json = JSON.stringify(nextPayload);
-  } else {
-    nextPart.payloadJson = JSON.stringify(nextPayload);
-  }
-  return nextPart;
-}
-
 async function decompressCasObjectData(data: Uint8Array, encoding: string): Promise<Uint8Array> {
   if (typeof DecompressionStream === "undefined") {
     throw new Error(`${encoding} CAS object requires DecompressionStream support`);
@@ -543,7 +510,11 @@ function toolCallIdFromToolResultPart(part: any): string {
   return typeof part?.id === "string" ? part.id : "";
 }
 
-function findHydratableToolResultPart(
+function toolResultHydrationCacheKey(messageId: string, toolCallId: string, objectKey: string): string {
+  return `${messageId}\u0000${toolCallId}\u0000${objectKey}`;
+}
+
+function findToolResultObjectPart(
   parts: unknown,
   toolCallId: string,
 ): { part: any; index: number; key: string; object: TalonChatObjectRef } | null {
@@ -551,16 +522,24 @@ function findHydratableToolResultPart(
   for (let index = 0; index < parts.length; index += 1) {
     const part = parts[index] as any;
     if (!part || typeof part !== "object" || !isToolResultPart(part)) continue;
-    if (typeof part.content === "string" && part.content.length > 0) continue;
-    const key = objectRefKey(objectRefFromPart(part));
-    if (!key) continue;
     const partToolCallId = toolCallIdFromToolResultPart(part);
     if (toolCallId && partToolCallId !== toolCallId) continue;
     const object = objectRefFromPart(part);
-    if (!object) continue;
+    const key = objectRefKey(object);
+    if (!object || !key) continue;
     return { part, index, key, object };
   }
   return null;
+}
+
+function findHydratableToolResultPart(
+  parts: unknown,
+  toolCallId: string,
+): { part: any; index: number; key: string; object: TalonChatObjectRef } | null {
+  const match = findToolResultObjectPart(parts, toolCallId);
+  return match && !(typeof match.part.content === "string" && match.part.content.length > 0)
+    ? match
+    : null;
 }
 
 function messageImageParts(
@@ -869,6 +848,7 @@ export function TalonSession({
   const [expandedThinkingMessages, setExpandedThinkingMessages] = useState<Record<string, boolean>>({});
   const [expandedToolItems, setExpandedToolItems] = useState<Record<string, boolean>>({});
   const [toolResultHydration, setToolResultHydration] = useState<Record<string, "loading" | { objectKey: string }>>({});
+  const [hydratedToolResultOutputs, setHydratedToolResultOutputs] = useState<Record<string, string>>({});
   const missingResourceClientWarnedRef = useRef(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingMessageValue, setEditingMessageValue] = useState("");
@@ -921,6 +901,7 @@ export function TalonSession({
     toolResultHydrationGenerationRef.current += 1;
     toolResultHydrationInFlightRef.current.clear();
     setToolResultHydration({});
+    setHydratedToolResultOutputs({});
   }, []);
 
   const updateTranscriptScrollThumb = useCallback(() => {
@@ -1029,7 +1010,7 @@ export function TalonSession({
 
   useSafeLayoutEffect(() => {
     updateTranscriptScrollThumb();
-  }, [messages, expandedThinkingMessages, expandedToolItems, toolResultHydration, isSessionLive, error, streamEvents, updateTranscriptScrollThumb]);
+  }, [messages, expandedThinkingMessages, expandedToolItems, toolResultHydration, hydratedToolResultOutputs, isSessionLive, error, streamEvents, updateTranscriptScrollThumb]);
 
   useEffect(() => {
     if (!isSessionLive || loadingStartedAt === null) {
@@ -1086,6 +1067,8 @@ export function TalonSession({
         : null);
       const cas = gatewayClient?.cas;
       if (!match || !cas?.getObject) return;
+      const outputCacheKey = toolResultHydrationCacheKey(message.id, toolCallId, match.key);
+      if (Object.prototype.hasOwnProperty.call(hydratedToolResultOutputs, outputCacheKey)) return;
       if (toolResultHydrationInFlightRef.current.has(toolKey)) return;
 
       toolResultHydrationInFlightRef.current.add(toolKey);
@@ -1100,43 +1083,7 @@ export function TalonSession({
         const data = await toolResultObjectData(response, match.object);
         const output = new TextDecoder().decode(data);
         if (toolResultHydrationGenerationRef.current !== generation) return;
-
-        setMessages((current) => {
-          if (toolResultHydrationGenerationRef.current !== generation) return current;
-          const nextMessages = current.map((candidate) => {
-            if (candidate.id !== message.id) return candidate;
-            const currentMatch = findHydratableToolResultPart(candidate.parts, toolCallId);
-            if (currentMatch && currentMatch.key === match.key && Array.isArray(candidate.parts)) {
-              const parts = [...candidate.parts];
-              parts[currentMatch.index] = withToolResultContent(currentMatch.part, output, match.key);
-              const timelineSource = {
-                role: candidate.role,
-                content: candidate.content,
-                parts,
-                reasoningContent: candidate.reasoningContent,
-                usage: candidate.usage,
-              };
-              return {
-                ...candidate,
-                parts,
-                content: getMessageContent(timelineSource),
-                timeline: getMessageAssistantTimeline(timelineSource),
-              };
-            }
-
-            const timeline = getMessageAssistantTimeline(candidate).map((item) =>
-              item.type === "tool" && item.toolCallId === toolCallId
-                ? { ...item, result: output }
-                : item,
-            );
-            return {
-              ...candidate,
-              timeline,
-            };
-          });
-          messagesRef.current = nextMessages;
-          return nextMessages;
-        });
+        setHydratedToolResultOutputs((previous) => ({ ...previous, [outputCacheKey]: output }));
         if (toolResultHydrationGenerationRef.current !== generation) return;
 
         setToolResultHydration((prev) => {
@@ -1156,7 +1103,7 @@ export function TalonSession({
         toolResultHydrationInFlightRef.current.delete(toolKey);
       }
     },
-    [gatewayClient],
+    [gatewayClient, hydratedToolResultOutputs],
   );
 
   const updateSessionMessage = useCallback(
@@ -1486,8 +1433,17 @@ export function TalonSession({
                       }
 
                       const toolKey = `${message.id}-work-tool-${item.toolCallId || index}`;
+                      const resultObject = findToolResultObjectPart(message.parts, item.toolCallId)?.object ?? objectRefFromValue(item.result);
+                      const resultObjectKey = objectRefKey(resultObject);
+                      const outputCacheKey = resultObjectKey
+                        ? toolResultHydrationCacheKey(message.id, item.toolCallId, resultObjectKey)
+                        : "";
+                      const cachedOutput = outputCacheKey && Object.prototype.hasOwnProperty.call(hydratedToolResultOutputs, outputCacheKey)
+                        ? hydratedToolResultOutputs[outputCacheKey]
+                        : undefined;
+                      const toolResult = cachedOutput ?? item.result;
                       const isToolExpanded = expandedToolItems[toolKey] ?? false;
-                      const isRunningTool = isLiveAssistantMessage && item.result === undefined;
+                      const isRunningTool = isLiveAssistantMessage && toolResult === undefined;
                       const toolHydrationState = toolResultHydration[toolKey];
                       return (
                         <div key={toolKey}>
@@ -1497,7 +1453,7 @@ export function TalonSession({
                             onClick={() => {
                               toggleToolItem(toolKey);
                               if (!isToolExpanded) {
-                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey, item.result);
+                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey, toolResult);
                               }
                             }}
                             style={{
@@ -1555,13 +1511,13 @@ export function TalonSession({
                                     </>
                                   )}
                                 </div>
-                              ) : item.result !== undefined ? (
+                              ) : toolResult !== undefined ? (
                                 <div>
                                   <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
                                     Output
                                   </div>
                                   <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
-                                    <code>{typeof item.result === "string" ? item.result : JSON.stringify(item.result, null, 2)}</code>
+                                    <code>{typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult, null, 2)}</code>
                                   </pre>
                                 </div>
                               ) : null}
@@ -1743,8 +1699,17 @@ export function TalonSession({
                       }
 
                       const toolKey = `${message.id}-timeline-tool-${item.toolCallId || index}`;
+                      const resultObject = findToolResultObjectPart(message.parts, item.toolCallId)?.object ?? objectRefFromValue(item.result);
+                      const resultObjectKey = objectRefKey(resultObject);
+                      const outputCacheKey = resultObjectKey
+                        ? toolResultHydrationCacheKey(message.id, item.toolCallId, resultObjectKey)
+                        : "";
+                      const cachedOutput = outputCacheKey && Object.prototype.hasOwnProperty.call(hydratedToolResultOutputs, outputCacheKey)
+                        ? hydratedToolResultOutputs[outputCacheKey]
+                        : undefined;
+                      const toolResult = cachedOutput ?? item.result;
                       const isToolExpanded = expandedToolItems[toolKey] ?? false;
-                      const isRunningTool = isLiveAssistantMessage && item.result === undefined;
+                      const isRunningTool = isLiveAssistantMessage && toolResult === undefined;
                       const toolHydrationState = toolResultHydration[toolKey];
                       return (
                         <div key={toolKey}>
@@ -1754,7 +1719,7 @@ export function TalonSession({
                             onClick={() => {
                               toggleToolItem(toolKey);
                               if (!isToolExpanded) {
-                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey, item.result);
+                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey, toolResult);
                               }
                             }}
                             style={{
@@ -1812,13 +1777,13 @@ export function TalonSession({
                                     </>
                                   )}
                                 </div>
-                              ) : item.result !== undefined ? (
+                              ) : toolResult !== undefined ? (
                                 <div>
                                   <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
                                     Output
                                   </div>
                                   <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
-                                    <code>{typeof item.result === "string" ? item.result : JSON.stringify(item.result, null, 2)}</code>
+                                    <code>{typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult, null, 2)}</code>
                                   </pre>
                                 </div>
                               ) : null}

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -542,6 +542,34 @@ function findHydratableToolResultPart(
     : null;
 }
 
+function toolResultWithHydratedObject(
+  part: unknown,
+  fallback: unknown,
+  objectKey: string,
+  hydratedOutput: string,
+): unknown {
+  const payload = parsePayloadJson((part as any)?.payloadJson ?? (part as any)?.payload_json);
+  const toolOutput = payload.tool_output ?? payload.toolOutput;
+  const contentParts = toolOutput && typeof toolOutput === "object"
+    ? (toolOutput as Record<string, unknown>).content_parts ?? (toolOutput as Record<string, unknown>).contentParts
+    : undefined;
+  if (!Array.isArray(contentParts)) return hydratedOutput;
+
+  let replacedObject = false;
+  const text = contentParts.map((contentPart) => {
+    if (!contentPart || typeof contentPart !== "object") return "";
+    const value = contentPart as { type?: unknown; text?: unknown };
+    if (value.type === "text" && typeof value.text === "string") return value.text;
+    const object = objectRefFromValue(contentPart);
+    if (object?.key === objectKey) {
+      replacedObject = true;
+      return hydratedOutput;
+    }
+    return "";
+  }).join("");
+  return replacedObject ? text : fallback;
+}
+
 function messageImageParts(
   message: CopilotMessage,
   objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined,
@@ -947,7 +975,7 @@ export function TalonSession({
   useEffect(() => {
     const previousTarget = previousSessionTargetRef.current;
     previousSessionTargetRef.current = currentSession;
-    if (!previousTarget || !currentSession || isSameSession(previousTarget, currentSession)) return;
+    if (!previousTarget || (currentSession && isSameSession(previousTarget, currentSession))) return;
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
     resumeAbortControllerRef.current?.abort();
@@ -1433,15 +1461,19 @@ export function TalonSession({
                       }
 
                       const toolKey = `${message.id}-work-tool-${item.toolCallId || index}`;
-                      const resultObject = findToolResultObjectPart(message.parts, item.toolCallId)?.object ?? objectRefFromValue(item.result);
+                      const resultPartMatch = findToolResultObjectPart(message.parts, item.toolCallId);
+                      const resultObject = resultPartMatch?.object ?? objectRefFromValue(item.result);
                       const resultObjectKey = objectRefKey(resultObject);
                       const outputCacheKey = resultObjectKey
                         ? toolResultHydrationCacheKey(message.id, item.toolCallId, resultObjectKey)
                         : "";
-                      const cachedOutput = outputCacheKey && Object.prototype.hasOwnProperty.call(hydratedToolResultOutputs, outputCacheKey)
+                      const hasCachedOutput = Boolean(outputCacheKey) && Object.prototype.hasOwnProperty.call(hydratedToolResultOutputs, outputCacheKey);
+                      const cachedOutput = hasCachedOutput
                         ? hydratedToolResultOutputs[outputCacheKey]
                         : undefined;
-                      const toolResult = cachedOutput ?? item.result;
+                      const toolResult = hasCachedOutput
+                        ? toolResultWithHydratedObject(resultPartMatch?.part, item.result, resultObjectKey, cachedOutput!)
+                        : item.result;
                       const isToolExpanded = expandedToolItems[toolKey] ?? false;
                       const isRunningTool = isLiveAssistantMessage && toolResult === undefined;
                       const toolHydrationState = toolResultHydration[toolKey];
@@ -1699,15 +1731,19 @@ export function TalonSession({
                       }
 
                       const toolKey = `${message.id}-timeline-tool-${item.toolCallId || index}`;
-                      const resultObject = findToolResultObjectPart(message.parts, item.toolCallId)?.object ?? objectRefFromValue(item.result);
+                      const resultPartMatch = findToolResultObjectPart(message.parts, item.toolCallId);
+                      const resultObject = resultPartMatch?.object ?? objectRefFromValue(item.result);
                       const resultObjectKey = objectRefKey(resultObject);
                       const outputCacheKey = resultObjectKey
                         ? toolResultHydrationCacheKey(message.id, item.toolCallId, resultObjectKey)
                         : "";
-                      const cachedOutput = outputCacheKey && Object.prototype.hasOwnProperty.call(hydratedToolResultOutputs, outputCacheKey)
+                      const hasCachedOutput = Boolean(outputCacheKey) && Object.prototype.hasOwnProperty.call(hydratedToolResultOutputs, outputCacheKey);
+                      const cachedOutput = hasCachedOutput
                         ? hydratedToolResultOutputs[outputCacheKey]
                         : undefined;
-                      const toolResult = cachedOutput ?? item.result;
+                      const toolResult = hasCachedOutput
+                        ? toolResultWithHydratedObject(resultPartMatch?.part, item.result, resultObjectKey, cachedOutput!)
+                        : item.result;
                       const isToolExpanded = expandedToolItems[toolKey] ?? false;
                       const isRunningTool = isLiveAssistantMessage && toolResult === undefined;
                       const toolHydrationState = toolResultHydration[toolKey];
@@ -1914,7 +1950,7 @@ export function TalonSession({
         </React.Fragment>
       );
     });
-  }, [allowMessageEditing, cancelEditingMessage, copyMessageContent, editingMessageId, editingMessageValue, enableDebugMessageEditing, expandedThinkingMessages, expandedToolItems, handleResourceClick, hydrateToolResultForExpandedItem, isLoading, isResuming, isSessionLive, isStopping, loadingNow, loadingStartedAt, messages, objectUrlForRef, reviewActionMessageId, saveEditingMessage, startEditingMessage, toggleThinkingMessage, toggleToolItem, toolResultHydration, updateConnectorDeliveryStatus]);
+  }, [allowMessageEditing, cancelEditingMessage, copyMessageContent, editingMessageId, editingMessageValue, enableDebugMessageEditing, expandedThinkingMessages, expandedToolItems, handleResourceClick, hydrateToolResultForExpandedItem, hydratedToolResultOutputs, isLoading, isResuming, isSessionLive, isStopping, loadingNow, loadingStartedAt, messages, objectUrlForRef, reviewActionMessageId, saveEditingMessage, startEditingMessage, toggleThinkingMessage, toggleToolItem, toolResultHydration, updateConnectorDeliveryStatus]);
 
   const resolvedHistoryPageSize = Math.max(
     1,

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -981,18 +981,19 @@ describe('TalonCopilot', () => {
                   tool_call_id: 'call-cas-cache',
                   tool_output: {
                     summary: '[Object: cached-output.txt (text/plain; charset=utf-8; 123 bytes)]',
-                    content_parts: [{
-                      type: 'object_ref',
-                      object_ref: {
-                        key: 'cas/ops/sessions/sess-cas-cache/messages/assistant-cas-cache/000001.txt',
-                        media_type: 'text/plain; charset=utf-8',
+                    content_parts: [
+                      { type: 'text', text: 'Before: ' },
+                      {
+                        type: 'object_ref',
+                        object_ref: {
+                          key: 'cas/ops/sessions/sess-cas-cache/messages/assistant-cas-cache/000001.txt',
+                          media_type: 'text/plain; charset=utf-8',
+                        },
                       },
-                    }],
+                      { type: 'text', text: ' :after' },
+                    ],
                   },
                 }),
-                object: {
-                  key: 'cas/ops/sessions/sess-cas-cache/messages/assistant-cas-cache/000001.txt',
-                },
               },
               {
                 partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
@@ -1030,7 +1031,7 @@ describe('TalonCopilot', () => {
       fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
       const toolToggle = await screen.findByRole('button', { name: /Called\s+knowledge_search/ });
       fireEvent.click(toolToggle);
-      expect(await screen.findByText('cached hydrated output')).toBeInTheDocument();
+      expect(await screen.findByText('Before: cached hydrated output :after')).toBeInTheDocument();
       expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
 
       await act(async () => {
@@ -1038,19 +1039,19 @@ describe('TalonCopilot', () => {
       });
 
       expect(listSessionMessages).toHaveBeenCalledTimes(2);
-      expect(screen.getByText('cached hydrated output')).toBeInTheDocument();
+      expect(screen.getByText('Before: cached hydrated output :after')).toBeInTheDocument();
       expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
 
       fireEvent.click(toolToggle);
       fireEvent.click(toolToggle);
-      expect(await screen.findByText('cached hydrated output')).toBeInTheDocument();
+      expect(await screen.findByText('Before: cached hydrated output :after')).toBeInTheDocument();
       expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
     } finally {
       jest.useRealTimers();
     }
   });
 
-  it('clears hydrated CAS tool output when changing sessions', async () => {
+  it('clears hydrated CAS tool output when changing through no active session', async () => {
     const responseFor = (sessionId: string) => ({
       sessionId,
       state: 'IDLE',
@@ -1112,6 +1113,14 @@ describe('TalonCopilot', () => {
     fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
     fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
     expect(await screen.findByText('first session hydrated output')).toBeInTheDocument();
+
+    rerender(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+      />,
+    );
 
     rerender(
       <TalonCopilot

--- a/ui/lib/talonCopilot.test.tsx
+++ b/ui/lib/talonCopilot.test.tsx
@@ -955,46 +955,60 @@ describe('TalonCopilot', () => {
     warnSpy.mockRestore();
   });
 
-  it('does not refetch a lazy CAS tool result after it has been hydrated once', async () => {
+  it('preserves a hydrated CAS tool result across a canonical history refresh', async () => {
+    jest.useFakeTimers();
+    const listSessionMessages = jest.fn().mockResolvedValue({
+      sessionId: 'sess-cas-cache',
+      state: 'IDLE',
+      items: [
+        {
+          message: {
+            id: 'assistant-cas-cache',
+            role: 'ROLE_ASSISTANT',
+            parts: [
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                toolCallId: 'call-cas-cache',
+                toolName: 'knowledge_search',
+                payloadJson: JSON.stringify({ tool_call_id: 'call-cas-cache', input: { query: 'docs' } }),
+              },
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                toolCallId: 'call-cas-cache',
+                toolName: 'knowledge_search',
+                content: '',
+                payloadJson: JSON.stringify({
+                  tool_call_id: 'call-cas-cache',
+                  tool_output: {
+                    summary: '[Object: cached-output.txt (text/plain; charset=utf-8; 123 bytes)]',
+                    content_parts: [{
+                      type: 'object_ref',
+                      object_ref: {
+                        key: 'cas/ops/sessions/sess-cas-cache/messages/assistant-cas-cache/000001.txt',
+                        media_type: 'text/plain; charset=utf-8',
+                      },
+                    }],
+                  },
+                }),
+                object: {
+                  key: 'cas/ops/sessions/sess-cas-cache/messages/assistant-cas-cache/000001.txt',
+                },
+              },
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                content: 'Done after cached hydrate.',
+              },
+            ],
+            createdAt: String(Date.now() * 1000),
+          },
+          steps: [],
+        },
+      ],
+      hasMore: false,
+    });
     const gatewayClient = {
       createSession: jest.fn(),
-      listSessionMessages: jest.fn().mockResolvedValue({
-        sessionId: 'sess-cas-cache',
-        state: 'IDLE',
-        items: [
-          {
-            message: {
-              id: 'assistant-cas-cache',
-              role: 'ROLE_ASSISTANT',
-              parts: [
-                {
-                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
-                  toolCallId: 'call-cas-cache',
-                  toolName: 'knowledge_search',
-                  payloadJson: JSON.stringify({ tool_call_id: 'call-cas-cache', input: { query: 'docs' } }),
-                },
-                {
-                  partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
-                  toolCallId: 'call-cas-cache',
-                  toolName: 'knowledge_search',
-                  content: '',
-                  payloadJson: JSON.stringify({ tool_call_id: 'call-cas-cache' }),
-                  object: {
-                    key: 'cas/ops/sessions/sess-cas-cache/messages/assistant-cas-cache/000001.txt',
-                  },
-                },
-                {
-                  partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
-                  content: 'Done after cached hydrate.',
-                },
-              ],
-              createdAt: String(Date.now() * 1000),
-            },
-            steps: [],
-          },
-        ],
-        hasMore: false,
-      }),
+      listSessionMessages,
       cas: {
         getObject: jest.fn().mockResolvedValue({
           data: new TextEncoder().encode('cached hydrated output'),
@@ -1002,25 +1016,114 @@ describe('TalonCopilot', () => {
       },
     };
 
-    render(
+    try {
+      render(
+        <TalonCopilot
+          namespace="ops"
+          agent="copilot"
+          gatewayClient={gatewayClient}
+          sessionId="sess-cas-cache"
+        />,
+      );
+
+      expect(await screen.findByText('Done after cached hydrate.')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+      const toolToggle = await screen.findByRole('button', { name: /Called\s+knowledge_search/ });
+      fireEvent.click(toolToggle);
+      expect(await screen.findByText('cached hydrated output')).toBeInTheDocument();
+      expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1_000);
+      });
+
+      expect(listSessionMessages).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('cached hydrated output')).toBeInTheDocument();
+      expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(toolToggle);
+      fireEvent.click(toolToggle);
+      expect(await screen.findByText('cached hydrated output')).toBeInTheDocument();
+      expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('clears hydrated CAS tool output when changing sessions', async () => {
+    const responseFor = (sessionId: string) => ({
+      sessionId,
+      state: 'IDLE',
+      items: [
+        {
+          message: {
+            // These are deliberately shared between sessions: cache isolation must come from session invalidation.
+            id: 'assistant-shared',
+            role: 'ROLE_ASSISTANT',
+            parts: [
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_CALL',
+                toolCallId: 'call-shared',
+                toolName: 'knowledge_search',
+                payloadJson: JSON.stringify({ tool_call_id: 'call-shared', input: { query: sessionId } }),
+              },
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TOOL_RESULT',
+                toolCallId: 'call-shared',
+                toolName: 'knowledge_search',
+                content: '',
+                payloadJson: JSON.stringify({ tool_call_id: 'call-shared' }),
+                object: {
+                  key: 'cas/ops/sessions/shared/messages/assistant-shared/000001.txt',
+                },
+              },
+              {
+                partType: 'SESSION_MESSAGE_PART_TYPE_TEXT',
+                content: `Done in ${sessionId}.`,
+              },
+            ],
+            createdAt: String(Date.now() * 1000),
+          },
+          steps: [],
+        },
+      ],
+      hasMore: false,
+    });
+    const gatewayClient = {
+      createSession: jest.fn(),
+      listSessionMessages: jest.fn((request: any) => Promise.resolve(responseFor(request.sessionId))),
+      cas: {
+        getObject: jest.fn().mockResolvedValue({
+          data: new TextEncoder().encode('first session hydrated output'),
+        }),
+      },
+    };
+
+    const { rerender } = render(
       <TalonCopilot
         namespace="ops"
         agent="copilot"
         gatewayClient={gatewayClient}
-        sessionId="sess-cas-cache"
+        sessionId="sess-one"
       />,
     );
 
-    expect(await screen.findByText('Done after cached hydrate.')).toBeInTheDocument();
+    expect(await screen.findByText('Done in sess-one.')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
-    const toolToggle = await screen.findByRole('button', { name: /Called\s+knowledge_search/ });
-    fireEvent.click(toolToggle);
-    expect(await screen.findByText('cached hydrated output')).toBeInTheDocument();
-    expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
+    fireEvent.click(await screen.findByRole('button', { name: /Called\s+knowledge_search/ }));
+    expect(await screen.findByText('first session hydrated output')).toBeInTheDocument();
 
-    fireEvent.click(toolToggle);
-    fireEvent.click(toolToggle);
-    expect(await screen.findByText('cached hydrated output')).toBeInTheDocument();
+    rerender(
+      <TalonCopilot
+        namespace="ops"
+        agent="copilot"
+        gatewayClient={gatewayClient}
+        sessionId="sess-two"
+      />,
+    );
+
+    expect(await screen.findByText('Done in sess-two.')).toBeInTheDocument();
+    expect(screen.queryByText('first session hydrated output')).not.toBeInTheDocument();
     expect(gatewayClient.cas.getObject).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

Sightline now retains successfully hydrated CAS-backed tool output when canonical session history refreshes.

## Root cause

CAS hydration previously updated only the in-memory message. When the stream completed, the session refresh replaced that message with canonical history, which intentionally contains the compact `[Object: …]` summary for object-backed tool output.

## Changes

- Cache successful CAS hydration by message, tool call, and CAS object key for the active session.
- Render cached text over canonical object summaries without changing the persisted ObjectRef.
- Clear cached results when the active session changes or resets.
- Add regressions for canonical refresh persistence and session isolation.

## Validation

- `pnpm exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`
- `pnpm --dir ui lint`
- `pnpm --dir packages/talon-chat build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved hydrated tool results when conversation history refreshes or the interface rerenders.
  * Prevented stale hydrated results from appearing after switching sessions.
  * Improved assistant timeline status and displayed results for ongoing and completed work.

* **Tests**
  * Added coverage for hydration persistence across history updates.
  * Added coverage ensuring hydrated results are cleared between sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->