### PR TITLE
Extract message presentation and generation lifecycle

### DIFF
--- a/packages/talon-chat/src/session/SessionMessage.tsx
+++ b/packages/talon-chat/src/session/SessionMessage.tsx
@@ -24,7 +24,7 @@ import { MessageEditForm } from "./MessageEditForm";
 import { MessageImages, type MessageImage } from "./MessageImages";
 import { formatWorkDuration, formatWorkingDuration } from "./sessionTiming";
 import type { TalonChatObjectRef } from "./types";
-import type { ToolResultHydrationState } from "./useToolResultHydration";
+import type { ToolResultHydrationState } from "./hooks/useToolResultHydration";
 import { historyMessageTimestamp } from "./history";
 
 const connectorDeliveryPendingReview = "pending_review";

--- a/packages/talon-chat/src/session/SessionMessage.tsx
+++ b/packages/talon-chat/src/session/SessionMessage.tsx
@@ -1,11 +1,389 @@
-import type React from "react";
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import {
+  formatUsageSummary,
+  getMessageAssistantTimeline,
+  getMessageContent,
+  getMessageReasoningContent,
+  getMessageUsage,
+  type CopilotMessage,
+} from "../lib/chatTimeline";
+import { MarkdownMessage } from "../lib/MarkdownMessage";
+import { objectRefFromPart } from "./objectRefs";
+import { parsePayloadJson, SESSION_MESSAGE_PART_TYPE } from "./protocol";
+import {
+  AssistantMessageTimeline,
+  coalesceAssistantMessageTimelineForDisplay,
+  splitAssistantMessageTimeline,
+} from "./AssistantMessageTimeline";
+import { AssistantMessage } from "./AssistantMessage";
+import { ConnectorDeliveryControls } from "./ConnectorDeliveryControls";
+import { MessageActions } from "./MessageActions";
+import { MessageEditForm } from "./MessageEditForm";
+import { MessageImages, type MessageImage } from "./MessageImages";
+import { formatWorkDuration, formatWorkingDuration } from "./sessionTiming";
+import type { TalonChatObjectRef } from "./types";
+import type { ToolResultHydrationState } from "./useToolResultHydration";
+import { historyMessageTimestamp } from "./history";
+
+const connectorDeliveryPendingReview = "pending_review";
+const connectorDeliveryStatusLabel = "talon.impalasys.com/connector-delivery-status";
+const messageFontSize = "var(--talon-chat-message-font-size, 1rem)";
+
+function border(color: string) {
+  return `1px solid ${color}`;
+}
+
+function classNames(...parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function isImagePart(part: any) {
+  const type = part?.type ?? part?.partType ?? part?.part_type;
+  return type === "image" || type === SESSION_MESSAGE_PART_TYPE.IMAGE || type === "SESSION_MESSAGE_PART_TYPE_IMAGE";
+}
+
+function imageSource(
+  part: any,
+  payload: Record<string, unknown>,
+  object: TalonChatObjectRef | undefined,
+  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined,
+) {
+  if (typeof part.previewUrl === "string") return part.previewUrl;
+  if (typeof part.url === "string") return part.url;
+  if (typeof payload.url === "string") return payload.url;
+  return object ? objectUrlForRef?.(object) : undefined;
+}
+
+function imageLabel(object: TalonChatObjectRef | undefined, payload: Record<string, unknown>, index: number) {
+  if (object?.filename) return object.filename;
+  if (typeof payload.filename === "string") return payload.filename;
+  return object?.key || `image-${index + 1}`;
+}
+
+function imageFromPart(
+  message: CopilotMessage,
+  part: any,
+  index: number,
+  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined,
+): MessageImage | null {
+  if (!isImagePart(part)) return null;
+  const payload = parsePayloadJson(part.payloadJson ?? part.payload_json);
+  const object = objectRefFromPart(part);
+  return {
+    id: `${message.id}-image-${index}`,
+    src: imageSource(part, payload, object, objectUrlForRef),
+    label: imageLabel(object, payload, index),
+  };
+}
+
+function messageImages(
+  message: CopilotMessage,
+  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined,
+): MessageImage[] {
+  if (!Array.isArray(message.parts)) return [];
+  return message.parts.flatMap((part: any, index) => {
+    const image = imageFromPart(message, part, index, objectUrlForRef);
+    return image ? [image] : [];
+  });
+}
+
+function actionTimestamp(message: CopilotMessage) {
+  const timestampMs = historyMessageTimestamp(message);
+  if (timestampMs === null) return null;
+  return new Date(timestampMs).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
 
 export type SessionMessageProps = {
-  messageId: string;
-  children: React.ReactNode;
+  message: CopilotMessage;
+  messageIndex: number;
+  messages: CopilotMessage[];
+  isSessionLive: boolean;
+  loadingStartedAt: string | number | null;
+  loadingNow: number;
+  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined;
+  allowEditing: boolean;
+  enableDebugEditing: boolean;
+  editingMessageId: string | null;
+  editingMessageValue: string;
+  reviewActionMessageId: string | null;
+  expandedThinkingMessages: Record<string, boolean>;
+  expandedToolItems: Record<string, boolean>;
+  hydrationState: Record<string, ToolResultHydrationState>;
+  resultFor: (message: CopilotMessage, toolCallId: string, fallback: unknown) => unknown;
+  onToggleThinking: (messageId: string) => void;
+  onToggleTool: (key: string) => void;
+  onHydrateTool: (message: CopilotMessage, toolCallId: string, key: string, fallback: unknown) => void;
+  onResourceClick: (uri: string) => void;
+  onEditingValueChange: (value: string) => void;
+  onSaveEdit: (message: CopilotMessage) => void;
+  onCancelEdit: () => void;
+  onStartEdit: (message: CopilotMessage) => void;
+  onCopy: (message: CopilotMessage) => void;
+  onUpdateConnectorDelivery: (message: CopilotMessage, status: string) => void;
 };
 
-/** Stable presentation boundary for one transcript message. */
-export function SessionMessage({ messageId, children }: SessionMessageProps) {
-  return <div data-session-message-id={messageId}>{children}</div>;
+type WorkDetailsProps = Pick<
+  SessionMessageProps,
+  | "message"
+  | "messageIndex"
+  | "messages"
+  | "isSessionLive"
+  | "loadingStartedAt"
+  | "loadingNow"
+  | "expandedThinkingMessages"
+  | "expandedToolItems"
+  | "hydrationState"
+  | "resultFor"
+  | "onToggleThinking"
+  | "onToggleTool"
+  | "onHydrateTool"
+  | "onResourceClick"
+>;
+
+function previousUserMessage(messages: CopilotMessage[], beforeIndex: number) {
+  for (let index = beforeIndex - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "user") return messages[index];
+  }
+  return undefined;
+}
+
+function hasExpandableWork(
+  workItemCount: number,
+  workHasReasoning: boolean,
+  reasoningContent: string,
+  workHasUsage: boolean,
+  usageSummary: string,
+) {
+  if (workItemCount > 0) return true;
+  if (!workHasReasoning && Boolean(reasoningContent)) return true;
+  return !workHasUsage && Boolean(usageSummary);
+}
+
+function WorkDetailsHeader({
+  canExpand,
+  isExpanded,
+  label,
+  onToggle,
+}: {
+  canExpand: boolean;
+  isExpanded: boolean;
+  label: string;
+  onToggle: () => void;
+}) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={!canExpand}
+        style={{ width: "100%", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, border: "none", background: "transparent", padding: "0 0 0.65rem", cursor: canExpand ? "pointer" : "default", textAlign: "left", color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}
+      >
+        <span style={{ fontSize: 13, fontWeight: 500 }}>{label}</span>
+        {canExpand ? <ChevronRight size="16" style={{ flexShrink: 0, transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)", transition: "transform 160ms ease", color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))" }} /> : null}
+      </button>
+      <div style={{ borderTop: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }} />
+    </>
+  );
+}
+
+type WorkDetailsContentProps = Pick<
+  WorkDetailsProps,
+  "message" | "expandedToolItems" | "hydrationState" | "resultFor" | "onToggleTool" | "onHydrateTool" | "onResourceClick"
+> & {
+  items: ReturnType<typeof splitAssistantMessageTimeline>["workTimeline"];
+  isLive: boolean;
+  showReasoningFallback: boolean;
+  reasoningContent: string;
+  showUsageFallback: boolean;
+  usageSummary: string;
+};
+
+function WorkDetailsContent({
+  message,
+  items,
+  isLive,
+  expandedToolItems,
+  hydrationState,
+  resultFor,
+  onToggleTool,
+  onHydrateTool,
+  onResourceClick,
+  showReasoningFallback,
+  reasoningContent,
+  showUsageFallback,
+  usageSummary,
+}: WorkDetailsContentProps) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, paddingTop: 12 }}>
+      <AssistantMessageTimeline message={message} items={items} isLive={isLive} expandedTools={expandedToolItems} hydrationState={hydrationState} resultFor={resultFor} onToggleTool={onToggleTool} onHydrateTool={onHydrateTool} onResourceClick={onResourceClick} />
+      {showReasoningFallback ? <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>{reasoningContent}</div> : null}
+      {showUsageFallback ? <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>{usageSummary}</div> : null}
+    </div>
+  );
+}
+
+function MessageWorkDetails({
+  message,
+  messageIndex,
+  messages,
+  isSessionLive,
+  loadingStartedAt,
+  loadingNow,
+  expandedThinkingMessages,
+  expandedToolItems,
+  hydrationState,
+  resultFor,
+  onToggleThinking,
+  onToggleTool,
+  onHydrateTool,
+  onResourceClick,
+}: WorkDetailsProps) {
+  if (message.role !== "assistant") return null;
+  const isLive = isSessionLive && messageIndex === messages.length - 1;
+  const timeline = coalesceAssistantMessageTimelineForDisplay(getMessageAssistantTimeline(message));
+  const workTimeline = splitAssistantMessageTimeline(timeline).workTimeline;
+  const reasoningContent = getMessageReasoningContent(message);
+  const usageSummary = formatUsageSummary(getMessageUsage(message));
+  const workHasReasoning = workTimeline.some((item) => item.type === "reasoning");
+  const workHasUsage = workTimeline.some((item) => item.type === "usage");
+  const canExpand = hasExpandableWork(
+    workTimeline.length,
+    workHasReasoning,
+    reasoningContent,
+    workHasUsage,
+    usageSummary,
+  );
+  if (!canExpand && !isLive) return null;
+  const isExpanded = isLive || (expandedThinkingMessages[message.id] ?? false);
+  const label = isLive
+    ? formatWorkingDuration(loadingStartedAt, loadingNow)
+    : formatWorkDuration(previousUserMessage(messages, messageIndex)?.createdAt, message.createdAt);
+  const toggle = () => { if (canExpand) onToggleThinking(message.id); };
+
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <WorkDetailsHeader canExpand={canExpand} isExpanded={isExpanded} label={label} onToggle={toggle} />
+      {isExpanded ? <WorkDetailsContent {...{
+        message, items: workTimeline, isLive, expandedToolItems, hydrationState,
+        resultFor, onToggleTool, onHydrateTool, onResourceClick,
+        showReasoningFallback: !workHasReasoning && Boolean(reasoningContent), reasoningContent,
+        showUsageFallback: !workHasUsage && Boolean(usageSummary), usageSummary,
+      }} /> : null}
+    </div>
+  );
+}
+
+type MessageContentProps = Pick<
+  SessionMessageProps,
+  "message" | "isSessionLive" | "expandedToolItems" | "hydrationState" | "resultFor" | "onToggleTool" | "onHydrateTool" | "onResourceClick"
+> & {
+  isLiveAssistantMessage: boolean;
+  content: string;
+};
+
+function MessageContent({
+  message,
+  isLiveAssistantMessage,
+  content,
+  expandedToolItems,
+  hydrationState,
+  resultFor,
+  onToggleTool,
+  onHydrateTool,
+  onResourceClick,
+}: MessageContentProps) {
+  const timeline = splitAssistantMessageTimeline(
+    coalesceAssistantMessageTimelineForDisplay(getMessageAssistantTimeline(message)),
+  ).finalTimeline;
+  return (
+    <div
+      className={classNames(message.role === "system" && "copilot-system-message")}
+      style={{ minWidth: 0, overflow: "hidden", overflowWrap: "anywhere", whiteSpace: message.role === "assistant" ? "normal" : "pre-wrap", fontSize: message.role === "system" ? 12 : messageFontSize, lineHeight: 1.65, opacity: message.role === "system" ? 0.72 : 0.94, fontFamily: message.role === "system" ? "ui-monospace, SFMono-Regular, monospace" : undefined }}
+    >
+      {message.role === "assistant" && timeline.length > 0 ? (
+        <AssistantMessage message={message} items={timeline} content={content} onResourceClick={onResourceClick} />
+      ) : message.role === "assistant" ? <MarkdownMessage onResourceClick={onResourceClick}>{content}</MarkdownMessage> : content}
+    </div>
+  );
+}
+
+/** Presentation and interaction boundary for one transcript message. */
+export function SessionMessage({
+  message,
+  messageIndex,
+  messages,
+  isSessionLive,
+  loadingStartedAt,
+  loadingNow,
+  objectUrlForRef,
+  allowEditing,
+  enableDebugEditing,
+  editingMessageId,
+  editingMessageValue,
+  reviewActionMessageId,
+  expandedThinkingMessages,
+  expandedToolItems,
+  hydrationState,
+  resultFor,
+  onToggleThinking,
+  onToggleTool,
+  onHydrateTool,
+  onResourceClick,
+  onEditingValueChange,
+  onSaveEdit,
+  onCancelEdit,
+  onStartEdit,
+  onCopy,
+  onUpdateConnectorDelivery,
+}: SessionMessageProps) {
+  const content = getMessageContent(message);
+  const images = messageImages(message, objectUrlForRef);
+  const isUserMessage = message.role === "user";
+  const isLatestMessage = messageIndex === messages.length - 1;
+  const isLiveAssistantMessage = isSessionLive && isLatestMessage && message.role === "assistant";
+  const isEditableMessage =
+    (allowEditing || enableDebugEditing) &&
+    (message.role === "user" || message.role === "assistant") &&
+    !isLiveAssistantMessage;
+  const isEditingMessage = editingMessageId === message.id;
+  const isPendingConnectorDelivery =
+    enableDebugEditing && message.labels?.[connectorDeliveryStatusLabel] === connectorDeliveryPendingReview;
+  const isReviewActionPending = reviewActionMessageId === message.id;
+
+  return (
+    <div
+      data-session-message-id={message.id}
+      className="talon-session-message-row"
+      style={{ display: "flex", justifyContent: isUserMessage ? "flex-end" : "stretch", width: "100%" }}
+    >
+      <div style={{ width: isUserMessage ? "auto" : "100%", maxWidth: isUserMessage ? "min(80%, 36rem)" : "100%", overflow: "hidden" }}>
+        <div
+          style={{
+            overflow: "hidden",
+            borderRadius: isUserMessage ? 18 : 0,
+            background: isUserMessage ? "var(--talon-chat-user-bubble-bg, rgba(24,24,27,0.07))" : "transparent",
+            color: isUserMessage ? "var(--talon-chat-user-bubble-fg, inherit)" : "inherit",
+            padding: isUserMessage ? "0.75rem 1rem" : 0,
+          }}
+        >
+          <MessageWorkDetails {...{
+            message, messageIndex, messages, isSessionLive, loadingStartedAt, loadingNow,
+            expandedThinkingMessages, expandedToolItems, hydrationState, resultFor, onToggleThinking,
+            onToggleTool, onHydrateTool, onResourceClick,
+          }} />
+
+          {isPendingConnectorDelivery ? <ConnectorDeliveryControls message={message} disabled={isReviewActionPending || isEditingMessage} onUpdate={onUpdateConnectorDelivery} /> : null}
+
+          {isEditingMessage ? <MessageEditForm message={message} value={editingMessageValue} onChange={onEditingValueChange} onSave={onSaveEdit} onCancel={onCancelEdit} /> : <MessageContent {...{
+            message, isSessionLive, isLiveAssistantMessage, content, expandedToolItems, hydrationState,
+            resultFor, onToggleTool, onHydrateTool, onResourceClick,
+          }} />}
+          <MessageImages images={images} hasContent={Boolean(content)} />
+        </div>
+        {isEditableMessage && !isEditingMessage ? <MessageActions message={message} timestamp={actionTimestamp(message)} onCopy={onCopy} onEdit={onStartEdit} /> : null}
+      </div>
+    </div>
+  );
 }

