### PR TITLE
Split assistant response and trace timeline

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -55,6 +55,7 @@ import {
   coalesceAssistantMessageTimelineForDisplay,
   splitAssistantMessageTimeline,
 } from "./session/AssistantMessageTimeline";
+import { AssistantMessage } from "./session/AssistantMessage";
 import {
   canCompareCanonicalMessageIds,
   historyMessageTimestamp,
@@ -1163,7 +1164,6 @@ export function TalonSession({
                     <AssistantMessageTimeline
                       message={message}
                       items={workTimeline}
-                      variant="work"
                       isLive={isLiveAssistantMessage}
                       expandedTools={expandedToolItems}
                       hydrationState={toolResultHydration}
@@ -1308,16 +1308,10 @@ export function TalonSession({
                 }}
               >
                 {message.role === "assistant" && visibleTimeline.length > 0 ? (
-                  <AssistantMessageTimeline
+                  <AssistantMessage
                     message={message}
                     items={visibleTimeline}
-                    variant="final"
-                    isLive={isLiveAssistantMessage}
-                    expandedTools={expandedToolItems}
-                    hydrationState={toolResultHydration}
-                    resultFor={toolResultFor}
-                    onToggleTool={toggleToolItem}
-                    onHydrateTool={(...args) => void hydrateToolResultForExpandedItem(...args)}
+                    content={content}
                     onResourceClick={handleResourceClick}
                   />
                 ) : (

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { data, type TalonClient } from "@impalasys/talon-client";
-import { Activity, Check, ChevronRight, Copy, Pencil, X, Wrench } from "lucide-react";
+import { Activity, Check, ChevronRight, Copy, Pencil, X } from "lucide-react";
 import {
   formatUsageSummary,
   getMessageAssistantTimeline,
@@ -50,6 +50,11 @@ import { SessionComposerDock } from "./session/SessionComposerDock";
 import { useSessionAttachments } from "./session/useSessionAttachments";
 import { useToolResultHydration } from "./session/useToolResultHydration";
 import { useResourcePane } from "./session/useResourcePane";
+import {
+  AssistantTimeline,
+  coalesceAssistantTimelineForDisplay,
+  splitFinalAssistantTimeline,
+} from "./session/AssistantTimeline";
 import {
   canCompareCanonicalMessageIds,
   historyMessageTimestamp,
@@ -470,97 +475,6 @@ function messageImageParts(
       `image-${index + 1}`;
     return [{ id: `${message.id}-image-${index}`, src, label }];
   });
-}
-
-function coalesceAssistantTimelineForDisplay(timeline: AssistantTimelineItem[]) {
-  const nextTimeline: AssistantTimelineItem[] = [];
-  let latestUsage: Extract<AssistantTimelineItem, { type: "usage" }> | null = null;
-
-  for (const item of timeline) {
-    if (item.type === "usage") {
-      latestUsage = item;
-      continue;
-    }
-
-    if (item.type === "text") {
-      const lastItem = nextTimeline.at(-1);
-      if (lastItem?.type === "text") {
-        nextTimeline[nextTimeline.length - 1] = {
-          type: "text",
-          text: `${lastItem.text}${item.text}`,
-        };
-      } else {
-        nextTimeline.push(item);
-      }
-      continue;
-    }
-
-    if (item.type === "reasoning") {
-      const lastItem = nextTimeline.at(-1);
-      if (lastItem?.type === "reasoning") {
-        nextTimeline[nextTimeline.length - 1] = {
-          type: "reasoning",
-          text: `${lastItem.text}${item.text}`,
-        };
-      } else {
-        nextTimeline.push(item);
-      }
-      continue;
-    }
-
-    nextTimeline.push(item);
-  }
-
-  if (latestUsage) {
-    nextTimeline.push(latestUsage);
-  }
-
-  return nextTimeline;
-}
-
-function ContextCompactionDivider({ compacting }: { compacting: boolean }) {
-  const label = compacting ? "Context compacting automatically" : "Context compacted";
-  return (
-    <div
-      className="talon-session-compaction-divider"
-      role="separator"
-      aria-label={label}
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 10,
-        width: "100%",
-        color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))",
-        fontSize: 12,
-        fontWeight: 500,
-        letterSpacing: "0.01em",
-        padding: "0.5rem 0",
-      }}
-    >
-      <span aria-hidden="true" style={{ flex: 1, borderTop: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }} />
-      <span>{label}</span>
-      <span aria-hidden="true" style={{ flex: 1, borderTop: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }} />
-    </div>
-  );
-}
-
-function splitFinalAssistantTimeline(timeline: AssistantTimelineItem[]) {
-  const displayTimeline = coalesceAssistantTimelineForDisplay(timeline);
-  let finalTextIndex = -1;
-  for (let index = displayTimeline.length - 1; index >= 0; index -= 1) {
-    const item = displayTimeline[index];
-    if (item?.type === "text" && item.text.trim().length > 0) {
-      finalTextIndex = index;
-      break;
-    }
-  }
-  if (finalTextIndex < 0) {
-    return { workTimeline: displayTimeline, finalTimeline: [] };
-  }
-  return {
-    workTimeline: displayTimeline.filter((_, index) => index !== finalTextIndex),
-    finalTimeline: [displayTimeline[finalTextIndex]],
-  };
 }
 
 function isNearScrollBottom(container: HTMLElement) {
@@ -1246,127 +1160,18 @@ export function TalonSession({
 
                 {isWorkExpanded ? (
                   <div style={{ display: "flex", flexDirection: "column", gap: 8, paddingTop: 12 }}>
-                    {workTimeline.map((item, index) => {
-                      if (item.type === "compaction") {
-                        return (
-                          <ContextCompactionDivider
-                            key={`${message.id}-work-${index}`}
-                            compacting={isLiveAssistantMessage}
-                          />
-                        );
-                      }
-
-                      if (item.type === "text") {
-                        return (
-                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-assistant-fg, inherit)" }}>
-                            <MarkdownMessage onResourceClick={handleResourceClick}>{item.text}</MarkdownMessage>
-                          </div>
-                        );
-                      }
-
-                      if (item.type === "reasoning") {
-                        return (
-                          <div key={`${message.id}-work-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
-                            {item.text}
-                          </div>
-                        );
-                      }
-
-                      if (item.type === "usage") {
-                        const itemUsageSummary = formatUsageSummary(item.usage);
-                        return itemUsageSummary ? (
-                          <div key={`${message.id}-work-${index}`} style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                            {itemUsageSummary}
-                          </div>
-                        ) : null;
-                      }
-
-                      const toolKey = `${message.id}-work-tool-${item.toolCallId || index}`;
-                      const toolResult = toolResultFor(message, item.toolCallId, item.result);
-                      const isToolExpanded = expandedToolItems[toolKey] ?? false;
-                      const isRunningTool = isLiveAssistantMessage && toolResult === undefined;
-                      const toolHydrationState = toolResultHydration[toolKey];
-                      return (
-                        <div key={toolKey}>
-                          <button
-                            className="talon-session-tool-row"
-                            type="button"
-                            onClick={() => {
-                              toggleToolItem(toolKey);
-                              if (!isToolExpanded) {
-                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey, toolResult);
-                              }
-                            }}
-                            style={{
-                              width: "auto",
-                              maxWidth: "100%",
-                              display: "flex",
-                              alignItems: "center",
-                              gap: 8,
-                              border: "none",
-                              background: "transparent",
-                              padding: "0.25rem 0",
-                              color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))",
-                              cursor: "pointer",
-                              textAlign: "left",
-                            }}
-                          >
-                            <Wrench size="14" strokeWidth={1.9} style={{ flexShrink: 0, color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))" }} />
-                            <span style={{ minWidth: 0, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                              Called <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{item.toolName}</span>
-                            </span>
-                            {isRunningTool ? (
-                              <span style={{ flexShrink: 0, borderRadius: 999, background: "var(--talon-chat-tool-running-bg, rgba(14,165,233,0.12))", color: "var(--talon-chat-tool-running-fg, #0369a1)", padding: "0.1rem 0.45rem", fontSize: 11, fontWeight: 700 }}>
-                                Running
-                              </span>
-                            ) : null}
-                            <ChevronRight
-                              className="talon-session-tool-chevron"
-                              size="14"
-                              style={{
-                                flexShrink: 0,
-                                transform: isToolExpanded ? "rotate(90deg)" : "rotate(0deg)",
-                                color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))",
-                              }}
-                            />
-                          </button>
-                          {isToolExpanded ? (
-                            <div style={{ display: "flex", flexDirection: "column", gap: 10, paddingBottom: 12, paddingLeft: 22 }}>
-                              <div>
-                                <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                  Input
-                                </div>
-                                <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
-                                  <code>{JSON.stringify(item.args ?? {}, null, 2)}</code>
-                                </pre>
-                              </div>
-                              {toolHydrationState ? (
-                                <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                  {toolHydrationState === "loading" ? "Loading output..." : (
-                                    <>
-                                      Historical output is unavailable.
-                                      <details style={{ marginTop: 4 }}>
-                                        <summary>Developer details</summary>
-                                        <code style={{ overflowWrap: "anywhere" }}>{toolHydrationState.objectKey}</code>
-                                      </details>
-                                    </>
-                                  )}
-                                </div>
-                              ) : toolResult !== undefined ? (
-                                <div>
-                                  <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                    Output
-                                  </div>
-                                  <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
-                                    <code>{typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult, null, 2)}</code>
-                                  </pre>
-                                </div>
-                              ) : null}
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    })}
+                    <AssistantTimeline
+                      message={message}
+                      items={workTimeline}
+                      variant="work"
+                      isLive={isLiveAssistantMessage}
+                      expandedTools={expandedToolItems}
+                      hydrationState={toolResultHydration}
+                      resultFor={toolResultFor}
+                      onToggleTool={toggleToolItem}
+                      onHydrateTool={(...args) => void hydrateToolResultForExpandedItem(...args)}
+                      onResourceClick={handleResourceClick}
+                    />
 
                     {!workHasReasoning && reasoningContent ? (
                       <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
@@ -1503,129 +1308,18 @@ export function TalonSession({
                 }}
               >
                 {message.role === "assistant" && visibleTimeline.length > 0 ? (
-                  <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                    {visibleTimeline.map((item, index) => {
-                      if (item.type === "compaction") {
-                        return (
-                          <ContextCompactionDivider
-                            key={`${message.id}-timeline-${index}`}
-                            compacting={isLiveAssistantMessage}
-                          />
-                        );
-                      }
-
-                      if (item.type === "text") {
-                        return (
-                          <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "normal", overflowWrap: "anywhere" }}>
-                            <MarkdownMessage onResourceClick={handleResourceClick}>{item.text}</MarkdownMessage>
-                          </div>
-                        );
-                      }
-
-                      if (item.type === "reasoning") {
-                        return (
-                          <div key={`${message.id}-timeline-${index}`} style={{ whiteSpace: "normal", overflowWrap: "break-word", color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
-                            {item.text}
-                          </div>
-                        );
-                      }
-
-                      if (item.type === "usage") {
-                        const itemUsageSummary = formatUsageSummary(item.usage);
-                        return itemUsageSummary ? (
-                          <div key={`${message.id}-timeline-${index}`} style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                            {itemUsageSummary}
-                          </div>
-                        ) : null;
-                      }
-
-                      const toolKey = `${message.id}-timeline-tool-${item.toolCallId || index}`;
-                      const toolResult = toolResultFor(message, item.toolCallId, item.result);
-                      const isToolExpanded = expandedToolItems[toolKey] ?? false;
-                      const isRunningTool = isLiveAssistantMessage && toolResult === undefined;
-                      const toolHydrationState = toolResultHydration[toolKey];
-                      return (
-                        <div key={toolKey}>
-                          <button
-                            className="talon-session-tool-row"
-                            type="button"
-                            onClick={() => {
-                              toggleToolItem(toolKey);
-                              if (!isToolExpanded) {
-                                void hydrateToolResultForExpandedItem(message, item.toolCallId, toolKey, toolResult);
-                              }
-                            }}
-                            style={{
-                              width: "auto",
-                              maxWidth: "100%",
-                              display: "flex",
-                              alignItems: "center",
-                              gap: 8,
-                              border: "none",
-                              background: "transparent",
-                              padding: "0.25rem 0",
-                              color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))",
-                              cursor: "pointer",
-                              textAlign: "left",
-                            }}
-                          >
-                            <Wrench size="14" strokeWidth={1.9} style={{ flexShrink: 0, color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))" }} />
-                            <span style={{ minWidth: 0, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                              Called <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{item.toolName}</span>
-                            </span>
-                            {isRunningTool ? (
-                              <span style={{ flexShrink: 0, borderRadius: 999, background: "var(--talon-chat-tool-running-bg, rgba(14,165,233,0.12))", color: "var(--talon-chat-tool-running-fg, #0369a1)", padding: "0.1rem 0.45rem", fontSize: 11, fontWeight: 700 }}>
-                                Running
-                              </span>
-                            ) : null}
-                            <ChevronRight
-                              className="talon-session-tool-chevron"
-                              size="14"
-                              style={{
-                                flexShrink: 0,
-                                transform: isToolExpanded ? "rotate(90deg)" : "rotate(0deg)",
-                                color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))",
-                              }}
-                            />
-                          </button>
-                          {isToolExpanded ? (
-                            <div style={{ display: "flex", flexDirection: "column", gap: 10, paddingBottom: 12, paddingLeft: 22 }}>
-                              <div>
-                                <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                  Input
-                                </div>
-                                <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
-                                  <code>{JSON.stringify(item.args ?? {}, null, 2)}</code>
-                                </pre>
-                              </div>
-                              {toolHydrationState ? (
-                                <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                  {toolHydrationState === "loading" ? "Loading output..." : (
-                                    <>
-                                      Historical output is unavailable.
-                                      <details style={{ marginTop: 4 }}>
-                                        <summary>Developer details</summary>
-                                        <code style={{ overflowWrap: "anywhere" }}>{toolHydrationState.objectKey}</code>
-                                      </details>
-                                    </>
-                                  )}
-                                </div>
-                              ) : toolResult !== undefined ? (
-                                <div>
-                                  <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                                    Output
-                                  </div>
-                                  <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}>
-                                    <code>{typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult, null, 2)}</code>
-                                  </pre>
-                                </div>
-                              ) : null}
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    })}
-                  </div>
+                  <AssistantTimeline
+                    message={message}
+                    items={visibleTimeline}
+                    variant="final"
+                    isLive={isLiveAssistantMessage}
+                    expandedTools={expandedToolItems}
+                    hydrationState={toolResultHydration}
+                    resultFor={toolResultFor}
+                    onToggleTool={toggleToolItem}
+                    onHydrateTool={(...args) => void hydrateToolResultForExpandedItem(...args)}
+                    onResourceClick={handleResourceClick}
+                  />
                 ) : (
                   message.role === "assistant" ? (
                     <MarkdownMessage onResourceClick={handleResourceClick}>{content}</MarkdownMessage>

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -51,10 +51,10 @@ import { useSessionAttachments } from "./session/useSessionAttachments";
 import { useToolResultHydration } from "./session/useToolResultHydration";
 import { useResourcePane } from "./session/useResourcePane";
 import {
-  AssistantTimeline,
-  coalesceAssistantTimelineForDisplay,
-  splitFinalAssistantTimeline,
-} from "./session/AssistantTimeline";
+  AssistantMessageTimeline,
+  coalesceAssistantMessageTimelineForDisplay,
+  splitAssistantMessageTimeline,
+} from "./session/AssistantMessageTimeline";
 import {
   canCompareCanonicalMessageIds,
   historyMessageTimestamp,
@@ -557,8 +557,8 @@ function messageWithEditedContent(message: CopilotMessage, nextContent: string):
 
 function editableMessageContent(message: CopilotMessage) {
   if (message.role === "assistant") {
-    const timeline = coalesceAssistantTimelineForDisplay(getMessageAssistantTimeline(message));
-    const { finalTimeline } = splitFinalAssistantTimeline(timeline);
+    const timeline = coalesceAssistantMessageTimelineForDisplay(getMessageAssistantTimeline(message));
+    const { finalTimeline } = splitAssistantMessageTimeline(timeline);
     const visibleTextTimeline = finalTimeline.length > 0 ? finalTimeline : timeline;
     const textItems = visibleTextTimeline
       .filter((item): item is Extract<AssistantTimelineItem, { type: "text" }> => item.type === "text");
@@ -1049,7 +1049,7 @@ export function TalonSession({
     return messages.map((message, messageIndex) => {
       const content = getMessageContent(message);
       const images = messageImageParts(message, objectUrlForRef);
-      const timeline = coalesceAssistantTimelineForDisplay(getMessageAssistantTimeline(message));
+      const timeline = coalesceAssistantMessageTimelineForDisplay(getMessageAssistantTimeline(message));
       const reasoningContent = getMessageReasoningContent(message);
       const usage = getMessageUsage(message);
       const usageSummary = formatUsageSummary(usage);
@@ -1062,7 +1062,7 @@ export function TalonSession({
         !isLiveAssistantMessage;
       const isEditingMessage = editingMessageId === message.id;
       const messageActionTimestamp = isEditableMessage ? formatMessageActionTimestamp(message) : null;
-      const finalizedTimeline = splitFinalAssistantTimeline(timeline);
+      const finalizedTimeline = splitAssistantMessageTimeline(timeline);
       const visibleTimeline = finalizedTimeline.finalTimeline;
       const workTimeline = finalizedTimeline.workTimeline;
       const workHasReasoning = workTimeline.some((item) => item.type === "reasoning");
@@ -1160,7 +1160,7 @@ export function TalonSession({
 
                 {isWorkExpanded ? (
                   <div style={{ display: "flex", flexDirection: "column", gap: 8, paddingTop: 12 }}>
-                    <AssistantTimeline
+                    <AssistantMessageTimeline
                       message={message}
                       items={workTimeline}
                       variant="work"
@@ -1308,7 +1308,7 @@ export function TalonSession({
                 }}
               >
                 {message.role === "assistant" && visibleTimeline.length > 0 ? (
-                  <AssistantTimeline
+                  <AssistantMessageTimeline
                     message={message}
                     items={visibleTimeline}
                     variant="final"

--- a/packages/talon-chat/src/session/AssistantMessage.tsx
+++ b/packages/talon-chat/src/session/AssistantMessage.tsx
@@ -1,0 +1,22 @@
+import { MarkdownMessage } from "../lib/MarkdownMessage";
+import type { AssistantTimelineItem, CopilotMessage } from "../lib/chatTimeline";
+
+export type AssistantMessageProps = {
+  content: string;
+  items: AssistantTimelineItem[];
+  message: CopilotMessage;
+  onResourceClick?: (uri: string) => void;
+};
+
+/** Renders the user-facing final response portion of an assistant message. */
+export function AssistantMessage({ content, items, message, onResourceClick }: AssistantMessageProps) {
+  const finalText = items
+    .filter((item): item is Extract<AssistantTimelineItem, { type: "text" }> => item.type === "text")
+    .map((item) => item.text)
+    .join("");
+  return (
+    <div data-assistant-message-id={message.id} style={{ minWidth: 0, overflow: "hidden", overflowWrap: "anywhere", whiteSpace: "normal", fontSize: "var(--talon-chat-message-font-size, 1rem)", lineHeight: 1.65, opacity: 0.94 }}>
+      <MarkdownMessage onResourceClick={onResourceClick}>{finalText || content}</MarkdownMessage>
+    </div>
+  );
+}

--- a/packages/talon-chat/src/session/AssistantMessageTimeline.tsx
+++ b/packages/talon-chat/src/session/AssistantMessageTimeline.tsx
@@ -10,12 +10,12 @@ import {
 import { MarkdownMessage } from "../lib/MarkdownMessage";
 import type { ToolResultHydrationState } from "./useToolResultHydration";
 
-export type AssistantTimelineVariant = "work" | "final";
+export type AssistantMessageTimelineVariant = "work" | "final";
 
-export type AssistantTimelineProps = {
+export type AssistantMessageTimelineProps = {
   message: CopilotMessage;
   items: AssistantTimelineItem[];
-  variant: AssistantTimelineVariant;
+  variant: AssistantMessageTimelineVariant;
   isLive: boolean;
   expandedTools: Record<string, boolean>;
   hydrationState: Record<string, ToolResultHydrationState>;
@@ -29,7 +29,7 @@ function border(color: string) {
   return `1px solid ${color}`;
 }
 
-export function coalesceAssistantTimelineForDisplay(timeline: AssistantTimelineItem[]) {
+export function coalesceAssistantMessageTimelineForDisplay(timeline: AssistantTimelineItem[]) {
   const nextTimeline: AssistantTimelineItem[] = [];
   let latestUsage: Extract<AssistantTimelineItem, { type: "usage" }> | null = null;
 
@@ -54,8 +54,8 @@ export function coalesceAssistantTimelineForDisplay(timeline: AssistantTimelineI
   return nextTimeline;
 }
 
-export function splitFinalAssistantTimeline(timeline: AssistantTimelineItem[]) {
-  const displayTimeline = coalesceAssistantTimelineForDisplay(timeline);
+export function splitAssistantMessageTimeline(timeline: AssistantTimelineItem[]) {
+  const displayTimeline = coalesceAssistantMessageTimelineForDisplay(timeline);
   const finalTextIndex = displayTimeline.findLastIndex(
     (item) => item.type === "text" && item.text.trim().length > 0,
   );
@@ -86,7 +86,7 @@ function ContextCompactionDivider({ compacting }: { compacting: boolean }) {
   );
 }
 
-type ToolInvocationCardProps = Pick<AssistantTimelineProps,
+type ToolInvocationCardProps = Pick<AssistantMessageTimelineProps,
   "message" | "variant" | "isLive" | "expandedTools" | "hydrationState" | "resultFor" | "onToggleTool" | "onHydrateTool"
 > & {
   item: Extract<AssistantTimelineItem, { type: "tool" }>;
@@ -169,7 +169,7 @@ function TimelineItem({
 }: {
   item: AssistantTimelineItem;
   index: number;
-  props: AssistantTimelineProps;
+  props: AssistantMessageTimelineProps;
 }) {
   const { message, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick } = props;
   const key = `${message.id}-${variant}-${index}`;
@@ -184,9 +184,9 @@ function TimelineItem({
   return <ToolInvocationCard key={`${key}-tool-${item.toolCallId}`} {...{ message, item, index, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool }} />;
 }
 
-export function AssistantTimeline({
+export function AssistantMessageTimeline({
   message, items, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick,
-}: AssistantTimelineProps) {
+}: AssistantMessageTimelineProps) {
   const isWork = variant === "work";
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: isWork ? 8 : 12 }}>

--- a/packages/talon-chat/src/session/AssistantMessageTimeline.tsx
+++ b/packages/talon-chat/src/session/AssistantMessageTimeline.tsx
@@ -10,12 +10,9 @@ import {
 import { MarkdownMessage } from "../lib/MarkdownMessage";
 import type { ToolResultHydrationState } from "./useToolResultHydration";
 
-export type AssistantMessageTimelineVariant = "work" | "final";
-
 export type AssistantMessageTimelineProps = {
   message: CopilotMessage;
   items: AssistantTimelineItem[];
-  variant: AssistantMessageTimelineVariant;
   isLive: boolean;
   expandedTools: Record<string, boolean>;
   hydrationState: Record<string, ToolResultHydrationState>;
@@ -87,7 +84,7 @@ function ContextCompactionDivider({ compacting }: { compacting: boolean }) {
 }
 
 type ToolInvocationCardProps = Pick<AssistantMessageTimelineProps,
-  "message" | "variant" | "isLive" | "expandedTools" | "hydrationState" | "resultFor" | "onToggleTool" | "onHydrateTool"
+  "message" | "isLive" | "expandedTools" | "hydrationState" | "resultFor" | "onToggleTool" | "onHydrateTool"
 > & {
   item: Extract<AssistantTimelineItem, { type: "tool" }>;
   index: number;
@@ -128,9 +125,9 @@ function ToolResultDetails({
 }
 
 function ToolInvocationCard({
-  message, item, index, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool,
+  message, item, index, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool,
 }: ToolInvocationCardProps) {
-  const toolKey = `${message.id}-${variant}-tool-${item.toolCallId || index}`;
+  const toolKey = `${message.id}-tool-${item.toolCallId || index}`;
   const toolResult = resultFor(message, item.toolCallId, item.result);
   const isExpanded = expandedTools[toolKey] ?? false;
   const isRunning = isLive && toolResult === undefined;
@@ -171,26 +168,24 @@ function TimelineItem({
   index: number;
   props: AssistantMessageTimelineProps;
 }) {
-  const { message, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick } = props;
-  const key = `${message.id}-${variant}-${index}`;
-  const isWork = variant === "work";
+  const { message, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick } = props;
+  const key = `${message.id}-timeline-${index}`;
   if (item.type === "compaction") return <ContextCompactionDivider compacting={isLive} />;
-  if (item.type === "text") return <div style={{ whiteSpace: "normal", overflowWrap: isWork ? "break-word" : "anywhere", fontSize: isWork ? 13 : undefined, lineHeight: isWork ? 1.55 : undefined, color: isWork ? "var(--talon-chat-assistant-fg, inherit)" : undefined }}><MarkdownMessage onResourceClick={onResourceClick}>{item.text}</MarkdownMessage></div>;
-  if (item.type === "reasoning") return <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: isWork ? 13 : undefined, lineHeight: isWork ? 1.55 : undefined, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>{item.text}</div>;
+  if (item.type === "text") return <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-assistant-fg, inherit)" }}><MarkdownMessage onResourceClick={onResourceClick}>{item.text}</MarkdownMessage></div>;
+  if (item.type === "reasoning") return <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>{item.text}</div>;
   if (item.type === "usage") {
     const summary = formatUsageSummary(item.usage);
     return summary ? <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>{summary}</div> : null;
   }
-  return <ToolInvocationCard key={`${key}-tool-${item.toolCallId}`} {...{ message, item, index, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool }} />;
+  return <ToolInvocationCard key={`${key}-tool-${item.toolCallId}`} {...{ message, item, index, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool }} />;
 }
 
 export function AssistantMessageTimeline({
-  message, items, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick,
+  message, items, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick,
 }: AssistantMessageTimelineProps) {
-  const isWork = variant === "work";
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: isWork ? 8 : 12 }}>
-      {items.map((item, index) => <TimelineItem key={`${message.id}-${variant}-${index}`} item={item} index={index} props={{ message, items, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick }} />)}
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {items.map((item, index) => <TimelineItem key={`${message.id}-timeline-${index}`} item={item} index={index} props={{ message, items, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick }} />)}
     </div>
   );
 }

--- a/packages/talon-chat/src/session/AssistantTimeline.tsx
+++ b/packages/talon-chat/src/session/AssistantTimeline.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import React from "react";
+import { ChevronRight, Wrench } from "lucide-react";
+import {
+  formatUsageSummary,
+  type AssistantTimelineItem,
+  type CopilotMessage,
+} from "../lib/chatTimeline";
+import { MarkdownMessage } from "../lib/MarkdownMessage";
+import type { ToolResultHydrationState } from "./useToolResultHydration";
+
+export type AssistantTimelineVariant = "work" | "final";
+
+export type AssistantTimelineProps = {
+  message: CopilotMessage;
+  items: AssistantTimelineItem[];
+  variant: AssistantTimelineVariant;
+  isLive: boolean;
+  expandedTools: Record<string, boolean>;
+  hydrationState: Record<string, ToolResultHydrationState>;
+  resultFor: (message: CopilotMessage, toolCallId: string, fallback: unknown) => unknown;
+  onToggleTool: (key: string) => void;
+  onHydrateTool: (message: CopilotMessage, toolCallId: string, key: string, fallback: unknown) => void;
+  onResourceClick?: (uri: string) => void;
+};
+
+function border(color: string) {
+  return `1px solid ${color}`;
+}
+
+export function coalesceAssistantTimelineForDisplay(timeline: AssistantTimelineItem[]) {
+  const nextTimeline: AssistantTimelineItem[] = [];
+  let latestUsage: Extract<AssistantTimelineItem, { type: "usage" }> | null = null;
+
+  for (const item of timeline) {
+    if (item.type === "usage") {
+      latestUsage = item;
+      continue;
+    }
+    if (item.type === "text" || item.type === "reasoning") {
+      const lastItem = nextTimeline.at(-1);
+      if (lastItem?.type === item.type) {
+        nextTimeline[nextTimeline.length - 1] = { type: item.type, text: `${lastItem.text}${item.text}` };
+      } else {
+        nextTimeline.push(item);
+      }
+      continue;
+    }
+    nextTimeline.push(item);
+  }
+
+  if (latestUsage) nextTimeline.push(latestUsage);
+  return nextTimeline;
+}
+
+export function splitFinalAssistantTimeline(timeline: AssistantTimelineItem[]) {
+  const displayTimeline = coalesceAssistantTimelineForDisplay(timeline);
+  const finalTextIndex = displayTimeline.findLastIndex(
+    (item) => item.type === "text" && item.text.trim().length > 0,
+  );
+  if (finalTextIndex < 0) return { workTimeline: displayTimeline, finalTimeline: [] };
+  return {
+    workTimeline: displayTimeline.filter((_, index) => index !== finalTextIndex),
+    finalTimeline: [displayTimeline[finalTextIndex]],
+  };
+}
+
+function ContextCompactionDivider({ compacting }: { compacting: boolean }) {
+  const label = compacting ? "Context compacting automatically" : "Context compacted";
+  return (
+    <div
+      className="talon-session-compaction-divider"
+      role="separator"
+      aria-label={label}
+      style={{
+        display: "flex", alignItems: "center", gap: 10, width: "100%",
+        color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))", fontSize: 12,
+        fontWeight: 500, letterSpacing: "0.01em", padding: "0.5rem 0",
+      }}
+    >
+      <span aria-hidden="true" style={{ flex: 1, borderTop: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }} />
+      <span>{label}</span>
+      <span aria-hidden="true" style={{ flex: 1, borderTop: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }} />
+    </div>
+  );
+}
+
+type ToolInvocationCardProps = Pick<AssistantTimelineProps,
+  "message" | "variant" | "isLive" | "expandedTools" | "hydrationState" | "resultFor" | "onToggleTool" | "onHydrateTool"
+> & {
+  item: Extract<AssistantTimelineItem, { type: "tool" }>;
+  index: number;
+};
+
+function ToolResultDetails({
+  args,
+  hydration,
+  result,
+}: {
+  args: unknown;
+  hydration: ToolResultHydrationState | undefined;
+  result: unknown;
+}) {
+  const output = hydration === "loading"
+    ? "Loading output..."
+    : hydration
+      ? <>
+        Historical output is unavailable.
+        <details style={{ marginTop: 4 }}><summary>Developer details</summary><code style={{ overflowWrap: "anywhere" }}>{hydration.objectKey}</code></details>
+      </>
+      : undefined;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, paddingBottom: 12, paddingLeft: 22 }}>
+      <div>
+        <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>Input</div>
+        <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}><code>{JSON.stringify(args ?? {}, null, 2)}</code></pre>
+      </div>
+      {output ? <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>{output}</div> : null}
+      {!hydration && result !== undefined ? (
+        <div>
+          <div style={{ marginBottom: 6, fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>Output</div>
+          <pre style={{ maxWidth: "100%", overflowX: "auto", whiteSpace: "pre-wrap", overflowWrap: "anywhere", borderRadius: 8, background: "var(--talon-chat-code-bg, rgba(24,24,27,0.05))", padding: 10, fontSize: 12, margin: 0 }}><code>{typeof result === "string" ? result : JSON.stringify(result, null, 2)}</code></pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ToolInvocationCard({
+  message, item, index, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool,
+}: ToolInvocationCardProps) {
+  const toolKey = `${message.id}-${variant}-tool-${item.toolCallId || index}`;
+  const toolResult = resultFor(message, item.toolCallId, item.result);
+  const isExpanded = expandedTools[toolKey] ?? false;
+  const isRunning = isLive && toolResult === undefined;
+  const hydration = hydrationState[toolKey];
+  return (
+    <div>
+      <button
+        className="talon-session-tool-row"
+        type="button"
+        onClick={() => {
+          onToggleTool(toolKey);
+          if (!isExpanded) onHydrateTool(message, item.toolCallId, toolKey, toolResult);
+        }}
+        style={{
+          width: "auto", maxWidth: "100%", display: "flex", alignItems: "center", gap: 8,
+          border: "none", background: "transparent", padding: "0.25rem 0",
+          color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))", cursor: "pointer", textAlign: "left",
+        }}
+      >
+        <Wrench size="14" strokeWidth={1.9} style={{ flexShrink: 0, color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))" }} />
+        <span style={{ minWidth: 0, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          Called <span style={{ fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{item.toolName}</span>
+        </span>
+        {isRunning ? <span style={{ flexShrink: 0, borderRadius: 999, background: "var(--talon-chat-tool-running-bg, rgba(14,165,233,0.12))", color: "var(--talon-chat-tool-running-fg, #0369a1)", padding: "0.1rem 0.45rem", fontSize: 11, fontWeight: 700 }}>Running</span> : null}
+        <ChevronRight className="talon-session-tool-chevron" size="14" style={{ flexShrink: 0, transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)", color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))" }} />
+      </button>
+      {isExpanded ? <ToolResultDetails args={item.args} hydration={hydration} result={toolResult} /> : null}
+    </div>
+  );
+}
+
+function TimelineItem({
+  item,
+  index,
+  props,
+}: {
+  item: AssistantTimelineItem;
+  index: number;
+  props: AssistantTimelineProps;
+}) {
+  const { message, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick } = props;
+  const key = `${message.id}-${variant}-${index}`;
+  const isWork = variant === "work";
+  if (item.type === "compaction") return <ContextCompactionDivider compacting={isLive} />;
+  if (item.type === "text") return <div style={{ whiteSpace: "normal", overflowWrap: isWork ? "break-word" : "anywhere", fontSize: isWork ? 13 : undefined, lineHeight: isWork ? 1.55 : undefined, color: isWork ? "var(--talon-chat-assistant-fg, inherit)" : undefined }}><MarkdownMessage onResourceClick={onResourceClick}>{item.text}</MarkdownMessage></div>;
+  if (item.type === "reasoning") return <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: isWork ? 13 : undefined, lineHeight: isWork ? 1.55 : undefined, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>{item.text}</div>;
+  if (item.type === "usage") {
+    const summary = formatUsageSummary(item.usage);
+    return summary ? <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>{summary}</div> : null;
+  }
+  return <ToolInvocationCard key={`${key}-tool-${item.toolCallId}`} {...{ message, item, index, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool }} />;
+}
+
+export function AssistantTimeline({
+  message, items, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick,
+}: AssistantTimelineProps) {
+  const isWork = variant === "work";
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: isWork ? 8 : 12 }}>
+      {items.map((item, index) => <TimelineItem key={`${message.id}-${variant}-${index}`} item={item} index={index} props={{ message, items, variant, isLive, expandedTools, hydrationState, resultFor, onToggleTool, onHydrateTool, onResourceClick }} />)}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- render trace/details through `AssistantMessageTimeline`
- render final user-facing response text through `AssistantMessage`
- remove the `work | final` presentation variant
- retain tool-card expansion, hydration status, input, and output UI in the trace timeline

## Why
An assistant message has two distinct presentation surfaces: expandable trace details and final response content. The component names now match those surfaces directly; liveness remains a separate concern.

## Validation
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false` (59 passed)