### PR TITLE
Refresh pnpm lockfile for js-yaml 5.2.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,8 +192,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1
       js-yaml:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.2.3
+        version: 5.2.3
       lucide-react:
         specifier: ^0.400.0
         version: 0.400.0(react@19.2.3)
@@ -4809,8 +4809,8 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
-  js-yaml@5.2.2:
-    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -11868,7 +11868,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@5.2.2:
+  js-yaml@5.2.3:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

Refreshes `pnpm-lock.yaml` so the UI importer's `js-yaml` entry matches `ui/package.json` (`^5.2.3`).

## Root cause

CI uses `pnpm install --frozen-lockfile`, which failed because the manifest specified `^5.2.3` while the lockfile still specified and resolved `5.2.2`. This also prevented the screenshot job from generating its required artifacts.

## Validation

- `pnpm install --frozen-lockfile`
- `git diff --check`