### PR TITLE
Add TCP keepalive for HTTP MCP clients

### DIFF
--- a/src/harness/mcp/mod.rs
+++ b/src/harness/mcp/mod.rs
@@ -60,6 +60,9 @@ const MCP_POST_ACCEPT_HEADER: &str = "text/event-stream, application/json";
 const MCP_HEADER_LAST_EVENT_ID: &str = "Last-Event-ID";
 const MCP_HEADER_SESSION_ID: &str = "Mcp-Session-Id";
 const MCP_TOOL_RESULT_MAX_CHARS: usize = 1_000_000;
+// reqwest 0.11 disables TCP keepalive by default. Keep long-running HTTP MCP
+// calls from appearing idle to the local network stack.
+const MCP_HTTP_TCP_KEEPALIVE: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 pub struct McpConnectionConfig {
@@ -107,6 +110,7 @@ impl McpClient {
             AuthenticatedReqwestClient::new(
                 reqwest::Client::builder()
                     .default_headers(default_headers)
+                    .tcp_keepalive(MCP_HTTP_TCP_KEEPALIVE)
                     .build()?,
                 None,
             ),


### PR DESCRIPTION
## Summary

- enable a 30-second TCP keepalive on Talon's HTTP MCP client
- retain the existing behavior for stdio MCP transports

## Why

Talon uses reqwest 0.11 for HTTP MCP connections, whose TCP keepalive is disabled by default. Long-running, otherwise idle tool calls can therefore be dropped by network infrastructure before the MCP server returns.

## Validation

- `cargo fmt --all --check`
- `cargo test --locked harness::mcp::tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of HTTP MCP connections by enabling a 30-second TCP keepalive setting.
  * Helps maintain long-lived connections and reduce unexpected disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->