### PR TITLE
Extract session timing helpers

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -52,6 +52,7 @@ import { useTranscriptPaginationAnchor } from "./session/hooks/useTranscriptPagi
 import { useTranscriptScrollState } from "./session/hooks/useTranscriptScrollState";
 import { fetchResourceFromGateway } from "./lib/resourceLoader";
 import { editableMessageContent, messageWithEditedContent, replaceMessageTextPart } from "./session/messageEditing";
+import { formatWorkDuration, formatWorkingDuration } from "./session/sessionTiming";
 import {
   AssistantMessageTimeline,
   coalesceAssistantMessageTimelineForDisplay,
@@ -345,35 +346,6 @@ function formatMessageActionTimestamp(message: CopilotMessage) {
     hour: "numeric",
     minute: "2-digit",
   });
-}
-
-function formatWorkDuration(start: unknown, end: unknown) {
-  const startMs = normalizeEpochToMilliseconds(start);
-  const endMs = normalizeEpochToMilliseconds(end);
-  if (startMs === null || endMs === null || endMs <= startMs) {
-    return "Worked";
-  }
-  const totalSeconds = Math.max(1, Math.round((endMs - startMs) / 1000));
-  if (totalSeconds < 60) {
-    return `Worked for ${totalSeconds}s`;
-  }
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return seconds > 0 ? `Worked for ${minutes}m ${seconds}s` : `Worked for ${minutes}m`;
-}
-
-function formatWorkingDuration(start: unknown, now = Date.now()) {
-  const startMs = normalizeEpochToMilliseconds(start);
-  if (startMs === null || now < startMs) {
-    return "Working";
-  }
-  const totalSeconds = Math.max(1, Math.floor((now - startMs) / 1000));
-  if (totalSeconds < 60) {
-    return `Working for ${totalSeconds}s`;
-  }
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return seconds > 0 ? `Working for ${minutes}m ${seconds}s` : `Working for ${minutes}m`;
 }
 
 function isSessionBusyError(error: unknown) {

--- a/packages/talon-chat/src/session/sessionTiming.ts
+++ b/packages/talon-chat/src/session/sessionTiming.ts
@@ -1,0 +1,33 @@
+function epochMilliseconds(value: unknown) {
+  let result: number | null = null;
+  if (typeof value === "bigint") {
+    if ((value < 0n ? -value : value) > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+    result = Number(value);
+  } else if (typeof value === "string") {
+    const numeric = Number(value);
+    result = Number.isFinite(numeric) ? numeric : Date.parse(value);
+  } else if (typeof value === "number") result = value;
+  if (!Number.isFinite(result) || !result || result < 0) return null;
+  if (result >= 1e15) return Math.trunc(result / 1000);
+  if (result >= 1e12) return Math.trunc(result);
+  return result >= 1e9 ? Math.trunc(result * 1000) : null;
+}
+
+export function formatWorkDuration(start: unknown, end: unknown) {
+  const startMs = epochMilliseconds(start);
+  const endMs = epochMilliseconds(end);
+  if (startMs === null || endMs === null || endMs <= startMs) return "Worked";
+  const seconds = Math.max(1, Math.round((endMs - startMs) / 1000));
+  if (seconds < 60) return `Worked for ${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  return seconds % 60 ? `Worked for ${minutes}m ${seconds % 60}s` : `Worked for ${minutes}m`;
+}
+
+export function formatWorkingDuration(start: unknown, now = Date.now()) {
+  const startMs = epochMilliseconds(start);
+  if (startMs === null || now < startMs) return "Working";
+  const seconds = Math.max(1, Math.floor((now - startMs) / 1000));
+  if (seconds < 60) return `Working for ${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  return seconds % 60 ? `Working for ${minutes}m ${seconds % 60}s` : `Working for ${minutes}m`;
+}


### PR DESCRIPTION
## Summary
- isolate work-duration formatting from session state and transport

## Validation
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`