### PR TITLE
Expose session maintenance commands in Sightline

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1407,7 +1407,7 @@ function DebuggerPageContent() {
                     sessionId={selectedSession.sessionId}
                     gatewayClient={getGatewayClient()}
                   historyPageSize={positiveIntParam(searchParams, 'historyPageSize')}
-                  enabledBuiltInCommands={['clear']}
+                  enabledBuiltInCommands={['clear', 'compact', 'doctor']}
                   onImageUpload={sessionComposerRole === 'assistant' || !imageUploadsEnabled ? undefined : uploadTalonImage}
                   objectUrlForRef={imageUploadsEnabled ? talonObjectUrl : undefined}
                   disabled={!isConnected}


### PR DESCRIPTION
## What changed
Enabled the existing `/compact` and `/doctor` session commands in Sightline alongside `/clear`.

## Why
The chat package and gateway already support these recovery operations, but Sightline passed only `clear` in its built-in command allowlist.

## Validation
- `pnpm --filter @impalasys/talon-client build`
- `pnpm --dir ui lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the built-in `clear`, `compact`, and `doctor` commands in TalonCopilot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->