### PR TITLE
Refetch pull request metadata for CLA checks

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,17 +31,14 @@ jobs:
             const signature = "I have read and agree to the Talon CLA.";
             const checkName = "Talon CLA Agreement";
 
-            let pullRequest;
-            if (context.eventName === "pull_request_target") {
-              pullRequest = context.payload.pull_request;
-            } else {
-              const response = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: context.issue.number,
-              });
-              pullRequest = response.data;
-            }
+            const pullRequestNumber =
+              context.payload.pull_request?.number ?? context.issue.number;
+            const response = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullRequestNumber,
+            });
+            const pullRequest = response.data;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,


### PR DESCRIPTION
## Summary

- Always refetch pull request metadata through the REST API before evaluating CLA eligibility.
- Use the current `author_association` value for both `pull_request_target` and `issue_comment` events.

## Root cause

The CLA workflow previously trusted the `pull_request_target` webhook snapshot, while the organization-member exemption depends on `author_association`. For member PRs, that snapshot can be stale or not reflect the current association, causing the custom `Talon CLA Agreement` check to remain `action_required` even though the author is an organization member.

## Validation

- Ruby YAML parse passed.
- `git diff --check` passed.

Related: #267