### PR TITLE
Extract Talon session composition hooks

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -1,217 +1,57 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { type TalonClient } from "@impalasys/talon-client";
-import { Activity } from "lucide-react";
+import React, { useCallback, useRef, useState } from "react";
 import {
-  getMessageContent,
   hydrateMessagesWithSteps,
   normalizeMessageRole,
   type CopilotMessage,
 } from "./lib/chatTimeline";
-import { TalonChatComposer, type TalonChatComposerVariant } from "./lib/TalonChatComposer";
-import { type TalonBuiltInCommandName, type TalonChatCommand } from "./lib/commands";
 import { ResourcePane } from "./lib/ResourcePane";
-import {
-  parseResourceUri,
-  type ResourceViewModel,
-} from "./lib/resourceUris";
 import { type StreamEventItem } from "./lib/uiStream";
-import { messagePartsForSessionUpdate } from "./session/protocol";
-import { objectRefSizeBytes } from "./session/objectRefs";
-import type { TalonChatObjectRef, TalonSessionHandle } from "./session/types";
-import { useSessionRuntime } from "./session/hooks/useSessionRuntime";
-import type { SessionTarget } from "./session/types";
 import { SessionTranscript } from "./session/SessionTranscript";
 import { SessionComposerDock } from "./session/SessionComposerDock";
 import { useSessionAttachments } from "./session/hooks/useSessionAttachments";
 import { useToolResultHydration } from "./session/hooks/useToolResultHydration";
-import { useResourcePane } from "./session/hooks/useResourcePane";
 import { useTranscriptExpansionState } from "./session/hooks/useTranscriptExpansionState";
 import { useTranscriptPaginationAnchor } from "./session/hooks/useTranscriptPaginationAnchor";
 import { useTranscriptScrollState } from "./session/hooks/useTranscriptScrollState";
 import { fetchResourceFromGateway } from "./lib/resourceLoader";
 import { useSessionGeneration } from "./session/useSessionGeneration";
 import { createLocalMessageId, useSessionActions } from "./session/useSessionActions";
-import { editableMessageContent, messageWithEditedContent, replaceMessageTextPart } from "./session/messageEditing";
+import { useSessionLifecycle } from "./session/useSessionLifecycle";
 import { copyMessageContent } from "./session/copyMessageContent";
 import { formatWorkingDuration } from "./session/sessionTiming";
 import { SessionStyles } from "./session/SessionStyles";
-import { SessionMessage } from "./session/SessionMessage";
+import { SessionMessageList } from "./session/SessionMessageList";
+import {
+  useSessionMessageEditing,
+} from "./session/useSessionMessageEditing";
+import { useSessionResourceClick } from "./session/useSessionResourceClick";
+import { useTalonSessionRuntime } from "./session/useTalonSessionRuntime";
+import { useSessionPresentationState } from "./session/useSessionPresentationState";
+import { useSessionResources } from "./session/useSessionResources";
+import { useSessionCommands } from "./session/useSessionCommands";
+import type {
+  TalonSessionProps,
+} from "./session/TalonSessionTypes";
 import {
   canCompareCanonicalMessageIds,
-  isLocalMessageId,
   mergeNewestCanonicalPage,
   normalizeHistoryPage,
   normalizeMessageLabels,
-  normalizeRawSessionMessage,
   type SessionHistoryPage,
 } from "./session/history";
 
-export type SessionServiceClientLike = {
-  sessions: Pick<
-    TalonClient["sessions"],
-    "create" | "clear" | "listMessages" | "submitTurn" | "streamParts" | "stopGeneration"
-  > & Partial<Pick<TalonClient["sessions"], "appendMessage" | "updateMessage">>;
-}["sessions"];
-
-export type CasServiceClientLike = Pick<TalonClient["cas"], "getObject">;
-
-export type ArtifactServiceClientLike = Pick<
-  TalonClient["artifacts"],
-  "readArtifact" | "getArtifactMetadata"
->;
-
-export type FileServiceClientLike = Pick<
-  TalonClient["files"],
-  "readFile" | "getFileMetadata"
->;
-
-export type GatewayClientLike = {
-  sessions: SessionServiceClientLike;
-  cas?: CasServiceClientLike;
-  artifacts?: ArtifactServiceClientLike;
-  files?: FileServiceClientLike;
-};
-
-export type { ResourceViewModel };
-
-export type TalonSessionCommandTarget = {
-  type: "session";
-  namespace: string;
-  agent: string;
-  sessionId: string | null;
-};
-
-export type TalonSessionCommand = TalonChatCommand<TalonSessionCommandTarget, CopilotMessage>;
-
-export type { TalonChatObjectRef } from "./session/types";
-
-export type TalonImageUploadContext = {
-  file: File;
-  namespace: string;
-  agent: string;
-  sessionId: string;
-  signal: AbortSignal;
-};
-
-export type TalonImageUploadResult = TalonChatObjectRef | {
-  object: TalonChatObjectRef;
-  url?: string;
-};
-
-export type TalonSessionPendingImageAttachment = {
-  id: string;
-  file: File;
-  previewUrl: string;
-  object?: TalonChatObjectRef;
-  status: "queued" | "uploading" | "ready" | "error";
-  error?: string;
-};
-
-/** Internal compatibility aliases while the action extraction remains image-shaped. */
-export type TalonAttachmentUploadContext = TalonImageUploadContext;
-export type TalonAttachmentUploadResult = TalonImageUploadResult;
-export type TalonSessionPendingAttachment = TalonSessionPendingImageAttachment;
-
-export type TalonSessionSubmitContext = {
-  text: string;
-  namespace: string;
-  agent: string;
-  sessionId: string | null;
-  imageAttachments: ReadonlyArray<TalonSessionPendingImageAttachment>;
-  ensureSession: () => Promise<TalonSessionHandle>;
-  clearInput: () => void;
-  refreshSession: () => Promise<void>;
-};
-
-export type TalonSessionMessageEditContext = {
-  message: CopilotMessage;
-  nextContent: string;
-  namespace: string;
-  agent: string;
-  sessionId: string | null;
-};
-
-export type TalonSessionProps = {
-  namespace: string;
-  agent: string;
-  gatewayClient: GatewayClientLike;
-  sessionId?: string;
-  onSessionChange?: (sessionId: string) => void;
-  className?: string;
-  style?: React.CSSProperties;
-  placeholder?: string;
-  autoFocus?: boolean;
-  disabled?: boolean;
-  historyPageSize?: number;
-  historyMessageLimit?: number;
-  historyStepLimit?: number;
-  commands?: TalonSessionCommand[];
-  enabledBuiltInCommands?: TalonBuiltInCommandName[];
-  onAttachmentUpload?: (context: TalonAttachmentUploadContext) => Promise<TalonAttachmentUploadResult>;
-  /**
-   * Uploads an image selected in the composer and returns the stored object ref.
-   * TalonSession performs client-side type and size checks for UX only; callers
-   * must validate file type, size, and content again in this upload handler
-   * before storing or processing the file.
-   */
-  onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
-  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined;
-  maxAttachments?: number;
-  maxAttachmentBytes?: number;
-  acceptedAttachmentTypes?: string[];
-  maxImageAttachments?: number;
-  /**
-   * Client-side image size limit in bytes. This improves UX only and must be
-   * enforced again by the onImageUpload implementation.
-   */
-  maxImageBytes?: number;
-  /**
-   * Client-side accepted image MIME types. This can be bypassed by callers and
-   * must be enforced again by the onImageUpload implementation.
-   */
-  acceptedImageTypes?: string[];
-  composerVariant?: TalonChatComposerVariant;
-  composerStartAdornment?: React.ReactNode;
-  composerEndAdornment?: React.ReactNode;
-  onSubmitMessage?: (context: TalonSessionSubmitContext) => Promise<boolean | void> | boolean | void;
-  allowMessageEditing?: boolean;
-  onMessageEdit?: (context: TalonSessionMessageEditContext) => Promise<boolean | void> | boolean | void;
-  enableDebugMessageEditing?: boolean;
-  /**
-   * Called when an artifact:// or file:// link is clicked.
-   * If omitted, the built-in split pane opens when the matching client is available.
-   */
-  onResourceClick?: (uri: string) => void;
-  /**
-   * Override content fetch for the built-in resource pane (both kinds).
-   */
-  fetchResource?: (uri: string, signal: AbortSignal) => Promise<ResourceViewModel>;
-};
-
-export type TalonCopilotProps = TalonSessionProps;
+export type * from "./session/TalonSessionTypes";
+export type { ResourceViewModel } from "./lib/resourceUris";
 
 const emptyMessages: CopilotMessage[] = [];
 const DEFAULT_HISTORY_PAGE_SIZE = 50;
 const DEFAULT_HISTORY_MESSAGE_LIMIT = 100;
 const DEFAULT_HISTORY_STEP_LIMIT = 1000;
