### PR TITLE
Add Cloud Run Worker Pool endpoint discovery

### DIFF
--- a/docs/04-operations/03-configuration.md
+++ b/docs/04-operations/03-configuration.md
@@ -318,9 +318,11 @@ Common runtime environment variables include:
 
 ### Cloud Run Worker Pool endpoint discovery
 
-Set `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool` to opt in to
-per-instance endpoint registration for a Cloud Run Worker Pool. The worker
-requests its private IPv4 address from:
+Cloud Run automatically sets `CLOUD_RUN_WORKER_POOL` inside Worker Pool
+containers. Talon uses that runtime marker to enable per-instance endpoint
+registration; `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool` remains
+available as an explicit compatibility override. The worker requests its
+private IPv4 address from:
 
 ```text
 http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip
@@ -340,7 +342,7 @@ have a load-balanced URL, so `CLOUD_RUN_SERVICE_URL` must not be used as a
 substitute for this per-instance endpoint.
 
 ```bash
-TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool
+# CLOUD_RUN_WORKER_POOL is injected by Cloud Run Worker Pools.
 PORT=8081
 ```
 

--- a/docs/04-operations/03-configuration.md
+++ b/docs/04-operations/03-configuration.md
@@ -309,7 +309,6 @@ Common runtime environment variables include:
 - `TALON_WORKER_URL`
 - `TALON_WORKER_ENDPOINT_PROTOCOL`
 - `TALON_WORKER_ENDPOINT_AUDIENCE`
-- `TALON_WORKER_ENDPOINT_DISCOVERY`
 - `TALON_SCHEDULER_DRIVER`
 - `TALON_LOCAL_SCHEDULER_TARGET_URL`
 - `TALON_LOCAL_SCHEDULER_RUNNER`
@@ -320,9 +319,7 @@ Common runtime environment variables include:
 
 Cloud Run automatically sets `CLOUD_RUN_WORKER_POOL` inside Worker Pool
 containers. Talon uses that runtime marker to enable per-instance endpoint
-registration; `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool` remains
-available as an explicit compatibility override. The worker requests its
-private IPv4 address from:
+registration. The worker requests its private IPv4 address from:
 
 ```text
 http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip
@@ -340,8 +337,8 @@ Talon gateway to the worker subnet, and worker firewall rules that allow the
 gateway to reach the configured listener port. Worker Pool IPs are ephemeral;
 they may change on restart, so the worker re-registers its current address and
 the existing heartbeat TTL removes stale registrations. Worker Pools do not
-have a load-balanced URL, so `CLOUD_RUN_SERVICE_URL` must not be used as a
-substitute for this per-instance endpoint.
+have a load-balanced URL; `CLOUD_RUN_SERVICE_URL` is not used as a per-instance
+endpoint.
 
 ```bash
 # CLOUD_RUN_WORKER_POOL is injected by Cloud Run Worker Pools.

--- a/docs/04-operations/03-configuration.md
+++ b/docs/04-operations/03-configuration.md
@@ -331,7 +331,9 @@ http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0
 and registers it with the worker port as an HTTP endpoint. `PORT` is used when
 set, with `8081` as the default. The metadata server request includes
 `Metadata-Flavor: Google` and the worker does not become ready if the response
-is missing, invalid, non-private, or localhost.
+is missing, invalid, loopback, link-local, multicast, broadcast, or otherwise
+not a usable VPC IPv4 address. VPC IPv4 ranges outside RFC1918, such as
+`100.64.0.0/10`, are accepted when they are routable from the gateway.
 
 This requires Cloud Run Worker Pool Direct VPC ingress, VPC routes from the
 Talon gateway to the worker subnet, and worker firewall rules that allow the

--- a/docs/04-operations/03-configuration.md
+++ b/docs/04-operations/03-configuration.md
@@ -304,11 +304,50 @@ Common runtime environment variables include:
 - `GRPC_ADDR`
 - `PORT`
 - `PULL_MODE`
+- `TALON_WORKER_ENDPOINT_URL`
+- `TALON_WORKER_PUBLIC_URL`
+- `TALON_WORKER_URL`
+- `TALON_WORKER_ENDPOINT_PROTOCOL`
+- `TALON_WORKER_ENDPOINT_AUDIENCE`
+- `TALON_WORKER_ENDPOINT_DISCOVERY`
 - `TALON_SCHEDULER_DRIVER`
 - `TALON_LOCAL_SCHEDULER_TARGET_URL`
 - `TALON_LOCAL_SCHEDULER_RUNNER`
 - `TALON_JWT_PRIVATE_KEY_PEM`
 - `TALON_JWT_ISSUER`
+
+### Cloud Run Worker Pool endpoint discovery
+
+Set `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool` to opt in to
+per-instance endpoint registration for a Cloud Run Worker Pool. The worker
+requests its private IPv4 address from:
+
+```text
+http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip
+```
+
+and registers it with the worker port as an HTTP endpoint. `PORT` is used when
+set, with `8081` as the default. The metadata server request includes
+`Metadata-Flavor: Google` and the worker does not become ready if the response
+is missing, invalid, non-private, or localhost.
+
+This requires Cloud Run Worker Pool Direct VPC ingress, VPC routes from the
+Talon gateway to the worker subnet, and worker firewall rules that allow the
+gateway to reach the configured listener port. Worker Pool IPs are ephemeral;
+they may change on restart, so the worker re-registers its current address and
+the existing heartbeat TTL removes stale registrations. Worker Pools do not
+have a load-balanced URL, so `CLOUD_RUN_SERVICE_URL` must not be used as a
+substitute for this per-instance endpoint.
+
+```bash
+TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool
+PORT=8081
+```
+
+Explicit `TALON_WORKER_ENDPOINT_URL` takes precedence over discovery. The
+existing `TALON_WORKER_PUBLIC_URL` and `TALON_WORKER_URL` overrides remain
+supported. When discovery is unset, Talon preserves its existing endpoint
+behavior.
 
 ## Platform JWT and JWKS
 

--- a/docs/04-operations/06-deployment-model.md
+++ b/docs/04-operations/06-deployment-model.md
@@ -27,7 +27,7 @@ Endpoint discovery is override-first. Set `TALON_WORKER_ENDPOINT_URL` only when 
 Platform behavior:
 
 - AWS ECS tasks with `ECS_CONTAINER_METADATA_URI_V4` register the task's first IPv4 address and the worker `PORT`.
-- Cloud Run Worker Pools do not have a load-balanced URL. Cloud Run injects `CLOUD_RUN_WORKER_POOL` into Worker Pool containers, so Talon automatically discovers each instance's ephemeral private VPC address from the metadata server and registers `http://<private-ip>:<PORT>`; `PORT` defaults to `8081`. `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool` remains available as an explicit compatibility override.
+- Cloud Run Worker Pools do not have a load-balanced URL. Cloud Run injects `CLOUD_RUN_WORKER_POOL` into Worker Pool containers, so Talon automatically discovers each instance's ephemeral VPC IPv4 address from the metadata server and registers `http://<private-ip>:<PORT>`; `PORT` defaults to `8081`. `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool` remains available as an explicit compatibility override. The address must be a usable VPC IPv4 address; RFC1918 is not required.
 - `TALON_WORKER_ENDPOINT_URL` always takes precedence, followed by `TALON_WORKER_PUBLIC_URL` and `TALON_WORKER_URL`. With Cloud Run Worker Pool discovery enabled, the metadata address takes precedence over `CLOUD_RUN_SERVICE_URL`; a Cloud Run service URL is not a per-worker endpoint.
 
 Cloud Run Worker Pool requirements:

--- a/docs/04-operations/06-deployment-model.md
+++ b/docs/04-operations/06-deployment-model.md
@@ -27,7 +27,24 @@ Endpoint discovery is override-first. Set `TALON_WORKER_ENDPOINT_URL` only when 
 Platform behavior:
 
 - AWS ECS tasks with `ECS_CONTAINER_METADATA_URI_V4` register the task's first IPv4 address and the worker `PORT`.
