### PR TITLE
Recover interrupted OpenAI Responses tool continuations

### DIFF
--- a/src/harness/llm/openai.rs
+++ b/src/harness/llm/openai.rs
@@ -904,10 +904,19 @@ impl OpenAiCompatibleProvider {
                 status,
                 &error,
             );
-            if previous_response_id.is_some() && is_stale_previous_response_id(status, &error) {
+            if previous_response_id.is_some()
+                && (is_stale_previous_response_id(status, &error)
+                    || is_missing_tool_output_for_previous_response(status, &error))
+            {
+                let recovery_reason = if is_stale_previous_response_id(status, &error) {
+                    "stale previous_response_id"
+                } else {
+                    "missing function-call output for previous_response_id"
+                };
                 tracing::warn!(
                     model = %self.model,
-                    "Retrying Responses request without stale previous_response_id"
+                    reason = recovery_reason,
+                    "Retrying Responses request without previous_response_id"
                 );
                 let full_input = self.serialize_responses_input(messages, None).await?;
                 payload = build_payload(full_input, None);
@@ -924,7 +933,7 @@ impl OpenAiCompatibleProvider {
                 let retry_status = retry_response.status();
                 let retry_error = retry_response.text().await?;
                 return Err(openai_api_error(
-                    "OpenAI Responses API error after stale previous_response_id retry",
+                    "OpenAI Responses API error after previous_response_id recovery retry",
                     &retry_error,
                 ))
                 .map_err(|error| {
@@ -962,6 +971,18 @@ fn is_stale_previous_response_id(status: reqwest::StatusCode, body: &str) -> boo
             || body.contains("expired")
             || body.contains("not found")
             || body.contains("does not exist"))
+}
+
+/// A cancelled or crashed tool turn can leave an OpenAI server-side response
+/// waiting for a function-call output.  The local transcript deliberately
+/// drops that incomplete interaction during recovery, so retrying from the
+/// complete local history is safe.  Keep this deliberately narrow: other 400s
+/// are request errors, not continuation-recovery signals.
+fn is_missing_tool_output_for_previous_response(status: reqwest::StatusCode, body: &str) -> bool {
+    status == reqwest::StatusCode::BAD_REQUEST
+        && body
+            .to_ascii_lowercase()
+            .contains("no tool output found for function call")
 }
 
 #[async_trait]
@@ -2708,6 +2729,88 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn responses_missing_tool_output_retries_from_complete_local_history() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(
+                "/responses",
+                post({
+                    let hits = hits.clone();
+                    let payloads = payloads.clone();
+                    move |Json(payload): Json<serde_json::Value>| {
+                        let hits = hits.clone();
+                        let payloads = payloads.clone();
+                        async move {
+                            payloads.lock().unwrap().push(payload);
+                            if hits.fetch_add(1, Ordering::SeqCst) == 0 {
+                                (
+                                    axum::http::StatusCode::BAD_REQUEST,
+                                    Json(serde_json::json!({
+                                        "error": {
+                                            "message": "No tool output found for function call call_123."
+                                        }
+                                    })),
+                                )
+                            } else {
+                                (
+                                    axum::http::StatusCode::OK,
+                                    Json(serde_json::json!({
+                                        "id": "resp_recovered",
+                                        "output": [{
+                                            "type": "message",
+                                            "content": [{"type": "output_text", "text": "recovered"}]
+                                        }]
+                                    })),
+                                )
+                            }
+                        }
+                    }
+                }),
+            )
+            .with_state(());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let provider = OpenAiCompatibleProvider::with_api(
+            "key".to_string(),
+            format!("http://{addr}"),
+            "model".to_string(),
+            test_cas_store(),
+            "responses",
+        );
+
+        let response = provider
+            .chat_completion(ChatRequest {
+                messages: vec![
+                    chat_message_text("system", "system instructions"),
+                    chat_message_text("user", "old question"),
+                    chat_message_text("assistant", "old answer"),
+                    chat_message_text("user", "new question"),
+                ],
+                tools: vec![],
+                thinking: None,
+                previous_response_id: Some("resp_poisoned".to_string()),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.content, "recovered");
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+        let payloads = payloads.lock().unwrap();
+        assert_eq!(payloads[0]["previous_response_id"], "resp_poisoned");
+        assert!(payloads[0]["input"].to_string().contains("new question"));
+        assert!(!payloads[0]["input"].to_string().contains("old question"));
+        assert!(payloads[1].get("previous_response_id").is_none());
+        assert!(payloads[1]["input"].to_string().contains("old question"));
+        assert!(payloads[1]["input"].to_string().contains("old answer"));
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn responses_input_without_previous_id_keeps_full_history() {
         let provider = test_provider();
         let input = provider
@@ -2807,6 +2910,22 @@ mod tests {
         assert!(!is_stale_previous_response_id(
             reqwest::StatusCode::BAD_REQUEST,
             "rate limit exceeded"
+        ));
+    }
+
+    #[test]
+    fn missing_tool_output_errors_are_retryable_but_generic_errors_are_not() {
+        assert!(is_missing_tool_output_for_previous_response(
+            reqwest::StatusCode::BAD_REQUEST,
+            "No tool output found for function call call_123."
+        ));
+        assert!(!is_missing_tool_output_for_previous_response(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "No tool output found for function call call_123."
+        ));
+        assert!(!is_missing_tool_output_for_previous_response(
+            reqwest::StatusCode::BAD_REQUEST,
+            "Invalid tool schema"
         ));
     }
 }

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1260,11 +1260,25 @@ impl PubSubSessionSink {
             usage_events: *self.usage_events.lock().unwrap(),
         }
     }
+
+    pub async fn clear_provider_continuation(&self) -> Result<()> {
+        sessions::clear_provider_request_id(self.kv.as_ref(), &self.claim).await
+    }
 }
 
 #[async_trait]
 impl ExecutionSink for PubSubSessionSink {
     async fn on_llm_response(&self, response: &ChatResponse) -> Result<()> {
+        // A Responses API response that asks for tools is waiting for matching
+        // function_call_output values on the provider. It remains usable only
+        // in this live executor turn; durable recovery must reconstruct from
+        // local history instead of reviving that incomplete continuation.
+        let mut durable_response = response.clone();
+        if !durable_response.tool_calls.is_empty() {
+            if let Some(counter) = durable_response.usage.as_mut() {
+                counter.provider_request_id = None;
+            }
+        }
         let entry = sessions::append_llm_response(
             self.kv.as_ref(),
             &self.ns,
@@ -1272,14 +1286,23 @@ impl ExecutionSink for PubSubSessionSink {
             &self.session_id,
             &self.submission_id,
             &self.attempt_id,
-            response,
+            &durable_response,
             chrono::Utc::now().timestamp_micros(),
         )
         .await?;
         *self.latest_journal_entry_id.lock().unwrap() = Some(entry.journal_entry_id);
         if let Some(counter) = response.usage.as_ref() {
+            // A Responses API response containing function calls is not a
+            // durable continuation point until every call has been answered.
+            // Keep the ID in the executor's in-memory counter for this turn,
+            // but never let cancellation/crash recovery resume this server-side
+            // response without its required function_call_output items.
+            let mut counter = counter.clone();
+            if !response.tool_calls.is_empty() {
+                counter.provider_request_id = None;
+            }
             if let Err(error) =
-                sessions::persist_context_tokens(self.kv.as_ref(), &self.claim, counter).await
+                sessions::persist_context_tokens(self.kv.as_ref(), &self.claim, &counter).await
             {
                 tracing::error!(
                     error = %error,
@@ -3023,6 +3046,107 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(journal_entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn tool_call_response_does_not_persist_provider_continuation_id() {
+        use crate::control::ProtoKeyValueStoreExt;
+        use crate::harness::llm::{ChatResponse, ToolCall};
+
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let kv = Arc::new(crate::test_support::MockKvStore::default());
+        let session_key = keys::session("conic", "infra", "session-1");
+        kv.set_msg(
+            &session_key,
+            &data_proto::Session {
+                id: "session-1".to_string(),
+                agent: "infra".to_string(),
+                ns: "conic".to_string(),
+                status: "PROCESSING".to_string(),
+                created_at: 1,
+                last_active: 1,
+                metadata: Default::default(),
+                labels: Default::default(),
+                context_tokens: None,
+            },
+        )
+        .await
+        .unwrap();
+        let mut submission =
+            sessions::pending_submission("submission-1", "session-1", "user-1", 100);
+        submission.status = data_proto::SessionSubmissionStatus::Claimed as i32;
+        submission.attempt_id = "attempt-1".to_string();
+        sessions::create_submission_if_absent(
+            kv.as_ref(),
+            "conic",
+            "infra",
+            "session-1",
+            &submission,
+        )
+        .await
+        .unwrap();
+        let sink = PubSubSessionSink::new(
+            kv.clone(),
+            Arc::new(MockPubSub { events }),
+            "conic",
+            "session-1",
+            "infra",
+            "reply-1",
+            reply_key(),
+            "submission-1",
+            "attempt-1",
+        );
+        sink.on_llm_response(&ChatResponse {
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                id: "call-1".to_string(),
+                name: "lookup".to_string(),
+                arguments: "{}".to_string(),
+            }],
+            usage: Some(TokenCounter {
+                provider_request_id: Some("resp-pending-tool".to_string()),
+                provider: "openai".to_string(),
+                model: "gpt-test".to_string(),
+                ..Default::default()
+            }),
+        })
+        .await
+        .unwrap();
+        let session = kv
+            .get_msg::<data_proto::Session>(&session_key)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(session
+            .context_tokens
+            .unwrap()
+            .provider_request_id
+            .is_none());
+        let entries = sessions::list_journal_entries(
+            kv.as_ref(),
+            "conic",
+            "infra",
+            "session-1",
+            "submission-1",
+        )
+        .await
+        .unwrap();
+        let persisted_response = entries[0]
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.payload.as_ref())
+            .and_then(|payload| match payload {
+                data_proto::session_journal_entry_payload::Payload::LlmResponse(response) => {
+                    response.response.as_ref()
+                }
+                _ => None,
+            })
+            .expect("LLM response should be journaled");
+        assert!(persisted_response
+            .usage
+            .as_ref()
+            .and_then(|usage| usage.provider_request_id.as_ref())
+            .is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed
- Do not persist provider continuation IDs for tool-bearing Responses turns.
- Retry the specific unresolved function-call-output 400 once from local canonical history.

## Why
Cancellation after a tool call can leave OpenAI waiting for output that will never arrive, poisoning a saved `previous_response_id`.

## Validation
- cargo test -q --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when provider response references become stale or required tool-call output is missing.
  - Retries now use the complete conversation history when safe, reducing failed LLM requests.
  - Prevented temporary provider continuation details from being retained in session history after tool-call responses.
  - Added safeguards to avoid retrying unrelated request errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->