### PR TITLE
Extract message copy fallback

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -52,6 +52,7 @@ import { useTranscriptPaginationAnchor } from "./session/hooks/useTranscriptPagi
 import { useTranscriptScrollState } from "./session/hooks/useTranscriptScrollState";
 import { fetchResourceFromGateway } from "./lib/resourceLoader";
 import { editableMessageContent, messageWithEditedContent, replaceMessageTextPart } from "./session/messageEditing";
+import { copyMessageContent } from "./session/copyMessageContent";
 import { formatWorkDuration, formatWorkingDuration } from "./session/sessionTiming";
 import {
   AssistantMessageTimeline,
@@ -769,31 +770,6 @@ export function TalonSession({
   useEffect(() => {
     clearResourcePaneState();
   }, [agent, clearResourcePaneState, currentSession?.sessionId, namespace, sessionId]);
-
-  const copyMessageContent = useCallback(async (message: CopilotMessage) => {
-    const nextContent = editableMessageContent(message);
-    if (!nextContent.trim()) {
-      return;
-    }
-    try {
-      if (!navigator.clipboard?.writeText) {
-        throw new Error("Clipboard API is unavailable.");
-      }
-      await navigator.clipboard.writeText(nextContent);
-    } catch {
-      const selection = window.getSelection();
-      const textArea = document.createElement("textarea");
-      textArea.value = nextContent;
-      textArea.setAttribute("readonly", "");
-      textArea.style.position = "fixed";
-      textArea.style.left = "-9999px";
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textArea);
-      selection?.removeAllRanges();
-    }
-  }, []);
 
   const renderedMessages = useMemo(() => {
     return messages.map((message, messageIndex) => {

--- a/packages/talon-chat/src/session/copyMessageContent.ts
+++ b/packages/talon-chat/src/session/copyMessageContent.ts
@@ -1,0 +1,23 @@
+import type { CopilotMessage } from "../lib/chatTimeline";
+import { editableMessageContent } from "./messageEditing";
+
+export async function copyMessageContent(message: CopilotMessage) {
+  const content = editableMessageContent(message);
+  if (!content.trim()) return;
+  try {
+    if (!navigator.clipboard?.writeText) throw new Error("Clipboard API is unavailable.");
+    await navigator.clipboard.writeText(content);
+  } catch {
+    const selection = window.getSelection();
+    const textArea = document.createElement("textarea");
+    textArea.value = content;
+    textArea.setAttribute("readonly", "");
+    textArea.style.position = "fixed";
+    textArea.style.left = "-9999px";
+    document.body.appendChild(textArea);
+    textArea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textArea);
+    selection?.removeAllRanges();
+  }
+}


### PR DESCRIPTION
## Summary
- move clipboard and DOM fallback behavior out of the session controller

## Validation
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`