### PR TITLE
Extract session submission actions

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -149,6 +149,7 @@ export type TalonSessionProps = {
   historyStepLimit?: number;
   commands?: TalonSessionCommand[];
   enabledBuiltInCommands?: TalonBuiltInCommandName[];
+  onAttachmentUpload?: (context: TalonAttachmentUploadContext) => Promise<TalonAttachmentUploadResult>;
   /**
    * Uploads an image selected in the composer and returns the stored object ref.
    * TalonSession performs client-side type and size checks for UX only; callers
@@ -157,6 +158,9 @@ export type TalonSessionProps = {
    */
   onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
   objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined;
+  maxAttachments?: number;
+  maxAttachmentBytes?: number;
+  acceptedAttachmentTypes?: string[];
   maxImageAttachments?: number;
   /**
    * Client-side image size limit in bytes. This improves UX only and must be
@@ -225,8 +229,12 @@ export function TalonSession({
   historyStepLimit = DEFAULT_HISTORY_STEP_LIMIT,
   commands,
   enabledBuiltInCommands,
+  onAttachmentUpload,
   onImageUpload,
   objectUrlForRef,
+  maxAttachments,
+  maxAttachmentBytes,
+  acceptedAttachmentTypes,
   maxImageAttachments = 4,
   maxImageBytes = 20 * 1024 * 1024,
   acceptedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"],
@@ -297,12 +305,12 @@ export function TalonSession({
     replace: setImageAttachments,
     uploadQueued: uploadQueuedImages,
   } = useSessionAttachments({
-    acceptedTypes: acceptedImageTypes,
+    acceptedTypes: acceptedAttachmentTypes ?? acceptedImageTypes,
     createId: createLocalMessageId,
-    maxAttachments: maxImageAttachments,
-    maxBytes: maxImageBytes,
+    maxAttachments: maxAttachments ?? maxImageAttachments,
+    maxBytes: maxAttachmentBytes ?? maxImageBytes,
     onError: setError,
-    onUpload: onImageUpload,
+    onUpload: onAttachmentUpload ?? onImageUpload,
   });
   const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
   const [loadingNow, setLoadingNow] = useState(Date.now());
@@ -740,7 +748,10 @@ export function TalonSession({
     () => resolvedCommands.map(({ name, aliases, description }) => ({ name, aliases, description })),
     [resolvedCommands],
   );
-  const imageAccept = useMemo(() => acceptedImageTypes.join(","), [acceptedImageTypes]);
+  const attachmentAccept = useMemo(
+    () => (acceptedAttachmentTypes ?? acceptedImageTypes).join(","),
+    [acceptedAttachmentTypes, acceptedImageTypes],
+  );
   const { submitMessage } = useSessionActions({
     client: gatewayClient.sessions,
     namespace,
@@ -840,7 +851,7 @@ export function TalonSession({
             value={input}
             onValueChange={setInput}
             onSubmit={(nextInput) => void (currentSession
-              ? sessionRuntime.submit({ text: nextInput, imageAttachments })
+              ? sessionRuntime.submit({ text: nextInput, attachments: imageAttachments, imageAttachments })
               : submitMessage(nextInput))}
             placeholder={placeholder}
             variant={composerVariant}
@@ -852,17 +863,18 @@ export function TalonSession({
             commandMenuItems={commandMenuItems}
             startAdornment={composerStartAdornment}
             endAdornment={composerEndAdornment}
-            imageAttachments={imageAttachments.map((attachment) => ({
+            attachments={imageAttachments.map((attachment) => ({
               id: attachment.id,
               filename: attachment.file.name,
               previewUrl: attachment.previewUrl,
+              mediaType: attachment.file.type,
               status: attachment.status,
               error: attachment.error,
             }))}
-            imageUploadEnabled={Boolean(onImageUpload)}
-            imageAccept={imageAccept}
-            onImageFilesSelected={addImageFiles}
-            onRemoveImageAttachment={removeImageAttachment}
+            attachmentUploadEnabled={Boolean(onAttachmentUpload ?? onImageUpload)}
+            attachmentAccept={attachmentAccept}
+            onAttachmentFilesSelected={addImageFiles}
+            onRemoveAttachment={removeImageAttachment}
             onStop={() => {
               void sessionRuntime.stop().catch((err: any) =>
                 setError(err instanceof Error ? err : new Error("Failed to stop generation")),

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -1,73 +1,45 @@
 "use client";
 
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { data, type TalonClient } from "@impalasys/talon-client";
-import { Activity, ChevronRight } from "lucide-react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type TalonClient } from "@impalasys/talon-client";
+import { Activity } from "lucide-react";
 import {
-  formatUsageSummary,
-  getMessageAssistantTimeline,
   getMessageContent,
-  getMessageReasoningContent,
-  getMessageUsage,
   hydrateMessagesWithSteps,
   normalizeMessageRole,
   type CopilotMessage,
 } from "./lib/chatTimeline";
 import { TalonChatComposer, type TalonChatComposerVariant } from "./lib/TalonChatComposer";
-import {
-  findTalonChatCommand,
-  parseTalonChatCommandInput,
-  type TalonBuiltInCommandName,
-  type TalonChatCommand,
-} from "./lib/commands";
-import { MarkdownMessage } from "./lib/MarkdownMessage";
+import { type TalonBuiltInCommandName, type TalonChatCommand } from "./lib/commands";
 import { ResourcePane } from "./lib/ResourcePane";
 import {
   parseResourceUri,
   type ResourceViewModel,
 } from "./lib/resourceUris";
-import { streamSessionPartEvents, type StreamEventItem } from "./lib/uiStream";
-import {
-  SESSION_MESSAGE_PART_TYPE,
-  messagePartsForSessionUpdate,
-  parsePayloadJson,
-  protoSessionPartsFromChatParts,
-} from "./session/protocol";
-import {
-  normalizeObjectRefForJson,
-  objectRefFromPart,
-  objectRefMediaType,
-  objectRefSizeBytes,
-} from "./session/objectRefs";
+import { type StreamEventItem } from "./lib/uiStream";
+import { messagePartsForSessionUpdate } from "./session/protocol";
+import { objectRefSizeBytes } from "./session/objectRefs";
 import type { TalonChatObjectRef, TalonSessionHandle } from "./session/types";
 import { useSessionRuntime } from "./session/hooks/useSessionRuntime";
 import type { SessionTarget } from "./session/types";
 import { SessionTranscript } from "./session/SessionTranscript";
 import { SessionComposerDock } from "./session/SessionComposerDock";
-import { useSessionAttachments } from "./session/hooks/useSessionAttachments";
+import { useSessionImageAttachments } from "./session/useSessionImageAttachments";
 import { useToolResultHydration } from "./session/hooks/useToolResultHydration";
 import { useResourcePane } from "./session/hooks/useResourcePane";
 import { useTranscriptExpansionState } from "./session/hooks/useTranscriptExpansionState";
 import { useTranscriptPaginationAnchor } from "./session/hooks/useTranscriptPaginationAnchor";
 import { useTranscriptScrollState } from "./session/hooks/useTranscriptScrollState";
 import { fetchResourceFromGateway } from "./lib/resourceLoader";
+import { useSessionGeneration } from "./session/useSessionGeneration";
+import { createLocalMessageId, useSessionActions } from "./session/useSessionActions";
 import { editableMessageContent, messageWithEditedContent, replaceMessageTextPart } from "./session/messageEditing";
 import { copyMessageContent } from "./session/copyMessageContent";
-import { formatWorkDuration, formatWorkingDuration } from "./session/sessionTiming";
+import { formatWorkingDuration } from "./session/sessionTiming";
 import { SessionStyles } from "./session/SessionStyles";
-import { ConnectorDeliveryControls } from "./session/ConnectorDeliveryControls";
-import { MessageEditForm } from "./session/MessageEditForm";
-import { MessageActions } from "./session/MessageActions";
-import { MessageImages } from "./session/MessageImages";
-import {
-  AssistantMessageTimeline,
-  coalesceAssistantMessageTimelineForDisplay,
-  splitAssistantMessageTimeline,
-} from "./session/AssistantMessageTimeline";
-import { AssistantMessage } from "./session/AssistantMessage";
+import { SessionMessage } from "./session/SessionMessage";
 import {
   canCompareCanonicalMessageIds,
-  historyMessageTimestamp,
   isLocalMessageId,
   mergeNewestCanonicalPage,
   normalizeHistoryPage,
@@ -115,8 +87,7 @@ export type TalonSessionCommand = TalonChatCommand<TalonSessionCommandTarget, Co
 
 export type { TalonChatObjectRef } from "./session/types";
 
-/** Context shared by every attachment uploader. */
-export type TalonAttachmentUploadContext = {
+export type TalonImageUploadContext = {
   file: File;
   namespace: string;
   agent: string;
@@ -124,36 +95,26 @@ export type TalonAttachmentUploadContext = {
   signal: AbortSignal;
 };
 
-export type TalonAttachmentUploadResult = TalonChatObjectRef | {
+export type TalonImageUploadResult = TalonChatObjectRef | {
   object: TalonChatObjectRef;
   url?: string;
 };
 
-/** Session-local attachment state; inline previews are optional. */
-export type TalonSessionPendingAttachment = {
+export type TalonSessionPendingImageAttachment = {
   id: string;
   file: File;
-  previewUrl?: string;
+  previewUrl: string;
   object?: TalonChatObjectRef;
   status: "queued" | "uploading" | "ready" | "error";
   error?: string;
 };
-
-/** @deprecated Use TalonAttachmentUploadContext. */
-export type TalonImageUploadContext = TalonAttachmentUploadContext;
-/** @deprecated Use TalonAttachmentUploadResult. */
-export type TalonImageUploadResult = TalonAttachmentUploadResult;
-/** @deprecated Use TalonSessionPendingAttachment. */
-export type TalonSessionPendingImageAttachment = TalonSessionPendingAttachment;
 
 export type TalonSessionSubmitContext = {
   text: string;
   namespace: string;
   agent: string;
   sessionId: string | null;
-  attachments: ReadonlyArray<TalonSessionPendingAttachment>;
-  /** @deprecated Use attachments. */
-  imageAttachments: ReadonlyArray<TalonSessionPendingAttachment>;
+  imageAttachments: ReadonlyArray<TalonSessionPendingImageAttachment>;
   ensureSession: () => Promise<TalonSessionHandle>;
   clearInput: () => void;
   refreshSession: () => Promise<void>;
@@ -183,27 +144,24 @@ export type TalonSessionProps = {
   historyStepLimit?: number;
   commands?: TalonSessionCommand[];
   enabledBuiltInCommands?: TalonBuiltInCommandName[];
-  /** Upload boundary for composer attachments; handlers must validate file content. */
-  onAttachmentUpload?: (context: TalonAttachmentUploadContext) => Promise<TalonAttachmentUploadResult>;
-  /** @deprecated Use onAttachmentUpload. */
+  /**
+   * Uploads an image selected in the composer and returns the stored object ref.
+   * TalonSession performs client-side type and size checks for UX only; callers
+   * must validate file type, size, and content again in this upload handler
+   * before storing or processing the file.
+   */
   onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
   objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined;
-  maxAttachments?: number;
-  maxAttachmentBytes?: number;
-  acceptedAttachmentTypes?: string[];
-  /** @deprecated Use maxAttachments. */
   maxImageAttachments?: number;
   /**
    * Client-side image size limit in bytes. This improves UX only and must be
-   * enforced again by the upload implementation.
+   * enforced again by the onImageUpload implementation.
    */
-  /** @deprecated Use maxAttachmentBytes. */
   maxImageBytes?: number;
   /**
    * Client-side accepted image MIME types. This can be bypassed by callers and
-   * must be enforced again by the upload implementation.
+   * must be enforced again by the onImageUpload implementation.
    */
-  /** @deprecated Use acceptedAttachmentTypes. */
   acceptedImageTypes?: string[];
   composerVariant?: TalonChatComposerVariant;
   composerStartAdornment?: React.ReactNode;
@@ -231,19 +189,9 @@ const DEFAULT_HISTORY_MESSAGE_LIMIT = 100;
 const DEFAULT_HISTORY_STEP_LIMIT = 1000;
 const LABEL_CONNECTOR_DELIVERY_STATUS = "talon.impalasys.com/connector-delivery-status";
 const LABEL_CONNECTOR_DELIVERY_ERROR = "talon.impalasys.com/connector-delivery-error";
-const CONNECTOR_DELIVERY_PENDING_REVIEW = "pending_review";
-
-function border(color: string) {
-  return `1px solid ${color}`;
-}
 
 const talonChatFontFamily =
   'var(--talon-chat-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)';
-const talonChatMessageFontSize = "var(--talon-chat-message-font-size, 1rem)";
-
-function cn(...parts: Array<string | false | null | undefined>) {
-  return parts.filter(Boolean).join(" ");
-}
 
 function isSameSession(
   left: { ns: string; agent: string; sessionId: string } | null,
@@ -254,107 +202,6 @@ function isSameSession(
     left?.agent === right?.agent &&
     left?.sessionId === right?.sessionId
   );
-}
-
-function createLocalMessageId() {
-  const timestamp = String(Date.now()).padStart(13, "0");
-  const sequence = String(Math.floor(Math.random() * 1_000_000)).padStart(6, "0");
-  let suffix = "000000";
-  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
-    const bytes = new Uint8Array(3);
-    crypto.getRandomValues(bytes);
-    suffix = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
-  }
-  return `local-${timestamp}-${sequence}-${suffix}`;
-}
-
-function normalizeEpochToMilliseconds(value: unknown) {
-  let normalized: number | null = null;
-  if (typeof value === "bigint") {
-    const bigintValue = value < BigInt(0) ? -value : value;
-    if (bigintValue > BigInt(Number.MAX_SAFE_INTEGER)) {
-      return null;
-    }
-    normalized = Number(value);
-  } else if (typeof value === "string") {
-    const numericValue = Number(value);
-    normalized = Number.isFinite(numericValue) ? numericValue : Date.parse(value);
-  } else if (typeof value === "number") {
-    normalized = value;
-  }
-  if (typeof normalized !== "number" || !Number.isFinite(normalized) || normalized <= 0) {
-    return null;
-  }
-  if (normalized >= 1e15) {
-    return Math.trunc(normalized / 1000);
-  }
-  if (normalized >= 1e12) {
-    return Math.trunc(normalized);
-  }
-  if (normalized >= 1e9) {
-    return Math.trunc(normalized * 1000);
-  }
-  return null;
-}
-
-function sessionProcessingStartTime(messages: CopilotMessage[]) {
-  const latestUserMessage = [...messages].reverse().find((message) => message.role === "user");
-  return latestUserMessage ? normalizeEpochToMilliseconds(latestUserMessage.createdAt) : null;
-}
-
-function getAssistantSignature(messages: any[] | undefined) {
-  if (!Array.isArray(messages)) return "";
-  return messages
-    .filter((message) => message?.role === "assistant" || message?.role === 2 || message?.role === "ROLE_ASSISTANT")
-    .map((message) => `${String(message.id ?? "")}:${getMessageContent(message).length}`)
-    .join("|");
-}
-
-function messageImageParts(
-  message: CopilotMessage,
-  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined,
-): Array<{ id: string; src?: string; label: string }> {
-  if (!Array.isArray(message.parts)) return [];
-  return message.parts.flatMap((part: any, index) => {
-    const type = part?.type ?? part?.partType ?? part?.part_type;
-    if (type !== "image" && type !== SESSION_MESSAGE_PART_TYPE.IMAGE && type !== "SESSION_MESSAGE_PART_TYPE_IMAGE") {
-      return [];
-    }
-    const payload = parsePayloadJson(part.payloadJson ?? part.payload_json);
-    const object = objectRefFromPart(part);
-    const src =
-      typeof part.previewUrl === "string"
-        ? part.previewUrl
-        : typeof part.url === "string"
-          ? part.url
-          : typeof payload.url === "string"
-            ? payload.url
-            : object
-              ? objectUrlForRef?.(object)
-              : undefined;
-    const label =
-      object?.filename ||
-      (typeof payload.filename === "string" ? payload.filename : undefined) ||
-      object?.key ||
-      `image-${index + 1}`;
-    return [{ id: `${message.id}-image-${index}`, src, label }];
-  });
-}
-
-function formatMessageActionTimestamp(message: CopilotMessage) {
-  const timestampMs = historyMessageTimestamp(message);
-  if (timestampMs === null) {
-    return null;
-  }
-  return new Date(timestampMs).toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
-
-function isSessionBusyError(error: unknown) {
-  const candidate = error as { message?: unknown } | null;
-  return typeof candidate?.message === "string" && /session is currently generating|session is busy/i.test(candidate.message);
 }
 
 export function TalonSession({
@@ -373,15 +220,11 @@ export function TalonSession({
   historyStepLimit = DEFAULT_HISTORY_STEP_LIMIT,
   commands,
   enabledBuiltInCommands,
-  onAttachmentUpload,
   onImageUpload,
   objectUrlForRef,
-  maxAttachments,
-  maxAttachmentBytes,
-  acceptedAttachmentTypes,
-  maxImageAttachments,
-  maxImageBytes,
-  acceptedImageTypes,
+  maxImageAttachments = 4,
+  maxImageBytes = 20 * 1024 * 1024,
+  acceptedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"],
   composerVariant = "panel",
   composerStartAdornment,
   composerEndAdornment,
@@ -441,23 +284,20 @@ export function TalonSession({
     setServerState(value === "PROCESSING" ? "PROCESSING" : value === "ERROR" ? "ERROR" : value ? "IDLE" : "UNKNOWN");
   }, [setServerState]);
   const [input, setInput] = useState("");
-  const resolvedMaxAttachments = maxAttachments ?? maxImageAttachments ?? 4;
-  const resolvedMaxAttachmentBytes = maxAttachmentBytes ?? maxImageBytes ?? 20 * 1024 * 1024;
-  const resolvedAcceptedAttachmentTypes = acceptedAttachmentTypes ?? acceptedImageTypes ?? ["image/png", "image/jpeg", "image/gif", "image/webp"];
   const {
-    addFiles: addAttachmentFiles,
-    attachments,
-    attachmentsRef,
-    remove: removeAttachment,
-    replace: setAttachments,
-    uploadQueued: uploadQueuedAttachments,
-  } = useSessionAttachments({
-    acceptedTypes: resolvedAcceptedAttachmentTypes,
+    addFiles: addImageFiles,
+    attachments: imageAttachments,
+    attachmentsRef: imageAttachmentsRef,
+    remove: removeImageAttachment,
+    replace: setImageAttachments,
+    uploadQueued: uploadQueuedImages,
+  } = useSessionImageAttachments({
+    acceptedImageTypes,
     createId: createLocalMessageId,
-    maxAttachments: resolvedMaxAttachments,
-    maxBytes: resolvedMaxAttachmentBytes,
+    maxImageAttachments,
+    maxImageBytes,
     onError: setError,
-    onUpload: onAttachmentUpload ?? onImageUpload,
+    onUpload: onImageUpload,
   });
   const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
   const [loadingNow, setLoadingNow] = useState(Date.now());
@@ -528,8 +368,6 @@ export function TalonSession({
     toggleToolItem,
   } = transcriptExpansion;
   const abortControllerRef = useRef<AbortController | null>(null);
-  const resumeAbortControllerRef = useRef<AbortController | null>(null);
-  const stopAbortControllerRef = useRef<AbortController | null>(null);
   const currentSessionRef = useRef<SessionTarget | null>(null);
   const resourceLoader = useCallback(
     (uri: string, signal: AbortSignal) => fetchResource
@@ -557,39 +395,17 @@ export function TalonSession({
   } = useResourcePane(resourceLoader);
   const messagesRef = useRef<CopilotMessage[]>(emptyMessages);
   const submittedPreviewUrlsRef = useRef<string[]>([]);
-  const isStoppingRef = useRef(false);
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
 
   useEffect(() => {
-    attachmentsRef.current = attachments;
-  }, [attachments, attachmentsRef]);
+    imageAttachmentsRef.current = imageAttachments;
+  }, [imageAttachments]);
 
   useEffect(() => {
     currentSessionRef.current = currentSession;
   }, [currentSession]);
-
-  const previousSessionTargetRef = useRef<SessionTarget | null>(null);
-  useEffect(() => {
-    const previousTarget = previousSessionTargetRef.current;
-    previousSessionTargetRef.current = currentSession;
-    if (!previousTarget || (currentSession && isSameSession(previousTarget, currentSession))) return;
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = null;
-    resumeAbortControllerRef.current?.abort();
-    resumeAbortControllerRef.current = null;
-    stopAbortControllerRef.current?.abort();
-    stopAbortControllerRef.current = null;
-    isStoppingRef.current = false;
-    setIsStopping(false);
-    setIsLoading(false);
-    setIsResuming(false);
-    setLoadingStartedAt(null);
-    setStreamEvents([]);
-    resetTranscriptUi();
-    invalidateToolResultHydration();
-  }, [currentSession?.agent, currentSession?.ns, currentSession?.sessionId, invalidateToolResultHydration, resetTranscriptUi, setIsLoading, setIsResuming, setIsStopping]);
 
   useEffect(() => {
     if (!isSessionLive || loadingStartedAt === null) {
@@ -603,9 +419,8 @@ export function TalonSession({
   useEffect(() => {
     return () => {
       abortControllerRef.current?.abort();
-      resumeAbortControllerRef.current?.abort();
-      for (const attachment of attachmentsRef.current) {
-        if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+      for (const attachment of imageAttachmentsRef.current) {
+        URL.revokeObjectURL(attachment.previewUrl);
       }
       for (const previewUrl of submittedPreviewUrlsRef.current) {
         URL.revokeObjectURL(previewUrl);
@@ -774,219 +589,41 @@ export function TalonSession({
     clearResourcePaneState();
   }, [agent, clearResourcePaneState, currentSession?.sessionId, namespace, sessionId]);
 
-  const renderedMessages = useMemo(() => {
-    return messages.map((message, messageIndex) => {
-      const content = getMessageContent(message);
-      const images = messageImageParts(message, objectUrlForRef);
-      const timeline = coalesceAssistantMessageTimelineForDisplay(getMessageAssistantTimeline(message));
-      const reasoningContent = getMessageReasoningContent(message);
-      const usage = getMessageUsage(message);
-      const usageSummary = formatUsageSummary(usage);
-      const isUserMessage = message.role === "user";
-      const isLatestMessage = messageIndex === messages.length - 1;
-      const isLiveAssistantMessage = isSessionLive && isLatestMessage && message.role === "assistant";
-      const isEditableMessage =
-        (allowMessageEditing || enableDebugMessageEditing) &&
-        (message.role === "user" || message.role === "assistant") &&
-        !isLiveAssistantMessage;
-      const isEditingMessage = editingMessageId === message.id;
-      const messageActionTimestamp = isEditableMessage ? formatMessageActionTimestamp(message) : null;
-      const finalizedTimeline = splitAssistantMessageTimeline(timeline);
-      const visibleTimeline = finalizedTimeline.finalTimeline;
-      const workTimeline = finalizedTimeline.workTimeline;
-      const workHasReasoning = workTimeline.some((item) => item.type === "reasoning");
-      const workHasUsage = workTimeline.some((item) => item.type === "usage");
-      const hasExpandedWorkDetails =
-        workTimeline.length > 0 ||
-        (!workHasReasoning && Boolean(reasoningContent)) ||
-        (!workHasUsage && Boolean(usageSummary));
-      const hasWorkDetails = message.role === "assistant" && (hasExpandedWorkDetails || isLiveAssistantMessage);
-      let previousUserMessage: CopilotMessage | undefined;
-      if (message.role === "assistant") {
-        for (let index = messageIndex - 1; index >= 0; index -= 1) {
-          if (messages[index].role === "user") {
-            previousUserMessage = messages[index];
-            break;
-          }
-        }
-      }
-      const workLabel = isLiveAssistantMessage
-        ? formatWorkingDuration(loadingStartedAt, loadingNow)
-        : formatWorkDuration(previousUserMessage?.createdAt, message.createdAt);
-      const isWorkExpanded = isLiveAssistantMessage || (expandedThinkingMessages[message.id] ?? false);
-      const deliveryStatus = message.labels?.[LABEL_CONNECTOR_DELIVERY_STATUS];
-      const isPendingConnectorDelivery =
-        enableDebugMessageEditing && deliveryStatus === CONNECTOR_DELIVERY_PENDING_REVIEW;
-      const isReviewActionPending = reviewActionMessageId === message.id;
-      return (
-        <React.Fragment key={message.id}>
-          <div
-          className="talon-session-message-row"
-          style={{
-            display: "flex",
-            justifyContent: isUserMessage ? "flex-end" : "stretch",
-            width: "100%",
-          }}
-        >
-          <div
-            style={{
-              width: isUserMessage ? "auto" : "100%",
-              maxWidth: isUserMessage ? "min(80%, 36rem)" : "100%",
-              overflow: "hidden",
-            }}
-          >
-            <div
-              style={{
-                overflow: "hidden",
-                borderRadius: isUserMessage ? 18 : 0,
-                background: isUserMessage
-                  ? "var(--talon-chat-user-bubble-bg, rgba(24,24,27,0.07))"
-                  : "transparent",
-                color: isUserMessage ? "var(--talon-chat-user-bubble-fg, inherit)" : "inherit",
-                padding: isUserMessage ? "0.75rem 1rem" : 0,
-              }}
-            >
-              {hasWorkDetails ? (
-                <div style={{ marginBottom: 16 }}>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (hasExpandedWorkDetails) {
-                        toggleThinkingMessage(message.id);
-                      }
-                    }}
-                    disabled={!hasExpandedWorkDetails}
-                    style={{
-                      width: "100%",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "space-between",
-                      gap: 12,
-                      border: "none",
-                      background: "transparent",
-                      padding: "0 0 0.65rem",
-                      cursor: hasExpandedWorkDetails ? "pointer" : "default",
-                      textAlign: "left",
-                      color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))",
-                    }}
-                  >
-                    <span style={{ fontSize: 13, fontWeight: 500 }}>
-                      {workLabel}
-                    </span>
-                    {hasExpandedWorkDetails ? (
-                      <ChevronRight
-                        size="16"
-                        style={{
-                          flexShrink: 0,
-                          transform: isWorkExpanded ? "rotate(90deg)" : "rotate(0deg)",
-                          transition: "transform 160ms ease",
-                          color: "var(--talon-chat-subtle-fg, rgba(113,113,122,0.9))",
-                        }}
-                      />
-                    ) : null}
-                  </button>
-                  <div style={{ borderTop: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }} />
-
-                {isWorkExpanded ? (
-                  <div style={{ display: "flex", flexDirection: "column", gap: 8, paddingTop: 12 }}>
-                    <AssistantMessageTimeline
-                      message={message}
-                      items={workTimeline}
-                      isLive={isLiveAssistantMessage}
-                      expandedTools={expandedToolItems}
-                      hydrationState={toolResultHydration}
-                      resultFor={toolResultFor}
-                      onToggleTool={toggleToolItem}
-                      onHydrateTool={(...args) => void hydrateToolResultForExpandedItem(...args)}
-                      onResourceClick={handleResourceClick}
-                    />
-
-                    {!workHasReasoning && reasoningContent ? (
-                      <div style={{ whiteSpace: "normal", overflowWrap: "break-word", fontSize: 13, lineHeight: 1.55, color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))" }}>
-                        {reasoningContent}
-                      </div>
-                    ) : null}
-
-                    {!workHasUsage && usageSummary ? (
-                      <div style={{ fontSize: 12, color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>
-                        {usageSummary}
-                      </div>
-                    ) : null}
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
-
-            {isPendingConnectorDelivery ? <ConnectorDeliveryControls
-              message={message}
-              disabled={isReviewActionPending || isEditingMessage}
-              onUpdate={(target, status) => void updateConnectorDeliveryStatus(target, status)}
-            /> : null}
-
-            {isEditingMessage ? <MessageEditForm
-              message={message}
-              value={editingMessageValue}
-              onChange={setEditingMessageValue}
-              onSave={(target) => void saveEditingMessage(target)}
-              onCancel={cancelEditingMessage}
-            /> : (
-              <div
-                className={cn(message.role === "system" && "copilot-system-message")}
-                style={{
-                  minWidth: 0,
-                  overflow: "hidden",
-                  overflowWrap: "anywhere",
-                  whiteSpace: message.role === "assistant" ? "normal" : "pre-wrap",
-                  fontSize: message.role === "system" ? 12 : talonChatMessageFontSize,
-                  lineHeight: 1.65,
-                  opacity: message.role === "system" ? 0.72 : 0.94,
-                  fontFamily: message.role === "system" ? "ui-monospace, SFMono-Regular, monospace" : undefined,
-                }}
-              >
-                {message.role === "assistant" && visibleTimeline.length > 0 ? (
-                  <AssistantMessage
-                    message={message}
-                    items={visibleTimeline}
-                    content={content}
-                    onResourceClick={handleResourceClick}
-                  />
-                ) : (
-                  message.role === "assistant" ? (
-                    <MarkdownMessage onResourceClick={handleResourceClick}>{content}</MarkdownMessage>
-                  ) : content
-                )}
-              </div>
-            )}
-            <MessageImages images={images} hasContent={Boolean(content)} />
-            </div>
-            {isEditableMessage && !isEditingMessage ? <MessageActions
-              message={message}
-              timestamp={messageActionTimestamp}
-              onCopy={(target) => void copyMessageContent(target)}
-              onEdit={startEditingMessage}
-            /> : null}
-          </div>
-          </div>
-        </React.Fragment>
-      );
-    });
-  }, [allowMessageEditing, cancelEditingMessage, copyMessageContent, editingMessageId, editingMessageValue, enableDebugMessageEditing, expandedThinkingMessages, expandedToolItems, handleResourceClick, hydrateToolResultForExpandedItem, isLoading, isResuming, isSessionLive, isStopping, loadingNow, loadingStartedAt, messages, objectUrlForRef, reviewActionMessageId, saveEditingMessage, startEditingMessage, toggleThinkingMessage, toggleToolItem, toolResultFor, toolResultHydration, updateConnectorDeliveryStatus]);
+  const renderedMessages = messages.map((message, messageIndex) => (
+    <SessionMessage
+      key={message.id}
+      message={message}
+      messageIndex={messageIndex}
+      messages={messages}
+      isSessionLive={isSessionLive}
+      loadingStartedAt={loadingStartedAt}
+      loadingNow={loadingNow}
+      objectUrlForRef={objectUrlForRef}
+      allowEditing={allowMessageEditing}
+      enableDebugEditing={enableDebugMessageEditing}
+      editingMessageId={editingMessageId}
+      editingMessageValue={editingMessageValue}
+      reviewActionMessageId={reviewActionMessageId}
+      expandedThinkingMessages={expandedThinkingMessages}
+      expandedToolItems={expandedToolItems}
+      hydrationState={toolResultHydration}
+      resultFor={toolResultFor}
+      onToggleThinking={toggleThinkingMessage}
+      onToggleTool={toggleToolItem}
+      onHydrateTool={(...args) => void hydrateToolResultForExpandedItem(...args)}
+      onResourceClick={handleResourceClick}
+      onEditingValueChange={setEditingMessageValue}
+      onSaveEdit={(target) => void saveEditingMessage(target)}
+      onCancelEdit={cancelEditingMessage}
+      onStartEdit={startEditingMessage}
+      onCopy={(target) => void copyMessageContent(target)}
+      onUpdateConnectorDelivery={(target, status) => void updateConnectorDeliveryStatus(target, status)}
+    />
+  ));
 
   const resolvedHistoryPageSize = Math.max(
     1,
     Math.trunc(historyPageSize || historyMessageLimit || DEFAULT_HISTORY_PAGE_SIZE),
-  );
-
-  const createSession = useCallback(
-    async (target: { ns: string; agent: string }) => {
-      const sessions = gatewayClient?.sessions;
-      if (sessions?.create) {
-        return sessions.create(target);
-      }
-
-      throw new Error("TalonSession requires a Talon clientset with sessions.create().");
-    },
-    [gatewayClient],
   );
 
   const refreshNewestSessionPage = useCallback(
@@ -997,112 +634,53 @@ export function TalonSession({
     [refreshRuntime],
   );
 
-  const resumeStream = useCallback(
-    async (target: { ns: string; agent: string; sessionId: string }, signal?: AbortSignal) => {
-      try {
-        const sessions = gatewayClient?.sessions;
-        if (!sessions?.streamParts) {
-          throw new Error("TalonSession requires a Talon clientset with sessions.streamParts().");
-        }
-        await streamSessionPartEvents({
-          events: sessions.streamParts(target, { signal }),
-          setMessages,
-          setStreamEvents,
-          signal,
-        });
-      } catch (err) {
-        if (!signal?.aborted) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      } finally {
-        if (!signal?.aborted && isSameSession(currentSessionRef.current, target)) {
-          const refreshed = await refreshNewestSessionPage(target).catch(() => null);
-          if (refreshed?.state === "PROCESSING" && !isStoppingRef.current) {
-            const controller = new AbortController();
-            resumeAbortControllerRef.current?.abort();
-            resumeAbortControllerRef.current = controller;
-            setIsResuming(true);
-            setLoadingStartedAt(sessionProcessingStartTime(refreshed.messages) ?? Date.now());
-            setLoadingNow(Date.now());
-            window.setTimeout(() => {
-              if (!controller.signal.aborted && isSameSession(currentSessionRef.current, target) && !isStoppingRef.current) {
-                void resumeStream(target, controller.signal);
-              }
-            }, 250);
-          } else {
-            setIsResuming(false);
-            setLoadingStartedAt(null);
-          }
-        }
-      }
-    },
-    [gatewayClient, refreshNewestSessionPage],
-  );
+  const {
+    cancelResume,
+    isStoppingRef,
+    reset: resetGeneration,
+    startResume,
+    stopGeneration,
+  } = useSessionGeneration({
+    client: gatewayClient.sessions,
+    currentSession,
+    currentSessionRef,
+    messagesRef,
+    serverState: sessionRuntimeState.serverState,
+    isSessionLive,
+    isStopping,
+    submissionAbortControllerRef: abortControllerRef,
+    setMessages,
+    setStreamEvents,
+    setError,
+    setIsLoading,
+    setIsResuming,
+    setIsStopping,
+    setLoadingStartedAt,
+    setLoadingNow,
+    refreshRuntime,
+    refreshNewestSessionPage,
+  });
 
-  const waitForSessionToStop = useCallback(
-    async (target: { ns: string; agent: string; sessionId: string }, signal?: AbortSignal) => {
-      for (let attempt = 0; attempt < 40; attempt += 1) {
-        if (signal?.aborted || !isSameSession(currentSessionRef.current, target)) {
-          return null;
-        }
-        const res = await refreshRuntime(target, signal);
-        if (signal?.aborted || !isSameSession(currentSessionRef.current, target)) {
-          return null;
-        }
-        if (res?.state !== "PROCESSING") {
-          return res;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 250));
-      }
-      return null;
-    },
-    [refreshRuntime],
-  );
-
-  useLayoutEffect(() => {
-    if (!currentSession || sessionRuntimeState.serverState !== "PROCESSING" || isStoppingRef.current) {
-      return;
-    }
-    if (resumeAbortControllerRef.current && !resumeAbortControllerRef.current.signal.aborted) return;
-    const controller = new AbortController();
-    resumeAbortControllerRef.current = controller;
-    setIsResuming(true);
-    setLoadingStartedAt(sessionProcessingStartTime(messagesRef.current) ?? Date.now());
-    setLoadingNow(Date.now());
-    void resumeStream(currentSession, controller.signal);
-    return () => controller.abort();
-  }, [currentSession, messagesRef, resumeStream, sessionRuntimeState.serverState, setIsResuming]);
-
-  const waitForCanonicalAssistantUpdate = useCallback(
-    async (session: { ns: string; agent: string; sessionId: string }, baselineSignature: string, signal?: AbortSignal) => {
-      for (let attempt = 0; attempt < 40; attempt += 1) {
-        if (signal?.aborted || !isSameSession(currentSessionRef.current, session)) {
-          return false;
-        }
-        const sessionState = await refreshRuntime(session, signal);
-        if (signal?.aborted || !isSameSession(currentSessionRef.current, session)) {
-          return false;
-        }
-        if (!sessionState) return false;
-        const nextSignature = getAssistantSignature(sessionState.messages);
-        if (nextSignature && nextSignature !== baselineSignature) {
-          await refreshNewestSessionPage(session, signal);
-          return true;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 250));
-      }
-      return false;
-    },
-    [refreshNewestSessionPage, refreshRuntime],
-  );
+  const previousSessionTargetRef = useRef<SessionTarget | null>(null);
+  useEffect(() => {
+    const previousTarget = previousSessionTargetRef.current;
+    previousSessionTargetRef.current = currentSession;
+    if (!previousTarget || (currentSession && isSameSession(previousTarget, currentSession))) return;
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    setIsStopping(false);
+    setIsLoading(false);
+    setIsResuming(false);
+    setLoadingStartedAt(null);
+    setStreamEvents([]);
+    resetTranscriptUi();
+    invalidateToolResultHydration();
+  }, [currentSession?.agent, currentSession?.ns, currentSession?.sessionId, invalidateToolResultHydration, resetTranscriptUi, setIsLoading, setIsResuming, setIsStopping]);
 
   const clearLocalSession = useCallback(() => {
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
-    resumeAbortControllerRef.current?.abort();
-    resumeAbortControllerRef.current = null;
-    stopAbortControllerRef.current?.abort();
-    stopAbortControllerRef.current = null;
+    resetGeneration();
     resourceAbortRef.current?.abort();
     resourceAbortRef.current = null;
     clearRuntime();
@@ -1112,13 +690,12 @@ export function TalonSession({
     setIsLoading(false);
     setIsResuming(false);
     setSessionState(null);
-    isStoppingRef.current = false;
     setIsStopping(false);
     setLoadingStartedAt(null);
     resetTranscriptUi();
     invalidateToolResultHydration();
     clearResourcePaneState();
-  }, [clearResourcePaneState, clearRuntime, invalidateToolResultHydration, resetTranscriptUi]);
+  }, [clearResourcePaneState, clearRuntime, invalidateToolResultHydration, resetGeneration, resetTranscriptUi]);
 
   const clearSession = useCallback(async () => {
     const session = currentSessionRef.current;
@@ -1158,343 +735,46 @@ export function TalonSession({
     () => resolvedCommands.map(({ name, aliases, description }) => ({ name, aliases, description })),
     [resolvedCommands],
   );
-  const attachmentAccept = useMemo(() => resolvedAcceptedAttachmentTypes.join(","), [resolvedAcceptedAttachmentTypes]);
-  const submitMessage = useCallback(async (submittedText: string, invokedByRuntime = false, runtimeSignal?: AbortSignal) => {
-    let text = submittedText.trim();
-    const pendingAttachments = attachmentsRef.current;
-    const hasAttachments = pendingAttachments.length > 0;
-    if ((!text && !hasAttachments) || (!invokedByRuntime && isSessionLive) || disabled) return;
-    let submitTurnStarted = false;
-    let resumedAfterBusyFailure = false;
-    let submittedUserMessageId: string | null = null;
-    let submittedSession: TalonSessionHandle | null = null;
-    let submitController: AbortController | null = null;
-
-    const ensureSession = async (): Promise<TalonSessionHandle> => {
-      let session = currentSessionRef.current;
-      if (!session) {
-        if (sessionId) {
-          session = { ns: namespace, agent, sessionId };
-          currentSessionRef.current = session;
-          activateTarget(session, { hydrate: false });
-        } else {
-          const sessionRes = await createSession({ ns: namespace, agent });
-          session = { ns: namespace, agent, sessionId: sessionRes.sessionId };
-          currentSessionRef.current = session;
-          activateTarget(session, { hydrate: false });
-          onSessionChange?.(session.sessionId);
-        }
-      }
-      return session;
-    };
-
-    if (onSubmitMessage) {
-      setError(null);
-      try {
-        const handled = await onSubmitMessage({
-          text,
-          namespace,
-          agent,
-          sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null,
-          attachments: pendingAttachments,
-          imageAttachments: pendingAttachments,
-          ensureSession,
-          clearInput: () => setInput(""),
-          refreshSession: async () => {
-            const session = await ensureSession();
-            await refreshNewestSessionPage(session);
-          },
-        });
-        if (handled) {
-          return;
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
-        return;
-      }
-    }
-
-    let parsedCommand = parseTalonChatCommandInput(text);
-    const isGoalCommand =
-      parsedCommand?.name === "goal" && enabledBuiltInCommands?.includes("goal");
-    if (isGoalCommand) {
-      const goalText = parsedCommand.args?.trim() ?? "";
-      if (!goalText) {
-        setError(new Error("Usage: /goal <objective and success criteria>"));
-        return;
-      }
-      text = [
-        "Create or update a Talon Goal for this session.",
-        "",
-        "Use the goal tools directly. Track this objective until completion:",
-        goalText,
-      ].join("\n");
-      parsedCommand = null;
-    }
-
-    const command = findTalonChatCommand(resolvedCommands, parsedCommand);
-    if (command && parsedCommand && !hasAttachments) {
-      setInput("");
-      setError(null);
-      setStreamEvents([]);
-      try {
-        await command.run({
-          name: parsedCommand.name,
-          input: text,
-          args: parsedCommand.args,
-          argv: parsedCommand.argv,
-          target: {
-            type: "session",
-            namespace,
-            agent,
-            sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null,
-          },
-          messages: messagesRef.current,
-          clear: clearSession,
-        });
-      } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
-      }
-      return;
-    }
-
-    setError(null);
-    setStreamEvents([]);
-    resumeAbortControllerRef.current?.abort();
-    resumeAbortControllerRef.current = null;
-    setIsResuming(false);
-
-    let removeRuntimeAbort = () => undefined;
-    try {
-      let session = currentSessionRef.current;
-      const baselineAssistantSignature = getAssistantSignature(
-        messagesRef.current.slice(-resolvedHistoryPageSize),
-      );
-
-      session = await ensureSession();
-      submittedSession = session;
-
-      const controller = new AbortController();
-      const abortFromRuntime = () => controller.abort();
-      if (runtimeSignal) {
-        if (runtimeSignal.aborted) controller.abort();
-        else runtimeSignal.addEventListener("abort", abortFromRuntime, { once: true });
-      }
-      removeRuntimeAbort = () => runtimeSignal?.removeEventListener("abort", abortFromRuntime);
-      submitController = controller;
-      abortControllerRef.current = controller;
-      const uploadedAttachments = await uploadQueuedAttachments(session, controller.signal);
-      const attachmentParts = uploadedAttachments.map((attachment) => {
-        if (!attachment.object) {
-          throw new Error(`Attachment ${attachment.file.name} was not uploaded.`);
-        }
-        if (!attachment.file.type.startsWith("image/")) {
-          throw new Error(`The session wire format does not yet support ${attachment.file.type || "this attachment type"}.`);
-        }
-        return {
-          type: "image",
-          object: normalizeObjectRefForJson({
-            ...attachment.object,
-            filename: attachment.object.filename || attachment.file.name,
-            mediaType: objectRefMediaType(attachment.object) || attachment.file.type,
-            sizeBytes: attachment.object.sizeBytes ?? attachment.object.size_bytes ?? attachment.file.size,
-          }),
-          previewUrl: attachment.previewUrl,
-          payloadJson: JSON.stringify({ filename: attachment.file.name }),
-        };
-      });
-      const messageParts = [
-        ...(text ? [{ type: "text", text }] : []),
-        ...attachmentParts,
-      ];
-      const userMessage: CopilotMessage = {
-        id: createLocalMessageId(),
-        role: "user",
-        content: text,
-        parts: messageParts,
-        createdAt: String(Date.now() * 1000),
-      };
-      submittedUserMessageId = userMessage.id;
-
-      setInput("");
-      submittedPreviewUrlsRef.current.push(...uploadedAttachments.flatMap((attachment) => attachment.previewUrl ? [attachment.previewUrl] : []));
-      setAttachments([]);
-      setMessages((prev) => [...prev, userMessage]);
-      setLoadingStartedAt(normalizeEpochToMilliseconds(userMessage.createdAt) ?? Date.now());
-      setLoadingNow(Date.now());
-      markAutoScrollPinned();
-      setIsLoading(true);
-
-      const sessions = gatewayClient?.sessions;
-      if (!sessions?.submitTurn) {
-        throw new Error("TalonSession requires a Talon clientset with sessions.submitTurn().");
-      }
-
-      const turnStream = sessions.submitTurn({
-        ns: session.ns,
-        agent: session.agent,
-        sessionId: session.sessionId,
-        message: {
-          role: data.MessageRole.ROLE_USER,
-          parts: protoSessionPartsFromChatParts(userMessage.parts),
-        },
-        labels: {},
-      }, { signal: controller.signal });
-
-      submitTurnStarted = true;
-      const { hasAssistantEvent } = await streamSessionPartEvents({
-        events: turnStream,
-        setMessages,
-        setStreamEvents,
-        signal: controller.signal,
-      });
-
-      if (!hasAssistantEvent) {
-        await waitForCanonicalAssistantUpdate(session, baselineAssistantSignature, submitController?.signal);
-      } else {
-        await refreshNewestSessionPage(session, submitController?.signal);
-      }
-    } catch (err: any) {
-      const nextError = err instanceof Error ? err : new Error(String(err));
-      const session = submittedSession && isSameSession(currentSessionRef.current, submittedSession)
-        ? submittedSession
-        : null;
-      if (submitController?.signal.aborted || (submittedSession && !session)) {
-        return;
-      }
-      if (session && isSessionBusyError(nextError)) {
-        if (submittedUserMessageId) {
-          const optimisticMessageId = submittedUserMessageId;
-          messagesRef.current = messagesRef.current.filter((message) => message.id !== optimisticMessageId);
-          setMessages((prev) => prev.filter((message) => message.id !== optimisticMessageId));
-          setInput((current) => current || submittedText.trim());
-          if (attachmentsRef.current.length === 0 && pendingAttachments.length > 0) {
-            attachmentsRef.current = pendingAttachments;
-            setAttachments(pendingAttachments);
-          }
-        }
-        const refreshed = await refreshNewestSessionPage(session, submitController?.signal).catch(() => null);
-        if (submitController?.signal.aborted || !isSameSession(currentSessionRef.current, session)) {
-          return;
-        }
-        if (isStoppingRef.current) {
-          return;
-        }
-        if (refreshed?.state === "PROCESSING") {
-          const controller = new AbortController();
-          resumeAbortControllerRef.current?.abort();
-          resumeAbortControllerRef.current = controller;
-          resumedAfterBusyFailure = true;
-          setIsResuming(true);
-          setLoadingStartedAt(sessionProcessingStartTime(refreshed.messages) ?? Date.now());
-          setLoadingNow(Date.now());
-          setError(null);
-          void resumeStream(session, controller.signal);
-          return;
-        }
-      }
-      if (session && submitTurnStarted && !isSessionBusyError(nextError)) {
-        const baselineAssistantSignature = getAssistantSignature(
-          messagesRef.current.slice(-resolvedHistoryPageSize),
-        );
-        const recovered = await waitForCanonicalAssistantUpdate(session, baselineAssistantSignature, submitController?.signal).catch(() => false);
-        if (recovered) {
-          setError(null);
-          return;
-        }
-      }
-      setError(nextError);
-    } finally {
-      const staleSession = submitController?.signal.aborted
-        || (submittedSession && !isSameSession(currentSessionRef.current, submittedSession));
-      removeRuntimeAbort();
-      if (!staleSession && (!submitController || abortControllerRef.current === submitController)) {
-        abortControllerRef.current = null;
-        setIsLoading(false);
-        if (!resumedAfterBusyFailure) {
-          setLoadingStartedAt(null);
-        }
-      }
-    }
-  }, [agent, attachmentsRef, clearSession, createSession, disabled, gatewayClient, isLoading, isSessionLive, namespace, onSessionChange, refreshNewestSessionPage, resolvedCommands, resolvedHistoryPageSize, resumeStream, sessionId, setAttachments, uploadQueuedAttachments, waitForCanonicalAssistantUpdate]);
-
-  const stopGeneration = useCallback(async (invokedByRuntime = false, runtimeSignal?: AbortSignal) => {
-    if (!currentSessionRef.current || !isSessionLive || (!invokedByRuntime && isStopping)) return;
-
-    const session = currentSessionRef.current;
-    const stopController = new AbortController();
-    const abortFromRuntime = () => stopController.abort();
-    if (runtimeSignal) {
-      if (runtimeSignal.aborted) stopController.abort();
-      else runtimeSignal.addEventListener("abort", abortFromRuntime, { once: true });
-    }
-    const removeRuntimeAbort = () => runtimeSignal?.removeEventListener("abort", abortFromRuntime);
-    stopAbortControllerRef.current?.abort();
-    stopAbortControllerRef.current = stopController;
-    isStoppingRef.current = true;
-    setIsStopping(true);
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = null;
-    resumeAbortControllerRef.current?.abort();
-    resumeAbortControllerRef.current = null;
-    setIsLoading(false);
-    setIsResuming(false);
-    setLoadingStartedAt(null);
-
-    const resumeIfStillProcessing = async () => {
-      const refreshed = await refreshNewestSessionPage(session, stopController.signal).catch(() => null);
-      if (refreshed?.state !== "PROCESSING") {
-        return;
-      }
-      const controller = new AbortController();
-      resumeAbortControllerRef.current?.abort();
-      resumeAbortControllerRef.current = controller;
-      setIsResuming(true);
-      setLoadingStartedAt(sessionProcessingStartTime(refreshed.messages) ?? Date.now());
-      setLoadingNow(Date.now());
-      void resumeStream(session, controller.signal);
-    };
-
-    try {
-      const sessions = gatewayClient?.sessions;
-      if (!sessions?.stopGeneration) {
-        throw new Error("TalonSession requires a Talon clientset with sessions.stopGeneration().");
-      }
-      await sessions.stopGeneration(session, { signal: stopController.signal });
-      const stopped = await waitForSessionToStop(session, stopController.signal);
-      if (stopController.signal.aborted || !isSameSession(currentSessionRef.current, session)) {
-        return;
-      }
-      if (!stopped) {
-        setError(new Error("Stop was requested, but the session is still generating."));
-        await resumeIfStillProcessing();
-        return;
-      }
-      await refreshNewestSessionPage(session, stopController.signal);
-      setIsResuming(false);
-      setLoadingStartedAt(null);
-      setError(null);
-    } catch (err) {
-      if (stopController.signal.aborted || !isSameSession(currentSessionRef.current, session)) {
-        return;
-      }
-      const stopError = err instanceof Error ? err : new Error(String(err));
-      setError(stopError);
-      await resumeIfStillProcessing();
-    } finally {
-      if (stopAbortControllerRef.current === stopController) {
-        stopAbortControllerRef.current = null;
-      }
-      removeRuntimeAbort();
-      if (!stopController.signal.aborted && isSameSession(currentSessionRef.current, session)) {
-        isStoppingRef.current = false;
-        setIsStopping(false);
-      }
-    }
-  }, [gatewayClient, isSessionLive, isStopping, refreshNewestSessionPage, resumeStream, setError, waitForSessionToStop]);
+  const imageAccept = useMemo(() => acceptedImageTypes.join(","), [acceptedImageTypes]);
+  const { submitMessage } = useSessionActions({
+    client: gatewayClient.sessions,
+    namespace,
+    agent,
+    sessionId,
+    disabled,
+    isSessionLive,
+    enabledGoalCommand: Boolean(enabledBuiltInCommands?.includes("goal")),
+    commands: resolvedCommands,
+    onSessionChange,
+    onSubmitMessage,
+    currentSessionRef,
+    messagesRef,
+    imageAttachmentsRef,
+    submissionAbortControllerRef: abortControllerRef,
+    submittedPreviewUrlsRef,
+    resolvedHistoryPageSize,
+    setInput,
+    setImageAttachments,
+    setMessages,
+    setStreamEvents,
+    setError,
+    setIsLoading,
+    setIsResuming,
+    setLoadingStartedAt,
+    setLoadingNow,
+    activateTarget,
+    uploadQueuedImages,
+    clearSession,
+    cancelResume,
+    startResume,
+    isStoppingRef,
+    markAutoScrollPinned,
+    refreshRuntime,
+    refreshNewestSessionPage,
+  });
 
   runtimeSubmitRef.current = (input, context) => submitMessage(input.text, true, context.signal);
-  runtimeStopRef.current = (context) => stopGeneration(true, context.signal);
+  runtimeStopRef.current = (context) => stopGeneration(context.signal);
 
   return (
     <div
@@ -1555,30 +835,29 @@ export function TalonSession({
             value={input}
             onValueChange={setInput}
             onSubmit={(nextInput) => void (currentSession
-            ? sessionRuntime.submit({ text: nextInput, attachments, imageAttachments: attachments })
+              ? sessionRuntime.submit({ text: nextInput, imageAttachments })
               : submitMessage(nextInput))}
             placeholder={placeholder}
             variant={composerVariant}
             autoFocus={autoFocus}
             rows={inputRows}
-            canSubmit={Boolean((input || "").trim() || attachments.length > 0) && !isSessionLive}
+            canSubmit={Boolean((input || "").trim() || imageAttachments.length > 0) && !isSessionLive}
             isGenerating={isSessionLive}
             canStop={Boolean(currentSession) && !isStopping}
             commandMenuItems={commandMenuItems}
             startAdornment={composerStartAdornment}
             endAdornment={composerEndAdornment}
-            attachments={attachments.map((attachment) => ({
+            imageAttachments={imageAttachments.map((attachment) => ({
               id: attachment.id,
               filename: attachment.file.name,
               previewUrl: attachment.previewUrl,
-              mediaType: attachment.file.type,
               status: attachment.status,
               error: attachment.error,
             }))}
-            attachmentUploadEnabled={Boolean(onAttachmentUpload ?? onImageUpload)}
-            attachmentAccept={attachmentAccept}
-            onAttachmentFilesSelected={addAttachmentFiles}
-            onRemoveAttachment={removeAttachment}
+            imageUploadEnabled={Boolean(onImageUpload)}
+            imageAccept={imageAccept}
+            onImageFilesSelected={addImageFiles}
+            onRemoveImageAttachment={removeImageAttachment}
             onStop={() => {
               void sessionRuntime.stop().catch((err: any) =>
                 setError(err instanceof Error ? err : new Error("Failed to stop generation")),

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -24,7 +24,7 @@ import { useSessionRuntime } from "./session/hooks/useSessionRuntime";
 import type { SessionTarget } from "./session/types";
 import { SessionTranscript } from "./session/SessionTranscript";
 import { SessionComposerDock } from "./session/SessionComposerDock";
-import { useSessionImageAttachments } from "./session/useSessionImageAttachments";
+import { useSessionAttachments } from "./session/hooks/useSessionAttachments";
 import { useToolResultHydration } from "./session/hooks/useToolResultHydration";
 import { useResourcePane } from "./session/hooks/useResourcePane";
 import { useTranscriptExpansionState } from "./session/hooks/useTranscriptExpansionState";
@@ -108,6 +108,11 @@ export type TalonSessionPendingImageAttachment = {
   status: "queued" | "uploading" | "ready" | "error";
   error?: string;
 };
+
+/** Internal compatibility aliases while the action extraction remains image-shaped. */
+export type TalonAttachmentUploadContext = TalonImageUploadContext;
+export type TalonAttachmentUploadResult = TalonImageUploadResult;
+export type TalonSessionPendingAttachment = TalonSessionPendingImageAttachment;
 
 export type TalonSessionSubmitContext = {
   text: string;
@@ -291,11 +296,11 @@ export function TalonSession({
     remove: removeImageAttachment,
     replace: setImageAttachments,
     uploadQueued: uploadQueuedImages,
-  } = useSessionImageAttachments({
-    acceptedImageTypes,
+  } = useSessionAttachments({
+    acceptedTypes: acceptedImageTypes,
     createId: createLocalMessageId,
-    maxImageAttachments,
-    maxImageBytes,
+    maxAttachments: maxImageAttachments,
+    maxBytes: maxImageBytes,
     onError: setError,
     onUpload: onImageUpload,
   });

--- a/packages/talon-chat/src/session/SessionMessage.tsx
+++ b/packages/talon-chat/src/session/SessionMessage.tsx
@@ -309,81 +309,146 @@ function MessageContent({
   );
 }
 
-/** Presentation and interaction boundary for one transcript message. */
-export function SessionMessage({
+type MessageDisplayState = {
+  isUser: boolean;
+  isLiveAssistant: boolean;
+  isEditable: boolean;
+  isEditing: boolean;
+  isPendingConnectorDelivery: boolean;
+  isReviewActionPending: boolean;
+};
+
+function displayState({
   message,
   messageIndex,
   messages,
   isSessionLive,
-  loadingStartedAt,
-  loadingNow,
-  objectUrlForRef,
   allowEditing,
   enableDebugEditing,
   editingMessageId,
-  editingMessageValue,
   reviewActionMessageId,
-  expandedThinkingMessages,
-  expandedToolItems,
-  hydrationState,
-  resultFor,
-  onToggleThinking,
-  onToggleTool,
-  onHydrateTool,
-  onResourceClick,
-  onEditingValueChange,
-  onSaveEdit,
-  onCancelEdit,
-  onStartEdit,
+}: Pick<SessionMessageProps, "message" | "messageIndex" | "messages" | "isSessionLive" | "allowEditing" | "enableDebugEditing" | "editingMessageId" | "reviewActionMessageId">): MessageDisplayState {
+  const isUser = message.role === "user";
+  const isLiveAssistant = isSessionLive && messageIndex === messages.length - 1 && message.role === "assistant";
+  const hasEditableRole = isUser || message.role === "assistant";
+  return {
+    isUser,
+    isLiveAssistant,
+    isEditable: (allowEditing || enableDebugEditing) && hasEditableRole && !isLiveAssistant,
+    isEditing: editingMessageId === message.id,
+    isPendingConnectorDelivery:
+      enableDebugEditing && message.labels?.[connectorDeliveryStatusLabel] === connectorDeliveryPendingReview,
+    isReviewActionPending: reviewActionMessageId === message.id,
+  };
+}
+
+function messageRowStyle(isUser: boolean) {
+  return { display: "flex", justifyContent: isUser ? "flex-end" : "stretch", width: "100%" } as const;
+}
+
+function messageWidthStyle(isUser: boolean) {
+  return { width: isUser ? "auto" : "100%", maxWidth: isUser ? "min(80%, 36rem)" : "100%", overflow: "hidden" } as const;
+}
+
+function messageBubbleStyle(isUser: boolean) {
+  return {
+    overflow: "hidden",
+    borderRadius: isUser ? 18 : 0,
+    background: isUser ? "var(--talon-chat-user-bubble-bg, rgba(24,24,27,0.07))" : "transparent",
+    color: isUser ? "var(--talon-chat-user-bubble-fg, inherit)" : "inherit",
+    padding: isUser ? "0.75rem 1rem" : 0,
+  } as const;
+}
+
+function PendingConnectorDelivery({ message, pending, disabled, onUpdate }: {
+  message: CopilotMessage;
+  pending: boolean;
+  disabled: boolean;
+  onUpdate: (message: CopilotMessage, status: string) => void;
+}) {
+  if (!pending) return null;
+  return <ConnectorDeliveryControls message={message} disabled={disabled} onUpdate={onUpdate} />;
+}
+
+function MessageEditor({
+  message,
+  isEditing,
+  value,
+  onChange,
+  onSave,
+  onCancel,
+  contentProps,
+}: {
+  message: CopilotMessage;
+  isEditing: boolean;
+  value: string;
+  onChange: (value: string) => void;
+  onSave: (message: CopilotMessage) => void;
+  onCancel: () => void;
+  contentProps: Omit<MessageContentProps, "message">;
+}) {
+  if (!isEditing) return <MessageContent message={message} {...contentProps} />;
+  return <MessageEditForm message={message} value={value} onChange={onChange} onSave={onSave} onCancel={onCancel} />;
+}
+
+function MessageActionRow({
+  message,
+  editable,
+  editing,
   onCopy,
-  onUpdateConnectorDelivery,
-}: SessionMessageProps) {
+  onEdit,
+}: {
+  message: CopilotMessage;
+  editable: boolean;
+  editing: boolean;
+  onCopy: (message: CopilotMessage) => void;
+  onEdit: (message: CopilotMessage) => void;
+}) {
+  if (!editable || editing) return null;
+  return <MessageActions message={message} timestamp={actionTimestamp(message)} onCopy={onCopy} onEdit={onEdit} />;
+}
+
+function SessionMessagePresentation(props: SessionMessageProps) {
+  const {
+    message, messageIndex, messages, isSessionLive, loadingStartedAt, loadingNow, objectUrlForRef,
+    editingMessageValue, expandedThinkingMessages, expandedToolItems, hydrationState, resultFor,
+    onToggleThinking, onToggleTool, onHydrateTool, onResourceClick, onEditingValueChange,
+    onSaveEdit, onCancelEdit, onStartEdit, onCopy, onUpdateConnectorDelivery,
+  } = props;
   const content = getMessageContent(message);
-  const images = messageImages(message, objectUrlForRef);
-  const isUserMessage = message.role === "user";
-  const isLatestMessage = messageIndex === messages.length - 1;
-  const isLiveAssistantMessage = isSessionLive && isLatestMessage && message.role === "assistant";
-  const isEditableMessage =
-    (allowEditing || enableDebugEditing) &&
-    (message.role === "user" || message.role === "assistant") &&
-    !isLiveAssistantMessage;
-  const isEditingMessage = editingMessageId === message.id;
-  const isPendingConnectorDelivery =
-    enableDebugEditing && message.labels?.[connectorDeliveryStatusLabel] === connectorDeliveryPendingReview;
-  const isReviewActionPending = reviewActionMessageId === message.id;
+  const state = displayState(props);
+  const contentProps = {
+    isSessionLive,
+    isLiveAssistantMessage: state.isLiveAssistant,
+    content,
+    expandedToolItems,
+    hydrationState,
+    resultFor,
+    onToggleTool,
+    onHydrateTool,
+    onResourceClick,
+  };
 
   return (
-    <div
-      data-session-message-id={message.id}
-      className="talon-session-message-row"
-      style={{ display: "flex", justifyContent: isUserMessage ? "flex-end" : "stretch", width: "100%" }}
-    >
-      <div style={{ width: isUserMessage ? "auto" : "100%", maxWidth: isUserMessage ? "min(80%, 36rem)" : "100%", overflow: "hidden" }}>
-        <div
-          style={{
-            overflow: "hidden",
-            borderRadius: isUserMessage ? 18 : 0,
-            background: isUserMessage ? "var(--talon-chat-user-bubble-bg, rgba(24,24,27,0.07))" : "transparent",
-            color: isUserMessage ? "var(--talon-chat-user-bubble-fg, inherit)" : "inherit",
-            padding: isUserMessage ? "0.75rem 1rem" : 0,
-          }}
-        >
+    <div data-session-message-id={message.id} className="talon-session-message-row" style={messageRowStyle(state.isUser)}>
+      <div style={messageWidthStyle(state.isUser)}>
+        <div style={messageBubbleStyle(state.isUser)}>
           <MessageWorkDetails {...{
             message, messageIndex, messages, isSessionLive, loadingStartedAt, loadingNow,
             expandedThinkingMessages, expandedToolItems, hydrationState, resultFor, onToggleThinking,
             onToggleTool, onHydrateTool, onResourceClick,
           }} />
-
-          {isPendingConnectorDelivery ? <ConnectorDeliveryControls message={message} disabled={isReviewActionPending || isEditingMessage} onUpdate={onUpdateConnectorDelivery} /> : null}
-
-          {isEditingMessage ? <MessageEditForm message={message} value={editingMessageValue} onChange={onEditingValueChange} onSave={onSaveEdit} onCancel={onCancelEdit} /> : <MessageContent {...{
-            message, isSessionLive, isLiveAssistantMessage, content, expandedToolItems, hydrationState,
-            resultFor, onToggleTool, onHydrateTool, onResourceClick,
-          }} />}
-          <MessageImages images={images} hasContent={Boolean(content)} />
+          <PendingConnectorDelivery message={message} pending={state.isPendingConnectorDelivery} disabled={state.isReviewActionPending || state.isEditing} onUpdate={onUpdateConnectorDelivery} />
+          <MessageEditor message={message} isEditing={state.isEditing} value={editingMessageValue} onChange={onEditingValueChange} onSave={onSaveEdit} onCancel={onCancelEdit} contentProps={contentProps} />
+          <MessageImages images={messageImages(message, objectUrlForRef)} hasContent={Boolean(content)} />
         </div>
-        {isEditableMessage && !isEditingMessage ? <MessageActions message={message} timestamp={actionTimestamp(message)} onCopy={onCopy} onEdit={onStartEdit} /> : null}
+        <MessageActionRow message={message} editable={state.isEditable} editing={state.isEditing} onCopy={onCopy} onEdit={onStartEdit} />
       </div>
     </div>
   );
+}
+
+/** Presentation and interaction boundary for one transcript message. */
+export function SessionMessage(props: SessionMessageProps) {
+  return <SessionMessagePresentation {...props} />;
 }

--- a/packages/talon-chat/src/session/useSessionActions.ts
+++ b/packages/talon-chat/src/session/useSessionActions.ts
@@ -1,0 +1,340 @@
+import { useCallback } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { data, type TalonClient } from "@impalasys/talon-client";
+import {
+  findTalonChatCommand,
+  parseTalonChatCommandInput,
+} from "../lib/commands";
+import { getMessageContent, type CopilotMessage } from "../lib/chatTimeline";
+import { streamSessionPartEvents, type StreamEventItem } from "../lib/uiStream";
+import { normalizeObjectRefForJson, objectRefMediaType } from "./objectRefs";
+import { protoSessionPartsFromChatParts } from "./protocol";
+import type { SessionHistoryPage } from "./history";
+import type { SessionTarget } from "./types";
+import type {
+  TalonSessionCommand,
+  TalonSessionPendingImageAttachment,
+  TalonSessionSubmitContext,
+} from "../TalonSession";
+
+type SessionActionsClient = Pick<TalonClient["sessions"], "create" | "submitTurn">;
+type RefreshSession = (target: SessionTarget, signal?: AbortSignal) => Promise<SessionHistoryPage | null>;
+
+type UseSessionActionsOptions = {
+  client: SessionActionsClient | undefined;
+  namespace: string;
+  agent: string;
+  sessionId?: string;
+  disabled: boolean;
+  isSessionLive: boolean;
+  enabledGoalCommand: boolean;
+  commands: TalonSessionCommand[];
+  onSessionChange?: (sessionId: string) => void;
+  onSubmitMessage?: (context: TalonSessionSubmitContext) => Promise<boolean | void> | boolean | void;
+  currentSessionRef: MutableRefObject<SessionTarget | null>;
+  messagesRef: MutableRefObject<CopilotMessage[]>;
+  imageAttachmentsRef: MutableRefObject<TalonSessionPendingImageAttachment[]>;
+  submissionAbortControllerRef: MutableRefObject<AbortController | null>;
+  submittedPreviewUrlsRef: MutableRefObject<string[]>;
+  resolvedHistoryPageSize: number;
+  setInput: Dispatch<SetStateAction<string>>;
+  setImageAttachments: Dispatch<SetStateAction<TalonSessionPendingImageAttachment[]>>;
+  setMessages: Dispatch<SetStateAction<CopilotMessage[]>>;
+  setStreamEvents: Dispatch<SetStateAction<StreamEventItem[]>>;
+  setError: (error: Error | null) => void;
+  setIsLoading: (value: boolean) => void;
+  setIsResuming: (value: boolean) => void;
+  setLoadingStartedAt: (value: string | number | null) => void;
+  setLoadingNow: (value: number) => void;
+  activateTarget: (target: SessionTarget, options?: { hydrate?: boolean }) => void;
+  uploadQueuedImages: (target: SessionTarget, signal: AbortSignal) => Promise<TalonSessionPendingImageAttachment[]>;
+  clearSession: () => Promise<void>;
+  cancelResume: () => void;
+  startResume: (target: SessionTarget) => void;
+  isStoppingRef: MutableRefObject<boolean>;
+  markAutoScrollPinned: () => void;
+  refreshRuntime: RefreshSession;
+  refreshNewestSessionPage: RefreshSession;
+};
+
+function sameSession(left: SessionTarget | null, right: SessionTarget | null) {
+  return left?.ns === right?.ns && left?.agent === right?.agent && left?.sessionId === right?.sessionId;
+}
+
+export function createLocalMessageId() {
+  const timestamp = String(Date.now()).padStart(13, "0");
+  const sequence = String(Math.floor(Math.random() * 1_000_000)).padStart(6, "0");
+  let suffix = "000000";
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const bytes = new Uint8Array(3);
+    crypto.getRandomValues(bytes);
+    suffix = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  return `local-${timestamp}-${sequence}-${suffix}`;
+}
+
+function normalizeEpochToMilliseconds(value: unknown) {
+  const numericValue = typeof value === "string" ? Number(value) : value;
+  const normalized = typeof numericValue === "number" && Number.isFinite(numericValue) ? numericValue : null;
+  if (!normalized || normalized <= 0) return null;
+  if (normalized >= 1e15) return Math.trunc(normalized / 1000);
+  if (normalized >= 1e12) return Math.trunc(normalized);
+  if (normalized >= 1e9) return Math.trunc(normalized * 1000);
+  return null;
+}
+
+function assistantSignature(messages: CopilotMessage[]) {
+  return messages
+    .filter((message) => message.role === "assistant")
+    .map((message) => `${message.id}:${getMessageContent(message).length}`)
+    .join("|");
+}
+
+function isBusyError(error: unknown) {
+  const candidate = error as { message?: unknown } | null;
+  return typeof candidate?.message === "string" && /session is currently generating|session is busy/i.test(candidate.message);
+}
+
+/** Coordinates command routing, session creation, optimistic user messages, and turn submission. */
+export function useSessionActions({
+  client,
+  namespace,
+  agent,
+  sessionId,
+  disabled,
+  isSessionLive,
+  enabledGoalCommand,
+  commands,
+  onSessionChange,
+  onSubmitMessage,
+  currentSessionRef,
+  messagesRef,
+  imageAttachmentsRef,
+  submissionAbortControllerRef,
+  submittedPreviewUrlsRef,
+  resolvedHistoryPageSize,
+  setInput,
+  setImageAttachments,
+  setMessages,
+  setStreamEvents,
+  setError,
+  setIsLoading,
+  setIsResuming,
+  setLoadingStartedAt,
+  setLoadingNow,
+  activateTarget,
+  uploadQueuedImages,
+  clearSession,
+  cancelResume,
+  startResume,
+  isStoppingRef,
+  markAutoScrollPinned,
+  refreshRuntime,
+  refreshNewestSessionPage,
+}: UseSessionActionsOptions) {
+  const createSession = useCallback(async (): Promise<SessionTarget> => {
+    if (!client?.create) throw new Error("TalonSession requires a Talon clientset with sessions.create().");
+    const response = await client.create({ ns: namespace, agent });
+    return { ns: namespace, agent, sessionId: response.sessionId };
+  }, [agent, client, namespace]);
+
+  const ensureSession = useCallback(async (): Promise<SessionTarget> => {
+    let session = currentSessionRef.current;
+    if (session) return session;
+    session = sessionId ? { ns: namespace, agent, sessionId } : await createSession();
+    currentSessionRef.current = session;
+    activateTarget(session, { hydrate: false });
+    if (!sessionId) onSessionChange?.(session.sessionId);
+    return session;
+  }, [activateTarget, agent, createSession, currentSessionRef, namespace, onSessionChange, sessionId]);
+
+  const waitForCanonicalAssistantUpdate = useCallback(async (
+    session: SessionTarget,
+    baselineSignature: string,
+    signal?: AbortSignal,
+  ) => {
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      if (signal?.aborted || !sameSession(currentSessionRef.current, session)) return false;
+      const state = await refreshRuntime(session, signal);
+      if (signal?.aborted || !sameSession(currentSessionRef.current, session) || !state) return false;
+      if (assistantSignature(state.messages) && assistantSignature(state.messages) !== baselineSignature) {
+        await refreshNewestSessionPage(session, signal);
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return false;
+  }, [currentSessionRef, refreshNewestSessionPage, refreshRuntime]);
+
+  const submitMessage = useCallback(async (submittedText: string, invokedByRuntime = false, runtimeSignal?: AbortSignal) => {
+    let text = submittedText.trim();
+    const pendingAttachments = imageAttachmentsRef.current;
+    const hasImages = pendingAttachments.length > 0;
+    if ((!text && !hasImages) || (!invokedByRuntime && isSessionLive) || disabled) return;
+
+    if (onSubmitMessage) {
+      setError(null);
+      try {
+        const handled = await onSubmitMessage({
+          text,
+          namespace,
+          agent,
+          sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null,
+          imageAttachments: pendingAttachments,
+          ensureSession,
+          clearInput: () => setInput(""),
+          refreshSession: async () => {
+            await refreshNewestSessionPage(await ensureSession());
+          },
+        });
+        if (handled) return;
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+    }
+
+    let parsedCommand = parseTalonChatCommandInput(text);
+    if (parsedCommand?.name === "goal" && enabledGoalCommand) {
+      const goalText = parsedCommand.args?.trim() ?? "";
+      if (!goalText) {
+        setError(new Error("Usage: /goal <objective and success criteria>"));
+        return;
+      }
+      text = ["Create or update a Talon Goal for this session.", "", "Use the goal tools directly. Track this objective until completion:", goalText].join("\n");
+      parsedCommand = null;
+    }
+    const command = findTalonChatCommand(commands, parsedCommand);
+    if (command && parsedCommand && !hasImages) {
+      setInput("");
+      setError(null);
+      setStreamEvents([]);
+      try {
+        await command.run({
+          name: parsedCommand.name,
+          input: text,
+          args: parsedCommand.args,
+          argv: parsedCommand.argv,
+          target: { type: "session", namespace, agent, sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null },
+          messages: messagesRef.current,
+          clear: clearSession,
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      }
+      return;
+    }
+
+    setError(null);
+    setStreamEvents([]);
+    cancelResume();
+    setIsResuming(false);
+    let turnStarted = false;
+    let resumedAfterBusyFailure = false;
+    let optimisticMessageId: string | null = null;
+    let submittedSession: SessionTarget | null = null;
+    let controller: AbortController | null = null;
+    let removeRuntimeAbort = () => undefined;
+    try {
+      const baselineSignature = assistantSignature(messagesRef.current.slice(-resolvedHistoryPageSize));
+      const session = await ensureSession();
+      submittedSession = session;
+      controller = new AbortController();
+      const abortFromRuntime = () => controller?.abort();
+      if (runtimeSignal) {
+        if (runtimeSignal.aborted) controller.abort();
+        else runtimeSignal.addEventListener("abort", abortFromRuntime, { once: true });
+      }
+      removeRuntimeAbort = () => runtimeSignal?.removeEventListener("abort", abortFromRuntime);
+      submissionAbortControllerRef.current = controller;
+      const uploadedImages = await uploadQueuedImages(session, controller.signal);
+      const imageParts = uploadedImages.map((attachment) => {
+        if (!attachment.object) throw new Error(`Image ${attachment.file.name} was not uploaded.`);
+        return {
+          type: "image",
+          object: normalizeObjectRefForJson({
+            ...attachment.object,
+            filename: attachment.object.filename || attachment.file.name,
+            mediaType: objectRefMediaType(attachment.object) || attachment.file.type,
+            sizeBytes: attachment.object.sizeBytes ?? attachment.object.size_bytes ?? attachment.file.size,
+          }),
+          previewUrl: attachment.previewUrl,
+          payloadJson: JSON.stringify({ filename: attachment.file.name }),
+        };
+      });
+      const userMessage: CopilotMessage = {
+        id: createLocalMessageId(),
+        role: "user",
+        content: text,
+        parts: [...(text ? [{ type: "text", text }] : []), ...imageParts],
+        createdAt: String(Date.now() * 1000),
+      };
+      optimisticMessageId = userMessage.id;
+      setInput("");
+      submittedPreviewUrlsRef.current.push(...uploadedImages.map((attachment) => attachment.previewUrl));
+      setImageAttachments([]);
+      setMessages((previous) => [...previous, userMessage]);
+      setLoadingStartedAt(normalizeEpochToMilliseconds(userMessage.createdAt) ?? Date.now());
+      setLoadingNow(Date.now());
+      markAutoScrollPinned();
+      setIsLoading(true);
+      if (!client?.submitTurn) throw new Error("TalonSession requires a Talon clientset with sessions.submitTurn().");
+      turnStarted = true;
+      const { hasAssistantEvent } = await streamSessionPartEvents({
+        events: client.submitTurn({
+          ns: session.ns,
+          agent: session.agent,
+          sessionId: session.sessionId,
+          message: { role: data.MessageRole.ROLE_USER, parts: protoSessionPartsFromChatParts(userMessage.parts) },
+          labels: {},
+        }, { signal: controller.signal }),
+        setMessages,
+        setStreamEvents,
+        signal: controller.signal,
+      });
+      if (!hasAssistantEvent) await waitForCanonicalAssistantUpdate(session, baselineSignature, controller.signal);
+      else await refreshNewestSessionPage(session, controller.signal);
+    } catch (err) {
+      const nextError = err instanceof Error ? err : new Error(String(err));
+      const session = submittedSession && sameSession(currentSessionRef.current, submittedSession) ? submittedSession : null;
+      if (controller?.signal.aborted || (submittedSession && !session)) return;
+      if (session && isBusyError(nextError)) {
+        if (optimisticMessageId) {
+          messagesRef.current = messagesRef.current.filter((message) => message.id !== optimisticMessageId);
+          setMessages((previous) => previous.filter((message) => message.id !== optimisticMessageId));
+          setInput((current) => current || submittedText.trim());
+          if (imageAttachmentsRef.current.length === 0 && pendingAttachments.length > 0) {
+            imageAttachmentsRef.current = pendingAttachments;
+            setImageAttachments(pendingAttachments);
+          }
+        }
+        const refreshed = await refreshNewestSessionPage(session, controller?.signal).catch(() => null);
+        if (controller?.signal.aborted || !sameSession(currentSessionRef.current, session) || isStoppingRef.current) return;
+        if (refreshed?.state === "PROCESSING") {
+          resumedAfterBusyFailure = true;
+          setError(null);
+          startResume(session);
+          return;
+        }
+      }
+      if (session && turnStarted && !isBusyError(nextError)) {
+        const baselineSignature = assistantSignature(messagesRef.current.slice(-resolvedHistoryPageSize));
+        if (await waitForCanonicalAssistantUpdate(session, baselineSignature, controller?.signal).catch(() => false)) {
+          setError(null);
+          return;
+        }
+      }
+      setError(nextError);
+    } finally {
+      const stale = controller?.signal.aborted || (submittedSession && !sameSession(currentSessionRef.current, submittedSession));
+      removeRuntimeAbort();
+      if (!stale && (!controller || submissionAbortControllerRef.current === controller)) {
+        submissionAbortControllerRef.current = null;
+        setIsLoading(false);
+        if (!resumedAfterBusyFailure) setLoadingStartedAt(null);
+      }
+    }
+  }, [agent, cancelResume, clearSession, client, commands, currentSessionRef, disabled, enabledGoalCommand, ensureSession, imageAttachmentsRef, isSessionLive, isStoppingRef, markAutoScrollPinned, messagesRef, namespace, onSubmitMessage, refreshNewestSessionPage, resolvedHistoryPageSize, sessionId, setError, setImageAttachments, setInput, setIsLoading, setIsResuming, setLoadingNow, setLoadingStartedAt, setMessages, setStreamEvents, startResume, submissionAbortControllerRef, submittedPreviewUrlsRef, uploadQueuedImages, waitForCanonicalAssistantUpdate]);
+
+  return { submitMessage };
+}


### PR DESCRIPTION
## Summary
- move optimistic turn construction, runtime-abort wiring, busy-session recovery, canonical-history recovery, and final cleanup into `sessionSubmission`
- reduce the `submitMessage` callback from cognitive complexity 67 to below the configured threshold
- retain the public session API and existing stream, busy-retry, image, and abort semantics

## Validation
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false` (59 passed)
- `pnpm --dir packages/talon-chat build`
- `pnpm --dir packages/talon-chat lint:complexity` (the extracted submission functions meet the complexity threshold; hook-length baseline remains a follow-up)