-- Cloud Run worker pools do not have a load-balanced endpoint. Use `TALON_WORKER_ENDPOINT_URL` only when you intentionally front the worker with another reachable service.
+- Cloud Run Worker Pools do not have a load-balanced URL. To register each instance's ephemeral private VPC address, opt in with `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool`. Talon reads the instance IPv4 address from the Google metadata server and registers `http://<private-ip>:<PORT>`; `PORT` defaults to `8081`.
+- `TALON_WORKER_ENDPOINT_URL` always takes precedence. `TALON_WORKER_PUBLIC_URL` and `TALON_WORKER_URL` remain compatible explicit overrides. With Cloud Run Worker Pool discovery enabled, the metadata address takes precedence over `CLOUD_RUN_SERVICE_URL`; a Cloud Run service URL is not a per-worker endpoint.
+
+Cloud Run Worker Pool requirements:
+
+- Configure Direct VPC ingress so the worker has a private VPC address and can receive traffic on its listening port.
+- The Talon gateway must have VPC reachability to the Worker Pool subnet and routes for the worker addresses.
+- Allow the gateway's source range or identity in the worker firewall rules for the worker listener port (normally `8081`, or the configured `PORT`). Do not expose the worker listener publicly for this discovery mode.
+- Worker Pool addresses are ephemeral and can change whenever an instance restarts. Each new instance registers its current address; heartbeat TTL expiry removes stale registrations.
+
+Minimal worker configuration:
+
+```bash
+TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool
+PORT=8081
+```
+
+Deploy the worker with Cloud Run Worker Pool Direct VPC ingress, and deploy the gateway on a network that can route to the Worker's VPC addresses. Do not set `CLOUD_RUN_SERVICE_URL` as the worker endpoint. Set `TALON_WORKER_ENDPOINT_URL` only if it intentionally names another reachable, per-worker endpoint.
 
 ## Local deployment shape
 

--- a/docs/04-operations/06-deployment-model.md
+++ b/docs/04-operations/06-deployment-model.md
@@ -27,8 +27,8 @@ Endpoint discovery is override-first. Set `TALON_WORKER_ENDPOINT_URL` only when 
 Platform behavior:
 
 - AWS ECS tasks with `ECS_CONTAINER_METADATA_URI_V4` register the task's first IPv4 address and the worker `PORT`.
-- Cloud Run Worker Pools do not have a load-balanced URL. To register each instance's ephemeral private VPC address, opt in with `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool`. Talon reads the instance IPv4 address from the Google metadata server and registers `http://<private-ip>:<PORT>`; `PORT` defaults to `8081`.
-- `TALON_WORKER_ENDPOINT_URL` always takes precedence. `TALON_WORKER_PUBLIC_URL` and `TALON_WORKER_URL` remain compatible explicit overrides. With Cloud Run Worker Pool discovery enabled, the metadata address takes precedence over `CLOUD_RUN_SERVICE_URL`; a Cloud Run service URL is not a per-worker endpoint.
+- Cloud Run Worker Pools do not have a load-balanced URL. Cloud Run injects `CLOUD_RUN_WORKER_POOL` into Worker Pool containers, so Talon automatically discovers each instance's ephemeral private VPC address from the metadata server and registers `http://<private-ip>:<PORT>`; `PORT` defaults to `8081`. `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool` remains available as an explicit compatibility override.
+- `TALON_WORKER_ENDPOINT_URL` always takes precedence, followed by `TALON_WORKER_PUBLIC_URL` and `TALON_WORKER_URL`. With Cloud Run Worker Pool discovery enabled, the metadata address takes precedence over `CLOUD_RUN_SERVICE_URL`; a Cloud Run service URL is not a per-worker endpoint.
 
 Cloud Run Worker Pool requirements:
 
@@ -40,7 +40,7 @@ Cloud Run Worker Pool requirements:
 Minimal worker configuration:
 
 ```bash
-TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool
+# CLOUD_RUN_WORKER_POOL is injected by Cloud Run Worker Pools.
 PORT=8081
 ```
 

--- a/docs/04-operations/06-deployment-model.md
+++ b/docs/04-operations/06-deployment-model.md
@@ -27,8 +27,8 @@ Endpoint discovery is override-first. Set `TALON_WORKER_ENDPOINT_URL` only when 
 Platform behavior:
 
 - AWS ECS tasks with `ECS_CONTAINER_METADATA_URI_V4` register the task's first IPv4 address and the worker `PORT`.
-- Cloud Run Worker Pools do not have a load-balanced URL. Cloud Run injects `CLOUD_RUN_WORKER_POOL` into Worker Pool containers, so Talon automatically discovers each instance's ephemeral VPC IPv4 address from the metadata server and registers `http://<private-ip>:<PORT>`; `PORT` defaults to `8081`. `TALON_WORKER_ENDPOINT_DISCOVERY=cloud_run_worker_pool` remains available as an explicit compatibility override. The address must be a usable VPC IPv4 address; RFC1918 is not required.
-- `TALON_WORKER_ENDPOINT_URL` always takes precedence, followed by `TALON_WORKER_PUBLIC_URL` and `TALON_WORKER_URL`. With Cloud Run Worker Pool discovery enabled, the metadata address takes precedence over `CLOUD_RUN_SERVICE_URL`; a Cloud Run service URL is not a per-worker endpoint.
+- Cloud Run Worker Pools do not have a load-balanced URL. Cloud Run injects `CLOUD_RUN_WORKER_POOL` into Worker Pool containers, so Talon automatically discovers each instance's ephemeral VPC IPv4 address from the metadata server and registers `http://<private-ip>:<PORT>`; `PORT` defaults to `8081`. The address must be a usable VPC IPv4 address; RFC1918 is not required.
+- `TALON_WORKER_ENDPOINT_URL` always takes precedence, followed by `TALON_WORKER_PUBLIC_URL` and `TALON_WORKER_URL`. Cloud Run service URLs are not used as per-worker endpoints.
 
 Cloud Run Worker Pool requirements:
 
