### PR TITLE
Extract message image display

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -58,6 +58,7 @@ import { SessionStyles } from "./session/SessionStyles";
 import { ConnectorDeliveryControls } from "./session/ConnectorDeliveryControls";
 import { MessageEditForm } from "./session/MessageEditForm";
 import { MessageActions } from "./session/MessageActions";
+import { MessageImages } from "./session/MessageImages";
 import {
   AssistantMessageTimeline,
   coalesceAssistantMessageTimelineForDisplay,
@@ -956,44 +957,7 @@ export function TalonSession({
                 )}
               </div>
             )}
-            {images.length > 0 ? (
-              <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: content ? 10 : 0 }}>
-                {images.map((image) => (
-                  image.src ? (
-                    <img
-                      key={image.id}
-                      src={image.src}
-                      alt={image.label}
-                      style={{
-                        width: 132,
-                        maxWidth: "100%",
-                        aspectRatio: "1 / 1",
-                        objectFit: "cover",
-                        borderRadius: 8,
-                        border: border("var(--talon-chat-image-border, rgba(212,212,216,0.86))"),
-                      }}
-                    />
-                  ) : (
-                    <div
-                      key={image.id}
-                      title={image.label}
-                      style={{
-                        maxWidth: "100%",
-                        borderRadius: 8,
-                        border: border("var(--talon-chat-image-border, rgba(212,212,216,0.86))"),
-                        padding: "0.45rem 0.6rem",
-                        fontSize: 12,
-                        lineHeight: 1.3,
-                        color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))",
-                        overflowWrap: "anywhere",
-                      }}
-                    >
-                      {image.label}
-                    </div>
-                  )
-                ))}
-              </div>
-            ) : null}
+            <MessageImages images={images} hasContent={Boolean(content)} />
             </div>
             {isEditableMessage && !isEditingMessage ? <MessageActions
               message={message}

--- a/packages/talon-chat/src/session/MessageImages.tsx
+++ b/packages/talon-chat/src/session/MessageImages.tsx
@@ -1,0 +1,9 @@
+export type MessageImage = { id: string; src?: string; label: string };
+
+export function MessageImages({ images, hasContent }: { images: MessageImage[]; hasContent: boolean }) {
+  if (images.length === 0) return null;
+  const border = "1px solid var(--talon-chat-image-border, rgba(212,212,216,0.86))";
+  return <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: hasContent ? 10 : 0 }}>
+    {images.map((image) => image.src ? <img key={image.id} src={image.src} alt={image.label} style={{ width: 132, maxWidth: "100%", aspectRatio: "1 / 1", objectFit: "cover", borderRadius: 8, border }} /> : <div key={image.id} title={image.label} style={{ maxWidth: "100%", borderRadius: 8, border, padding: "0.45rem 0.6rem", fontSize: 12, lineHeight: 1.3, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))", overflowWrap: "anywhere" }}>{image.label}</div>)}
+  </div>;
+}


### PR DESCRIPTION
## Summary
- move image thumbnails and object-reference fallback labels out of the transcript renderer

## Validation
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false`