### PR TITLE
Extract message editing helpers

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -11,7 +11,6 @@ import {
   getMessageUsage,
   hydrateMessagesWithSteps,
   normalizeMessageRole,
-  type AssistantTimelineItem,
   type CopilotMessage,
 } from "./lib/chatTimeline";
 import { TalonChatComposer, type TalonChatComposerVariant } from "./lib/TalonChatComposer";
@@ -33,7 +32,6 @@ import {
   messagePartsForSessionUpdate,
   parsePayloadJson,
   protoSessionPartsFromChatParts,
-  isSessionTextPart,
 } from "./session/protocol";
 import {
   normalizeObjectRefForJson,
@@ -53,6 +51,7 @@ import { useTranscriptExpansionState } from "./session/hooks/useTranscriptExpans
 import { useTranscriptPaginationAnchor } from "./session/hooks/useTranscriptPaginationAnchor";
 import { useTranscriptScrollState } from "./session/hooks/useTranscriptScrollState";
 import { fetchResourceFromGateway } from "./lib/resourceLoader";
+import { editableMessageContent, messageWithEditedContent, replaceMessageTextPart } from "./session/messageEditing";
 import {
   AssistantMessageTimeline,
   coalesceAssistantMessageTimelineForDisplay,
@@ -306,34 +305,6 @@ function getAssistantSignature(messages: any[] | undefined) {
     .join("|");
 }
 
-function replaceMessageTextPart(message: CopilotMessage, text: string) {
-  const sourceParts = Array.isArray(message.parts) ? message.parts : [];
-  const parts = sourceParts.map((part: any) => part && typeof part === "object" ? { ...part } : part);
-  let textPartIndex = -1;
-  for (let index = parts.length - 1; index >= 0; index -= 1) {
-    if (isSessionTextPart(parts[index])) {
-      textPartIndex = index;
-      break;
-    }
-  }
-  if (textPartIndex >= 0) {
-    const part = parts[textPartIndex] as any;
-    if ("text" in part) {
-      part.text = text;
-    } else {
-      part.content = text;
-    }
-    return parts;
-  }
-  return [
-    ...parts,
-    {
-      partType: SESSION_MESSAGE_PART_TYPE.TEXT,
-      content: text,
-    },
-  ];
-}
-
 function messageImageParts(
   message: CopilotMessage,
   objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined,
@@ -408,49 +379,6 @@ function formatWorkingDuration(start: unknown, now = Date.now()) {
 function isSessionBusyError(error: unknown) {
   const candidate = error as { message?: unknown } | null;
   return typeof candidate?.message === "string" && /session is currently generating|session is busy/i.test(candidate.message);
-}
-
-function messageWithEditedContent(message: CopilotMessage, nextContent: string): CopilotMessage {
-  const nextMessage: CopilotMessage = { ...message, content: nextContent };
-  if (Array.isArray(nextMessage.parts)) {
-    let replacedTextPart = false;
-    nextMessage.parts = nextMessage.parts.map((part: any) => {
-      if (!part || typeof part !== "object") {
-        return part;
-      }
-      const type = part?.partType ?? part?.part_type ?? part?.type;
-      const isTextPart =
-        type === "text" ||
-        type === SESSION_MESSAGE_PART_TYPE.TEXT ||
-        type === "SESSION_MESSAGE_PART_TYPE_TEXT";
-      if (!isTextPart || replacedTextPart) {
-        return part;
-      }
-      replacedTextPart = true;
-      const nextPart = { ...part };
-      if ("text" in nextPart) nextPart.text = nextContent;
-      if ("content" in nextPart) nextPart.content = nextContent;
-      return nextPart;
-    });
-  }
-  if (message.role === "assistant") {
-    nextMessage.timeline = [{ type: "text", text: nextContent }];
-  }
-  return nextMessage;
-}
-
-function editableMessageContent(message: CopilotMessage) {
-  if (message.role === "assistant") {
-    const timeline = coalesceAssistantMessageTimelineForDisplay(getMessageAssistantTimeline(message));
-    const { finalTimeline } = splitAssistantMessageTimeline(timeline);
-    const visibleTextTimeline = finalTimeline.length > 0 ? finalTimeline : timeline;
-    const textItems = visibleTextTimeline
-      .filter((item): item is Extract<AssistantTimelineItem, { type: "text" }> => item.type === "text");
-    if (textItems.length > 0) {
-      return textItems.map((item) => item.text).join("");
-    }
-  }
-  return getMessageContent(message);
 }
 
 export function TalonSession({

--- a/packages/talon-chat/src/session/messageEditing.ts
+++ b/packages/talon-chat/src/session/messageEditing.ts
@@ -1,5 +1,8 @@
 import { getMessageAssistantTimeline, getMessageContent, type AssistantTimelineItem, type CopilotMessage } from "../lib/chatTimeline";
-import { coalesceAssistantTimelineForDisplay, splitFinalAssistantTimeline } from "./AssistantTimeline";
+import {
+  coalesceAssistantMessageTimelineForDisplay,
+  splitAssistantMessageTimeline,
+} from "./AssistantMessageTimeline";
 import { SESSION_MESSAGE_PART_TYPE, isSessionTextPart } from "./protocol";
 
 export function replaceMessageTextPart(message: CopilotMessage, text: string) {
@@ -34,8 +37,8 @@ export function messageWithEditedContent(message: CopilotMessage, content: strin
 
 export function editableMessageContent(message: CopilotMessage) {
   if (message.role !== "assistant") return getMessageContent(message);
-  const timeline = coalesceAssistantTimelineForDisplay(getMessageAssistantTimeline(message));
-  const { finalTimeline } = splitFinalAssistantTimeline(timeline);
+  const timeline = coalesceAssistantMessageTimelineForDisplay(getMessageAssistantTimeline(message));
+  const { finalTimeline } = splitAssistantMessageTimeline(timeline);
   const visible = finalTimeline.length > 0 ? finalTimeline : timeline;
   const text = visible.filter((item): item is Extract<AssistantTimelineItem, { type: "text" }> => item.type === "text");
   return text.length > 0 ? text.map((item) => item.text).join("") : getMessageContent(message);

--- a/packages/talon-chat/src/session/messageEditing.ts
+++ b/packages/talon-chat/src/session/messageEditing.ts
@@ -1,0 +1,42 @@
+import { getMessageAssistantTimeline, getMessageContent, type AssistantTimelineItem, type CopilotMessage } from "../lib/chatTimeline";
+import { coalesceAssistantTimelineForDisplay, splitFinalAssistantTimeline } from "./AssistantTimeline";
+import { SESSION_MESSAGE_PART_TYPE, isSessionTextPart } from "./protocol";
+
+export function replaceMessageTextPart(message: CopilotMessage, text: string) {
+  const parts = (Array.isArray(message.parts) ? message.parts : []).map((part: any) =>
+    part && typeof part === "object" ? { ...part } : part,
+  );
+  const index = parts.findLastIndex((part) => isSessionTextPart(part));
+  if (index >= 0) {
+    const part = parts[index] as any;
+    if ("text" in part) part.text = text;
+    else part.content = text;
+    return parts;
+  }
+  return [...parts, { partType: SESSION_MESSAGE_PART_TYPE.TEXT, content: text }];
+}
+
+export function messageWithEditedContent(message: CopilotMessage, content: string): CopilotMessage {
+  const next = { ...message, content };
+  if (Array.isArray(next.parts)) {
+    let replaced = false;
+    next.parts = next.parts.map((part: any) => {
+      const type = part?.partType ?? part?.part_type ?? part?.type;
+      const isText = type === "text" || type === SESSION_MESSAGE_PART_TYPE.TEXT || type === "SESSION_MESSAGE_PART_TYPE_TEXT";
+      if (!part || typeof part !== "object" || !isText || replaced) return part;
+      replaced = true;
+      return { ...part, ...("text" in part ? { text: content } : {}), ...("content" in part ? { content } : {}) };
+    });
+  }
+  if (message.role === "assistant") next.timeline = [{ type: "text", text: content }];
+  return next;
+}
+
+export function editableMessageContent(message: CopilotMessage) {
+  if (message.role !== "assistant") return getMessageContent(message);
+  const timeline = coalesceAssistantTimelineForDisplay(getMessageAssistantTimeline(message));
+  const { finalTimeline } = splitFinalAssistantTimeline(timeline);
+  const visible = finalTimeline.length > 0 ? finalTimeline : timeline;
+  const text = visible.filter((item): item is Extract<AssistantTimelineItem, { type: "text" }> => item.type === "text");
+  return text.length > 0 ? text.map((item) => item.text).join("") : getMessageContent(message);
+}


### PR DESCRIPTION
## Summary
- move editable-content derivation and text-part replacement into `session/messageEditing`
- preserve assistant timeline editing semantics and wire-format text updates

## Validation
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`