@@ -44,7 +44,7 @@ Minimal worker configuration:
 PORT=8081
 ```
 
-Deploy the worker with Cloud Run Worker Pool Direct VPC ingress, and deploy the gateway on a network that can route to the Worker's VPC addresses. Do not set `CLOUD_RUN_SERVICE_URL` as the worker endpoint. Set `TALON_WORKER_ENDPOINT_URL` only if it intentionally names another reachable, per-worker endpoint.
+Deploy the worker with Cloud Run Worker Pool Direct VPC ingress, and deploy the gateway on a network that can route to the Worker's VPC addresses. Set `TALON_WORKER_ENDPOINT_URL` only if it intentionally names another reachable, per-worker endpoint.
 
 ## Local deployment shape
 

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -1230,6 +1230,17 @@ where
     let project_id = pubsub_project_id(&env_get);
     let port = worker_port(&env_get);
     let endpoints = talon::worker::registration::discover_worker_endpoints(&env_get, &port).await;
+    if talon::worker::registration::cloud_run_worker_pool_discovery_enabled(&env_get)
+        && endpoints.is_empty()
+    {
+        anyhow::bail!(
+            "{}",
+            concat!(
+                "Cloud Run Worker Pool endpoint discovery produced no usable private IP; ",
+                "verify Direct VPC ingress, metadata access, and gateway VPC reachability"
+            )
+        );
+    }
     let shutdown_token = CancellationToken::new();
     let worker_registration =
         talon::worker::registration::WorkerRegistration::new(worker_id, env!("CARGO_PKG_VERSION"))

--- a/src/bin/worker.rs
+++ b/src/bin/worker.rs
@@ -1229,18 +1229,7 @@ where
     let pull_mode = pull_mode_enabled(&env_get);
     let project_id = pubsub_project_id(&env_get);
     let port = worker_port(&env_get);
-    let endpoints = talon::worker::registration::discover_worker_endpoints(&env_get, &port).await;
-    if talon::worker::registration::cloud_run_worker_pool_discovery_enabled(&env_get)
-        && endpoints.is_empty()
-    {
-        anyhow::bail!(
-            "{}",
-            concat!(
-                "Cloud Run Worker Pool endpoint discovery produced no usable private IP; ",
-                "verify Direct VPC ingress, metadata access, and gateway VPC reachability"
-            )
-        );
-    }
+    let endpoints = talon::worker::registration::discover_worker_endpoints(&env_get, &port).await?;
     let shutdown_token = CancellationToken::new();
     let worker_registration =
         talon::worker::registration::WorkerRegistration::new(worker_id, env!("CARGO_PKG_VERSION"))

--- a/src/worker/registration.rs
+++ b/src/worker/registration.rs
@@ -156,8 +156,9 @@ pub fn cloud_run_worker_pool_discovery_enabled<F>(get: &F) -> bool
 where
     F: Fn(&str) -> Option<String>,
 {
-    get("TALON_WORKER_ENDPOINT_DISCOVERY")
-        .is_some_and(|value| value.trim() == CLOUD_RUN_WORKER_POOL_DISCOVERY)
+    get("CLOUD_RUN_WORKER_POOL").is_some_and(|value| !value.trim().is_empty())
+        || get("TALON_WORKER_ENDPOINT_DISCOVERY")
+            .is_some_and(|value| value.trim() == CLOUD_RUN_WORKER_POOL_DISCOVERY)
 }
 
 pub async fn discover_worker_endpoints<F>(
@@ -644,10 +645,7 @@ mod tests {
         let metadata = MockMetadataClient::success("10.0.0.15");
         let endpoints = discover_worker_endpoints_with_metadata_client(
             env(&[
-                (
-                    "TALON_WORKER_ENDPOINT_DISCOVERY",
-                    CLOUD_RUN_WORKER_POOL_DISCOVERY,
-                ),
+                ("CLOUD_RUN_WORKER_POOL", "worker-pool-a"),
                 (
                     "TALON_WORKER_ENDPOINT_URL",
                     "http://worker.example.com:8081",
@@ -679,10 +677,7 @@ mod tests {
         let metadata = MockMetadataClient::success("10.0.0.15");
         let endpoints = discover_worker_endpoints_with_metadata_client(
             env(&[
-                (
-                    "TALON_WORKER_ENDPOINT_DISCOVERY",
-                    CLOUD_RUN_WORKER_POOL_DISCOVERY,
-                ),
+                ("CLOUD_RUN_WORKER_POOL", "worker-pool-a"),
                 ("CLOUD_RUN_SERVICE_URL", "https://service.example.com"),
             ]),
             "8081",
@@ -695,19 +690,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn worker_endpoint_discovery_ignores_cloud_run_worker_pool_without_url() {
-        let endpoints = discover_worker_endpoints(
-            |name| match name {
-                "K_CONFIGURATION" => Some("worker-pool-a".to_string()),
-                "K_REVISION" => Some("worker-pool-a-00001".to_string()),
-                _ => None,
-            },
+    async fn worker_endpoint_discovery_auto_detects_cloud_run_worker_pool() {
+        let metadata = MockMetadataClient::success("10.0.0.15");
+        let endpoints = discover_worker_endpoints_with_metadata_client(
+            env(&[("CLOUD_RUN_WORKER_POOL", "worker-pool-a")]),
             "8081",
+            &metadata,
         )
         .await
         .unwrap();
 
-        assert!(endpoints.is_empty());
+        assert_eq!(endpoints[0].url, "http://10.0.0.15:8081");
     }
 
     #[test]

--- a/src/worker/registration.rs
+++ b/src/worker/registration.rs
@@ -4,13 +4,21 @@
 use crate::control::{ns, ControlPlane};
 use crate::gateway::rpc::resources_proto;
 use anyhow::{Context, Result};
+use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
+use std::net::Ipv4Addr;
 use std::sync::{Arc, OnceLock};
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
 pub const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 pub const HEARTBEAT_TTL: chrono::Duration = chrono::Duration::seconds(30);
+pub const CLOUD_RUN_WORKER_POOL_DISCOVERY: &str = "cloud_run_worker_pool";
+
+const CLOUD_RUN_METADATA_URL: &str =
+    "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip";
+const CLOUD_RUN_METADATA_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(750);
+const CLOUD_RUN_METADATA_MAX_ATTEMPTS: usize = 3;
 
 static GENERATED_WORKER_ID: OnceLock<String> = OnceLock::new();
 
@@ -114,6 +122,44 @@ pub fn worker_status(
     }
 }
 
+#[async_trait::async_trait]
+pub trait MetadataClient: Send + Sync {
+    async fn get(&self, url: &str, headers: HeaderMap) -> Result<String>;
+}
+
+struct HttpMetadataClient;
+
+#[async_trait::async_trait]
+impl MetadataClient for HttpMetadataClient {
+    async fn get(&self, url: &str, headers: HeaderMap) -> Result<String> {
+        let client = reqwest::Client::builder()
+            .timeout(CLOUD_RUN_METADATA_TIMEOUT)
+            .build()
+            .context("failed to build metadata client")?;
+        let response = client
+            .get(url)
+            .headers(headers)
+            .send()
+            .await
+            .context("metadata request failed")?;
+        if !response.status().is_success() {
+            anyhow::bail!("metadata server returned HTTP {}", response.status());
+        }
+        response
+            .text()
+            .await
+            .context("failed to read metadata response")
+    }
+}
+
+pub fn cloud_run_worker_pool_discovery_enabled<F>(get: &F) -> bool
+where
+    F: Fn(&str) -> Option<String>,
+{
+    get("TALON_WORKER_ENDPOINT_DISCOVERY")
+        .is_some_and(|value| value.trim() == CLOUD_RUN_WORKER_POOL_DISCOVERY)
+}
+
 pub async fn discover_worker_endpoints<F>(
     get: F,
     port: &str,
@@ -121,6 +167,29 @@ pub async fn discover_worker_endpoints<F>(
 where
     F: Fn(&str) -> Option<String>,
 {
+    let metadata_client = HttpMetadataClient;
+    discover_worker_endpoints_with_metadata_client(get, port, &metadata_client).await
+}
+
+pub async fn discover_worker_endpoints_with_metadata_client<F>(
+    get: F,
+    port: &str,
+    metadata_client: &dyn MetadataClient,
+) -> Vec<resources_proto::WorkerEndpoint>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if cloud_run_worker_pool_discovery_enabled(&get) {
+        if let Some(endpoint) = talon_explicit_worker_endpoint(&get) {
+            return vec![endpoint];
+        }
+
+        return cloud_run_worker_endpoint(&get, port, metadata_client)
+            .await
+            .into_iter()
+            .collect();
+    }
+
     if let Some(endpoint) = explicit_worker_endpoint(&get) {
         return vec![endpoint];
     }
@@ -130,6 +199,20 @@ where
     }
 
     Vec::new()
+}
+
+fn talon_explicit_worker_endpoint<F>(get: &F) -> Option<resources_proto::WorkerEndpoint>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    [
+        "TALON_WORKER_ENDPOINT_URL",
+        "TALON_WORKER_PUBLIC_URL",
+        "TALON_WORKER_URL",
+    ]
+    .into_iter()
+    .find_map(|name| get(name))
+    .and_then(|url| worker_endpoint_from_url(&url, get))
 }
 
 fn explicit_worker_endpoint<F>(get: &F) -> Option<resources_proto::WorkerEndpoint>
@@ -178,6 +261,58 @@ where
     let metadata = fetch_json_metadata(&metadata_uri).await?;
     let address = first_ecs_ipv4_address(&metadata)?;
     worker_endpoint_from_url(&format!("http://{}:{}", address, port), get)
+}
+
+async fn cloud_run_worker_endpoint<F>(
+    get: &F,
+    port: &str,
+    metadata_client: &dyn MetadataClient,
+) -> Option<resources_proto::WorkerEndpoint>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    for attempt in 1..=CLOUD_RUN_METADATA_MAX_ATTEMPTS {
+        match fetch_cloud_run_ipv4(metadata_client).await {
+            Ok(address) => {
+                return worker_endpoint_from_url(&format!("http://{}:{}", address, port), get);
+            }
+            Err(err) if attempt < CLOUD_RUN_METADATA_MAX_ATTEMPTS => {
+                tracing::warn!(
+                    attempt,
+                    max_attempts = CLOUD_RUN_METADATA_MAX_ATTEMPTS,
+                    error = %err,
+                    "Cloud Run Worker Pool metadata discovery failed; retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    100 * 2u64.pow((attempt - 1) as u32),
+                ))
+                .await;
+            }
+            Err(err) => {
+                tracing::error!(
+                    attempt,
+                    error = %err,
+                    "Cloud Run Worker Pool metadata discovery failed; worker will not be marked ready"
+                );
+                return None;
+            }
+        }
+    }
+    None
+}
+
+async fn fetch_cloud_run_ipv4(metadata_client: &dyn MetadataClient) -> Result<Ipv4Addr> {
+    let mut headers = HeaderMap::new();
+    headers.insert("Metadata-Flavor", HeaderValue::from_static("Google"));
+    let raw_address = metadata_client.get(CLOUD_RUN_METADATA_URL, headers).await?;
+    let address = raw_address
+        .trim()
+        .parse::<Ipv4Addr>()
+        .context("metadata response was not a valid IPv4 address")?;
+    if !address.is_private() || address.is_loopback() {
+        anyhow::bail!("metadata response was not a private IPv4 address");
+    }
+    Ok(address)
 }
 
 async fn fetch_json_metadata(url: &str) -> Option<Value> {
@@ -270,6 +405,59 @@ async fn patch_ready_with_registration_retry(cp: &ControlPlane, registration: &W
 mod tests {
     use super::*;
     use crate::test_support::{EmptyPubSub, MockKvStore};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    struct MockMetadataClient {
+        response: MockMetadataResponse,
+        requests: Mutex<Vec<(String, Option<String>)>>,
+    }
+
+    enum MockMetadataResponse {
+        Success(String),
+        Failure,
+    }
+
+    impl MockMetadataClient {
+        fn success(response: &str) -> Self {
+            Self {
+                response: MockMetadataResponse::Success(response.to_string()),
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn failure() -> Self {
+            Self {
+                response: MockMetadataResponse::Failure,
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MetadataClient for MockMetadataClient {
+        async fn get(&self, url: &str, headers: HeaderMap) -> Result<String> {
+            self.requests.lock().unwrap().push((
+                url.to_string(),
+                headers
+                    .get("Metadata-Flavor")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string),
+            ));
+            match &self.response {
+                MockMetadataResponse::Success(response) => Ok(response.clone()),
+                MockMetadataResponse::Failure => anyhow::bail!("metadata request timed out"),
+            }
+        }
+    }
+
+    fn env(values: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let values: HashMap<String, String> = values
+            .iter()
+            .map(|(name, value)| ((*name).to_string(), (*value).to_string()))
+            .collect();
+        move |name| values.get(name).cloned()
+    }
 
     fn control_plane() -> ControlPlane {
         ControlPlane::builder(Arc::new(MockKvStore::default()), Arc::new(EmptyPubSub)).build()
@@ -362,6 +550,136 @@ mod tests {
         assert_eq!(endpoints.len(), 1);
         assert_eq!(endpoints[0].url, "unix:///tmp/talon-worker.sock");
         assert_eq!(endpoints[0].protocol, "grpc");
+    }
+
+    #[tokio::test]
+    async fn cloud_run_worker_pool_discovery_registers_private_ipv4_and_port() {
+        let metadata = MockMetadataClient::success("10.0.0.15\n");
+        let endpoints = discover_worker_endpoints_with_metadata_client(
+            env(&[(
+                "TALON_WORKER_ENDPOINT_DISCOVERY",
+                CLOUD_RUN_WORKER_POOL_DISCOVERY,
+            )]),
+            "9090",
+            &metadata,
+        )
+        .await;
+
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].url, "http://10.0.0.15:9090");
+        assert_eq!(endpoints[0].protocol, "http");
+        assert_eq!(
+            metadata.requests.lock().unwrap().as_slice(),
+            &[(
+                CLOUD_RUN_METADATA_URL.to_string(),
+                Some("Google".to_string())
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn cloud_run_worker_pool_discovery_rejects_invalid_or_empty_metadata() {
+        for response in ["", "not-an-ip", "2001:db8::1"] {
+            let metadata = MockMetadataClient::success(response);
+            let endpoints = discover_worker_endpoints_with_metadata_client(
+                env(&[(
+                    "TALON_WORKER_ENDPOINT_DISCOVERY",
+                    CLOUD_RUN_WORKER_POOL_DISCOVERY,
+                )]),
+                "8081",
+                &metadata,
+            )
+            .await;
+            assert!(endpoints.is_empty(), "unexpected endpoint for {response:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn cloud_run_worker_pool_discovery_retries_metadata_failure() {
+        let metadata = MockMetadataClient::failure();
+        let endpoints = discover_worker_endpoints_with_metadata_client(
+            env(&[(
+                "TALON_WORKER_ENDPOINT_DISCOVERY",
+                CLOUD_RUN_WORKER_POOL_DISCOVERY,
+            )]),
+            "8081",
+            &metadata,
+        )
+        .await;
+
+        assert!(endpoints.is_empty());
+        assert_eq!(
+            metadata.requests.lock().unwrap().len(),
+            CLOUD_RUN_METADATA_MAX_ATTEMPTS
+        );
+    }
+
+    #[tokio::test]
+    async fn cloud_run_worker_pool_discovery_rejects_localhost() {
+        let metadata = MockMetadataClient::success("127.0.0.1");
+        let endpoints = discover_worker_endpoints_with_metadata_client(
+            env(&[(
+                "TALON_WORKER_ENDPOINT_DISCOVERY",
+                CLOUD_RUN_WORKER_POOL_DISCOVERY,
+            )]),
+            "8081",
+            &metadata,
+        )
+        .await;
+
+        assert!(endpoints.is_empty());
+    }
+
+    #[tokio::test]
+    async fn explicit_worker_endpoint_overrides_cloud_run_metadata_discovery() {
+        let metadata = MockMetadataClient::success("10.0.0.15");
+        let endpoints = discover_worker_endpoints_with_metadata_client(
+            env(&[
+                (
+                    "TALON_WORKER_ENDPOINT_DISCOVERY",
+                    CLOUD_RUN_WORKER_POOL_DISCOVERY,
+                ),
+                (
+                    "TALON_WORKER_ENDPOINT_URL",
+                    "http://worker.example.com:8081",
+                ),
+            ]),
+            "9090",
+            &metadata,
+        )
+        .await;
+
+        assert_eq!(endpoints[0].url, "http://worker.example.com:8081");
+        assert!(metadata.requests.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn disabled_cloud_run_discovery_does_not_lookup_metadata() {
+        let metadata = MockMetadataClient::success("10.0.0.15");
+        let endpoints =
+            discover_worker_endpoints_with_metadata_client(env(&[]), "8081", &metadata).await;
+
+        assert!(endpoints.is_empty());
+        assert!(metadata.requests.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cloud_run_service_url_is_not_used_when_worker_pool_discovery_is_enabled() {
+        let metadata = MockMetadataClient::success("10.0.0.15");
+        let endpoints = discover_worker_endpoints_with_metadata_client(
+            env(&[
+                (
+                    "TALON_WORKER_ENDPOINT_DISCOVERY",
+                    CLOUD_RUN_WORKER_POOL_DISCOVERY,
+                ),
+                ("CLOUD_RUN_SERVICE_URL", "https://service.example.com"),
+            ]),
+            "8081",
+            &metadata,
+        )
+        .await;
+
+        assert_eq!(endpoints[0].url, "http://10.0.0.15:8081");
     }
 
     #[tokio::test]

--- a/src/worker/registration.rs
+++ b/src/worker/registration.rs
@@ -163,7 +163,7 @@ where
 pub async fn discover_worker_endpoints<F>(
     get: F,
     port: &str,
-) -> Vec<resources_proto::WorkerEndpoint>
+) -> Result<Vec<resources_proto::WorkerEndpoint>>
 where
     F: Fn(&str) -> Option<String>,
 {
@@ -175,30 +175,36 @@ pub async fn discover_worker_endpoints_with_metadata_client<F>(
     get: F,
     port: &str,
     metadata_client: &dyn MetadataClient,
-) -> Vec<resources_proto::WorkerEndpoint>
+) -> Result<Vec<resources_proto::WorkerEndpoint>>
 where
     F: Fn(&str) -> Option<String>,
 {
     if cloud_run_worker_pool_discovery_enabled(&get) {
         if let Some(endpoint) = talon_explicit_worker_endpoint(&get) {
-            return vec![endpoint];
+            return Ok(vec![endpoint]);
         }
 
-        return cloud_run_worker_endpoint(&get, port, metadata_client)
+        let endpoints: Vec<_> = cloud_run_worker_endpoint(&get, port, metadata_client)
             .await
             .into_iter()
             .collect();
+        if endpoints.is_empty() {
+            anyhow::bail!(
+                "Cloud Run Worker Pool endpoint discovery produced no usable private IP; verify Direct VPC ingress, metadata access, and gateway VPC reachability"
+            );
+        }
+        return Ok(endpoints);
     }
 
     if let Some(endpoint) = explicit_worker_endpoint(&get) {
-        return vec![endpoint];
+        return Ok(vec![endpoint]);
     }
 
     if let Some(endpoint) = ecs_worker_endpoint(&get, port).await {
-        return vec![endpoint];
+        return Ok(vec![endpoint]);
     }
 
-    Vec::new()
+    Ok(Vec::new())
 }
 
 fn talon_explicit_worker_endpoint<F>(get: &F) -> Option<resources_proto::WorkerEndpoint>
@@ -529,6 +535,7 @@ mod tests {
             "8081",
         )
         .await;
+        let endpoints = endpoints.unwrap();
 
         assert_eq!(endpoints.len(), 1);
         assert_eq!(endpoints[0].url, "https://worker.example.com");
@@ -546,6 +553,7 @@ mod tests {
             "8081",
         )
         .await;
+        let endpoints = endpoints.unwrap();
 
         assert_eq!(endpoints.len(), 1);
         assert_eq!(endpoints[0].url, "unix:///tmp/talon-worker.sock");
@@ -563,7 +571,8 @@ mod tests {
             "9090",
             &metadata,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(endpoints.len(), 1);
         assert_eq!(endpoints[0].url, "http://10.0.0.15:9090");
@@ -581,7 +590,7 @@ mod tests {
     async fn cloud_run_worker_pool_discovery_rejects_invalid_or_empty_metadata() {
         for response in ["", "not-an-ip", "2001:db8::1"] {
             let metadata = MockMetadataClient::success(response);
-            let endpoints = discover_worker_endpoints_with_metadata_client(
+            let result = discover_worker_endpoints_with_metadata_client(
                 env(&[(
                     "TALON_WORKER_ENDPOINT_DISCOVERY",
                     CLOUD_RUN_WORKER_POOL_DISCOVERY,
@@ -590,14 +599,14 @@ mod tests {
                 &metadata,
             )
             .await;
-            assert!(endpoints.is_empty(), "unexpected endpoint for {response:?}");
+            assert!(result.is_err(), "unexpected endpoint for {response:?}");
         }
     }
 
     #[tokio::test]
     async fn cloud_run_worker_pool_discovery_retries_metadata_failure() {
         let metadata = MockMetadataClient::failure();
-        let endpoints = discover_worker_endpoints_with_metadata_client(
+        let result = discover_worker_endpoints_with_metadata_client(
             env(&[(
                 "TALON_WORKER_ENDPOINT_DISCOVERY",
                 CLOUD_RUN_WORKER_POOL_DISCOVERY,
@@ -607,7 +616,7 @@ mod tests {
         )
         .await;
 
-        assert!(endpoints.is_empty());
+        assert!(result.is_err());
         assert_eq!(
             metadata.requests.lock().unwrap().len(),
             CLOUD_RUN_METADATA_MAX_ATTEMPTS
@@ -617,7 +626,7 @@ mod tests {
     #[tokio::test]
     async fn cloud_run_worker_pool_discovery_rejects_localhost() {
         let metadata = MockMetadataClient::success("127.0.0.1");
-        let endpoints = discover_worker_endpoints_with_metadata_client(
+        let result = discover_worker_endpoints_with_metadata_client(
             env(&[(
                 "TALON_WORKER_ENDPOINT_DISCOVERY",
                 CLOUD_RUN_WORKER_POOL_DISCOVERY,
@@ -627,7 +636,7 @@ mod tests {
         )
         .await;
 
-        assert!(endpoints.is_empty());
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -647,7 +656,8 @@ mod tests {
             "9090",
             &metadata,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(endpoints[0].url, "http://worker.example.com:8081");
         assert!(metadata.requests.lock().unwrap().is_empty());
@@ -656,8 +666,9 @@ mod tests {
     #[tokio::test]
     async fn disabled_cloud_run_discovery_does_not_lookup_metadata() {
         let metadata = MockMetadataClient::success("10.0.0.15");
-        let endpoints =
-            discover_worker_endpoints_with_metadata_client(env(&[]), "8081", &metadata).await;
+        let endpoints = discover_worker_endpoints_with_metadata_client(env(&[]), "8081", &metadata)
+            .await
+            .unwrap();
 
         assert!(endpoints.is_empty());
         assert!(metadata.requests.lock().unwrap().is_empty());
@@ -677,7 +688,8 @@ mod tests {
             "8081",
             &metadata,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(endpoints[0].url, "http://10.0.0.15:8081");
     }
@@ -692,7 +704,8 @@ mod tests {
             },
             "8081",
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(endpoints.is_empty());
     }

--- a/src/worker/registration.rs
+++ b/src/worker/registration.rs
@@ -12,7 +12,6 @@ use url::Url;
 
 pub const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 pub const HEARTBEAT_TTL: chrono::Duration = chrono::Duration::seconds(30);
-pub const CLOUD_RUN_WORKER_POOL_DISCOVERY: &str = "cloud_run_worker_pool";
 
 const CLOUD_RUN_METADATA_URL: &str =
     "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip";
@@ -121,15 +120,6 @@ pub fn worker_status(
     }
 }
 
-pub fn cloud_run_worker_pool_discovery_enabled<F>(get: &F) -> bool
-where
-    F: Fn(&str) -> Option<String>,
-{
-    get("CLOUD_RUN_WORKER_POOL").is_some_and(|value| !value.trim().is_empty())
-        || get("TALON_WORKER_ENDPOINT_DISCOVERY")
-            .is_some_and(|value| value.trim() == CLOUD_RUN_WORKER_POOL_DISCOVERY)
-}
-
 pub async fn discover_worker_endpoints<F>(
     get: F,
     port: &str,
@@ -137,17 +127,8 @@ pub async fn discover_worker_endpoints<F>(
 where
     F: Fn(&str) -> Option<String>,
 {
-    let cloud_run_worker_pool = cloud_run_worker_pool_discovery_enabled(&get);
     if let Some(endpoint) = explicit_worker_endpoint(&get) {
         return Ok(vec![endpoint]);
-    }
-
-    if !cloud_run_worker_pool {
-        if let Some(endpoint) =
-            get("CLOUD_RUN_SERVICE_URL").and_then(|url| worker_endpoint_from_url(&url, &get))
-        {
-            return Ok(vec![endpoint]);
-        }
     }
 
     if let Some(endpoint) = ecs_worker_endpoint(&get, port).await {
@@ -217,7 +198,7 @@ async fn cloud_run_worker_pool_endpoint<F>(
 where
     F: Fn(&str) -> Option<String>,
 {
-    if !cloud_run_worker_pool_discovery_enabled(get) {
+    if !get("CLOUD_RUN_WORKER_POOL").is_some_and(|value| !value.trim().is_empty()) {
         return Ok(None);
     }
 
@@ -647,18 +628,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cloud_run_service_url_is_not_used_when_worker_pool_discovery_is_enabled() {
-        let server = metadata_server("10.0.0.15").await;
-        let environment = env(&[
-            ("CLOUD_RUN_WORKER_POOL", "worker-pool-a"),
-            ("CLOUD_RUN_SERVICE_URL", "https://service.example.com"),
-        ]);
-        let endpoint = cloud_run_worker_pool_endpoint(&environment, "8081", &server.url)
-            .await
-            .unwrap()
-            .unwrap();
+    async fn cloud_run_service_url_is_not_used_as_worker_endpoint() {
+        let endpoints = discover_worker_endpoints(
+            env(&[("CLOUD_RUN_SERVICE_URL", "https://service.example.com")]),
+            "8081",
+        )
+        .await
+        .unwrap();
 
-        assert_eq!(endpoint.url, "http://10.0.0.15:8081");
+        assert!(endpoints.is_empty());
     }
 
     #[test]

--- a/src/worker/registration.rs
+++ b/src/worker/registration.rs
@@ -173,8 +173,7 @@ where
         "TALON_WORKER_URL",
     ]
     .into_iter()
-    .find_map(|name| get(name))
-    .and_then(|url| worker_endpoint_from_url(&url, get))
+    .find_map(|name| get(name).and_then(|url| worker_endpoint_from_url(&url, get)))
 }
 
 fn worker_endpoint_from_url<F>(raw_url: &str, get: &F) -> Option<resources_proto::WorkerEndpoint>
@@ -223,6 +222,7 @@ where
     }
 
     let client = reqwest::Client::builder()
+        .no_proxy()
         .timeout(CLOUD_RUN_METADATA_TIMEOUT)
         .build()
         .context("failed to build Cloud Run metadata client")?;
@@ -244,8 +244,8 @@ where
                 .trim()
                 .parse::<Ipv4Addr>()
                 .context("metadata response was not a valid IPv4 address")?;
-            if !address.is_private() || address.is_loopback() {
-                anyhow::bail!("metadata response was not a private IPv4 address");
+            if !is_usable_cloud_run_ipv4(address) {
+                anyhow::bail!("metadata response was not a usable VPC IPv4 address");
             }
             Ok::<Ipv4Addr, anyhow::Error>(address)
         }
@@ -277,12 +277,20 @@ where
                     "Cloud Run Worker Pool metadata discovery failed; worker will not be marked ready"
                 );
                 anyhow::bail!(
-                    "Cloud Run Worker Pool endpoint discovery produced no usable private IP; verify Direct VPC ingress, metadata access, and gateway VPC reachability"
+                    "Cloud Run Worker Pool endpoint discovery produced no usable VPC IPv4 address; verify Direct VPC ingress, metadata access, and gateway VPC reachability"
                 );
             }
         }
     }
     Ok(None)
+}
+
+fn is_usable_cloud_run_ipv4(address: Ipv4Addr) -> bool {
+    !address.is_unspecified()
+        && !address.is_loopback()
+        && !address.is_link_local()
+        && !address.is_multicast()
+        && !address.is_broadcast()
 }
 
 async fn fetch_json_metadata(url: &str) -> Option<Value> {
@@ -549,8 +557,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cloud_run_worker_pool_discovery_accepts_non_rfc1918_vpc_ipv4() {
+        let server = metadata_server("100.64.0.15").await;
+        let environment = env(&[("CLOUD_RUN_WORKER_POOL", "worker-pool-a")]);
+        let endpoint = cloud_run_worker_pool_endpoint(&environment, "8081", &server.url)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(endpoint.url, "http://100.64.0.15:8081");
+    }
+
+    #[tokio::test]
     async fn cloud_run_worker_pool_discovery_rejects_invalid_or_empty_metadata() {
-        for response in ["", "not-an-ip", "2001:db8::1"] {
+        for response in [
+            "",
+            "not-an-ip",
+            "2001:db8::1",
+            "0.0.0.0",
+            "169.254.1.1",
+            "224.0.0.1",
+            "255.255.255.255",
+        ] {
             let server = metadata_server(response).await;
             let environment = env(&[("CLOUD_RUN_WORKER_POOL", "worker-pool-a")]);
             let result = cloud_run_worker_pool_endpoint(&environment, "8081", &server.url).await;
@@ -586,6 +614,22 @@ mod tests {
                     "TALON_WORKER_ENDPOINT_URL",
                     "http://worker.example.com:8081",
                 ),
+            ]),
+            "9090",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(endpoints[0].url, "http://worker.example.com:8081");
+    }
+
+    #[tokio::test]
+    async fn explicit_endpoint_candidates_skip_invalid_values() {
+        let endpoints = discover_worker_endpoints(
+            env(&[
+                ("CLOUD_RUN_WORKER_POOL", "worker-pool-a"),
+                ("TALON_WORKER_ENDPOINT_URL", "not-a-url"),
+                ("TALON_WORKER_PUBLIC_URL", "http://worker.example.com:8081"),
             ]),
             "9090",
         )

--- a/src/worker/registration.rs
+++ b/src/worker/registration.rs
@@ -4,7 +4,6 @@
 use crate::control::{ns, ControlPlane};
 use crate::gateway::rpc::resources_proto;
 use anyhow::{Context, Result};
-use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
 use std::net::Ipv4Addr;
 use std::sync::{Arc, OnceLock};
@@ -122,36 +121,6 @@ pub fn worker_status(
     }
 }
 
-#[async_trait::async_trait]
-pub trait MetadataClient: Send + Sync {
-    async fn get(&self, url: &str, headers: HeaderMap) -> Result<String>;
-}
-
-struct HttpMetadataClient;
-
-#[async_trait::async_trait]
-impl MetadataClient for HttpMetadataClient {
-    async fn get(&self, url: &str, headers: HeaderMap) -> Result<String> {
-        let client = reqwest::Client::builder()
-            .timeout(CLOUD_RUN_METADATA_TIMEOUT)
-            .build()
-            .context("failed to build metadata client")?;
-        let response = client
-            .get(url)
-            .headers(headers)
-            .send()
-            .await
-            .context("metadata request failed")?;
-        if !response.status().is_success() {
-            anyhow::bail!("metadata server returned HTTP {}", response.status());
-        }
-        response
-            .text()
-            .await
-            .context("failed to read metadata response")
-    }
-}
-
 pub fn cloud_run_worker_pool_discovery_enabled<F>(get: &F) -> bool
 where
     F: Fn(&str) -> Option<String>,
@@ -168,58 +137,30 @@ pub async fn discover_worker_endpoints<F>(
 where
     F: Fn(&str) -> Option<String>,
 {
-    let metadata_client = HttpMetadataClient;
-    discover_worker_endpoints_with_metadata_client(get, port, &metadata_client).await
-}
-
-pub async fn discover_worker_endpoints_with_metadata_client<F>(
-    get: F,
-    port: &str,
-    metadata_client: &dyn MetadataClient,
-) -> Result<Vec<resources_proto::WorkerEndpoint>>
-where
-    F: Fn(&str) -> Option<String>,
-{
-    if cloud_run_worker_pool_discovery_enabled(&get) {
-        if let Some(endpoint) = talon_explicit_worker_endpoint(&get) {
-            return Ok(vec![endpoint]);
-        }
-
-        let endpoints: Vec<_> = cloud_run_worker_endpoint(&get, port, metadata_client)
-            .await
-            .into_iter()
-            .collect();
-        if endpoints.is_empty() {
-            anyhow::bail!(
-                "Cloud Run Worker Pool endpoint discovery produced no usable private IP; verify Direct VPC ingress, metadata access, and gateway VPC reachability"
-            );
-        }
-        return Ok(endpoints);
-    }
-
+    let cloud_run_worker_pool = cloud_run_worker_pool_discovery_enabled(&get);
     if let Some(endpoint) = explicit_worker_endpoint(&get) {
         return Ok(vec![endpoint]);
+    }
+
+    if !cloud_run_worker_pool {
+        if let Some(endpoint) =
+            get("CLOUD_RUN_SERVICE_URL").and_then(|url| worker_endpoint_from_url(&url, &get))
+        {
+            return Ok(vec![endpoint]);
+        }
     }
 
     if let Some(endpoint) = ecs_worker_endpoint(&get, port).await {
         return Ok(vec![endpoint]);
     }
 
-    Ok(Vec::new())
-}
+    if let Some(endpoint) =
+        cloud_run_worker_pool_endpoint(&get, port, CLOUD_RUN_METADATA_URL).await?
+    {
+        return Ok(vec![endpoint]);
+    }
 
-fn talon_explicit_worker_endpoint<F>(get: &F) -> Option<resources_proto::WorkerEndpoint>
-where
-    F: Fn(&str) -> Option<String>,
-{
-    [
-        "TALON_WORKER_ENDPOINT_URL",
-        "TALON_WORKER_PUBLIC_URL",
-        "TALON_WORKER_URL",
-    ]
-    .into_iter()
-    .find_map(|name| get(name))
-    .and_then(|url| worker_endpoint_from_url(&url, get))
+    Ok(Vec::new())
 }
 
 fn explicit_worker_endpoint<F>(get: &F) -> Option<resources_proto::WorkerEndpoint>
@@ -230,7 +171,6 @@ where
         "TALON_WORKER_ENDPOINT_URL",
         "TALON_WORKER_PUBLIC_URL",
         "TALON_WORKER_URL",
-        "CLOUD_RUN_SERVICE_URL",
     ]
     .into_iter()
     .find_map(|name| get(name))
@@ -270,18 +210,53 @@ where
     worker_endpoint_from_url(&format!("http://{}:{}", address, port), get)
 }
 
-async fn cloud_run_worker_endpoint<F>(
+async fn cloud_run_worker_pool_endpoint<F>(
     get: &F,
     port: &str,
-    metadata_client: &dyn MetadataClient,
-) -> Option<resources_proto::WorkerEndpoint>
+    metadata_url: &str,
+) -> Result<Option<resources_proto::WorkerEndpoint>>
 where
     F: Fn(&str) -> Option<String>,
 {
+    if !cloud_run_worker_pool_discovery_enabled(get) {
+        return Ok(None);
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(CLOUD_RUN_METADATA_TIMEOUT)
+        .build()
+        .context("failed to build Cloud Run metadata client")?;
     for attempt in 1..=CLOUD_RUN_METADATA_MAX_ATTEMPTS {
-        match fetch_cloud_run_ipv4(metadata_client).await {
+        let result = async {
+            let response = client
+                .get(metadata_url)
+                .header("Metadata-Flavor", "Google")
+                .send()
+                .await
+                .context("metadata request failed")?;
+            if !response.status().is_success() {
+                anyhow::bail!("metadata server returned HTTP {}", response.status());
+            }
+            let address = response
+                .text()
+                .await
+                .context("failed to read metadata response")?
+                .trim()
+                .parse::<Ipv4Addr>()
+                .context("metadata response was not a valid IPv4 address")?;
+            if !address.is_private() || address.is_loopback() {
+                anyhow::bail!("metadata response was not a private IPv4 address");
+            }
+            Ok::<Ipv4Addr, anyhow::Error>(address)
+        }
+        .await;
+
+        match result {
             Ok(address) => {
-                return worker_endpoint_from_url(&format!("http://{}:{}", address, port), get);
+                return Ok(worker_endpoint_from_url(
+                    &format!("http://{}:{}", address, port),
+                    get,
+                ));
             }
             Err(err) if attempt < CLOUD_RUN_METADATA_MAX_ATTEMPTS => {
                 tracing::warn!(
@@ -301,25 +276,13 @@ where
                     error = %err,
                     "Cloud Run Worker Pool metadata discovery failed; worker will not be marked ready"
                 );
-                return None;
+                anyhow::bail!(
+                    "Cloud Run Worker Pool endpoint discovery produced no usable private IP; verify Direct VPC ingress, metadata access, and gateway VPC reachability"
+                );
             }
         }
     }
-    None
-}
-
-async fn fetch_cloud_run_ipv4(metadata_client: &dyn MetadataClient) -> Result<Ipv4Addr> {
-    let mut headers = HeaderMap::new();
-    headers.insert("Metadata-Flavor", HeaderValue::from_static("Google"));
-    let raw_address = metadata_client.get(CLOUD_RUN_METADATA_URL, headers).await?;
-    let address = raw_address
-        .trim()
-        .parse::<Ipv4Addr>()
-        .context("metadata response was not a valid IPv4 address")?;
-    if !address.is_private() || address.is_loopback() {
-        anyhow::bail!("metadata response was not a private IPv4 address");
-    }
-    Ok(address)
+    Ok(None)
 }
 
 async fn fetch_json_metadata(url: &str) -> Option<Value> {
@@ -413,48 +376,56 @@ mod tests {
     use super::*;
     use crate::test_support::{EmptyPubSub, MockKvStore};
     use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::task::JoinHandle;
 
-    struct MockMetadataClient {
-        response: MockMetadataResponse,
-        requests: Mutex<Vec<(String, Option<String>)>>,
+    struct MetadataServer {
+        url: String,
+        requests: Arc<Mutex<Vec<String>>>,
+        task: JoinHandle<()>,
     }
 
-    enum MockMetadataResponse {
-        Success(String),
-        Failure,
-    }
-
-    impl MockMetadataClient {
-        fn success(response: &str) -> Self {
-            Self {
-                response: MockMetadataResponse::Success(response.to_string()),
-                requests: Mutex::new(Vec::new()),
-            }
-        }
-
-        fn failure() -> Self {
-            Self {
-                response: MockMetadataResponse::Failure,
-                requests: Mutex::new(Vec::new()),
-            }
+    impl Drop for MetadataServer {
+        fn drop(&mut self) {
+            self.task.abort();
         }
     }
 
-    #[async_trait::async_trait]
-    impl MetadataClient for MockMetadataClient {
-        async fn get(&self, url: &str, headers: HeaderMap) -> Result<String> {
-            self.requests.lock().unwrap().push((
-                url.to_string(),
-                headers
-                    .get("Metadata-Flavor")
-                    .and_then(|value| value.to_str().ok())
-                    .map(str::to_string),
-            ));
-            match &self.response {
-                MockMetadataResponse::Success(response) => Ok(response.clone()),
-                MockMetadataResponse::Failure => anyhow::bail!("metadata request timed out"),
+    async fn metadata_server(body: &str) -> MetadataServer {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured_requests = requests.clone();
+        let body = body.to_string();
+        let task = tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let mut request = vec![0; 4096];
+                let size = tokio::time::timeout(
+                    std::time::Duration::from_secs(1),
+                    socket.read(&mut request),
+                )
+                .await
+                .ok()
+                .and_then(Result::ok)
+                .unwrap_or_default();
+                request.truncate(size);
+                captured_requests
+                    .lock()
+                    .unwrap()
+                    .push(String::from_utf8_lossy(&request).into_owned());
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
             }
+        });
+        MetadataServer {
+            url: format!("http://{}", address),
+            requests,
+            task,
         }
     }
 
@@ -562,88 +533,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cloud_run_worker_pool_discovery_registers_private_ipv4_and_port() {
-        let metadata = MockMetadataClient::success("10.0.0.15\n");
-        let endpoints = discover_worker_endpoints_with_metadata_client(
-            env(&[(
-                "TALON_WORKER_ENDPOINT_DISCOVERY",
-                CLOUD_RUN_WORKER_POOL_DISCOVERY,
-            )]),
-            "9090",
-            &metadata,
-        )
-        .await
-        .unwrap();
+    async fn cloud_run_worker_pool_discovery_auto_detects_private_ipv4_and_port() {
+        let server = metadata_server("10.0.0.15\n").await;
+        let environment = env(&[("CLOUD_RUN_WORKER_POOL", "worker-pool-a")]);
+        let endpoint = cloud_run_worker_pool_endpoint(&environment, "9090", &server.url)
+            .await
+            .unwrap()
+            .unwrap();
 
-        assert_eq!(endpoints.len(), 1);
-        assert_eq!(endpoints[0].url, "http://10.0.0.15:9090");
-        assert_eq!(endpoints[0].protocol, "http");
-        assert_eq!(
-            metadata.requests.lock().unwrap().as_slice(),
-            &[(
-                CLOUD_RUN_METADATA_URL.to_string(),
-                Some("Google".to_string())
-            )]
-        );
+        assert_eq!(endpoint.url, "http://10.0.0.15:9090");
+        assert_eq!(endpoint.protocol, "http");
+        assert!(server.requests.lock().unwrap()[0]
+            .to_ascii_lowercase()
+            .contains("metadata-flavor: google"));
     }
 
     #[tokio::test]
     async fn cloud_run_worker_pool_discovery_rejects_invalid_or_empty_metadata() {
         for response in ["", "not-an-ip", "2001:db8::1"] {
-            let metadata = MockMetadataClient::success(response);
-            let result = discover_worker_endpoints_with_metadata_client(
-                env(&[(
-                    "TALON_WORKER_ENDPOINT_DISCOVERY",
-                    CLOUD_RUN_WORKER_POOL_DISCOVERY,
-                )]),
-                "8081",
-                &metadata,
-            )
-            .await;
+            let server = metadata_server(response).await;
+            let environment = env(&[("CLOUD_RUN_WORKER_POOL", "worker-pool-a")]);
+            let result = cloud_run_worker_pool_endpoint(&environment, "8081", &server.url).await;
             assert!(result.is_err(), "unexpected endpoint for {response:?}");
         }
     }
 
     #[tokio::test]
     async fn cloud_run_worker_pool_discovery_retries_metadata_failure() {
-        let metadata = MockMetadataClient::failure();
-        let result = discover_worker_endpoints_with_metadata_client(
-            env(&[(
-                "TALON_WORKER_ENDPOINT_DISCOVERY",
-                CLOUD_RUN_WORKER_POOL_DISCOVERY,
-            )]),
-            "8081",
-            &metadata,
-        )
-        .await;
+        let environment = env(&[("CLOUD_RUN_WORKER_POOL", "worker-pool-a")]);
+        let result =
+            cloud_run_worker_pool_endpoint(&environment, "8081", "http://127.0.0.1:1/metadata")
+                .await;
 
         assert!(result.is_err());
-        assert_eq!(
-            metadata.requests.lock().unwrap().len(),
-            CLOUD_RUN_METADATA_MAX_ATTEMPTS
-        );
     }
 
     #[tokio::test]
     async fn cloud_run_worker_pool_discovery_rejects_localhost() {
-        let metadata = MockMetadataClient::success("127.0.0.1");
-        let result = discover_worker_endpoints_with_metadata_client(
-            env(&[(
-                "TALON_WORKER_ENDPOINT_DISCOVERY",
-                CLOUD_RUN_WORKER_POOL_DISCOVERY,
-            )]),
-            "8081",
-            &metadata,
-        )
-        .await;
+        let server = metadata_server("127.0.0.1").await;
+        let environment = env(&[("CLOUD_RUN_WORKER_POOL", "worker-pool-a")]);
+        let result = cloud_run_worker_pool_endpoint(&environment, "8081", &server.url).await;
 
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn explicit_worker_endpoint_overrides_cloud_run_metadata_discovery() {
-        let metadata = MockMetadataClient::success("10.0.0.15");
-        let endpoints = discover_worker_endpoints_with_metadata_client(
+        let endpoints = discover_worker_endpoints(
             env(&[
                 ("CLOUD_RUN_WORKER_POOL", "worker-pool-a"),
                 (
@@ -652,55 +588,33 @@ mod tests {
                 ),
             ]),
             "9090",
-            &metadata,
         )
         .await
         .unwrap();
 
         assert_eq!(endpoints[0].url, "http://worker.example.com:8081");
-        assert!(metadata.requests.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
     async fn disabled_cloud_run_discovery_does_not_lookup_metadata() {
-        let metadata = MockMetadataClient::success("10.0.0.15");
-        let endpoints = discover_worker_endpoints_with_metadata_client(env(&[]), "8081", &metadata)
-            .await
-            .unwrap();
+        let endpoints = discover_worker_endpoints(env(&[]), "8081").await.unwrap();
 
         assert!(endpoints.is_empty());
-        assert!(metadata.requests.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
     async fn cloud_run_service_url_is_not_used_when_worker_pool_discovery_is_enabled() {
-        let metadata = MockMetadataClient::success("10.0.0.15");
-        let endpoints = discover_worker_endpoints_with_metadata_client(
-            env(&[
-                ("CLOUD_RUN_WORKER_POOL", "worker-pool-a"),
-                ("CLOUD_RUN_SERVICE_URL", "https://service.example.com"),
-            ]),
-            "8081",
-            &metadata,
-        )
-        .await
-        .unwrap();
+        let server = metadata_server("10.0.0.15").await;
+        let environment = env(&[
+            ("CLOUD_RUN_WORKER_POOL", "worker-pool-a"),
+            ("CLOUD_RUN_SERVICE_URL", "https://service.example.com"),
+        ]);
+        let endpoint = cloud_run_worker_pool_endpoint(&environment, "8081", &server.url)
+            .await
+            .unwrap()
+            .unwrap();
 
-        assert_eq!(endpoints[0].url, "http://10.0.0.15:8081");
-    }
-
-    #[tokio::test]
-    async fn worker_endpoint_discovery_auto_detects_cloud_run_worker_pool() {
-        let metadata = MockMetadataClient::success("10.0.0.15");
-        let endpoints = discover_worker_endpoints_with_metadata_client(
-            env(&[("CLOUD_RUN_WORKER_POOL", "worker-pool-a")]),
-            "8081",
-            &metadata,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(endpoints[0].url, "http://10.0.0.15:8081");
+        assert_eq!(endpoint.url, "http://10.0.0.15:8081");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds automatic per-instance endpoint discovery for Cloud Run Worker Pools using the VPC IPv4 address exposed by the Google metadata server.

## Changes

- Detects Cloud Run Worker Pool containers through the platform-injected `CLOUD_RUN_WORKER_POOL` environment variable.
- Resolves valid explicit Talon worker endpoints before ECS and Cloud Run platform discovery; malformed higher-priority values do not mask valid compatible fallbacks.
- Requests the worker IPv4 address with `Metadata-Flavor: Google`, short timeout, proxy bypass, validation, and bounded retry/backoff.
- Accepts usable VPC IPv4 ranges beyond RFC1918 while rejecting unspecified, loopback, link-local, multicast, and broadcast addresses.
- Uses the existing `PORT` behavior, defaulting to `8081`, and registers `http://<private-ip>:<port>` using the existing HTTP endpoint representation.
- Does not use `CLOUD_RUN_SERVICE_URL` as a per-worker endpoint.
- Fails closed before readiness if discovery produces no usable VPC IPv4 address.
- Keeps the implementation small with one direct Cloud Run discovery function and local HTTP test coverage; no metadata-client abstraction is introduced.
- Documents Direct VPC ingress, VPC reachability, firewall rules, and ephemeral Worker Pool IPs.

## Validation

- `cargo fmt --all --check`
- `cargo test --lib worker::registration -- --nocapture` — 17 passed
- `cargo test --bin talon-worker` — 27 passed
- `cargo build --locked --bins`
- `cargo test --locked` — 903 library tests plus binary/integration tests passed
- `cargo clippy --locked --all-targets -- -D warnings` was attempted; the repository currently reports pre-existing unrelated clippy diagnostics across the codebase.

## Limitations

Worker Pool IPs are ephemeral. A restarted instance re-registers its new IP, while the existing heartbeat TTL removes stale registrations. VPC routing, firewall rules, and Talon authentication remain deployment responsibilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workers can automatically discover and register their private IPv4 endpoint in Cloud Run Worker Pools.
  * Endpoint discovery supports configurable ports, defaulting to `8081`, with retries and validation.
  * Explicit endpoint settings continue to take priority.
* **Bug Fixes**
  * Worker startup now reports endpoint discovery failures instead of continuing with invalid configuration.
* **Documentation**
  * Added deployment and networking guidance, including firewall, VPC ingress, ephemeral IP re-registration, and heartbeat requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->