### PR TITLE
Skip CLA signature for organization members

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -49,7 +49,10 @@ jobs:
               issue_number: pullRequest.number,
               per_page: 100,
             });
-            const signed = comments.some((comment) =>
+            const isImpalasysMember =
+              pullRequest.author_association === "MEMBER" ||
+              pullRequest.author_association === "OWNER";
+            const signed = isImpalasysMember || comments.some((comment) =>
               comment.user?.id === pullRequest.user.id &&
               comment.body
                 ?.replace(/\r/g, "")


### PR DESCRIPTION
## Summary

- Treat pull request authors with `MEMBER` or `OWNER` association as having satisfied the CLA.
- Continue requiring the exact CLA comment from external contributors.

## Root cause

The CLA workflow only inspected pull request comments. As a result, organization members could receive an `action_required` CLA check even though they should be exempt.

## Validation

- `git diff --check`
- Embedded `github-script` JavaScript syntax check