-const LABEL_CONNECTOR_DELIVERY_STATUS = "talon.impalasys.com/connector-delivery-status";
-const LABEL_CONNECTOR_DELIVERY_ERROR = "talon.impalasys.com/connector-delivery-error";
 
 const talonChatFontFamily =
   'var(--talon-chat-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)';
-
-function isSameSession(
-  left: { ns: string; agent: string; sessionId: string } | null,
-  right: { ns: string; agent: string; sessionId: string } | null,
-) {
-  return (
-    left?.ns === right?.ns &&
-    left?.agent === right?.agent &&
-    left?.sessionId === right?.sessionId
-  );
-}
 
 export function TalonSession({
   namespace,
@@ -235,9 +75,9 @@ export function TalonSession({
   maxAttachments,
   maxAttachmentBytes,
   acceptedAttachmentTypes,
-  maxImageAttachments = 4,
-  maxImageBytes = 20 * 1024 * 1024,
-  acceptedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"],
+  maxImageAttachments,
+  maxImageBytes,
+  acceptedImageTypes,
   composerVariant = "panel",
   composerStartAdornment,
   composerEndAdornment,
@@ -248,28 +88,21 @@ export function TalonSession({
   onResourceClick: onResourceClickProp,
   fetchResource,
 }: TalonSessionProps) {
-  const initialSessionTarget = useMemo<SessionTarget | null>(
-    () => sessionId ? { ns: namespace, agent, sessionId } : null,
-    [agent, namespace, sessionId],
-  );
-  const runtimeClient = useMemo(() => ({
-    listMessages: async (target: SessionTarget, options?: { beforeMessageId?: string | null; pageSize?: number; signal?: AbortSignal }) => {
-      const response = await gatewayClient.sessions.listMessages({
-        ...target,
-        pageSize: options?.pageSize,
-        beforeMessageId: options?.beforeMessageId || undefined,
-      });
-      return normalizeHistoryPage(response);
-    },
-  }), [gatewayClient]);
-  const runtimeSubmitRef = useRef<((input: any, context: any) => Promise<void>) | null>(null);
-  const runtimeStopRef = useRef<((context: any) => Promise<void>) | null>(null);
-  const sessionRuntime = useSessionRuntime({
-    target: initialSessionTarget,
-    client: runtimeClient,
-    pageSize: Math.max(1, Math.trunc(historyPageSize || historyMessageLimit || DEFAULT_HISTORY_PAGE_SIZE)),
-    submit: (input, context) => runtimeSubmitRef.current?.(input, context) ?? Promise.resolve(),
-    stop: (_input, context) => runtimeStopRef.current?.(context) ?? Promise.resolve(),
+  const {
+    runtime: sessionRuntime,
+    setIsLoading,
+    setIsResuming,
+    setIsStopping,
+    setSessionState,
+    submitRef: runtimeSubmitRef,
+    stopRef: runtimeStopRef,
+  } = useTalonSessionRuntime({
+    agent,
+    gatewayClient,
+    historyPageSize,
+    historyMessageLimit,
+    namespace,
+    sessionId,
   });
   const {
     state: sessionRuntimeState,
@@ -290,13 +123,10 @@ export function TalonSession({
   const isStopping = sessionRuntimeState.phase === "stopping";
   const sessionState = sessionRuntimeState.serverState === "UNKNOWN" ? null : sessionRuntimeState.serverState;
   const isSessionLive = runtimeIsLive;
-  const setIsLoading = useCallback((value: boolean) => setPhase(value ? "submitting" : "idle"), [setPhase]);
-  const setIsResuming = useCallback((value: boolean) => setPhase(value ? "resuming" : "idle"), [setPhase]);
-  const setIsStopping = useCallback((value: boolean) => setPhase(value ? "stopping" : "idle"), [setPhase]);
-  const setSessionState = useCallback((value: string | null) => {
-    setServerState(value === "PROCESSING" ? "PROCESSING" : value === "ERROR" ? "ERROR" : value ? "IDLE" : "UNKNOWN");
-  }, [setServerState]);
   const [input, setInput] = useState("");
+  const resolvedMaxAttachments = maxAttachments ?? maxImageAttachments ?? 4;
+  const resolvedMaxAttachmentBytes = maxAttachmentBytes ?? maxImageBytes ?? 20 * 1024 * 1024;
+  const resolvedAcceptedAttachmentTypes = acceptedAttachmentTypes ?? acceptedImageTypes ?? ["image/png", "image/jpeg", "image/gif", "image/webp"];
   const {
     addFiles: addImageFiles,
     attachments: imageAttachments,
@@ -305,15 +135,14 @@ export function TalonSession({
     replace: setImageAttachments,
     uploadQueued: uploadQueuedImages,
   } = useSessionAttachments({
-    acceptedTypes: acceptedAttachmentTypes ?? acceptedImageTypes,
+    acceptedTypes: resolvedAcceptedAttachmentTypes,
     createId: createLocalMessageId,
-    maxAttachments: maxAttachments ?? maxImageAttachments,
-    maxBytes: maxAttachmentBytes ?? maxImageBytes,
+    maxAttachments: resolvedMaxAttachments,
+    maxBytes: resolvedMaxAttachmentBytes,
     onError: setError,
     onUpload: onAttachmentUpload ?? onImageUpload,
   });
   const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
-  const [loadingNow, setLoadingNow] = useState(Date.now());
   const error = sessionRuntimeState.error;
   const [streamEvents, setStreamEvents] = useState<StreamEventItem[]>([]);
   const {
@@ -325,10 +154,6 @@ export function TalonSession({
     gatewayClient?.cas,
     currentSession ? `${currentSession.ns}\u0000${currentSession.agent}\u0000${currentSession.sessionId}` : null,
   );
-  const missingResourceClientWarnedRef = useRef(false);
-  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
-  const [editingMessageValue, setEditingMessageValue] = useState("");
-  const [reviewActionMessageId, setReviewActionMessageId] = useState<string | null>(null);
   const hasMoreHistory = sessionRuntimeState.history.hasMoreOlder;
   const nextBeforeMessageId = sessionRuntimeState.history.beforeMessageId;
   const loadOlderHistory = useCallback(async () => {
@@ -381,19 +206,21 @@ export function TalonSession({
     toggleToolItem,
   } = transcriptExpansion;
   const abortControllerRef = useRef<AbortController | null>(null);
-  const currentSessionRef = useRef<SessionTarget | null>(null);
-  const resourceLoader = useCallback(
-    (uri: string, signal: AbortSignal) => fetchResource
-      ? fetchResource(uri, signal)
-      : fetchResourceFromGateway({
-          uri,
-          gatewayClient,
-          agent,
-          sessionId: currentSession?.sessionId ?? sessionId ?? null,
-          signal,
-        }),
-    [agent, currentSession?.sessionId, fetchResource, gatewayClient, sessionId],
-  );
+  const {
+    currentSessionRef,
+    inputRows,
+    loadingNow,
+    messagesRef,
+    setLoadingNow,
+    submittedPreviewUrlsRef,
+  } = useSessionPresentationState({
+    abortControllerRef,
+    currentSession,
+    input,
+    isSessionLive,
+    loadingStartedAt,
+    messages,
+  });
   const {
     openResourceUri,
     resourcePaneOpen,
@@ -405,234 +232,69 @@ export function TalonSession({
     reset: clearResourcePaneState,
     completeClose: handleResourcePaneExitComplete,
     abortRef: resourceAbortRef,
-  } = useResourcePane(resourceLoader);
-  const messagesRef = useRef<CopilotMessage[]>(emptyMessages);
-  const submittedPreviewUrlsRef = useRef<string[]>([]);
-  useEffect(() => {
-    messagesRef.current = messages;
-  }, [messages]);
+  } = useSessionResources({ agent, currentSessionId: currentSession?.sessionId ?? null, fetchResource, gatewayClient, sessionId });
+  const {
+    editingMessageId,
+    editingMessageValue,
+    reviewActionMessageId,
+    setEditingMessageValue,
+    startEditingMessage,
+    cancelEditingMessage,
+    saveEditingMessage,
+    updateConnectorDeliveryStatus,
+  } = useSessionMessageEditing({
+    agent,
+    client: gatewayClient.sessions,
+    currentSessionRef,
+    enableDebugMessageEditing,
+    fallbackSessionId: sessionId,
+    messagesRef,
+    namespace,
+    onMessageEdit,
+    setError,
+    setMessages,
+  });
 
-  useEffect(() => {
-    imageAttachmentsRef.current = imageAttachments;
-  }, [imageAttachments]);
+  const handleResourceClick = useSessionResourceClick({
+    canFetchArtifact: Boolean(fetchResource) || Boolean(gatewayClient.artifacts?.readArtifact),
+    canFetchFile: Boolean(fetchResource) || Boolean(gatewayClient.files?.readFile),
+    closeResourcePane,
+    onResourceClick: onResourceClickProp,
+    openResource,
+    openResourceUri,
+    resourcePaneOpen,
+  });
 
-  useEffect(() => {
-    currentSessionRef.current = currentSession;
-  }, [currentSession]);
-
-  useEffect(() => {
-    if (!isSessionLive || loadingStartedAt === null) {
-      return;
-    }
-    setLoadingNow(Date.now());
-    const intervalId = window.setInterval(() => setLoadingNow(Date.now()), 250);
-    return () => window.clearInterval(intervalId);
-  }, [isSessionLive, loadingStartedAt]);
-
-  useEffect(() => {
-    return () => {
-      abortControllerRef.current?.abort();
-      for (const attachment of imageAttachmentsRef.current) {
-        URL.revokeObjectURL(attachment.previewUrl);
-      }
-      for (const previewUrl of submittedPreviewUrlsRef.current) {
-        URL.revokeObjectURL(previewUrl);
-      }
-    };
-  }, []);
-
-  const inputRows = useMemo(() => {
-    let rowCount = 1;
-    for (let index = 0; index < input.length; index += 1) {
-      if (input.charCodeAt(index) === 10) {
-        rowCount += 1;
-      }
-    }
-    return Math.min(rowCount, 8);
-  }, [input]);
-
-  const updateSessionMessage = useCallback(
-    async (message: CopilotMessage, parts: unknown[], labels: Record<string, string>) => {
-      const session = currentSessionRef.current ?? (sessionId ? { ns: namespace, agent, sessionId } : null);
-      const sessions = gatewayClient?.sessions;
-      if (!session) {
-        throw new Error("No active session to update.");
-      }
-      if (!sessions?.updateMessage) {
-        throw new Error("Gateway client does not support sessions.updateMessage().");
-      }
-      const response = await sessions.updateMessage({
-        ns: session.ns,
-        agent: session.agent,
-        sessionId: session.sessionId,
-        messageId: message.id,
-        parts,
-        labels,
-      });
-      const updated = response?.message
-        ? { ...message, ...normalizeRawSessionMessage(response.message) }
-        : { ...message, parts, labels, content: getMessageContent({ ...message, parts }) };
-      setMessages((current) => {
-        const nextMessages = current.map((item) => item.id === message.id ? updated : item);
-        messagesRef.current = nextMessages;
-        return nextMessages;
-      });
-      return updated;
-    },
-    [agent, gatewayClient, namespace, sessionId],
-  );
-
-  const startEditingMessage = useCallback((message: CopilotMessage) => {
-    setEditingMessageId(message.id);
-    setEditingMessageValue(editableMessageContent(message));
-  }, []);
-
-  const cancelEditingMessage = useCallback(() => {
-    setEditingMessageId(null);
-    setEditingMessageValue("");
-  }, []);
-
-  const saveEditingMessage = useCallback(async (message: CopilotMessage) => {
-    const nextContent = editingMessageValue.trim();
-    if (!nextContent) {
-      return;
-    }
-    setError(null);
-    const shouldPersistSessionEdit =
-      enableDebugMessageEditing &&
-      (message.role === "user" || message.role === "assistant") &&
-      !isLocalMessageId(message.id);
-    try {
-      if (shouldPersistSessionEdit) {
-        setReviewActionMessageId(message.id);
-        await updateSessionMessage(message, replaceMessageTextPart(message, nextContent), { ...(message.labels ?? {}) });
-        cancelEditingMessage();
-        return;
-      }
-      const handled = await onMessageEdit?.({
-        message,
-        nextContent,
-        namespace,
-        agent,
-        sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null,
-      });
-      if (handled === false) {
-        return;
-      }
-      setMessages((prev) => {
-        const nextMessages = prev.map((item) => item.id === message.id ? messageWithEditedContent(item, nextContent) : item);
-        messagesRef.current = nextMessages;
-        return nextMessages;
-      });
-      cancelEditingMessage();
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error(String(err)));
-    } finally {
-      setReviewActionMessageId(null);
-    }
-  }, [agent, cancelEditingMessage, editingMessageValue, enableDebugMessageEditing, namespace, onMessageEdit, sessionId, updateSessionMessage]);
-
-  const updateConnectorDeliveryStatus = useCallback(
-    async (message: CopilotMessage, status: string) => {
-      const labels = {
-        ...(message.labels ?? {}),
-        [LABEL_CONNECTOR_DELIVERY_STATUS]: status,
-      };
-      delete labels[LABEL_CONNECTOR_DELIVERY_ERROR];
-      setError(null);
-      setReviewActionMessageId(message.id);
-      try {
-        await updateSessionMessage(message, messagePartsForSessionUpdate(message), labels);
-      } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
-      } finally {
-        setReviewActionMessageId(null);
-      }
-    },
-    [updateSessionMessage],
-  );
-
-  const handleResourceClick = useCallback(
-    (uri: string) => {
-      if (onResourceClickProp) {
-        onResourceClickProp(uri);
-        return;
-      }
-
-      const parsed = parseResourceUri(uri);
-      if (!parsed) return;
-
-      if (openResourceUri === parsed.uri && resourcePaneOpen) {
-        closeResourcePane();
-        return;
-      }
-
-      const canFetchArtifact =
-        Boolean(fetchResource) || Boolean(gatewayClient?.artifacts?.readArtifact);
-      const canFetchFile = Boolean(fetchResource) || Boolean(gatewayClient?.files?.readFile);
-      const canOpen =
-        (parsed.kind === "artifact" && canFetchArtifact) ||
-        (parsed.kind === "file" && canFetchFile);
-
-      if (!canOpen) {
-        if (!missingResourceClientWarnedRef.current && typeof console !== "undefined") {
-          missingResourceClientWarnedRef.current = true;
-          console.warn(
-            "[talon-chat] Resource link clicked but no artifacts/files client (or fetchResource) is available.",
-          );
-        }
-        return;
-      }
-
-      void openResource(parsed.uri);
-    },
-    [
-      closeResourcePane,
-      fetchResource,
-      gatewayClient,
-      openResource,
-      onResourceClickProp,
-      openResourceUri,
-      resourcePaneOpen,
-    ],
-  );
-
-  // Reset open resource pane when the session identity changes.
-  useEffect(() => {
-    clearResourcePaneState();
-  }, [agent, clearResourcePaneState, currentSession?.sessionId, namespace, sessionId]);
-
-  const renderedMessages = messages.map((message, messageIndex) => (
-    <SessionMessage
-      key={message.id}
-      message={message}
-      messageIndex={messageIndex}
+  const renderedMessages = (
+    <SessionMessageList
       messages={messages}
-      isSessionLive={isSessionLive}
-      loadingStartedAt={loadingStartedAt}
-      loadingNow={loadingNow}
-      objectUrlForRef={objectUrlForRef}
-      allowEditing={allowMessageEditing}
-      enableDebugEditing={enableDebugMessageEditing}
-      editingMessageId={editingMessageId}
-      editingMessageValue={editingMessageValue}
-      reviewActionMessageId={reviewActionMessageId}
-      expandedThinkingMessages={expandedThinkingMessages}
-      expandedToolItems={expandedToolItems}
-      hydrationState={toolResultHydration}
-      resultFor={toolResultFor}
-      onToggleThinking={toggleThinkingMessage}
-      onToggleTool={toggleToolItem}
-      onHydrateTool={(...args) => void hydrateToolResultForExpandedItem(...args)}
-      onResourceClick={handleResourceClick}
-      onEditingValueChange={setEditingMessageValue}
-      onSaveEdit={(target) => void saveEditingMessage(target)}
-      onCancelEdit={cancelEditingMessage}
-      onStartEdit={startEditingMessage}
-      onCopy={(target) => void copyMessageContent(target)}
-      onUpdateConnectorDelivery={(target, status) => void updateConnectorDeliveryStatus(target, status)}
+      messageProps={{
+        isSessionLive,
+        loadingStartedAt,
+        loadingNow,
+        objectUrlForRef,
+        allowEditing: allowMessageEditing,
+        enableDebugEditing: enableDebugMessageEditing,
+        editingMessageId,
+        editingMessageValue,
+        reviewActionMessageId,
+        expandedThinkingMessages,
+        expandedToolItems,
+        hydrationState: toolResultHydration,
+        resultFor: toolResultFor,
+        onToggleThinking: toggleThinkingMessage,
+        onToggleTool: toggleToolItem,
+        onHydrateTool: (...args) => void hydrateToolResultForExpandedItem(...args),
+        onResourceClick: handleResourceClick,
+        onEditingValueChange: setEditingMessageValue,
+        onSaveEdit: (target) => void saveEditingMessage(target),
+        onCancelEdit: cancelEditingMessage,
+        onStartEdit: startEditingMessage,
+        onCopy: (target) => void copyMessageContent(target),
+        onUpdateConnectorDelivery: (target, status) => void updateConnectorDeliveryStatus(target, status),
+      }}
     />
-  ));
+  );
 
   const resolvedHistoryPageSize = Math.max(
     1,
@@ -674,84 +336,31 @@ export function TalonSession({
     refreshNewestSessionPage,
   });
 
-  const previousSessionTargetRef = useRef<SessionTarget | null>(null);
-  useEffect(() => {
-    const previousTarget = previousSessionTargetRef.current;
-    previousSessionTargetRef.current = currentSession;
-    if (!previousTarget || (currentSession && isSameSession(previousTarget, currentSession))) return;
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = null;
-    setIsStopping(false);
-    setIsLoading(false);
-    setIsResuming(false);
-    setLoadingStartedAt(null);
-    setStreamEvents([]);
-    resetTranscriptUi();
-    invalidateToolResultHydration();
-  }, [currentSession?.agent, currentSession?.ns, currentSession?.sessionId, invalidateToolResultHydration, resetTranscriptUi, setIsLoading, setIsResuming, setIsStopping]);
+  const { clearSession } = useSessionLifecycle({
+    client: gatewayClient.sessions,
+    currentSession,
+    currentSessionRef,
+    requestedSessionKey: `${namespace}\u0000${agent}\u0000${sessionId ?? ""}\u0000${currentSession?.sessionId ?? ""}`,
+    submissionAbortControllerRef: abortControllerRef,
+    resourceAbortControllerRef: resourceAbortRef,
+    messagesRef,
+    emptyMessages,
+    clearRuntime,
+    resetGeneration,
+    resetTranscriptUi,
+    invalidateToolResultHydration,
+    resetResourcePane: clearResourcePaneState,
+    setStreamEvents,
+    setError,
+    setIsLoading,
+    setIsResuming,
+    setIsStopping,
+    setSessionState,
+    setLoadingStartedAt,
+  });
 
-  const clearLocalSession = useCallback(() => {
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = null;
-    resetGeneration();
-    resourceAbortRef.current?.abort();
-    resourceAbortRef.current = null;
-    clearRuntime();
-    messagesRef.current = emptyMessages;
-    setStreamEvents([]);
-    setError(null);
-    setIsLoading(false);
-    setIsResuming(false);
-    setSessionState(null);
-    setIsStopping(false);
-    setLoadingStartedAt(null);
-    resetTranscriptUi();
-    invalidateToolResultHydration();
-    clearResourcePaneState();
-  }, [clearResourcePaneState, clearRuntime, invalidateToolResultHydration, resetGeneration, resetTranscriptUi]);
-
-  const clearSession = useCallback(async () => {
-    const session = currentSessionRef.current;
-    if (session) {
-      try {
-        const sessions = gatewayClient?.sessions;
-        if (!sessions?.clear) {
-          throw new Error("TalonSession requires a Talon clientset with sessions.clear().");
-        }
-        await sessions.clear(session);
-      } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
-      }
-    }
-    clearLocalSession();
-  }, [clearLocalSession, gatewayClient, setError]);
-
-  const resolvedCommands = useMemo<Array<TalonSessionCommand>>(() => {
-    const builtInCommands: TalonSessionCommand[] = [];
-    if (enabledBuiltInCommands?.includes("clear")) {
-      builtInCommands.push({
-        name: "clear",
-        description: "Clear the current session history.",
-        run: ({ clear }) => clear?.(),
-      });
-    }
-    if (enabledBuiltInCommands?.includes("goal")) {
-      builtInCommands.push({
-        name: "goal",
-        description: "Create or update a session Goal.",
-        run: () => undefined,
-      });
-    }
-    return [...(commands ?? []), ...builtInCommands];
-  }, [clearSession, commands, enabledBuiltInCommands]);
-  const commandMenuItems = useMemo(
-    () => resolvedCommands.map(({ name, aliases, description }) => ({ name, aliases, description })),
-    [resolvedCommands],
-  );
-  const attachmentAccept = useMemo(
-    () => (acceptedAttachmentTypes ?? acceptedImageTypes).join(","),
-    [acceptedAttachmentTypes, acceptedImageTypes],
-  );
+  const { commandMenuItems, resolvedCommands } = useSessionCommands({ clearSession, commands, enabledBuiltInCommands });
+  const imageAccept = acceptedImageTypes.join(",");
   const { submitMessage } = useSessionActions({
     client: gatewayClient.sessions,
     namespace,
@@ -851,7 +460,7 @@ export function TalonSession({
             value={input}
             onValueChange={setInput}
             onSubmit={(nextInput) => void (currentSession
-              ? sessionRuntime.submit({ text: nextInput, attachments: imageAttachments, imageAttachments })
+              ? sessionRuntime.submit({ text: nextInput, imageAttachments })
               : submitMessage(nextInput))}
             placeholder={placeholder}
             variant={composerVariant}
@@ -863,18 +472,17 @@ export function TalonSession({
             commandMenuItems={commandMenuItems}
             startAdornment={composerStartAdornment}
             endAdornment={composerEndAdornment}
-            attachments={imageAttachments.map((attachment) => ({
+            imageAttachments={imageAttachments.map((attachment) => ({
               id: attachment.id,
               filename: attachment.file.name,
               previewUrl: attachment.previewUrl,
-              mediaType: attachment.file.type,
               status: attachment.status,
               error: attachment.error,
             }))}
-            attachmentUploadEnabled={Boolean(onAttachmentUpload ?? onImageUpload)}
-            attachmentAccept={attachmentAccept}
-            onAttachmentFilesSelected={addImageFiles}
-            onRemoveAttachment={removeImageAttachment}
+            imageUploadEnabled={Boolean(onImageUpload)}
+            imageAccept={imageAccept}
+            onImageFilesSelected={addImageFiles}
+            onRemoveImageAttachment={removeImageAttachment}
             onStop={() => {
               void sessionRuntime.stop().catch((err: any) =>
                 setError(err instanceof Error ? err : new Error("Failed to stop generation")),

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -360,7 +360,7 @@ export function TalonSession({
   });
 
   const { commandMenuItems, resolvedCommands } = useSessionCommands({ clearSession, commands, enabledBuiltInCommands });
-  const imageAccept = acceptedImageTypes.join(",");
+  const attachmentAccept = resolvedAcceptedAttachmentTypes.join(",");
   const { submitMessage } = useSessionActions({
     client: gatewayClient.sessions,
     namespace,
@@ -460,7 +460,7 @@ export function TalonSession({
             value={input}
             onValueChange={setInput}
             onSubmit={(nextInput) => void (currentSession
-              ? sessionRuntime.submit({ text: nextInput, imageAttachments })
+              ? sessionRuntime.submit({ text: nextInput, attachments: imageAttachments, imageAttachments })
               : submitMessage(nextInput))}
             placeholder={placeholder}
             variant={composerVariant}
@@ -472,17 +472,18 @@ export function TalonSession({
             commandMenuItems={commandMenuItems}
             startAdornment={composerStartAdornment}
             endAdornment={composerEndAdornment}
-            imageAttachments={imageAttachments.map((attachment) => ({
+            attachments={imageAttachments.map((attachment) => ({
               id: attachment.id,
               filename: attachment.file.name,
               previewUrl: attachment.previewUrl,
+              mediaType: attachment.file.type,
               status: attachment.status,
               error: attachment.error,
             }))}
-            imageUploadEnabled={Boolean(onImageUpload)}
-            imageAccept={imageAccept}
-            onImageFilesSelected={addImageFiles}
-            onRemoveImageAttachment={removeImageAttachment}
+            attachmentUploadEnabled={Boolean(onAttachmentUpload ?? onImageUpload)}
+            attachmentAccept={attachmentAccept}
+            onAttachmentFilesSelected={addImageFiles}
+            onRemoveAttachment={removeImageAttachment}
             onStop={() => {
               void sessionRuntime.stop().catch((err: any) =>
                 setError(err instanceof Error ? err : new Error("Failed to stop generation")),

--- a/packages/talon-chat/src/session/SessionMessageList.tsx
+++ b/packages/talon-chat/src/session/SessionMessageList.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import type { CopilotMessage } from "../lib/chatTimeline";
+import { SessionMessage, type SessionMessageProps } from "./SessionMessage";
+
+type SessionMessageListProps = {
+  messages: CopilotMessage[];
+  messageProps: Omit<SessionMessageProps, "message" | "messageIndex" | "messages">;
+};
+
+/** Renders every transcript row through the single shared message presentation boundary. */
+export function SessionMessageList({ messages, messageProps }: SessionMessageListProps) {
+  return messages.map((message, messageIndex) => (
+    <SessionMessage
+      key={message.id}
+      message={message}
+      messageIndex={messageIndex}
+      messages={messages}
+      {...messageProps}
+    />
+  ));
+}

--- a/packages/talon-chat/src/session/TalonSessionTypes.ts
+++ b/packages/talon-chat/src/session/TalonSessionTypes.ts
@@ -1,0 +1,136 @@
+import type React from "react";
+import type { TalonClient } from "@impalasys/talon-client";
+import type { CopilotMessage } from "../lib/chatTimeline";
+import type { TalonBuiltInCommandName, TalonChatCommand } from "../lib/commands";
+import type { TalonChatComposerVariant } from "../lib/TalonChatComposer";
+import type { ResourceViewModel } from "../lib/resourceUris";
+import type { TalonChatObjectRef, TalonSessionHandle } from "./types";
+
+export type { TalonChatObjectRef } from "./types";
+
+/** The gateway capabilities used by a Talon session. */
+export type SessionServiceClientLike = {
+  sessions: Pick<
+    TalonClient["sessions"],
+    "create" | "clear" | "listMessages" | "submitTurn" | "streamParts" | "stopGeneration"
+  > & Partial<Pick<TalonClient["sessions"], "appendMessage" | "updateMessage">>;
+}["sessions"];
+
+export type CasServiceClientLike = Pick<TalonClient["cas"], "getObject">;
+export type ArtifactServiceClientLike = Pick<TalonClient["artifacts"], "readArtifact" | "getArtifactMetadata">;
+export type FileServiceClientLike = Pick<TalonClient["files"], "readFile" | "getFileMetadata">;
+
+export type GatewayClientLike = {
+  sessions: SessionServiceClientLike;
+  cas?: CasServiceClientLike;
+  artifacts?: ArtifactServiceClientLike;
+  files?: FileServiceClientLike;
+};
+
+export type TalonSessionCommandTarget = {
+  type: "session";
+  namespace: string;
+  agent: string;
+  sessionId: string | null;
+};
+
+export type TalonSessionCommand = TalonChatCommand<TalonSessionCommandTarget, CopilotMessage>;
+
+/** Context shared by every attachment uploader. */
+export type TalonAttachmentUploadContext = {
+  file: File;
+  namespace: string;
+  agent: string;
+  sessionId: string;
+  signal: AbortSignal;
+};
+
+export type TalonAttachmentUploadResult = TalonChatObjectRef | {
+  object: TalonChatObjectRef;
+  url?: string;
+};
+
+/** Session-local attachment state; inline previews are optional. */
+export type TalonSessionPendingAttachment = {
+  id: string;
+  file: File;
+  previewUrl?: string;
+  object?: TalonChatObjectRef;
+  status: "queued" | "uploading" | "ready" | "error";
+  error?: string;
+};
+
+/** @deprecated Use TalonAttachmentUploadContext. */
+export type TalonImageUploadContext = TalonAttachmentUploadContext;
+/** @deprecated Use TalonAttachmentUploadResult. */
+export type TalonImageUploadResult = TalonAttachmentUploadResult;
+/** @deprecated Use TalonSessionPendingAttachment. */
+export type TalonSessionPendingImageAttachment = TalonSessionPendingAttachment;
+
+export type TalonSessionSubmitContext = {
+  text: string;
+  namespace: string;
+  agent: string;
+  sessionId: string | null;
+  attachments: ReadonlyArray<TalonSessionPendingAttachment>;
+  /** @deprecated Use attachments. */
+  imageAttachments: ReadonlyArray<TalonSessionPendingAttachment>;
+  ensureSession: () => Promise<TalonSessionHandle>;
+  clearInput: () => void;
+  refreshSession: () => Promise<void>;
+};
+
+export type TalonSessionMessageEditContext = {
+  message: CopilotMessage;
+  nextContent: string;
+  namespace: string;
+  agent: string;
+  sessionId: string | null;
+};
+
+export type TalonSessionProps = {
+  namespace: string;
+  agent: string;
+  gatewayClient: GatewayClientLike;
+  sessionId?: string;
+  onSessionChange?: (sessionId: string) => void;
+  className?: string;
+  style?: React.CSSProperties;
+  placeholder?: string;
+  autoFocus?: boolean;
+  disabled?: boolean;
+  historyPageSize?: number;
+  historyMessageLimit?: number;
+  historyStepLimit?: number;
+  commands?: TalonSessionCommand[];
+  enabledBuiltInCommands?: TalonBuiltInCommandName[];
+  /** Upload boundary for composer attachments; handlers must validate file content. */
+  onAttachmentUpload?: (context: TalonAttachmentUploadContext) => Promise<TalonAttachmentUploadResult>;
+  /** @deprecated Use onAttachmentUpload. */
+  onImageUpload?: (context: TalonImageUploadContext) => Promise<TalonImageUploadResult>;
+  objectUrlForRef?: (object: TalonChatObjectRef) => string | undefined;
+  maxAttachments?: number;
+  maxAttachmentBytes?: number;
+  acceptedAttachmentTypes?: string[];
+  /** @deprecated Use maxAttachments. */
+  maxImageAttachments?: number;
+  /** Client-side only; enforce the size limit again in the upload handler. */
+  /** @deprecated Use maxAttachmentBytes. */
+  maxImageBytes?: number;
+  /** Client-side only; enforce accepted types again in the upload handler. */
+  /** @deprecated Use acceptedAttachmentTypes. */
+  acceptedImageTypes?: string[];
+  composerVariant?: TalonChatComposerVariant;
+  composerStartAdornment?: React.ReactNode;
+  composerEndAdornment?: React.ReactNode;
+  onSubmitMessage?: (context: TalonSessionSubmitContext) => Promise<boolean | void> | boolean | void;
+  allowMessageEditing?: boolean;
+  onMessageEdit?: (context: TalonSessionMessageEditContext) => Promise<boolean | void> | boolean | void;
+  enableDebugMessageEditing?: boolean;
+  /** Override artifact:// and file:// interaction instead of opening the built-in pane. */
+  onResourceClick?: (uri: string) => void;
+  /** Override resource fetching for the built-in pane. */
+  fetchResource?: (uri: string, signal: AbortSignal) => Promise<ResourceViewModel>;
+};
+
+export type TalonCopilotProps = TalonSessionProps;

--- a/packages/talon-chat/src/session/objectRefs.ts
+++ b/packages/talon-chat/src/session/objectRefs.ts
@@ -1,4 +1,4 @@
-import type { TalonAttachmentUploadResult, TalonChatObjectRef } from "../TalonSession";
+import type { TalonAttachmentUploadResult, TalonChatObjectRef } from "./TalonSessionTypes";
 
 export function objectRefMediaType(object: TalonChatObjectRef | undefined): string {
   return object?.mediaType || object?.media_type || "";

--- a/packages/talon-chat/src/session/useSessionActions.ts
+++ b/packages/talon-chat/src/session/useSessionActions.ts
@@ -15,7 +15,7 @@ import type {
   TalonSessionCommand,
   TalonSessionPendingImageAttachment,
   TalonSessionSubmitContext,
-} from "../TalonSession";
+} from "./TalonSessionTypes";
 
 type SessionActionsClient = Pick<TalonClient["sessions"], "create" | "submitTurn">;
 type RefreshSession = (target: SessionTarget, signal?: AbortSignal) => Promise<SessionHistoryPage | null>;
@@ -180,6 +180,7 @@ export function useSessionActions({
           namespace,
           agent,
           sessionId: currentSessionRef.current?.sessionId ?? sessionId ?? null,
+          attachments: pendingAttachments,
           imageAttachments: pendingAttachments,
           ensureSession,
           clearInput: () => setInput(""),

--- a/packages/talon-chat/src/session/useSessionCommands.ts
+++ b/packages/talon-chat/src/session/useSessionCommands.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import type { TalonBuiltInCommandName } from "../lib/commands";
+import type { TalonSessionCommand } from "./TalonSessionTypes";
+
+type UseSessionCommandsOptions = {
+  clearSession: () => Promise<void>;
+  commands?: TalonSessionCommand[];
+  enabledBuiltInCommands?: TalonBuiltInCommandName[];
+};
+
+/** Combines host commands with the session-local clear and goal commands. */
+export function useSessionCommands({ clearSession, commands, enabledBuiltInCommands }: UseSessionCommandsOptions) {
+  const resolvedCommands = useMemo<TalonSessionCommand[]>(() => {
+    const builtIns: TalonSessionCommand[] = [];
+    if (enabledBuiltInCommands?.includes("clear")) {
+      builtIns.push({ name: "clear", description: "Clear the current session history.", run: ({ clear }) => clear?.() });
+    }
+    if (enabledBuiltInCommands?.includes("goal")) {
+      builtIns.push({ name: "goal", description: "Create or update a session Goal.", run: () => undefined });
+    }
+    return [...(commands ?? []), ...builtIns];
+  }, [clearSession, commands, enabledBuiltInCommands]);
+  const commandMenuItems = useMemo(
+    () => resolvedCommands.map(({ name, aliases, description }) => ({ name, aliases, description })),
+    [resolvedCommands],
+  );
+  return { commandMenuItems, resolvedCommands };
+}

--- a/packages/talon-chat/src/session/useSessionLifecycle.ts
+++ b/packages/talon-chat/src/session/useSessionLifecycle.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { TalonClient } from "@impalasys/talon-client";
+import type { CopilotMessage } from "../lib/chatTimeline";
+import type { StreamEventItem } from "../lib/uiStream";
+import type { SessionTarget } from "./types";
+
+type SessionLifecycleClient = Pick<TalonClient["sessions"], "clear">;
+
+type UseSessionLifecycleOptions = {
+  client: SessionLifecycleClient | undefined;
+  currentSession: SessionTarget | null;
+  currentSessionRef: MutableRefObject<SessionTarget | null>;
+  requestedSessionKey: string;
+  submissionAbortControllerRef: MutableRefObject<AbortController | null>;
+  resourceAbortControllerRef: MutableRefObject<AbortController | null>;
+  messagesRef: MutableRefObject<CopilotMessage[]>;
+  emptyMessages: CopilotMessage[];
+  clearRuntime: () => void;
+  resetGeneration: () => void;
+  resetTranscriptUi: () => void;
+  invalidateToolResultHydration: () => void;
+  resetResourcePane: () => void;
+  setStreamEvents: Dispatch<SetStateAction<StreamEventItem[]>>;
+  setError: (error: Error | null) => void;
+  setIsLoading: (value: boolean) => void;
+  setIsResuming: (value: boolean) => void;
+  setIsStopping: (value: boolean) => void;
+  setSessionState: (value: string | null) => void;
+  setLoadingStartedAt: (value: string | number | null) => void;
+};
+
+function sameSession(left: SessionTarget | null, right: SessionTarget | null) {
+  return left?.ns === right?.ns && left?.agent === right?.agent && left?.sessionId === right?.sessionId;
+}
+
+/**
+ * Owns client-side cleanup at session boundaries. Transport generation itself
+ * remains in useSessionGeneration; this hook only clears UI/runtime state when
+ * a session changes or is explicitly cleared.
+ */
+export function useSessionLifecycle({
+  client,
+  currentSession,
+  currentSessionRef,
+  requestedSessionKey,
+  submissionAbortControllerRef,
+  resourceAbortControllerRef,
+  messagesRef,
+  emptyMessages,
+  clearRuntime,
+  resetGeneration,
+  resetTranscriptUi,
+  invalidateToolResultHydration,
+  resetResourcePane,
+  setStreamEvents,
+  setError,
+  setIsLoading,
+  setIsResuming,
+  setIsStopping,
+  setSessionState,
+  setLoadingStartedAt,
+}: UseSessionLifecycleOptions) {
+  const previousSessionRef = useRef<SessionTarget | null>(null);
+
+  useEffect(() => {
+    const previousSession = previousSessionRef.current;
+    previousSessionRef.current = currentSession;
+    if (!previousSession || (currentSession && sameSession(previousSession, currentSession))) return;
+
+    submissionAbortControllerRef.current?.abort();
+    submissionAbortControllerRef.current = null;
+    setIsStopping(false);
+    setIsLoading(false);
+    setIsResuming(false);
+    setLoadingStartedAt(null);
+    setStreamEvents([]);
+    resetTranscriptUi();
+    invalidateToolResultHydration();
+  }, [
+    currentSession,
+    invalidateToolResultHydration,
+    resetTranscriptUi,
+    setIsLoading,
+    setIsResuming,
+    setIsStopping,
+    setLoadingStartedAt,
+    setStreamEvents,
+    submissionAbortControllerRef,
+  ]);
+
+  // A pane is scoped to the requested session as well as a session created in-place.
+  useEffect(() => {
+    resetResourcePane();
+  }, [requestedSessionKey, resetResourcePane]);
+
+  const clearLocalSession = useCallback(() => {
+    submissionAbortControllerRef.current?.abort();
+    submissionAbortControllerRef.current = null;
+    resetGeneration();
+    resourceAbortControllerRef.current?.abort();
+    resourceAbortControllerRef.current = null;
+    clearRuntime();
+    messagesRef.current = emptyMessages;
+    setStreamEvents([]);
+    setError(null);
+    setIsLoading(false);
+    setIsResuming(false);
+    setSessionState(null);
+    setIsStopping(false);
+    setLoadingStartedAt(null);
+    resetTranscriptUi();
+    invalidateToolResultHydration();
+    resetResourcePane();
+  }, [
+    clearRuntime,
+    emptyMessages,
+    invalidateToolResultHydration,
+    messagesRef,
+    resetGeneration,
+    resetResourcePane,
+    resetTranscriptUi,
+    resourceAbortControllerRef,
+    setError,
+    setIsLoading,
+    setIsResuming,
+    setIsStopping,
+    setLoadingStartedAt,
+    setSessionState,
+    setStreamEvents,
+    submissionAbortControllerRef,
+  ]);
+
+  const clearSession = useCallback(async () => {
+    const session = currentSessionRef.current;
+    if (session) {
+      try {
+        if (!client?.clear) {
+          throw new Error("TalonSession requires a Talon clientset with sessions.clear().");
+        }
+        await client.clear(session);
+      } catch (error) {
+        setError(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+    clearLocalSession();
+  }, [clearLocalSession, client, currentSessionRef, setError]);
+
+  return { clearSession };
+}

--- a/packages/talon-chat/src/session/useSessionMessageEditing.ts
+++ b/packages/talon-chat/src/session/useSessionMessageEditing.ts
@@ -1,0 +1,203 @@
+import { useCallback, useState, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import type { TalonClient } from "@impalasys/talon-client";
+import { getMessageContent, type CopilotMessage } from "../lib/chatTimeline";
+import {
+  isLocalMessageId,
+  normalizeRawSessionMessage,
+} from "./history";
+import {
+  editableMessageContent,
+  messageWithEditedContent,
+  replaceMessageTextPart,
+} from "./messageEditing";
+import { messagePartsForSessionUpdate } from "./protocol";
+import type { SessionTarget } from "./types";
+
+const LABEL_CONNECTOR_DELIVERY_STATUS = "talon.impalasys.com/connector-delivery-status";
+const LABEL_CONNECTOR_DELIVERY_ERROR = "talon.impalasys.com/connector-delivery-error";
+
+export type SessionMessageEditContext = {
+  message: CopilotMessage;
+  nextContent: string;
+  namespace: string;
+  agent: string;
+  sessionId: string | null;
+};
+
+type SessionMessageUpdateClient = Partial<Pick<TalonClient["sessions"], "updateMessage">>;
+
+type UseSessionMessageEditingOptions = {
+  agent: string;
+  client: SessionMessageUpdateClient;
+  currentSessionRef: MutableRefObject<SessionTarget | null>;
+  enableDebugMessageEditing: boolean;
+  fallbackSessionId: string | undefined;
+  messagesRef: MutableRefObject<CopilotMessage[]>;
+  namespace: string;
+  onMessageEdit?: (context: SessionMessageEditContext) => Promise<boolean | void> | boolean | void;
+  setError: Dispatch<SetStateAction<Error | null>>;
+  setMessages: Dispatch<SetStateAction<CopilotMessage[]>>;
+};
+
+type SessionMessageUpdaterOptions = Pick<
+  UseSessionMessageEditingOptions,
+  "agent" | "client" | "currentSessionRef" | "fallbackSessionId" | "messagesRef" | "namespace" | "setMessages"
+>;
+
+function errorFromUnknown(error: unknown) {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function shouldPersistSessionEdit(message: CopilotMessage, enabled: boolean) {
+  return enabled &&
+    (message.role === "user" || message.role === "assistant") &&
+    !isLocalMessageId(message.id);
+}
+
+function useSessionMessageUpdater({
+  agent,
+  client,
+  currentSessionRef,
+  fallbackSessionId,
+  messagesRef,
+  namespace,
+  setMessages,
+}: SessionMessageUpdaterOptions) {
+  return useCallback(
+    async (message: CopilotMessage, parts: unknown[], labels: Record<string, string>) => {
+      const session = currentSessionRef.current ?? (fallbackSessionId
+        ? { ns: namespace, agent, sessionId: fallbackSessionId }
+        : null);
+      if (!session) throw new Error("No active session to update.");
+      if (!client.updateMessage) {
+        throw new Error("Gateway client does not support sessions.updateMessage().");
+      }
+      const response = await client.updateMessage({
+        ns: session.ns,
+        agent: session.agent,
+        sessionId: session.sessionId,
+        messageId: message.id,
+        parts,
+        labels,
+      });
+      const updated = response?.message
+        ? { ...message, ...normalizeRawSessionMessage(response.message) }
+        : { ...message, parts, labels, content: getMessageContent({ ...message, parts }) };
+      setMessages((current) => {
+        const nextMessages = current.map((item) => item.id === message.id ? updated : item);
+        messagesRef.current = nextMessages;
+        return nextMessages;
+      });
+      return updated;
+    },
+    [agent, client, currentSessionRef, fallbackSessionId, messagesRef, namespace, setMessages],
+  );
+}
+
+/** Owns local editing state and the two message-update workflows used by a transcript row. */
+export function useSessionMessageEditing({
+  agent,
+  client,
+  currentSessionRef,
+  enableDebugMessageEditing,
+  fallbackSessionId,
+  messagesRef,
+  namespace,
+  onMessageEdit,
+  setError,
+  setMessages,
+}: UseSessionMessageEditingOptions) {
+  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+  const [editingMessageValue, setEditingMessageValue] = useState("");
+  const [reviewActionMessageId, setReviewActionMessageId] = useState<string | null>(null);
+  const updateSessionMessage = useSessionMessageUpdater({
+    agent,
+    client,
+    currentSessionRef,
+    fallbackSessionId,
+    messagesRef,
+    namespace,
+    setMessages,
+  });
+
+  const startEditingMessage = useCallback((message: CopilotMessage) => {
+    setEditingMessageId(message.id);
+    setEditingMessageValue(editableMessageContent(message));
+  }, []);
+
+  const cancelEditingMessage = useCallback(() => {
+    setEditingMessageId(null);
+    setEditingMessageValue("");
+  }, []);
+
+  const applyLocalEdit = useCallback((message: CopilotMessage, nextContent: string) => {
+    setMessages((current) => {
+      const nextMessages = current.map((item) => item.id === message.id
+        ? messageWithEditedContent(item, nextContent)
+        : item);
+      messagesRef.current = nextMessages;
+      return nextMessages;
+    });
+  }, [messagesRef, setMessages]);
+
+  const saveEditingMessage = useCallback(async (message: CopilotMessage) => {
+    const nextContent = editingMessageValue.trim();
+    if (!nextContent) return;
+
+    setError(null);
+    try {
+      if (shouldPersistSessionEdit(message, enableDebugMessageEditing)) {
+        setReviewActionMessageId(message.id);
+        await updateSessionMessage(message, replaceMessageTextPart(message, nextContent), { ...(message.labels ?? {}) });
+        cancelEditingMessage();
+        return;
+      }
+      const handled = await onMessageEdit?.({
+        message,
+        nextContent,
+        namespace,
+        agent,
+        sessionId: currentSessionRef.current?.sessionId ?? fallbackSessionId ?? null,
+      });
+      if (handled === false) return;
+
+      applyLocalEdit(message, nextContent);
+      cancelEditingMessage();
+    } catch (error) {
+      setError(errorFromUnknown(error));
+    } finally {
+      setReviewActionMessageId(null);
+    }
+  }, [agent, applyLocalEdit, cancelEditingMessage, currentSessionRef, editingMessageValue, enableDebugMessageEditing, fallbackSessionId, namespace, onMessageEdit, setError, updateSessionMessage]);
+
+  const updateConnectorDeliveryStatus = useCallback(
+    async (message: CopilotMessage, status: string) => {
+      const labels = {
+        ...(message.labels ?? {}),
+        [LABEL_CONNECTOR_DELIVERY_STATUS]: status,
+      };
+      delete labels[LABEL_CONNECTOR_DELIVERY_ERROR];
+      setError(null);
+      setReviewActionMessageId(message.id);
+      try {
+        await updateSessionMessage(message, messagePartsForSessionUpdate(message), labels);
+      } catch (error) {
+        setError(errorFromUnknown(error));
+      } finally {
+        setReviewActionMessageId(null);
+      }
+    },
+    [setError, updateSessionMessage],
+  );
+
+  return {
+    editingMessageId,
+    editingMessageValue,
+    reviewActionMessageId,
+    setEditingMessageValue,
+    startEditingMessage,
+    cancelEditingMessage,
+    saveEditingMessage,
+    updateConnectorDeliveryStatus,
+  };
+}

--- a/packages/talon-chat/src/session/useSessionPresentationState.ts
+++ b/packages/talon-chat/src/session/useSessionPresentationState.ts
@@ -1,0 +1,48 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
+import type { CopilotMessage } from "../lib/chatTimeline";
+import type { SessionTarget } from "./types";
+
+type UseSessionPresentationStateOptions = {
+  abortControllerRef: MutableRefObject<AbortController | null>;
+  currentSession: SessionTarget | null;
+  input: string;
+  isSessionLive: boolean;
+  loadingStartedAt: string | number | null;
+  messages: CopilotMessage[];
+};
+
+/** Owns refs and lightweight display state that are shared by session actions and the transcript. */
+export function useSessionPresentationState({
+  abortControllerRef,
+  currentSession,
+  input,
+  isSessionLive,
+  loadingStartedAt,
+  messages,
+}: UseSessionPresentationStateOptions) {
+  const messagesRef = useRef<CopilotMessage[]>(messages);
+  const currentSessionRef = useRef<SessionTarget | null>(currentSession);
+  const submittedPreviewUrlsRef = useRef<string[]>([]);
+  const [loadingNow, setLoadingNow] = useState(Date.now());
+  const inputRows = useMemo(() => Math.min(input.split("\n").length, 8), [input]);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+  useEffect(() => {
+    currentSessionRef.current = currentSession;
+  }, [currentSession]);
+  useEffect(() => {
+    if (!isSessionLive || loadingStartedAt === null) return;
+    setLoadingNow(Date.now());
+    const intervalId = window.setInterval(() => setLoadingNow(Date.now()), 250);
+    return () => window.clearInterval(intervalId);
+  }, [isSessionLive, loadingStartedAt]);
+  useEffect(() => () => {
+    abortControllerRef.current?.abort();
+    for (const previewUrl of submittedPreviewUrlsRef.current) URL.revokeObjectURL(previewUrl);
+  }, [abortControllerRef]);
+
+  return { currentSessionRef, inputRows, loadingNow, messagesRef, setLoadingNow, submittedPreviewUrlsRef };
+}

--- a/packages/talon-chat/src/session/useSessionResourceClick.ts
+++ b/packages/talon-chat/src/session/useSessionResourceClick.ts
@@ -1,0 +1,55 @@
+import { useCallback, useRef } from "react";
+import { parseResourceUri } from "../lib/resourceUris";
+
+type UseSessionResourceClickOptions = {
+  canFetchArtifact: boolean;
+  canFetchFile: boolean;
+  closeResourcePane: () => void;
+  onResourceClick?: (uri: string) => void;
+  openResource: (uri: string) => Promise<void>;
+  openResourceUri: string | null;
+  resourcePaneOpen: boolean;
+};
+
+/** Routes artifact and file links to a host override or the built-in resource pane. */
+export function useSessionResourceClick({
+  canFetchArtifact,
+  canFetchFile,
+  closeResourcePane,
+  onResourceClick,
+  openResource,
+  openResourceUri,
+  resourcePaneOpen,
+}: UseSessionResourceClickOptions) {
+  const missingResourceClientWarnedRef = useRef(false);
+
+  return useCallback((uri: string) => {
+    if (onResourceClick) {
+      onResourceClick(uri);
+      return;
+    }
+
+    const parsed = parseResourceUri(uri);
+    if (!parsed) return;
+
+    if (openResourceUri === parsed.uri && resourcePaneOpen) {
+      closeResourcePane();
+      return;
+    }
+
+    const canOpen =
+      (parsed.kind === "artifact" && canFetchArtifact) ||
+      (parsed.kind === "file" && canFetchFile);
+    if (!canOpen) {
+      if (!missingResourceClientWarnedRef.current && typeof console !== "undefined") {
+        missingResourceClientWarnedRef.current = true;
+        console.warn(
+          "[talon-chat] Resource link clicked but no artifacts/files client (or fetchResource) is available.",
+        );
+      }
+      return;
+    }
+
+    void openResource(parsed.uri);
+  }, [canFetchArtifact, canFetchFile, closeResourcePane, onResourceClick, openResource, openResourceUri, resourcePaneOpen]);
+}

--- a/packages/talon-chat/src/session/useSessionResources.ts
+++ b/packages/talon-chat/src/session/useSessionResources.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { fetchResourceFromGateway } from "./resourceLoader";
 import type { GatewayClientLike } from "./TalonSessionTypes";
 import type { ResourceViewModel } from "../lib/resourceUris";
-import { useResourcePane } from "./useResourcePane";
+import { useResourcePane } from "./hooks/useResourcePane";
 
 type UseSessionResourcesOptions = {
   agent: string;

--- a/packages/talon-chat/src/session/useSessionResources.ts
+++ b/packages/talon-chat/src/session/useSessionResources.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { fetchResourceFromGateway } from "./resourceLoader";
+import { fetchResourceFromGateway } from "../lib/resourceLoader";
 import type { GatewayClientLike } from "./TalonSessionTypes";
 import type { ResourceViewModel } from "../lib/resourceUris";
 import { useResourcePane } from "./hooks/useResourcePane";

--- a/packages/talon-chat/src/session/useSessionResources.ts
+++ b/packages/talon-chat/src/session/useSessionResources.ts
@@ -1,0 +1,24 @@
+import { useCallback } from "react";
+import { fetchResourceFromGateway } from "./resourceLoader";
+import type { GatewayClientLike } from "./TalonSessionTypes";
+import type { ResourceViewModel } from "../lib/resourceUris";
+import { useResourcePane } from "./useResourcePane";
+
+type UseSessionResourcesOptions = {
+  agent: string;
+  currentSessionId: string | null;
+  fetchResource?: (uri: string, signal: AbortSignal) => Promise<ResourceViewModel>;
+  gatewayClient: GatewayClientLike;
+  sessionId?: string;
+};
+
+/** Selects host or gateway loading and owns the built-in resource pane state. */
+export function useSessionResources({ agent, currentSessionId, fetchResource, gatewayClient, sessionId }: UseSessionResourcesOptions) {
+  const loadResource = useCallback(
+    (uri: string, signal: AbortSignal) => fetchResource
+      ? fetchResource(uri, signal)
+      : fetchResourceFromGateway({ uri, gatewayClient, agent, sessionId: currentSessionId ?? sessionId ?? null, signal }),
+    [agent, currentSessionId, fetchResource, gatewayClient, sessionId],
+  );
+  return useResourcePane(loadResource);
+}

--- a/packages/talon-chat/src/session/useTalonSessionRuntime.ts
+++ b/packages/talon-chat/src/session/useTalonSessionRuntime.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef } from "react";
 import type { GatewayClientLike } from "./TalonSessionTypes";
 import { normalizeHistoryPage } from "./history";
-import { useSessionRuntime } from "./useSessionRuntime";
+import { useSessionRuntime } from "./hooks/useSessionRuntime";
 import type { SessionTarget } from "./types";
 
 type UseTalonSessionRuntimeOptions = {

--- a/packages/talon-chat/src/session/useTalonSessionRuntime.ts
+++ b/packages/talon-chat/src/session/useTalonSessionRuntime.ts
@@ -1,0 +1,57 @@
+import { useCallback, useMemo, useRef } from "react";
+import type { GatewayClientLike } from "./TalonSessionTypes";
+import { normalizeHistoryPage } from "./history";
+import { useSessionRuntime } from "./useSessionRuntime";
+import type { SessionTarget } from "./types";
+
+type UseTalonSessionRuntimeOptions = {
+  agent: string;
+  gatewayClient: GatewayClientLike;
+  historyPageSize: number;
+  historyMessageLimit: number;
+  namespace: string;
+  sessionId?: string;
+};
+
+/** Adapts gateway history calls to the generic session runtime and exposes its phase helpers. */
+export function useTalonSessionRuntime({
+  agent,
+  gatewayClient,
+  historyPageSize,
+  historyMessageLimit,
+  namespace,
+  sessionId,
+}: UseTalonSessionRuntimeOptions) {
+  const target = useMemo<SessionTarget | null>(
+    () => sessionId ? { ns: namespace, agent, sessionId } : null,
+    [agent, namespace, sessionId],
+  );
+  const client = useMemo(() => ({
+    listMessages: async (session: SessionTarget, options?: { beforeMessageId?: string | null; pageSize?: number }) => {
+      const response = await gatewayClient.sessions.listMessages({
+        ...session,
+        pageSize: options?.pageSize,
+        beforeMessageId: options?.beforeMessageId || undefined,
+      });
+      return normalizeHistoryPage(response);
+    },
+  }), [gatewayClient]);
+  const submitRef = useRef<((input: any, context: any) => Promise<void>) | null>(null);
+  const stopRef = useRef<((context: any) => Promise<void>) | null>(null);
+  const runtime = useSessionRuntime({
+    target,
+    client,
+    pageSize: Math.max(1, Math.trunc(historyPageSize || historyMessageLimit || 50)),
+    submit: (input, context) => submitRef.current?.(input, context) ?? Promise.resolve(),
+    stop: (_input, context) => stopRef.current?.(context) ?? Promise.resolve(),
+  });
+  const { setPhase, setServerState } = runtime;
+  const setIsLoading = useCallback((value: boolean) => setPhase(value ? "submitting" : "idle"), [setPhase]);
+  const setIsResuming = useCallback((value: boolean) => setPhase(value ? "resuming" : "idle"), [setPhase]);
+  const setIsStopping = useCallback((value: boolean) => setPhase(value ? "stopping" : "idle"), [setPhase]);
+  const setSessionState = useCallback((value: string | null) => {
+    setServerState(value === "PROCESSING" ? "PROCESSING" : value === "ERROR" ? "ERROR" : value ? "IDLE" : "UNKNOWN");
+  }, [setServerState]);
+
+  return { runtime, setIsLoading, setIsResuming, setIsStopping, setSessionState, submitRef, stopRef };
+}


### PR DESCRIPTION
## Summary
- reduce `useSessionActions` to a 48-line composition hook
- isolate session target creation, canonical history refresh, host/command routing, and backend turn execution into dedicated session hooks
- retain the existing public session API and submission behavior

## Validation
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir ui exec jest lib/talonCopilot.test.tsx --runInBand --coverage=false` (59 passed)
- `pnpm --dir packages/talon-chat build`
- `pnpm --dir packages/talon-chat lint:complexity` (all new action modules satisfy function complexity/length rules)