--- a/packages/talon-chat/src/session/useSessionGeneration.ts
+++ b/packages/talon-chat/src/session/useSessionGeneration.ts
@@ -1,0 +1,232 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { TalonClient } from "@impalasys/talon-client";
+import type { CopilotMessage } from "../lib/chatTimeline";
+import { streamSessionPartEvents, type StreamEventItem } from "../lib/uiStream";
+import type { SessionHistoryPage } from "./history";
+import type { SessionTarget } from "./types";
+
+type SessionGenerationClient = Pick<TalonClient["sessions"], "streamParts" | "stopGeneration">;
+type RefreshSession = (target: SessionTarget, signal?: AbortSignal) => Promise<SessionHistoryPage | null>;
+
+type UseSessionGenerationOptions = {
+  client: SessionGenerationClient | undefined;
+  currentSession: SessionTarget | null;
+  currentSessionRef: MutableRefObject<SessionTarget | null>;
+  messagesRef: MutableRefObject<CopilotMessage[]>;
+  serverState: string;
+  isSessionLive: boolean;
+  isStopping: boolean;
+  submissionAbortControllerRef: MutableRefObject<AbortController | null>;
+  setMessages: Dispatch<SetStateAction<CopilotMessage[]>>;
+  setStreamEvents: Dispatch<SetStateAction<StreamEventItem[]>>;
+  setError: (error: Error | null) => void;
+  setIsLoading: (value: boolean) => void;
+  setIsResuming: (value: boolean) => void;
+  setIsStopping: (value: boolean) => void;
+  setLoadingStartedAt: (value: string | number | null) => void;
+  setLoadingNow: (value: number) => void;
+  refreshRuntime: RefreshSession;
+  refreshNewestSessionPage: RefreshSession;
+};
+
+function sameSession(left: SessionTarget | null, right: SessionTarget | null) {
+  return left?.ns === right?.ns && left?.agent === right?.agent && left?.sessionId === right?.sessionId;
+}
+
+function normalizeEpochToMilliseconds(value: unknown) {
+  let normalized: number | null = null;
+  if (typeof value === "bigint") {
+    const bigintValue = value < BigInt(0) ? -value : value;
+    if (bigintValue > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+    normalized = Number(value);
+  } else if (typeof value === "string") {
+    const numericValue = Number(value);
+    normalized = Number.isFinite(numericValue) ? numericValue : Date.parse(value);
+  } else if (typeof value === "number") {
+    normalized = value;
+  }
+  if (typeof normalized !== "number" || !Number.isFinite(normalized) || normalized <= 0) return null;
+  if (normalized >= 1e15) return Math.trunc(normalized / 1000);
+  if (normalized >= 1e12) return Math.trunc(normalized);
+  if (normalized >= 1e9) return Math.trunc(normalized * 1000);
+  return null;
+}
+
+function processingStartTime(messages: CopilotMessage[]) {
+  const latestUserMessage = [...messages].reverse().find((message) => message.role === "user");
+  return latestUserMessage ? normalizeEpochToMilliseconds(latestUserMessage.createdAt) : null;
+}
+
+/**
+ * Owns the long-lived generation transport: reconnecting an in-flight stream
+ * and requesting a stop. Submission stays separate because it also owns the
+ * composer, optimistic message, and image-upload workflows.
+ */
+export function useSessionGeneration({
+  client,
+  currentSession,
+  currentSessionRef,
+  messagesRef,
+  serverState,
+  isSessionLive,
+  isStopping,
+  submissionAbortControllerRef,
+  setMessages,
+  setStreamEvents,
+  setError,
+  setIsLoading,
+  setIsResuming,
+  setIsStopping,
+  setLoadingStartedAt,
+  setLoadingNow,
+  refreshRuntime,
+  refreshNewestSessionPage,
+}: UseSessionGenerationOptions) {
+  const resumeAbortControllerRef = useRef<AbortController | null>(null);
+  const stopAbortControllerRef = useRef<AbortController | null>(null);
+  const isStoppingRef = useRef(false);
+  const resumeStreamRef = useRef<(target: SessionTarget, signal?: AbortSignal) => Promise<void>>(async () => undefined);
+
+  const cancelResume = useCallback(() => {
+    resumeAbortControllerRef.current?.abort();
+    resumeAbortControllerRef.current = null;
+  }, []);
+
+  const startResume = useCallback((target: SessionTarget, delayMs = 0, allowWhileStopping = false) => {
+    if (isStoppingRef.current && !allowWhileStopping) return;
+    const controller = new AbortController();
+    cancelResume();
+    resumeAbortControllerRef.current = controller;
+    setIsResuming(true);
+    setLoadingStartedAt(processingStartTime(messagesRef.current) ?? Date.now());
+    setLoadingNow(Date.now());
+    const run = () => {
+      if (!controller.signal.aborted && sameSession(currentSessionRef.current, target) && (allowWhileStopping || !isStoppingRef.current)) {
+        void resumeStreamRef.current(target, controller.signal);
+      }
+    };
+    if (delayMs > 0) window.setTimeout(run, delayMs);
+    else run();
+  }, [cancelResume, currentSessionRef, messagesRef, setIsResuming, setLoadingNow, setLoadingStartedAt]);
+
+  const resumeStream = useCallback(async (target: SessionTarget, signal?: AbortSignal) => {
+    try {
+      if (!client?.streamParts) {
+        throw new Error("TalonSession requires a Talon clientset with sessions.streamParts().");
+      }
+      await streamSessionPartEvents({
+        events: client.streamParts(target, { signal }),
+        setMessages,
+        setStreamEvents,
+        signal,
+      });
+    } catch (err) {
+      if (!signal?.aborted) setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (!signal?.aborted && sameSession(currentSessionRef.current, target)) {
+        const refreshed = await refreshNewestSessionPage(target).catch(() => null);
+        if (refreshed?.state === "PROCESSING" && !isStoppingRef.current) {
+          startResume(target, 250);
+        } else {
+          setIsResuming(false);
+          setLoadingStartedAt(null);
+        }
+      }
+    }
+  }, [client, currentSessionRef, refreshNewestSessionPage, setError, setIsResuming, setLoadingStartedAt, setMessages, setStreamEvents, startResume]);
+  resumeStreamRef.current = resumeStream;
+
+  const waitForSessionToStop = useCallback(async (target: SessionTarget, signal?: AbortSignal) => {
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      if (signal?.aborted || !sameSession(currentSessionRef.current, target)) return null;
+      const refreshed = await refreshRuntime(target, signal);
+      if (signal?.aborted || !sameSession(currentSessionRef.current, target)) return null;
+      if (refreshed?.state !== "PROCESSING") return refreshed;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return null;
+  }, [currentSessionRef, refreshRuntime]);
+
+  const stopGeneration = useCallback(async (runtimeSignal?: AbortSignal) => {
+    if (!currentSessionRef.current || !isSessionLive || isStopping) return;
+    const session = currentSessionRef.current;
+    const stopController = new AbortController();
+    const abortFromRuntime = () => stopController.abort();
+    if (runtimeSignal) {
+      if (runtimeSignal.aborted) stopController.abort();
+      else runtimeSignal.addEventListener("abort", abortFromRuntime, { once: true });
+    }
+    const removeRuntimeAbort = () => runtimeSignal?.removeEventListener("abort", abortFromRuntime);
+    stopAbortControllerRef.current?.abort();
+    stopAbortControllerRef.current = stopController;
+    isStoppingRef.current = true;
+    setIsStopping(true);
+    submissionAbortControllerRef.current?.abort();
+    submissionAbortControllerRef.current = null;
+    cancelResume();
+    setIsLoading(false);
+    setIsResuming(false);
+    setLoadingStartedAt(null);
+
+    const resumeIfStillProcessing = async () => {
+      const refreshed = await refreshNewestSessionPage(session, stopController.signal).catch(() => null);
+      if (refreshed?.state === "PROCESSING") startResume(session, 0, true);
+    };
+
+    try {
+      if (!client?.stopGeneration) {
+        throw new Error("TalonSession requires a Talon clientset with sessions.stopGeneration().");
+      }
+      await client.stopGeneration(session, { signal: stopController.signal });
+      const stopped = await waitForSessionToStop(session, stopController.signal);
+      if (stopController.signal.aborted || !sameSession(currentSessionRef.current, session)) return;
+      if (!stopped) {
+        setError(new Error("Stop was requested, but the session is still generating."));
+        await resumeIfStillProcessing();
+        return;
+      }
+      await refreshNewestSessionPage(session, stopController.signal);
+      setIsResuming(false);
+      setLoadingStartedAt(null);
+      setError(null);
+    } catch (err) {
+      if (stopController.signal.aborted || !sameSession(currentSessionRef.current, session)) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+      await resumeIfStillProcessing();
+    } finally {
+      if (stopAbortControllerRef.current === stopController) stopAbortControllerRef.current = null;
+      removeRuntimeAbort();
+      if (!stopController.signal.aborted && sameSession(currentSessionRef.current, session)) {
+        isStoppingRef.current = false;
+        setIsStopping(false);
+      }
+    }
+  }, [cancelResume, client, currentSessionRef, isSessionLive, isStopping, refreshNewestSessionPage, setError, setIsLoading, setIsResuming, setIsStopping, setLoadingStartedAt, startResume, submissionAbortControllerRef, waitForSessionToStop]);
+
+  const reset = useCallback(() => {
+    cancelResume();
+    stopAbortControllerRef.current?.abort();
+    stopAbortControllerRef.current = null;
+    isStoppingRef.current = false;
+  }, [cancelResume]);
+
+  const previousSessionRef = useRef<SessionTarget | null>(currentSession);
+  useLayoutEffect(() => {
+    const previousSession = previousSessionRef.current;
+    previousSessionRef.current = currentSession;
+    if (!previousSession || (currentSession && sameSession(previousSession, currentSession))) return;
+    reset();
+  }, [currentSession?.agent, currentSession?.ns, currentSession?.sessionId, reset]);
+
+  useLayoutEffect(() => {
+    if (!currentSession || serverState !== "PROCESSING" || isStoppingRef.current) return;
+    if (resumeAbortControllerRef.current && !resumeAbortControllerRef.current.signal.aborted) return;
+    startResume(currentSession);
+    return cancelResume;
+  }, [cancelResume, currentSession, serverState, startResume]);
+
+  useLayoutEffect(() => () => reset(), [reset]);
+
+  return { cancelResume, isStoppingRef, reset, startResume, stopGeneration };
+}


### PR DESCRIPTION
## Summary
- move one transcript row into `SessionMessage`, including assistant trace placement, final response, image rendering, edit controls, actions, and connector controls
- use `AssistantMessageTimeline` for trace/details and `AssistantMessage` for final response content
- move resume/retry, stop/poll/recovery, abort propagation, and lifecycle cleanup into `useSessionGeneration`
- move session creation, commands, optimistic submit, image upload, streaming, busy recovery, and abort cleanup into `useSessionActions`

## Validation
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false` (59 passed)
- `pnpm --dir packages/talon-chat build`