### PR TITLE
Queue busy connector session messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,7 @@ jobs:
             tests/test_mock_llm.py \
             tests/test_workers.py \
             tests/test_chat.py \
+            tests/test_connectors.py \
             tests/test_delegation.py \
             tests/test_search.py \
             tests/test_resources.py \

--- a/src/control/session_queue.rs
+++ b/src/control/session_queue.rs
@@ -230,9 +230,13 @@ async fn publish_queued_message(
 ) -> Result<DispatchedQueuedSessionMessage> {
     let now_micros = now.timestamp_micros();
     message.id = crate::control::uuid::session_message_id();
-    message.created_at = now_micros;
+    if message.created_at == 0 {
+        message.created_at = now_micros;
+    }
     for part in &mut message.parts {
-        part.created_at = now_micros;
+        if part.created_at == 0 {
+            part.created_at = message.created_at;
+        }
     }
 
     let message_key = keys::session_message(ns, agent, session_id, &message.id);
@@ -484,11 +488,11 @@ mod tests {
             .unwrap()
             .expect("dispatched message should be stored");
         assert_eq!(stored_message.id, dispatched.message_id);
-        assert_eq!(stored_message.created_at, dispatched_at.timestamp_micros());
+        assert_eq!(stored_message.created_at, queued_at.timestamp_micros());
         assert!(stored_message
             .parts
             .iter()
-            .all(|part| part.created_at == dispatched_at.timestamp_micros()));
+            .all(|part| part.created_at == queued_at.timestamp_micros()));
         assert!(kv
             .get_msg::<SessionSubmission>(&keys::session_submission(
                 "Tenant:acme:Ops",

--- a/src/control/session_queue.rs
+++ b/src/control/session_queue.rs
@@ -111,7 +111,10 @@ pub async fn queue_session_message(
         }
     }
 
-    let entry_id = format!("{:020}-{queue_entry_suffix}", message.created_at);
+    // Queue order is the order Talon admitted messages, not a producer supplied
+    // timestamp. Connector event times may arrive out of order, and using them
+    // here would allow a later accepted message to overtake an earlier one.
+    let entry_id = format!("{now_micros:020}-{queue_entry_suffix}");
     kv.set_msg(
         &keys::session_queue_entry(ns, agent, session_id, queue, &entry_id),
         &message,

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -2221,6 +2221,8 @@ mod tests {
             .unwrap()
             .expect("canonical session message should exist");
         assert_eq!(message.parts[0].content, "immediate connector message");
+        assert_eq!(message.created_at, 1_700_000_000_000_000);
+        assert_eq!(message.parts[0].created_at, 1_700_000_000_000_000);
         assert_eq!(
             message.labels.get(LABEL_CONNECTOR_EVENT),
             Some(&"event-1".to_string())

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -2238,12 +2238,12 @@ mod tests {
             (
                 "event-1",
                 "first queued connector message",
-                1_700_000_000_000,
+                1_700_000_001_000,
             ),
             (
                 "event-2",
                 "second queued connector message",
-                1_700_000_001_000,
+                1_700_000_000_000,
             ),
         ] {
             dispatch_to_session(

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -1231,13 +1231,24 @@ async fn dispatch_to_session(
         elapsed_ms = started.elapsed().as_millis(),
         "connector message dispatching to session"
     );
-    scheduling::send_session_message(
+    crate::control::session_queue::queue_session_message(
+        cp.kv.as_ref(),
+        &agent_namespace,
+        agent_name,
+        &session_id,
+        crate::control::session_queue::NEXT_QUEUE,
+        message,
+        chrono::Utc::now(),
+    )
+    .await
+    .map_err(map_dispatch_error)?;
+    crate::control::session_queue::dispatch_next_queued_message(
         cp.kv.as_ref(),
         cp.pubsub.as_ref(),
         &agent_namespace,
         agent_name,
         &session_id,
-        message,
+        crate::control::session_queue::NEXT_QUEUE,
         chrono::Utc::now(),
     )
     .await
@@ -1989,6 +2000,99 @@ fn map_dispatch_error(err: anyhow::Error) -> tonic::Status {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::control::{keys, ControlPlane, KeyValueStore, ProtoKeyValueStoreExt};
+    use crate::test_support::{MockKvStore, RecordingPubSub};
+    use chrono::Utc;
+    use prost::Message;
+    use std::sync::Arc;
+
+    const TEST_NAMESPACE: &str = "conic:test";
+    const TEST_AGENT: &str = "connector-agent";
+    const TEST_SESSION: &str = "session-1";
+
+    async fn put_session(kv: &MockKvStore, status: &str, last_active: i64) {
+        kv.set_msg(
+            &keys::session(TEST_NAMESPACE, TEST_AGENT, TEST_SESSION),
+            &data_proto::Session {
+                id: TEST_SESSION.to_string(),
+                agent: TEST_AGENT.to_string(),
+                ns: TEST_NAMESPACE.to_string(),
+                status: status.to_string(),
+                created_at: 1,
+                last_active,
+                metadata: Default::default(),
+                labels: Default::default(),
+                context_tokens: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    fn test_route() -> data_proto::Route {
+        data_proto::Route {
+            connector_uid: "connector-uid".to_string(),
+            connector: Some(data_proto::ResourceRef {
+                namespace: TEST_NAMESPACE.to_string(),
+                name: "room-one".to_string(),
+            }),
+            consumer: None,
+        }
+    }
+
+    fn test_consumer() -> data_proto::SessionMessageConsumer {
+        data_proto::SessionMessageConsumer {
+            agent: Some(data_proto::ResourceRef {
+                namespace: TEST_NAMESPACE.to_string(),
+                name: TEST_AGENT.to_string(),
+            }),
+            session_id: TEST_SESSION.to_string(),
+            continuity: "pinned".to_string(),
+            reply_mode: String::new(),
+        }
+    }
+
+    fn test_event(
+        event_id: &str,
+        text: &str,
+        event_time_ms: i64,
+    ) -> external_proto::ConnectorMessageEvent {
+        external_proto::ConnectorMessageEvent {
+            event_id: event_id.to_string(),
+            event_kind: external_proto::ConnectorMessageEventKind::Created as i32,
+            registration_id: format!("Namespace/{TEST_NAMESPACE}/ConnectorClass/mock-chat"),
+            connector_class: "mock-chat".to_string(),
+            external_conversation_id: "room-1".to_string(),
+            external_message_id: format!("provider-{event_id}"),
+            conversation_type: "room".to_string(),
+            text: text.to_string(),
+            event_time_ms,
+            ..Default::default()
+        }
+    }
+
+    fn control_plane(kv: Arc<MockKvStore>, pubsub: Arc<RecordingPubSub>) -> ControlPlane {
+        ControlPlane::builder(kv, pubsub).build()
+    }
+
+    async fn queued_messages(kv: &MockKvStore) -> Vec<data_proto::SessionMessage> {
+        let entries = kv
+            .list_entries(
+                &keys::session_queue_prefix(
+                    TEST_NAMESPACE,
+                    TEST_AGENT,
+                    TEST_SESSION,
+                    crate::control::session_queue::NEXT_QUEUE,
+                ),
+                None,
+            )
+            .await
+            .unwrap();
+        entries
+            .into_iter()
+            .map(|(_, bytes)| data_proto::SessionMessage::decode(bytes.as_slice()).unwrap())
+            .collect()
+    }
 
     #[test]
     fn connector_session_message_uses_chronological_uuid_message_id() {
@@ -2046,5 +2150,122 @@ mod tests {
                 "Tenant/acme"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn connector_session_dispatch_queues_when_the_pinned_session_is_busy() {
+        let kv = Arc::new(MockKvStore::new());
+        let pubsub = Arc::new(RecordingPubSub::default());
+        put_session(&kv, "PROCESSING", Utc::now().timestamp_micros()).await;
+        let cp = control_plane(kv.clone(), pubsub.clone());
+
+        dispatch_to_session(
+            &cp,
+            &test_route(),
+            &test_consumer(),
+            &test_event("event-1", "queued connector message", 1_700_000_000_000),
+        )
+        .await
+        .unwrap();
+
+        let queued = queued_messages(&kv).await;
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].id, "");
+        assert_eq!(queued[0].parts[0].content, "queued connector message");
+        assert_eq!(
+            queued[0].labels.get(LABEL_CONNECTOR_EVENT),
+            Some(&"event-1".to_string())
+        );
+        assert!(pubsub
+            .published
+            .lock()
+            .await
+            .iter()
+            .all(|(topic, _)| { topic != crate::control::topics::SESSION_DISPATCH_TOPIC }));
+    }
+
+    #[tokio::test]
+    async fn connector_session_dispatch_immediately_dispatches_when_the_session_is_idle() {
+        let kv = Arc::new(MockKvStore::new());
+        let pubsub = Arc::new(RecordingPubSub::default());
+        put_session(&kv, "IDLE", 1).await;
+        let cp = control_plane(kv.clone(), pubsub.clone());
+
+        dispatch_to_session(
+            &cp,
+            &test_route(),
+            &test_consumer(),
+            &test_event("event-1", "immediate connector message", 1_700_000_000_000),
+        )
+        .await
+        .unwrap();
+
+        assert!(queued_messages(&kv).await.is_empty());
+        let published = pubsub.published.lock().await;
+        let dispatches = published
+            .iter()
+            .filter(|(topic, _)| topic == crate::control::topics::SESSION_DISPATCH_TOPIC)
+            .map(|(_, bytes)| {
+                crate::control::events::SessionMessageEvent::decode(bytes.as_slice()).unwrap()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(dispatches.len(), 1);
+        let message = kv
+            .get_msg::<data_proto::SessionMessage>(&keys::session_message(
+                TEST_NAMESPACE,
+                TEST_AGENT,
+                TEST_SESSION,
+                &dispatches[0].message_id,
+            ))
+            .await
+            .unwrap()
+            .expect("canonical session message should exist");
+        assert_eq!(message.parts[0].content, "immediate connector message");
+        assert_eq!(
+            message.labels.get(LABEL_CONNECTOR_EVENT),
+            Some(&"event-1".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn busy_connector_session_messages_are_queued_in_event_order() {
+        let kv = Arc::new(MockKvStore::new());
+        let pubsub = Arc::new(RecordingPubSub::default());
+        put_session(&kv, "PROCESSING", Utc::now().timestamp_micros()).await;
+        let cp = control_plane(kv.clone(), pubsub);
+
+        for (event_id, text, event_time_ms) in [
+            (
+                "event-1",
+                "first queued connector message",
+                1_700_000_000_000,
+            ),
+            (
+                "event-2",
+                "second queued connector message",
+                1_700_000_001_000,
+            ),
+        ] {
+            dispatch_to_session(
+                &cp,
+                &test_route(),
+                &test_consumer(),
+                &test_event(event_id, text, event_time_ms),
+            )
+            .await
+            .unwrap();
+        }
+
+        let queued = queued_messages(&kv).await;
+        assert_eq!(
+            queued
+                .iter()
+                .map(|message| message.parts[0].content.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "first queued connector message",
+                "second queued connector message"
+            ]
+        );
     }
 }

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -3,11 +3,12 @@ import time
 import uuid
 from typing import Any
 
+import requests
 import uvicorn
 from fastapi import FastAPI, Request
 
 from e2e.blackbox import create_agent_resource, create_resource, ensure_namespace, message_text
-from e2e.stack import E2EStack, unused_tcp_port
+from e2e.stack import E2EStack, MOCK_LLM_PORT, unused_tcp_port
 from talon_client import (
     GetResourceRequest,
     ListSessionMessagesRequest,
@@ -17,6 +18,7 @@ from talon_client import (
 )
 from talon_client.data import (
     ROLE_ASSISTANT,
+    ROLE_USER,
     SESSION_MESSAGE_PART_TYPE_TEXT,
     MessageConsumer,
     Principal,
@@ -27,6 +29,7 @@ from talon_client.data import (
 from talon_client.proto.external.connectors_pb2 import (
     CONNECTOR_MESSAGE_EVENT_KIND_CREATED,
     CONNECTOR_MESSAGE_EVENT_STATUS_ACCEPTED,
+    CONNECTOR_MESSAGE_EVENT_STATUS_DUPLICATE,
     ConnectorMessageEvent,
 )
 from talon_client.resources import (
@@ -44,9 +47,29 @@ from talon_client.resources import (
 
 
 LABEL_CONNECTOR_DELIVERY_STATUS = "talon.impalasys.com/connector-delivery-status"
+LABEL_CONNECTOR_EVENT = "talon.impalasys.com/connector-event"
 CONNECTOR_DELIVERY_PENDING_REVIEW = "pending_review"
 CONNECTOR_DELIVERY_REQUESTED = "delivery_requested"
 CONNECTOR_DELIVERY_DELIVERED = "delivered"
+
+
+def mock_llm_control(method: str, path: str, payload: dict | None = None) -> dict[str, Any]:
+    response = requests.request(
+        method,
+        f"http://127.0.0.1:{MOCK_LLM_PORT}{path}",
+        json=payload,
+        timeout=5,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def wait_for_mock_llm_stream_blocked() -> None:
+    for _ in range(100):
+        if mock_llm_control("GET", "/__control/state").get("blocked"):
+            return
+        time.sleep(0.1)
+    raise AssertionError("mock LLM did not block its stream")
 
 
 class MockConnectorRuntime:
@@ -327,4 +350,179 @@ def test_connector_hold_for_review_can_edit_then_deliver(
         assert delivery["connectorName"] == connector_name
         assert delivery["externalConversationId"] == "room-1"
     finally:
+        runtime.stop()
+
+
+def test_connector_reuse_session_queues_messages_while_a_turn_is_busy(
+    talon_infrastructure_sqlite: E2EStack,
+    gateway_channel_sqlite,
+) -> None:
+    runtime = MockConnectorRuntime().start()
+    client = TalonClient(gateway_channel_sqlite)
+    namespace = f"talon-connector-queue-{uuid.uuid4().hex[:8]}"
+    agent_name = "connector-queue-agent"
+    class_name = "mock-chat"
+    connector_name = "room-one"
+    registration_id = f"Namespace/{namespace}/ConnectorClass/{class_name}"
+    first_event_id = f"evt-{uuid.uuid4().hex}"
+    second_event_id = f"evt-{uuid.uuid4().hex}"
+    try:
+        mock_llm_control("POST", "/__control/reset")
+        ensure_namespace(client, namespace)
+        create_agent_resource(
+            client,
+            namespace,
+            agent_name,
+            AgentSpec(
+                model_policy={
+                    "profiles": [
+                        {
+                            "name": "default",
+                            "model": Model(provider="mock", name="minimax-m2.7"),
+                        }
+                    ]
+                },
+                system_prompt="Reply briefly to connector messages.",
+            ),
+        )
+        create_resource(
+            client,
+            namespace,
+            "ConnectorClass",
+            class_name,
+            ResourceSpec(
+                connector_class=ConnectorClassSpec(
+                    platform="mock",
+                    runtime=ConnectorClassRuntimeSpec(kind="http", endpoint=runtime.base_url),
+                    auth=ConnectorClassAuthSpec(
+                        kind="apiKey",
+                        api_key=ConnectorSecretRef(plain="mock-secret"),
+                    ),
+                    match_indexes=[
+                        ConnectorMatchIndex(name="room", fields=["roomId"]),
+                    ],
+                )
+            ),
+        )
+        wait_for_connector_class_ready(client, namespace, class_name, runtime)
+        create_resource(
+            client,
+            namespace,
+            "Connector",
+            connector_name,
+            ResourceSpec(
+                connector=ConnectorSpec(
+                    class_ref=ResourceRef(name=class_name),
+                    enabled=True,
+                    match_fields={"roomId": "room-1"},
+                    consumer=MessageConsumer(
+                        session=SessionMessageConsumer(
+                            agent=DataResourceRef(name=agent_name),
+                            continuity="reuse",
+                            reply_mode="hold_for_review",
+                        )
+                    ),
+                )
+            ),
+        )
+        wait_for_connector_ready(client, namespace, connector_name)
+
+        mock_llm_control("POST", "/__control/block_stream_after_chunks", {"chunks": 1})
+        first_response = client.connectors.IngestMessageEvent(
+            ConnectorMessageEvent(
+                event_id=first_event_id,
+                event_kind=CONNECTOR_MESSAGE_EVENT_KIND_CREATED,
+                registration_id=registration_id,
+                connector_class=class_name,
+                match_fields={"roomId": "room-1"},
+                external_conversation_id="room-1",
+                external_message_id="msg-1",
+                conversation_type="room",
+                sender=Principal(external_id="operator-1", display_name="Operator", kind="user"),
+                text="first connector message",
+                event_time_ms=int(time.time() * 1000),
+            ),
+            timeout=10,
+        )
+        assert first_response.status == CONNECTOR_MESSAGE_EVENT_STATUS_ACCEPTED
+        wait_for_mock_llm_stream_blocked()
+
+        second_response = client.connectors.IngestMessageEvent(
+            ConnectorMessageEvent(
+                event_id=second_event_id,
+                event_kind=CONNECTOR_MESSAGE_EVENT_KIND_CREATED,
+                registration_id=registration_id,
+                connector_class=class_name,
+                match_fields={"roomId": "room-1"},
+                external_conversation_id="room-1",
+                external_message_id="msg-2",
+                conversation_type="room",
+                sender=Principal(external_id="operator-1", display_name="Operator", kind="user"),
+                text="second connector message",
+                event_time_ms=int(time.time() * 1000),
+            ),
+            timeout=10,
+        )
+        assert second_response.status == CONNECTOR_MESSAGE_EVENT_STATUS_ACCEPTED
+
+        session_id = latest_session_id(client, namespace, agent_name)
+        mock_llm_control("POST", "/__control/unblock_stream")
+        deadline = time.time() + 45
+        while time.time() < deadline:
+            response = client.sessions.ListMessages(
+                ListSessionMessagesRequest(
+                    ns=namespace,
+                    agent=agent_name,
+                    session_id=session_id,
+                    page_size=50,
+                )
+            )
+            messages = [item.message for item in response.items]
+            connector_user_positions = [
+                (index, message.labels.get(LABEL_CONNECTOR_EVENT))
+                for index, message in enumerate(messages)
+                if message.role == ROLE_USER
+                and message.labels.get(LABEL_CONNECTOR_EVENT) in {first_event_id, second_event_id}
+            ]
+            assistant_positions = [
+                index
+                for index, message in enumerate(messages)
+                if message.role == ROLE_ASSISTANT
+                and message.labels.get(LABEL_CONNECTOR_DELIVERY_STATUS)
+                == CONNECTOR_DELIVERY_PENDING_REVIEW
+            ]
+            if (
+                [event_id for _, event_id in connector_user_positions]
+                == [first_event_id, second_event_id]
+                and len(assistant_positions) == 2
+                and connector_user_positions[0][0]
+                < assistant_positions[0]
+                < connector_user_positions[1][0]
+                < assistant_positions[1]
+            ):
+                break
+            time.sleep(0.5)
+        else:
+            raise AssertionError(f"queued connector messages did not complete: {messages!r}")
+
+        duplicate_response = client.connectors.IngestMessageEvent(
+            ConnectorMessageEvent(
+                event_id=second_event_id,
+                event_kind=CONNECTOR_MESSAGE_EVENT_KIND_CREATED,
+                registration_id=registration_id,
+                connector_class=class_name,
+                match_fields={"roomId": "room-1"},
+                external_conversation_id="room-1",
+                external_message_id="msg-2",
+                conversation_type="room",
+                sender=Principal(external_id="operator-1", display_name="Operator", kind="user"),
+                text="second connector message",
+                event_time_ms=int(time.time() * 1000),
+            ),
+            timeout=10,
+        )
+        assert duplicate_response.status == CONNECTOR_MESSAGE_EVENT_STATUS_DUPLICATE
+    finally:
+        mock_llm_control("POST", "/__control/unblock_stream")
+        mock_llm_control("POST", "/__control/reset")
         runtime.stop()


### PR DESCRIPTION
## Summary
- Queue ConnectorService session messages in the durable next-turn queue before attempting dispatch.
- Accept busy-session connector events and drain them serially after the active turn finishes.
- Add focused Rust coverage plus a SQLite E2E regression with the mock connector runtime and blocked mock LLM.
- Run connector E2E coverage in CI.

## Why
Connector events previously attempted to acquire the session lock immediately and failed with resource exhaustion while a response was generating.

## Validation
- `cargo fmt --check`
- `cargo test -q`
- `uv run --with-requirements tests/requirements.txt --with-editable ./sdk/python/talon-client pytest -q tests/test_connectors.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connector messages now queue reliably when a session is busy and dispatch in order when it becomes available.
  * Connector events preserve timestamps, labels, and delivery ordering.
  * Repeated event IDs are reported as duplicates.

* **Bug Fixes**
  * Queued messages now retain their original creation timestamps while using acceptance time for queue ordering.

* **Tests**
  * Added end-to-end coverage for connector queuing, blocked sessions, ordered completion, and duplicate events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->