### PR TITLE
Cap compaction at long-context thresholds

### DIFF
--- a/docs/04-operations/03-configuration.md
+++ b/docs/04-operations/03-configuration.md
@@ -98,8 +98,9 @@ provider context window. When `maxOutputTokens` is present, compaction reserves
 that many tokens for generation and uses the remainder as the history limit.
 `longContextTokens` is an input-token pricing threshold. When it is set, the
 corresponding `longContext*CostPerMillionTokens` fields describe the rates that
-apply once a request exceeds that threshold; it does not change compaction or
-the model's physical context window.
+apply once a request exceeds that threshold. It does not change the model's
+physical context window, but compaction uses the lower of that threshold and
+the model's normal input budget to avoid crossing the higher pricing tier.
 
 ```yaml
 models:

--- a/docs/05-reference/generated/config-schema.md
+++ b/docs/05-reference/generated/config-schema.md
@@ -20,7 +20,7 @@ This page summarizes the major configuration messages exposed by Talon's runtime
 
 ## `ModelConfig`
 
-Static metadata for a model configured in the model catalog. Costs are in USD per one million tokens. The context window includes generated output; compaction reserves max_output_tokens from it when both are configured. long_context_tokens is the input-token threshold above which the optional long-context cost fields replace their corresponding standard cost fields.
+Static metadata for a model configured in the model catalog. Costs are in USD per one million tokens. The context window includes generated output; compaction reserves max_output_tokens from it when both are configured. long_context_tokens is the input-token threshold above which the optional long-context cost fields replace their corresponding standard cost fields; compaction also uses it as an operational input ceiling.
 
 | Field | Type | Notes |
 | --- | --- | --- |

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -18,7 +18,8 @@ message TalonConfig {
 // USD per one million tokens. The context window includes generated output;
 // compaction reserves max_output_tokens from it when both are configured.
 // long_context_tokens is the input-token threshold above which the optional
-// long-context cost fields replace their corresponding standard cost fields.
+// long-context cost fields replace their corresponding standard cost fields;
+// compaction also uses it as an operational input ceiling.
 message ModelConfig {
   string provider = 1;
   optional uint64 context_window_tokens = 2;

--- a/sdk/go/talon-client/talon/config/config.pb.go
+++ b/sdk/go/talon-client/talon/config/config.pb.go
@@ -237,7 +237,8 @@ func (x *TalonConfig) GetModels() map[string]*ModelConfig {
 // USD per one million tokens. The context window includes generated output;
 // compaction reserves max_output_tokens from it when both are configured.
 // long_context_tokens is the input-token threshold above which the optional
-// long-context cost fields replace their corresponding standard cost fields.
+// long-context cost fields replace their corresponding standard cost fields;
+// compaction also uses it as an operational input ceiling.
 type ModelConfig struct {
 	state                                     protoimpl.MessageState `protogen:"open.v1"`
 	Provider                                  string                 `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`

--- a/sdk/java/talon-client/src/main/java/talon/config/Config.java
+++ b/sdk/java/talon-client/src/main/java/talon/config/Config.java
@@ -2604,7 +2604,8 @@ talon.config.Config.ModelConfig defaultValue) {
    * USD per one million tokens. The context window includes generated output;
    * compaction reserves max_output_tokens from it when both are configured.
    * long_context_tokens is the input-token threshold above which the optional
-   * long-context cost fields replace their corresponding standard cost fields.
+   * long-context cost fields replace their corresponding standard cost fields;
+   * compaction also uses it as an operational input ceiling.
    * </pre>
    *
    * Protobuf type {@code talon.config.ModelConfig}
@@ -3255,7 +3256,8 @@ talon.config.Config.ModelConfig defaultValue) {
      * USD per one million tokens. The context window includes generated output;
      * compaction reserves max_output_tokens from it when both are configured.
      * long_context_tokens is the input-token threshold above which the optional
-     * long-context cost fields replace their corresponding standard cost fields.
+     * long-context cost fields replace their corresponding standard cost fields;
+     * compaction also uses it as an operational input ceiling.
      * </pre>
      *
      * Protobuf type {@code talon.config.ModelConfig}

--- a/sdk/js/talon-client/src/gen/proto/config_pb.ts
+++ b/sdk/js/talon-client/src/gen/proto/config_pb.ts
@@ -96,7 +96,8 @@ export class TalonConfig extends Message<TalonConfig> {
  * USD per one million tokens. The context window includes generated output;
  * compaction reserves max_output_tokens from it when both are configured.
  * long_context_tokens is the input-token threshold above which the optional
- * long-context cost fields replace their corresponding standard cost fields.
+ * long-context cost fields replace their corresponding standard cost fields;
+ * compaction also uses it as an operational input ceiling.
  *
  * @generated from message talon.config.ModelConfig
  */

--- a/sdk/rust/talon-client/src/generated/talon.config.rs
+++ b/sdk/rust/talon-client/src/generated/talon.config.rs
@@ -33,7 +33,8 @@ pub struct TalonConfig {
 /// USD per one million tokens. The context window includes generated output;
 /// compaction reserves max_output_tokens from it when both are configured.
 /// long_context_tokens is the input-token threshold above which the optional
-/// long-context cost fields replace their corresponding standard cost fields.
+/// long-context cost fields replace their corresponding standard cost fields;
+/// compaction also uses it as an operational input ceiling.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModelConfig {
     #[prost(string, tag = "1")]

--- a/src/harness/executor/compaction.rs
+++ b/src/harness/executor/compaction.rs
@@ -271,6 +271,7 @@ pub fn compact_history_for_llm_with_budget(
 pub struct ModelContextLimits {
     pub context_window_tokens: Option<u64>,
     pub max_output_tokens: Option<u64>,
+    pub long_context_tokens: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -303,8 +304,15 @@ impl ModelContextLimits {
     }
 
     pub fn effective_input_tokens(self) -> Option<u64> {
-        self.context_window_tokens
-            .map(|context| context.saturating_sub(self.reserved_output_tokens()))
+        let physical_input_limit = self
+            .context_window_tokens
+            .map(|context| context.saturating_sub(self.reserved_output_tokens()));
+        match (physical_input_limit, self.long_context_tokens) {
+            (Some(physical), Some(long_context)) => Some(physical.min(long_context)),
+            (Some(physical), None) => Some(physical),
+            (None, Some(long_context)) => Some(long_context),
+            (None, None) => None,
+        }
     }
 
     pub fn effective_input_chars(self) -> Option<usize> {
@@ -1457,6 +1465,7 @@ None recorded."#;
         let limits = ModelContextLimits {
             context_window_tokens: Some(128_000),
             max_output_tokens: Some(16_000),
+            long_context_tokens: None,
         };
 
         assert_eq!(limits.effective_input_tokens(), Some(112_000));
@@ -1468,6 +1477,7 @@ None recorded."#;
         let limits = ModelContextLimits {
             context_window_tokens: Some(1_048_576),
             max_output_tokens: Some(1_048_576),
+            long_context_tokens: None,
         };
 
         assert_eq!(limits.reserved_output_tokens(), 157_286);
@@ -1475,10 +1485,33 @@ None recorded."#;
     }
 
     #[test]
+    fn model_context_limits_cap_input_at_long_context_threshold() {
+        let limits = ModelContextLimits {
+            context_window_tokens: Some(1_048_576),
+            max_output_tokens: Some(128_000),
+            long_context_tokens: Some(272_000),
+        };
+
+        assert_eq!(limits.effective_input_tokens(), Some(272_000));
+    }
+
+    #[test]
+    fn model_context_limits_keep_lower_physical_input_limit() {
+        let limits = ModelContextLimits {
+            context_window_tokens: Some(128_000),
+            max_output_tokens: Some(16_000),
+            long_context_tokens: Some(120_000),
+        };
+
+        assert_eq!(limits.effective_input_tokens(), Some(112_000));
+    }
+
+    #[test]
     fn tool_schema_chars_reduce_the_history_budget() {
         let limits = ModelContextLimits {
             context_window_tokens: Some(1_000),
             max_output_tokens: Some(1_000),
+            long_context_tokens: None,
         };
         let budget = ContextBudget {
             total_chars: 4_000,
@@ -1536,6 +1569,7 @@ None recorded."#;
             ModelContextLimits {
                 context_window_tokens: Some(128),
                 max_output_tokens: Some(32),
+                long_context_tokens: None,
             },
         );
 

--- a/src/harness/llm/resolver.rs
+++ b/src/harness/llm/resolver.rs
@@ -43,6 +43,7 @@ pub fn model_context_limits(config: &Config, provider: &str, model: &str) -> Mod
         .map(|model| ModelContextLimits {
             context_window_tokens: model.context_window_tokens,
             max_output_tokens: model.max_output_tokens,
+            long_context_tokens: model.long_context_tokens,
         })
         .unwrap_or_default()
 }
@@ -375,6 +376,7 @@ mod tests {
                 provider: "openai".to_string(),
                 context_window_tokens: Some(16_000),
                 max_output_tokens: Some(2_000),
+                long_context_tokens: Some(8_000),
                 ..Default::default()
             },
         );
@@ -384,6 +386,7 @@ mod tests {
             crate::harness::executor::ModelContextLimits {
                 context_window_tokens: Some(16_000),
                 max_output_tokens: Some(2_000),
+                long_context_tokens: Some(8_000),
             }
         );
     }

--- a/src/harness/telemetry.rs
+++ b/src/harness/telemetry.rs
@@ -181,6 +181,12 @@ pub fn record_chat_operation_details(
             max_output as i64,
         ));
     }
+    if let Some(long_context) = model_limits.long_context_tokens {
+        attributes.push(KeyValue::new(
+            "talon.context.long_context_tokens",
+            long_context as i64,
+        ));
+    }
     span.add_event("gen_ai.client.inference.operation.details", attributes);
 }
 


### PR DESCRIPTION
## Summary

- cap the compaction input budget at the lower of the existing physical input limit and the configured long-context threshold
- pass long-context thresholds through model resolution and record them in operation telemetry
- document the compaction behavior and regenerate SDK configuration docs

This prevents compaction from crossing into a model's higher-priced long-context tier when a lower threshold is configured.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib model_context_limits -- --nocapture`
- `cargo test --lib control::config::tests::tests::test_checked_in_talon_config_loads_shared_model_catalog -- --exact`
- `git diff --check`