### PR TITLE
Expose session compact and doctor commands

### DIFF
--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -8,6 +8,7 @@ import {
 } from "./lib/chatTimeline";
 import { ResourcePane } from "./lib/ResourcePane";
 import { type StreamEventItem } from "./lib/uiStream";
+import { streamSessionPartEvents as parseSessionPartEvents } from "./session/stream";
 import { SessionTranscript } from "./session/SessionTranscript";
 import { SessionComposerDock } from "./session/SessionComposerDock";
 import { useSessionAttachments } from "./session/hooks/useSessionAttachments";
@@ -147,6 +148,7 @@ export function TalonSession({
   const [loadingStartedAt, setLoadingStartedAt] = useState<string | number | null>(null);
   const error = sessionRuntimeState.error;
   const [streamEvents, setStreamEvents] = useState<StreamEventItem[]>([]);
+  const [maintenanceNotice, setMaintenanceNotice] = useState<string | null>(null);
   const {
     state: toolResultHydration,
     resultFor: toolResultFor,
@@ -361,7 +363,48 @@ export function TalonSession({
     setLoadingStartedAt,
   });
 
-  const { commandMenuItems, resolvedCommands } = useSessionCommands({ clearSession, commands, enabledBuiltInCommands });
+  const compactSession = useCallback(async () => {
+    const session = currentSessionRef.current;
+    if (!session) throw new Error("Cannot compact a session that has not been created.");
+    if (!gatewayClient.sessions.compact) throw new Error("TalonSession requires a Talon clientset with sessions.compact().");
+    setMaintenanceNotice(null);
+    setError(null);
+    setIsLoading(true);
+    try {
+      // Maintenance parts include an internal compaction marker. Consume the
+      // stream for lifecycle/error handling but do not feed that marker into
+      // the chat timeline as a synthetic assistant message.
+      let compacted = false;
+      for await (const event of parseSessionPartEvents(gatewayClient.sessions.compact(session))) {
+        if (event.type === "stream-failed") throw event.error;
+        if (event.type === "stream-completed") break;
+        if (event.type === "assistant-part") {
+          const partType = event.part.partType ?? event.part.part_type;
+          compacted ||= partType === 13 || partType === "SESSION_MESSAGE_PART_TYPE_COMPACTION";
+        }
+      }
+      await refreshNewestSessionPage(session);
+      setMaintenanceNotice(compacted
+        ? "Session history compacted; provider continuation was reset."
+        : "History already minimal; provider continuation was reset.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentSessionRef, gatewayClient.sessions, refreshNewestSessionPage, setError, setIsLoading]);
+
+  const doctorSession = useCallback(async () => {
+    const session = currentSessionRef.current;
+    if (!session) throw new Error("Cannot diagnose a session that has not been created.");
+    if (!gatewayClient.sessions.doctor) throw new Error("TalonSession requires a Talon clientset with sessions.doctor().");
+    setMaintenanceNotice(null);
+    const result = await gatewayClient.sessions.doctor(session);
+    await refreshNewestSessionPage(session);
+    setMaintenanceNotice(result.providerContinuationReset
+      ? `Session doctor reset the saved provider continuation${result.incompleteToolBatches ? ` and found ${result.incompleteToolBatches} incomplete tool batch(es)` : ""}.`
+      : "Session doctor found no saved provider continuation to reset.");
+  }, [currentSessionRef, gatewayClient.sessions, refreshNewestSessionPage]);
+
+  const { commandMenuItems, resolvedCommands } = useSessionCommands({ clearSession, compactSession, doctorSession, commands, enabledBuiltInCommands });
   const attachmentAccept = resolvedAcceptedAttachmentTypes.join(",");
   const { submitMessage } = useSessionActions({
     client: gatewayClient.sessions,
@@ -449,6 +492,7 @@ export function TalonSession({
             incident={sessionState === "ERROR" && !error
               ? "This session previously encountered an error. You can continue, but any unavailable historical output will be marked in the transcript."
               : null}
+            notice={maintenanceNotice}
             scrollThumb={scrollThumb}
             transcriptRef={scrollContainerRef}
             bottomRef={bottomRef}

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -4,7 +4,7 @@ import type { TalonClient } from "@impalasys/talon-client";
 export type GatewayClientLike = {
   sessions: Pick<
     TalonClient["sessions"],
-    "create" | "clear" | "listMessages" | "submitTurn" | "streamParts" | "stopGeneration"
+    "create" | "clear" | "compact" | "doctor" | "listMessages" | "submitTurn" | "streamParts" | "stopGeneration"
   > & Partial<Pick<TalonClient["sessions"], "appendMessage" | "updateMessage" | "listQueuedMessages">>;
   cas?: CasServiceClientLike;
   artifacts?: ArtifactServiceClientLike;
@@ -100,7 +100,7 @@ export type CopilotMessage = {
   toolInvocations?: ToolInvocationItem[];
 };
 
-export type TalonBuiltInCommandName = "clear" | "goal";
+export type TalonBuiltInCommandName = "clear" | "goal" | "compact" | "doctor";
 
 export type TalonChatCommandContext<TTarget, TMessage> = {
   name: string;

--- a/packages/talon-chat/src/lib/commands.ts
+++ b/packages/talon-chat/src/lib/commands.ts
@@ -1,4 +1,4 @@
-export type TalonBuiltInCommandName = "clear" | "goal";
+export type TalonBuiltInCommandName = "clear" | "goal" | "compact" | "doctor";
 
 export type TalonChatCommandContext<TTarget, TMessage> = {
   name: string;

--- a/packages/talon-chat/src/session/SessionTranscript.tsx
+++ b/packages/talon-chat/src/session/SessionTranscript.tsx
@@ -10,6 +10,7 @@ export type SessionTranscriptProps = {
   workingLabel?: string | null;
   error: Error | null;
   incident?: string | null;
+  notice?: string | null;
   scrollThumb: SessionScrollThumb;
   transcriptRef: React.RefObject<HTMLDivElement | null>;
   bottomRef: React.RefObject<HTMLDivElement | null>;
@@ -27,6 +28,7 @@ export function SessionTranscript({
   workingLabel,
   error,
   incident,
+  notice,
   scrollThumb,
   transcriptRef,
   bottomRef,
@@ -63,6 +65,11 @@ export function SessionTranscript({
                   {error?.message || incident || "An error occurred while connecting to the agent."}
                 </div>
               </div>
+            </div>
+          ) : null}
+          {notice ? (
+            <div role="status" style={{ fontSize: 13, borderRadius: 10, background: "rgba(236,253,245,1)", border: border("rgba(110,231,183,0.8)"), color: "rgba(4,120,87,1)", padding: 12 }}>
+              {notice}
             </div>
           ) : null}
           <div ref={bottomRef} />

--- a/packages/talon-chat/src/session/TalonSessionTypes.ts
+++ b/packages/talon-chat/src/session/TalonSessionTypes.ts
@@ -12,7 +12,7 @@ export type { TalonChatObjectRef } from "./types";
 export type SessionServiceClientLike = {
   sessions: Pick<
     TalonClient["sessions"],
-    "create" | "clear" | "listMessages" | "submitTurn" | "streamParts" | "stopGeneration"
+    "create" | "clear" | "compact" | "doctor" | "listMessages" | "submitTurn" | "streamParts" | "stopGeneration"
   > & Partial<Pick<TalonClient["sessions"], "appendMessage" | "updateMessage" | "listQueuedMessages">>;
 }["sessions"];
 

--- a/packages/talon-chat/src/session/useSessionCommands.ts
+++ b/packages/talon-chat/src/session/useSessionCommands.ts
@@ -4,12 +4,14 @@ import type { TalonSessionCommand } from "./TalonSessionTypes";
 
 type UseSessionCommandsOptions = {
   clearSession: () => Promise<void>;
+  compactSession: () => Promise<void>;
+  doctorSession: () => Promise<void>;
   commands?: TalonSessionCommand[];
   enabledBuiltInCommands?: TalonBuiltInCommandName[];
 };
 
 /** Combines host commands with the session-local clear and goal commands. */
-export function useSessionCommands({ clearSession, commands, enabledBuiltInCommands }: UseSessionCommandsOptions) {
+export function useSessionCommands({ clearSession, compactSession, doctorSession, commands, enabledBuiltInCommands }: UseSessionCommandsOptions) {
   const resolvedCommands = useMemo<TalonSessionCommand[]>(() => {
     const builtIns: TalonSessionCommand[] = [];
     if (enabledBuiltInCommands?.includes("clear")) {
@@ -18,8 +20,14 @@ export function useSessionCommands({ clearSession, commands, enabledBuiltInComma
     if (enabledBuiltInCommands?.includes("goal")) {
       builtIns.push({ name: "goal", description: "Create or update a session Goal.", run: () => undefined });
     }
+    if (enabledBuiltInCommands?.includes("compact")) {
+      builtIns.push({ name: "compact", description: "Compact session history and reset provider continuation state.", run: () => compactSession() });
+    }
+    if (enabledBuiltInCommands?.includes("doctor")) {
+      builtIns.push({ name: "doctor", description: "Diagnose and repair stale session continuation state.", run: () => doctorSession() });
+    }
     return [...(commands ?? []), ...builtIns];
-  }, [clearSession, commands, enabledBuiltInCommands]);
+  }, [clearSession, compactSession, doctorSession, commands, enabledBuiltInCommands]);
   const commandMenuItems = useMemo(
     () => resolvedCommands.map(({ name, aliases, description }) => ({ name, aliases, description })),
     [resolvedCommands],


### PR DESCRIPTION
## What changed
- Add opt-in Talon Chat `/compact` and `/doctor` built-in commands.
- Stream `/compact` as maintenance without creating a synthetic assistant chat message.
- Display transient maintenance outcome banners and refresh canonical history.

## Why
Give operators a safe in-chat recovery escape hatch for stale provider continuation state.

## Validation
- pnpm --filter @impalasys/talon-client build
- pnpm --filter @impalasys/talon-chat build
- pnpm --filter @impalasys/talon-chat test