### PR TITLE
Add session artifact browser

### DIFF
--- a/packages/talon-chat/README.md
+++ b/packages/talon-chat/README.md
@@ -202,6 +202,25 @@ exported for host apps.
 
 OS-style paths like `file:///tmp/foo` are **not** treated as Talon file URIs.
 
+## Session Artifacts
+
+Enable the optional session Artifact card when users should be able to browse
+outputs that are not linked directly in the transcript:
+
+```tsx
+<TalonSession
+  namespace="support"
+  agent="docs"
+  sessionId={sessionId}
+  gatewayClient={gatewayClient}
+  showSessionArtifacts
+/>
+```
+
+The card appears only when the session has Artifacts, lists them via
+`artifacts.listArtifacts`, and selecting
+one opens the same read-only split-pane viewer used by `artifact://` links.
+
 ## Storybook and Chromatic
 
 Run the component preview locally:

--- a/packages/talon-chat/src/TalonSession.stories.tsx
+++ b/packages/talon-chat/src/TalonSession.stories.tsx
@@ -395,6 +395,14 @@ function createSessionClient(messages: typeof resourceCatalogMessages): GatewayC
 const resourceGatewayClient: GatewayClientLike = {
   sessions: createSessionClient(resourceCatalogMessages),
   artifacts: {
+    listArtifacts: async ({ pageToken }) => {
+      const artifacts = [
+        { id: "final-draft", title: "Final draft", mediaType: "text/markdown", objectRef: { sizeBytes: 1_436 }, createdAt: 1_780_750_000_000_000 },
+        { id: "metrics-json", title: "Metrics snapshot", mediaType: "application/json", objectRef: { sizeBytes: 84 }, createdAt: 1_780_740_000_000_000 },
+        { id: "plain-notes", title: "Plain notes", mediaType: "text/plain", objectRef: { sizeBytes: 42 }, createdAt: 1_780_730_000_000_000 },
+      ];
+      return pageToken ? { artifacts: [], nextPageToken: "" } : { artifacts, nextPageToken: "more" };
+    },
     readArtifact: async ({ artifactUri }) => {
       if (artifactUri === ARTIFACT_DENIED_URI) {
         throw new Error("PermissionDenied: artifact access denied");
@@ -539,6 +547,22 @@ export const ResourceUris: Story = {
   },
   render: (args) => (
     <ResourceSessionFrame>
+      <TalonSession {...args} />
+    </ResourceSessionFrame>
+  ),
+};
+
+/** Session-scoped Artifacts are discoverable without a URI in the transcript. */
+export const SessionArtifactCatalog: Story = {
+  name: "Session artifacts · corner card",
+  args: {
+    gatewayClient: resourceGatewayClient,
+    sessionId: "storybook-session",
+    showSessionArtifacts: true,
+    placeholder: "Browse artifacts beside this session...",
+  },
+  render: (args) => (
+    <ResourceSessionFrame maxWidth={960}>
       <TalonSession {...args} />
     </ResourceSessionFrame>
   ),

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -16,7 +16,7 @@ import { useToolResultHydration } from "./session/hooks/useToolResultHydration";
 import { useTranscriptExpansionState } from "./session/hooks/useTranscriptExpansionState";
 import { useTranscriptPaginationAnchor } from "./session/hooks/useTranscriptPaginationAnchor";
 import { useTranscriptScrollState } from "./session/hooks/useTranscriptScrollState";
-import { fetchResourceFromGateway } from "./lib/resourceLoader";
+import { parseResourceUri } from "./lib/resourceUris";
 import { useSessionGeneration } from "./session/useSessionGeneration";
 import { createLocalMessageId, useSessionActions } from "./session/useSessionActions";
 import { useSessionLifecycle } from "./session/useSessionLifecycle";
@@ -248,9 +248,18 @@ export function TalonSession({
   });
   const wasSessionLiveRef = useRef(isSessionLive);
   useEffect(() => {
-    if (wasSessionLiveRef.current && !isSessionLive) void sessionArtifacts.refresh();
+    if (wasSessionLiveRef.current && !isSessionLive) {
+      void sessionArtifacts.refresh().then((latestArtifacts) => {
+        const parsed = openResourceUri ? parseResourceUri(openResourceUri) : null;
+        if (parsed?.kind !== "artifact" || resourceView?.kind !== "artifact" || !resourceView.objectKey) return;
+        const latest = latestArtifacts?.find((artifact) => artifact.id === parsed.artifactId);
+        if (latest?.objectKey && latest.objectKey !== resourceView.objectKey) {
+          void openResource(parsed.uri);
+        }
+      });
+    }
     wasSessionLiveRef.current = isSessionLive;
-  }, [isSessionLive, sessionArtifacts.refresh]);
+  }, [isSessionLive, openResource, openResourceUri, resourceView, sessionArtifacts.refresh]);
   const handleCloseResourcePane = useCallback(() => {
     closeResourcePane();
   }, [closeResourcePane]);

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -131,6 +131,7 @@ export function TalonSession({
   const sessionState = sessionRuntimeState.serverState === "UNKNOWN" ? null : sessionRuntimeState.serverState;
   const isSessionLive = runtimeIsLive;
   const [input, setInput] = useState("");
+  const [sessionArtifactsDismissed, setSessionArtifactsDismissed] = useState(false);
   const resolvedMaxAttachments = maxAttachments ?? maxImageAttachments ?? 4;
   const resolvedMaxAttachmentBytes = maxAttachmentBytes ?? maxImageBytes ?? 20 * 1024 * 1024;
   const resolvedAcceptedAttachmentTypes = acceptedAttachmentTypes ?? acceptedImageTypes ?? ["image/png", "image/jpeg", "image/gif", "image/webp"];
@@ -246,6 +247,12 @@ export function TalonSession({
     gatewayClient,
     target: currentSession,
   });
+  const sessionArtifactScope = currentSession
+    ? `${currentSession.ns}\u0000${currentSession.agent}\u0000${currentSession.sessionId}`
+    : "";
+  useEffect(() => {
+    setSessionArtifactsDismissed(false);
+  }, [sessionArtifactScope]);
   const wasSessionLiveRef = useRef(isSessionLive);
   useEffect(() => {
     if (wasSessionLiveRef.current && !isSessionLive) {
@@ -577,7 +584,7 @@ export function TalonSession({
           />
         </div>
 
-        {sessionArtifacts.available && (sessionArtifacts.artifacts.length > 0 || sessionArtifacts.error) && !openResourceUri ? (
+        {sessionArtifacts.available && !sessionArtifactsDismissed && (sessionArtifacts.artifacts.length > 0 || sessionArtifacts.error) && !openResourceUri ? (
           <SessionArtifactsRail
             artifacts={sessionArtifacts.artifacts}
             error={sessionArtifacts.error}
@@ -585,6 +592,7 @@ export function TalonSession({
             isLoading={sessionArtifacts.isLoading}
             onLoadMore={() => void sessionArtifacts.loadMore()}
             onSelect={handleSelectArtifact}
+            onDismiss={() => setSessionArtifactsDismissed(true)}
           />
         ) : null}
 

--- a/packages/talon-chat/src/TalonSession.tsx
+++ b/packages/talon-chat/src/TalonSession.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   hydrateMessagesWithSteps,
   normalizeMessageRole,
@@ -33,6 +33,9 @@ import { useSessionPresentationState } from "./session/useSessionPresentationSta
 import { useSessionResources } from "./session/useSessionResources";
 import { useSessionCommands } from "./session/useSessionCommands";
 import { useSessionPendingMessages } from "./session/useSessionPendingMessages";
+import { SessionArtifactsRail } from "./session/SessionArtifactsRail";
+import { artifactUriFor, type SessionArtifact } from "./session/artifacts";
+import { useSessionArtifacts } from "./session/hooks/useSessionArtifacts";
 import type {
   TalonSessionProps,
 } from "./session/TalonSessionTypes";
@@ -87,6 +90,7 @@ export function TalonSession({
   allowMessageEditing = false,
   onMessageEdit,
   enableDebugMessageEditing = false,
+  showSessionArtifacts = false,
   onResourceClick: onResourceClickProp,
   fetchResource,
 }: TalonSessionProps) {
@@ -234,9 +238,34 @@ export function TalonSession({
     open: openResource,
     close: closeResourcePane,
     reset: clearResourcePaneState,
-    completeClose: handleResourcePaneExitComplete,
+    completeClose: completeResourcePaneClose,
     abortRef: resourceAbortRef,
   } = useSessionResources({ agent, currentSessionId: currentSession?.sessionId ?? null, fetchResource, gatewayClient, sessionId });
+  const sessionArtifacts = useSessionArtifacts({
+    enabled: showSessionArtifacts,
+    gatewayClient,
+    target: currentSession,
+  });
+  const wasSessionLiveRef = useRef(isSessionLive);
+  useEffect(() => {
+    if (wasSessionLiveRef.current && !isSessionLive) void sessionArtifacts.refresh();
+    wasSessionLiveRef.current = isSessionLive;
+  }, [isSessionLive, sessionArtifacts.refresh]);
+  const handleCloseResourcePane = useCallback(() => {
+    closeResourcePane();
+  }, [closeResourcePane]);
+  const handleResourcePaneExitComplete = useCallback(() => {
+    completeResourcePaneClose();
+  }, [completeResourcePaneClose]);
+  const handleSelectArtifact = useCallback((artifact: SessionArtifact) => {
+    if (!currentSession) return;
+    const artifactUri = artifactUriFor(currentSession, artifact.id);
+    if (onResourceClickProp) {
+      onResourceClickProp(artifactUri);
+      return;
+    }
+    void openResource(artifactUri);
+  }, [currentSession, onResourceClickProp, openResource]);
   const {
     editingMessageId,
     editingMessageValue,
@@ -262,7 +291,7 @@ export function TalonSession({
   const handleResourceClick = useSessionResourceClick({
     canFetchArtifact: Boolean(fetchResource) || Boolean(gatewayClient.artifacts?.readArtifact),
     canFetchFile: Boolean(fetchResource) || Boolean(gatewayClient.files?.readFile),
-    closeResourcePane,
+    closeResourcePane: handleCloseResourcePane,
     onResourceClick: onResourceClickProp,
     openResource,
     openResourceUri,
@@ -539,6 +568,17 @@ export function TalonSession({
           />
         </div>
 
+        {sessionArtifacts.available && (sessionArtifacts.artifacts.length > 0 || sessionArtifacts.error) && !openResourceUri ? (
+          <SessionArtifactsRail
+            artifacts={sessionArtifacts.artifacts}
+            error={sessionArtifacts.error}
+            hasMore={sessionArtifacts.hasMore}
+            isLoading={sessionArtifacts.isLoading}
+            onLoadMore={() => void sessionArtifacts.loadMore()}
+            onSelect={handleSelectArtifact}
+          />
+        ) : null}
+
         {openResourceUri ? (
           <ResourcePane
             uri={openResourceUri}
@@ -546,7 +586,7 @@ export function TalonSession({
             isLoading={resourceLoading}
             error={resourceError}
             open={resourcePaneOpen}
-            onClose={closeResourcePane}
+            onClose={handleCloseResourcePane}
             onExitComplete={handleResourcePaneExitComplete}
             onResourceClick={handleResourceClick}
           />

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -48,6 +48,8 @@ export type ResourceViewModel = {
   mediaType: string;
   content?: Uint8Array | string;
   signedUrl?: string;
+  /** Immutable CAS/object-store key, if supplied by the gateway. */
+  objectKey?: string;
   path?: string;
   sessionId?: string;
   agent?: string;

--- a/packages/talon-chat/src/index.d.ts
+++ b/packages/talon-chat/src/index.d.ts
@@ -16,7 +16,7 @@ export type CasServiceClientLike = Pick<TalonClient["cas"], "getObject">;
 export type ArtifactServiceClientLike = Pick<
   TalonClient["artifacts"],
   "readArtifact" | "getArtifactMetadata"
->;
+> & Partial<Pick<TalonClient["artifacts"], "listArtifacts">>;
 
 export type FileServiceClientLike = Pick<
   TalonClient["files"],
@@ -268,6 +268,8 @@ export type TalonSessionProps = {
   allowMessageEditing?: boolean;
   onMessageEdit?: (context: TalonSessionMessageEditContext) => Promise<boolean | void> | boolean | void;
   enableDebugMessageEditing?: boolean;
+  /** Show the current session's Artifact catalog in a collapsible corner card. */
+  showSessionArtifacts?: boolean;
   /**
    * Called when an artifact:// or file:// link is clicked.
    * If omitted, the built-in split pane opens when the matching client is available.

--- a/packages/talon-chat/src/lib/ResourcePane.tsx
+++ b/packages/talon-chat/src/lib/ResourcePane.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { X } from "lucide-react";
 import { MarkdownMessage } from "./MarkdownMessage";
+import { splitYamlFrontmatter } from "./yamlFrontmatter";
 import {
   parseResourceUri,
   type ResourceViewModel,
@@ -138,6 +139,12 @@ export function ResourcePane({
     }
     return decodeContentAsText(resource.content);
   }, [resource]);
+  const markdownDocument = useMemo(
+    () => isMarkdownMediaType(resource?.mediaType || "") && textContent != null
+      ? splitYamlFrontmatter(textContent)
+      : null,
+    [resource?.mediaType, textContent],
+  );
 
   const imageSrc = resource?.signedUrl || blobUrl || null;
   const downloadHref = resource?.signedUrl || blobUrl || null;
@@ -245,11 +252,14 @@ export function ResourcePane({
             minHeight: 0,
             overflowY: "auto",
             overflowX: "hidden",
-            padding: "1rem",
-            fontSize: 13,
-            lineHeight: 1.55,
+            // Artifacts are documents, not chat bubbles. Give prose a more
+            // comfortable reading size without changing transcript density.
+            padding: "1.25rem",
+            fontSize: 15,
+            lineHeight: 1.65,
           }}
         >
+          <div style={{ width: "100%", maxWidth: "48rem", margin: "0 auto" }}>
           {isLoading ? (
             <div style={{ color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))" }}>Loading…</div>
           ) : null}
@@ -270,8 +280,11 @@ export function ResourcePane({
           ) : null}
 
           {!isLoading && !error && resource ? (
-            isMarkdownMediaType(resource.mediaType) && textContent != null ? (
-              <MarkdownMessage onResourceClick={onResourceClick}>{textContent}</MarkdownMessage>
+            isMarkdownMediaType(resource.mediaType) && markdownDocument ? (
+              <>
+                {markdownDocument.raw ? <YamlFrontmatter raw={markdownDocument.raw} /> : null}
+                <MarkdownMessage onResourceClick={onResourceClick}>{markdownDocument.body}</MarkdownMessage>
+              </>
             ) : isTextMediaType(resource.mediaType) && textContent != null ? (
               <pre
                 style={{
@@ -324,6 +337,7 @@ export function ResourcePane({
               </div>
             )
           ) : null}
+          </div>
         </div>
       </div>
 
@@ -362,4 +376,43 @@ function formatResourceError(error: Error): string {
     return "Not found";
   }
   return message;
+}
+
+function YamlFrontmatter({ raw }: { raw: string }) {
+  return (
+    <details
+      style={{
+        margin: "0 0 1rem",
+        border: border("rgba(148,163,184,0.24)"),
+        borderRadius: 10,
+        background: "var(--talon-chat-code-bg, rgba(24,24,27,0.04))",
+      }}
+    >
+      <summary
+        style={{
+          cursor: "pointer",
+          padding: "0.625rem 0.75rem",
+          color: "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))",
+          fontSize: 13,
+          fontWeight: 600,
+        }}
+      >
+        Document metadata
+      </summary>
+      <pre
+        style={{
+          margin: 0,
+          padding: "0 0.75rem 0.75rem",
+          overflowX: "auto",
+          whiteSpace: "pre-wrap",
+          fontFamily: "ui-monospace, SFMono-Regular, monospace",
+          fontSize: 12,
+          lineHeight: 1.5,
+          color: "var(--talon-chat-subtle-fg, rgba(82,82,91,0.96))",
+        }}
+      >
+        {raw}
+      </pre>
+    </details>
+  );
 }

--- a/packages/talon-chat/src/lib/resourceLoader.test.ts
+++ b/packages/talon-chat/src/lib/resourceLoader.test.ts
@@ -52,7 +52,7 @@ test("does not download a large signed text artifact for inline preview", async 
   }
 });
 
-test("does not download a signed artifact when its size is unknown or its empty content is present", async () => {
+test("does not download a signed artifact when its size is unknown or an empty inline body is complete", async () => {
   const originalFetch = globalThis.fetch;
   let fetchCalls = 0;
   globalThis.fetch = async () => {
@@ -71,7 +71,7 @@ test("does not download a signed artifact when its size is unknown or its empty 
     const emptyContent = await loadSignedInlineContent({
       content: new Uint8Array(),
       mediaType: "text/markdown",
-      signedUrl: "https://objects.example/artifacts/empty",
+      signedUrl: undefined,
       sizeBytes: 0,
       signal: new AbortController().signal,
     });
@@ -79,6 +79,23 @@ test("does not download a signed artifact when its size is unknown or its empty 
     assert.equal(fetchCalls, 0);
     assert.equal(unknownSize, undefined);
     assert.equal(emptyContent?.byteLength, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("downloads a signed artifact when protobuf supplies default empty bytes", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response("Signed content");
+  try {
+    const content = await loadSignedInlineContent({
+      content: new Uint8Array(),
+      mediaType: "text/markdown",
+      signedUrl: "https://objects.example/artifacts/signed",
+      sizeBytes: 14,
+      signal: new AbortController().signal,
+    });
+    assert.equal(new TextDecoder().decode(content), "Signed content");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/talon-chat/src/lib/resourceLoader.test.ts
+++ b/packages/talon-chat/src/lib/resourceLoader.test.ts
@@ -12,7 +12,7 @@ test("downloads text artifact content from its signed object URL", async () => {
 
   try {
     const content = await loadSignedInlineContent({
-      content: new Uint8Array(),
+      content: undefined,
       mediaType: "text/markdown",
       signedUrl: "https://objects.example/artifacts/draft?signature=redacted",
       sizeBytes: 18,
@@ -38,7 +38,7 @@ test("does not download a large signed text artifact for inline preview", async 
 
   try {
     const content = await loadSignedInlineContent({
-      content: new Uint8Array(),
+      content: undefined,
       mediaType: "text/markdown",
       signedUrl: "https://objects.example/artifacts/large-draft",
       sizeBytes: 3 * 1024 * 1024 + 1,
@@ -46,7 +46,39 @@ test("does not download a large signed text artifact for inline preview", async 
     });
 
     assert.equal(fetchCalls, 0);
-    assert.equal(content?.byteLength, 0);
+    assert.equal(content, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("does not download a signed artifact when its size is unknown or its empty content is present", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    return new Response("unexpected");
+  };
+
+  try {
+    const unknownSize = await loadSignedInlineContent({
+      content: undefined,
+      mediaType: "text/markdown",
+      signedUrl: "https://objects.example/artifacts/unknown-size",
+      sizeBytes: undefined,
+      signal: new AbortController().signal,
+    });
+    const emptyContent = await loadSignedInlineContent({
+      content: new Uint8Array(),
+      mediaType: "text/markdown",
+      signedUrl: "https://objects.example/artifacts/empty",
+      sizeBytes: 0,
+      signal: new AbortController().signal,
+    });
+
+    assert.equal(fetchCalls, 0);
+    assert.equal(unknownSize, undefined);
+    assert.equal(emptyContent?.byteLength, 0);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/talon-chat/src/lib/resourceLoader.test.ts
+++ b/packages/talon-chat/src/lib/resourceLoader.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { loadSignedInlineContent } from "./resourceSignedContent.ts";
+
+test("downloads text artifact content from its signed object URL", async () => {
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ url: string; options?: RequestInit }> = [];
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url: String(url), options });
+    return new Response("# Stored artifact", { status: 200 });
+  };
+
+  try {
+    const content = await loadSignedInlineContent({
+      content: new Uint8Array(),
+      mediaType: "text/markdown",
+      signedUrl: "https://objects.example/artifacts/draft?signature=redacted",
+      sizeBytes: 18,
+      signal: new AbortController().signal,
+    });
+
+    assert.equal(new TextDecoder().decode(content), "# Stored artifact");
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0]?.url, "https://objects.example/artifacts/draft?signature=redacted");
+    assert.equal(requests[0]?.options?.credentials, "omit");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("does not download a large signed text artifact for inline preview", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    return new Response("unexpected");
+  };
+
+  try {
+    const content = await loadSignedInlineContent({
+      content: new Uint8Array(),
+      mediaType: "text/markdown",
+      signedUrl: "https://objects.example/artifacts/large-draft",
+      sizeBytes: 3 * 1024 * 1024 + 1,
+      signal: new AbortController().signal,
+    });
+
+    assert.equal(fetchCalls, 0);
+    assert.equal(content?.byteLength, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/talon-chat/src/lib/resourceLoader.ts
+++ b/packages/talon-chat/src/lib/resourceLoader.ts
@@ -1,4 +1,5 @@
 import { parseResourceUri, type ResourceViewModel } from "./resourceUris";
+import { loadSignedInlineContent } from "./resourceSignedContent";
 import type { TalonClient } from "@impalasys/talon-client";
 
 type ResourceGatewayClient = {
@@ -54,11 +55,20 @@ export async function fetchResourceFromGateway({
     if (!artifacts?.readArtifact) throw new Error("Gateway client does not expose artifacts.readArtifact().");
     const response = await (artifacts.readArtifact as any)({ artifactUri: parsed.uri }, options);
     const artifact = response?.artifact ?? {};
+    const mediaType = artifact.mediaType || artifact.media_type || "application/octet-stream";
+    const signedUrl = response?.signedUrl || response?.signed_url || undefined;
+    const content = await loadSignedInlineContent({
+      content: contentBytes(response?.content),
+      mediaType,
+      signedUrl,
+      sizeBytes: artifact.objectRef?.sizeBytes ?? artifact.object_ref?.size_bytes,
+      signal,
+    });
     return {
       kind: "artifact", uri: parsed.uri,
       title: (typeof artifact.title === "string" && artifact.title) || parsed.artifactId,
-      mediaType: artifact.mediaType || artifact.media_type || "application/octet-stream",
-      content: contentBytes(response?.content), signedUrl: response?.signedUrl || response?.signed_url || undefined,
+      mediaType,
+      content, signedUrl,
       sessionId: parsed.sessionId, agent: parsed.agent,
     };
   }

--- a/packages/talon-chat/src/lib/resourceLoader.ts
+++ b/packages/talon-chat/src/lib/resourceLoader.ts
@@ -69,6 +69,11 @@ export async function fetchResourceFromGateway({
       title: (typeof artifact.title === "string" && artifact.title) || parsed.artifactId,
       mediaType,
       content, signedUrl,
+      objectKey: typeof artifact.objectRef?.key === "string"
+        ? artifact.objectRef.key
+        : typeof artifact.object_ref?.key === "string"
+          ? artifact.object_ref.key
+          : undefined,
       sessionId: parsed.sessionId, agent: parsed.agent,
     };
   }

--- a/packages/talon-chat/src/lib/resourceSignedContent.ts
+++ b/packages/talon-chat/src/lib/resourceSignedContent.ts
@@ -1,0 +1,44 @@
+const MAX_INLINE_PREVIEW_BYTES = 3 * 1024 * 1024;
+
+function isInlinePreviewMediaType(mediaType: string): boolean {
+  const base = mediaType.split(";", 1)[0]?.trim().toLowerCase() || "";
+  return base.startsWith("text/") || base === "application/json";
+}
+
+function byteLength(value: unknown): number | null {
+  if (typeof value === "bigint") return value <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(value) : null;
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value;
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/** Fetch a signed object URL only when its bytes can be rendered inline. */
+export async function loadSignedInlineContent({
+  content,
+  mediaType,
+  signedUrl,
+  sizeBytes,
+  signal,
+}: {
+  content: Uint8Array | undefined;
+  mediaType: string;
+  signedUrl: string | undefined;
+  sizeBytes: unknown;
+  signal: AbortSignal;
+}): Promise<Uint8Array | undefined> {
+  const knownSize = byteLength(sizeBytes);
+  if (
+    !signedUrl ||
+    (content && content.byteLength > 0) ||
+    !isInlinePreviewMediaType(mediaType) ||
+    (knownSize != null && knownSize > MAX_INLINE_PREVIEW_BYTES)
+  ) {
+    return content;
+  }
+  const response = await fetch(signedUrl, { signal, credentials: "omit" });
+  if (!response.ok) throw new Error(`Could not download resource content (HTTP ${response.status}).`);
+  return new Uint8Array(await response.arrayBuffer());
+}

--- a/packages/talon-chat/src/lib/resourceSignedContent.ts
+++ b/packages/talon-chat/src/lib/resourceSignedContent.ts
@@ -32,7 +32,11 @@ export async function loadSignedInlineContent({
   const knownSize = byteLength(sizeBytes);
   if (
     !signedUrl ||
-    content !== undefined ||
+    // Connect decodes an omitted protobuf `bytes` field as an empty
+    // Uint8Array. A signed URL disambiguates that default value from a real
+    // zero-byte inline body: when it is present, the object store is
+    // authoritative and must be fetched.
+    (content !== undefined && (content.byteLength > 0 || !signedUrl)) ||
     !isInlinePreviewMediaType(mediaType) ||
     knownSize == null ||
     knownSize > MAX_INLINE_PREVIEW_BYTES

--- a/packages/talon-chat/src/lib/resourceSignedContent.ts
+++ b/packages/talon-chat/src/lib/resourceSignedContent.ts
@@ -32,9 +32,10 @@ export async function loadSignedInlineContent({
   const knownSize = byteLength(sizeBytes);
   if (
     !signedUrl ||
-    (content && content.byteLength > 0) ||
+    content !== undefined ||
     !isInlinePreviewMediaType(mediaType) ||
-    (knownSize != null && knownSize > MAX_INLINE_PREVIEW_BYTES)
+    knownSize == null ||
+    knownSize > MAX_INLINE_PREVIEW_BYTES
   ) {
     return content;
   }

--- a/packages/talon-chat/src/lib/resourceUris.ts
+++ b/packages/talon-chat/src/lib/resourceUris.ts
@@ -267,6 +267,8 @@ export type ResourceViewModel = {
   mediaType: string;
   content?: Uint8Array | string;
   signedUrl?: string;
+  /** Immutable CAS/object-store key, if supplied by the gateway. */
+  objectKey?: string;
   path?: string;
   sessionId?: string;
   agent?: string;

--- a/packages/talon-chat/src/lib/yamlFrontmatter.test.ts
+++ b/packages/talon-chat/src/lib/yamlFrontmatter.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { splitYamlFrontmatter } from "./yamlFrontmatter.ts";
+
+test("separates leading YAML frontmatter from Markdown", () => {
+  assert.deepEqual(
+    splitYamlFrontmatter("---\ntitle: Draft\ntags:\n  - review\n---\n# Document"),
+    { raw: "title: Draft\ntags:\n  - review", body: "# Document" },
+  );
+});
+
+test("leaves non-frontmatter Markdown unchanged", () => {
+  assert.deepEqual(splitYamlFrontmatter("---\nNot a closed frontmatter block"), {
+    raw: null,
+    body: "---\nNot a closed frontmatter block",
+  });
+});

--- a/packages/talon-chat/src/lib/yamlFrontmatter.ts
+++ b/packages/talon-chat/src/lib/yamlFrontmatter.ts
@@ -1,0 +1,23 @@
+export type YamlFrontmatter = {
+  body: string;
+  raw: string | null;
+};
+
+/** Separates a leading YAML frontmatter block from a Markdown document. */
+export function splitYamlFrontmatter(source: string): YamlFrontmatter {
+  const normalized = source.startsWith("\uFEFF") ? source.slice(1) : source;
+  const opening = /^(?:---)[ \t]*(?:\r?\n)/.exec(normalized);
+  if (!opening) return { body: source, raw: null };
+
+  const closing = /^(?:---|\.\.\.)[ \t]*\r?$/m;
+  closing.lastIndex = opening[0].length;
+  const match = closing.exec(normalized.slice(opening[0].length));
+  if (!match) return { body: source, raw: null };
+
+  const contentEnd = opening[0].length + match.index;
+  const bodyStart = contentEnd + match[0].length;
+  return {
+    raw: normalized.slice(opening[0].length, contentEnd).trim(),
+    body: normalized.slice(bodyStart).replace(/^\r?\n/, ""),
+  };
+}

--- a/packages/talon-chat/src/session/SessionArtifactsRail.tsx
+++ b/packages/talon-chat/src/session/SessionArtifactsRail.tsx
@@ -47,7 +47,7 @@ export function SessionArtifactsRail({
         border: border("var(--talon-chat-divider, rgba(212,212,216,0.7))"),
         borderRadius: 18,
         background: "var(--talon-chat-resource-pane-bg, var(--talon-chat-composer-bg, rgba(255,255,255,0.96)))",
-        boxShadow: "0 12px 32px rgba(24,24,27,0.10), 0 2px 7px rgba(24,24,27,0.06)",
+        boxShadow: "0 5px 16px rgba(24,24,27,0.06), 0 1px 3px rgba(24,24,27,0.04)",
         transition: "width 220ms cubic-bezier(0.22, 1, 0.36, 1), box-shadow 180ms ease",
       }}
     >

--- a/packages/talon-chat/src/session/SessionArtifactsRail.tsx
+++ b/packages/talon-chat/src/session/SessionArtifactsRail.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { FileText } from "lucide-react";
+import {
+  formatArtifactBytes,
+  formatArtifactCreatedAt,
+  type SessionArtifact,
+} from "./artifacts";
+
+type SessionArtifactsRailProps = {
+  artifacts: SessionArtifact[];
+  error: Error | null;
+  hasMore: boolean;
+  isLoading: boolean;
+  onLoadMore: () => void;
+  onSelect: (artifact: SessionArtifact) => void;
+};
+
+function border(color: string) {
+  return `1px solid ${color}`;
+}
+
+export function SessionArtifactsRail({
+  artifacts,
+  error,
+  hasMore,
+  isLoading,
+  onLoadMore,
+  onSelect,
+}: SessionArtifactsRailProps) {
+  return (
+    <aside
+      aria-label="Session artifacts"
+      data-testid="session-artifacts-rail"
+      className="talon-session-artifacts-rail"
+      style={{
+        position: "absolute",
+        top: 16,
+        right: 16,
+        zIndex: 12,
+        width: 304,
+        maxHeight: "calc(100% - 32px)",
+        minWidth: 0,
+        minHeight: 0,
+        overflow: "hidden",
+        border: border("var(--talon-chat-divider, rgba(212,212,216,0.7))"),
+        borderRadius: 18,
+        background: "var(--talon-chat-resource-pane-bg, var(--talon-chat-composer-bg, rgba(255,255,255,0.96)))",
+        boxShadow: "0 12px 32px rgba(24,24,27,0.10), 0 2px 7px rgba(24,24,27,0.06)",
+        transition: "width 220ms cubic-bezier(0.22, 1, 0.36, 1), box-shadow 180ms ease",
+      }}
+    >
+      <div style={{ width: 304, maxHeight: "calc(100vh - 32px)", display: "flex", flexDirection: "column" }}>
+        <header style={{ minHeight: 48, padding: "0 0.85rem", display: "flex", alignItems: "center", borderBottom: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }}>
+          <span style={{ minWidth: 0, fontSize: 14, fontWeight: 500, opacity: 0.64 }}>Artifacts</span>
+        </header>
+
+        <div style={{ minHeight: 0, maxHeight: "min(420px, calc(100vh - 96px))", overflowY: "auto", padding: "0.5rem" }}>
+          {error ? <RailNotice tone="error">{error.message || "Could not load artifacts."}</RailNotice> : null}
+          {artifacts.map((artifact) => {
+            const details = [artifact.mediaType, formatArtifactBytes(artifact.sizeBytes), formatArtifactCreatedAt(artifact.createdAt)].filter(Boolean).join(" · ");
+            return (
+              <button key={artifact.id} type="button" onClick={() => onSelect(artifact)} style={{ width: "100%", border: "none", borderRadius: 10, background: "transparent", color: "inherit", cursor: "pointer", textAlign: "left", padding: "0.625rem", display: "flex", gap: 10, alignItems: "flex-start" }}>
+                <FileText size="18" strokeWidth={1.7} style={{ marginTop: 1, flexShrink: 0, opacity: 0.48 }} />
+                <span style={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 3 }}>
+                  <span title={artifact.title || artifact.id} style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontSize: 14, fontWeight: 500, lineHeight: 1.35, opacity: 0.64 }}>{artifact.title || artifact.id}</span>
+                  {details ? <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontSize: 11, lineHeight: 1.35, opacity: 0.62 }}>{details}</span> : null}
+                </span>
+              </button>
+            );
+          })}
+          {hasMore ? <button type="button" onClick={onLoadMore} disabled={isLoading} style={{ ...loadMoreStyle, opacity: isLoading ? 0.6 : 1 }}>{isLoading ? "Loading…" : "Load more"}</button> : null}
+        </div>
+      </div>
+      <style>{`
+        .talon-session-artifacts-rail button:not(:disabled):hover { background: var(--talon-chat-hover-bg, rgba(24, 24, 27, 0.06)); }
+        @media (max-width: 640px) {
+          .talon-session-artifacts-rail { position: absolute !important; inset: 0 !important; z-index: 21; width: 100% !important; max-height: none !important; border-radius: 0 !important; box-shadow: none !important; }
+        }
+      `}</style>
+    </aside>
+  );
+}
+
+function RailNotice({ children, tone }: { children: React.ReactNode; tone?: "error" }) {
+  return <div style={{ margin: "0.25rem", padding: "0.75rem", borderRadius: 10, color: tone === "error" ? "rgba(220,38,38,1)" : "var(--talon-chat-muted-fg, rgba(82,82,91,0.88))", background: tone === "error" ? "rgba(254,242,242,1)" : "rgba(148,163,184,0.09)", fontSize: 12, lineHeight: 1.45 }}>{children}</div>;
+}
+
+const loadMoreStyle: React.CSSProperties = { width: "calc(100% - 0.5rem)", margin: "0.5rem 0.25rem", padding: "0.5rem", border: border("var(--talon-chat-divider, rgba(212,212,216,0.7))"), borderRadius: 8, background: "transparent", color: "inherit", fontSize: 12, cursor: "pointer" };

--- a/packages/talon-chat/src/session/SessionArtifactsRail.tsx
+++ b/packages/talon-chat/src/session/SessionArtifactsRail.tsx
@@ -52,7 +52,7 @@ export function SessionArtifactsRail({
       }}
     >
       <div style={{ width: 304, maxHeight: "calc(100vh - 32px)", display: "flex", flexDirection: "column" }}>
-        <header style={{ minHeight: 48, padding: "0 0.85rem", display: "flex", alignItems: "center", borderBottom: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }}>
+        <header style={{ minHeight: 48, padding: "0 0.85rem", display: "flex", alignItems: "center" }}>
           <span style={{ minWidth: 0, fontSize: 14, fontWeight: 500, opacity: 0.64 }}>Artifacts</span>
           <button className="talon-session-artifacts-dismiss" type="button" aria-label="Close artifacts" onClick={onDismiss} style={{ marginLeft: "auto", border: "none", borderRadius: 6, background: "transparent", color: "inherit", cursor: "pointer", padding: 4 }}>
             <X size="18" strokeWidth={1.8} />

--- a/packages/talon-chat/src/session/SessionArtifactsRail.tsx
+++ b/packages/talon-chat/src/session/SessionArtifactsRail.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FileText } from "lucide-react";
+import { FileText, X } from "lucide-react";
 import {
   formatArtifactBytes,
   formatArtifactCreatedAt,
@@ -13,6 +13,7 @@ type SessionArtifactsRailProps = {
   isLoading: boolean;
   onLoadMore: () => void;
   onSelect: (artifact: SessionArtifact) => void;
+  onDismiss: () => void;
 };
 
 function border(color: string) {
@@ -26,6 +27,7 @@ export function SessionArtifactsRail({
   isLoading,
   onLoadMore,
   onSelect,
+  onDismiss,
 }: SessionArtifactsRailProps) {
   return (
     <aside
@@ -52,6 +54,9 @@ export function SessionArtifactsRail({
       <div style={{ width: 304, maxHeight: "calc(100vh - 32px)", display: "flex", flexDirection: "column" }}>
         <header style={{ minHeight: 48, padding: "0 0.85rem", display: "flex", alignItems: "center", borderBottom: border("var(--talon-chat-divider, rgba(212,212,216,0.7))") }}>
           <span style={{ minWidth: 0, fontSize: 14, fontWeight: 500, opacity: 0.64 }}>Artifacts</span>
+          <button className="talon-session-artifacts-dismiss" type="button" aria-label="Close artifacts" onClick={onDismiss} style={{ marginLeft: "auto", border: "none", borderRadius: 6, background: "transparent", color: "inherit", cursor: "pointer", padding: 4 }}>
+            <X size="18" strokeWidth={1.8} />
+          </button>
         </header>
 
         <div style={{ minHeight: 0, maxHeight: "min(420px, calc(100vh - 96px))", overflowY: "auto", padding: "0.5rem" }}>
@@ -73,8 +78,10 @@ export function SessionArtifactsRail({
       </div>
       <style>{`
         .talon-session-artifacts-rail button:not(:disabled):hover { background: var(--talon-chat-hover-bg, rgba(24, 24, 27, 0.06)); }
+        .talon-session-artifacts-dismiss { display: none; }
         @media (max-width: 640px) {
           .talon-session-artifacts-rail { position: absolute !important; inset: 0 !important; z-index: 21; width: 100% !important; max-height: none !important; border-radius: 0 !important; box-shadow: none !important; }
+          .talon-session-artifacts-dismiss { display: inline-flex; align-items: center; justify-content: center; }
         }
       `}</style>
     </aside>

--- a/packages/talon-chat/src/session/TalonSessionTypes.ts
+++ b/packages/talon-chat/src/session/TalonSessionTypes.ts
@@ -17,7 +17,9 @@ export type SessionServiceClientLike = {
 }["sessions"];
 
 export type CasServiceClientLike = Pick<TalonClient["cas"], "getObject">;
-export type ArtifactServiceClientLike = Pick<TalonClient["artifacts"], "readArtifact" | "getArtifactMetadata">;
+export type ArtifactServiceClientLike =
+  Pick<TalonClient["artifacts"], "readArtifact" | "getArtifactMetadata">
+  & Partial<Pick<TalonClient["artifacts"], "listArtifacts">>;
 export type FileServiceClientLike = Pick<TalonClient["files"], "readFile" | "getFileMetadata">;
 
 export type GatewayClientLike = {
@@ -127,6 +129,8 @@ export type TalonSessionProps = {
   allowMessageEditing?: boolean;
   onMessageEdit?: (context: TalonSessionMessageEditContext) => Promise<boolean | void> | boolean | void;
   enableDebugMessageEditing?: boolean;
+  /** Show the current session's Artifact catalog in a collapsible corner card. */
+  showSessionArtifacts?: boolean;
   /** Override artifact:// and file:// interaction instead of opening the built-in pane. */
   onResourceClick?: (uri: string) => void;
   /** Override resource fetching for the built-in pane. */

--- a/packages/talon-chat/src/session/artifacts.test.ts
+++ b/packages/talon-chat/src/session/artifacts.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  artifactUriFor,
+  formatArtifactBytes,
+  mergeSessionArtifacts,
+  normalizeSessionArtifact,
+} from "./artifacts.ts";
+
+test("normalizes generated Artifact fields and constructs the owning session URI", () => {
+  const artifact = normalizeSessionArtifact({
+    id: "draft",
+    title: "Launch draft",
+    media_type: "text/markdown",
+    object_ref: { size_bytes: "2048" },
+    created_at: "1777755592000000",
+  });
+  assert.deepEqual(artifact, {
+    id: "draft",
+    title: "Launch draft",
+    mediaType: "text/markdown",
+    sizeBytes: "2048",
+    createdAt: "1777755592000000",
+  });
+  assert.equal(
+    artifactUriFor({ ns: "Tenant:acme", agent: "writer", sessionId: "sess-1" }, artifact!.id),
+    "artifact://Tenant:acme/writer/sess-1/draft",
+  );
+});
+
+test("deduplicates paginated artifacts and displays newest artifacts first", () => {
+  const merged = mergeSessionArtifacts(
+    [{ id: "old", title: "Old", mediaType: "text/plain", createdAt: 1_700_000_000_000_000 }],
+    [
+      { id: "old", title: "Old revision", mediaType: "text/plain", createdAt: 1_700_000_000_000_000 },
+      { id: "new", title: "New", mediaType: "text/plain", createdAt: 1_800_000_000_000_000 },
+    ],
+  );
+  assert.deepEqual(merged.map((artifact) => [artifact.id, artifact.title]), [
+    ["new", "New"],
+    ["old", "Old revision"],
+  ]);
+});
+
+test("formats byte sizes for rail metadata", () => {
+  assert.equal(formatArtifactBytes(999), "999 B");
+  assert.equal(formatArtifactBytes("2048"), "2.0 KB");
+  assert.equal(formatArtifactBytes(undefined), null);
+});

--- a/packages/talon-chat/src/session/artifacts.test.ts
+++ b/packages/talon-chat/src/session/artifacts.test.ts
@@ -12,13 +12,14 @@ test("normalizes generated Artifact fields and constructs the owning session URI
     id: "draft",
     title: "Launch draft",
     media_type: "text/markdown",
-    object_ref: { size_bytes: "2048" },
+    object_ref: { key: "cas/Tenant%3Aacme/artifacts/draft-v2", size_bytes: "2048" },
     created_at: "1777755592000000",
   });
   assert.deepEqual(artifact, {
     id: "draft",
     title: "Launch draft",
     mediaType: "text/markdown",
+    objectKey: "cas/Tenant%3Aacme/artifacts/draft-v2",
     sizeBytes: "2048",
     createdAt: "1777755592000000",
   });
@@ -30,10 +31,10 @@ test("normalizes generated Artifact fields and constructs the owning session URI
 
 test("deduplicates paginated artifacts and displays newest artifacts first", () => {
   const merged = mergeSessionArtifacts(
-    [{ id: "old", title: "Old", mediaType: "text/plain", createdAt: 1_700_000_000_000_000 }],
+    [{ id: "old", title: "Old", mediaType: "text/plain", objectKey: "old-v1", createdAt: 1_700_000_000_000_000 }],
     [
-      { id: "old", title: "Old revision", mediaType: "text/plain", createdAt: 1_700_000_000_000_000 },
-      { id: "new", title: "New", mediaType: "text/plain", createdAt: 1_800_000_000_000_000 },
+      { id: "old", title: "Old revision", mediaType: "text/plain", objectKey: "old-v2", createdAt: 1_700_000_000_000_000 },
+      { id: "new", title: "New", mediaType: "text/plain", objectKey: "new-v1", createdAt: 1_800_000_000_000_000 },
     ],
   );
   assert.deepEqual(merged.map((artifact) => [artifact.id, artifact.title]), [

--- a/packages/talon-chat/src/session/artifacts.ts
+++ b/packages/talon-chat/src/session/artifacts.ts
@@ -1,0 +1,91 @@
+export type SessionArtifact = {
+  id: string;
+  title: string;
+  mediaType: string;
+  sizeBytes: number | bigint | string | undefined;
+  createdAt: number | bigint | string | undefined;
+};
+
+export type SessionArtifactTarget = {
+  ns: string;
+  agent: string;
+  sessionId: string;
+};
+
+function valueOf(source: Record<string, unknown>, camelCase: string, snakeCase: string) {
+  return source[camelCase] ?? source[snakeCase];
+}
+
+export function normalizeSessionArtifact(value: unknown): SessionArtifact | null {
+  if (!value || typeof value !== "object") return null;
+  const source = value as Record<string, unknown>;
+  const id = valueOf(source, "id", "id");
+  if (typeof id !== "string" || !id) return null;
+  const objectRef = valueOf(source, "objectRef", "object_ref");
+  const object = objectRef && typeof objectRef === "object" ? objectRef as Record<string, unknown> : {};
+  const title = valueOf(source, "title", "title");
+  const mediaType = valueOf(source, "mediaType", "media_type");
+  const sizeBytes = valueOf(object, "sizeBytes", "size_bytes");
+  const createdAt = valueOf(source, "createdAt", "created_at");
+  return {
+    id,
+    title: typeof title === "string" ? title : "",
+    mediaType: typeof mediaType === "string" ? mediaType : "",
+    sizeBytes: typeof sizeBytes === "number" || typeof sizeBytes === "bigint" || typeof sizeBytes === "string"
+      ? sizeBytes
+      : undefined,
+    createdAt: typeof createdAt === "number" || typeof createdAt === "bigint" || typeof createdAt === "string"
+      ? createdAt
+      : undefined,
+  };
+}
+
+export function artifactUriFor(target: SessionArtifactTarget, artifactId: string) {
+  return `artifact://${target.ns}/${target.agent}/${target.sessionId}/${artifactId}`;
+}
+
+function epochMilliseconds(value: SessionArtifact["createdAt"]): number {
+  if (typeof value === "bigint") {
+    if (value > BigInt(Number.MAX_SAFE_INTEGER) || value < BigInt(Number.MIN_SAFE_INTEGER)) return 0;
+    const numeric = Number(value);
+    return numeric >= 1e15 ? Math.trunc(numeric / 1000) : numeric;
+  }
+  if (typeof value === "number") return value >= 1e15 ? Math.trunc(value / 1000) : value;
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric >= 1e15 ? Math.trunc(numeric / 1000) : numeric;
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+/** De-duplicate by ID and present the most recently created artifacts first. */
+export function mergeSessionArtifacts(existing: SessionArtifact[], incoming: SessionArtifact[]) {
+  const byId = new Map<string, SessionArtifact>();
+  for (const artifact of [...existing, ...incoming]) byId.set(artifact.id, artifact);
+  return Array.from(byId.values()).sort((left, right) => {
+    const timestampDifference = epochMilliseconds(right.createdAt) - epochMilliseconds(left.createdAt);
+    return timestampDifference || left.id.localeCompare(right.id);
+  });
+}
+
+export function formatArtifactBytes(value: SessionArtifact["sizeBytes"]) {
+  const bytes = typeof value === "bigint" ? Number(value) : Number(value);
+  if (!Number.isFinite(bytes) || bytes < 0) return null;
+  if (bytes < 1024) return `${Math.trunc(bytes)} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let amount = bytes / 1024;
+  let unit = 0;
+  while (amount >= 1024 && unit < units.length - 1) {
+    amount /= 1024;
+    unit += 1;
+  }
+  return `${amount >= 10 ? amount.toFixed(0) : amount.toFixed(1)} ${units[unit]}`;
+}
+
+export function formatArtifactCreatedAt(value: SessionArtifact["createdAt"]) {
+  const milliseconds = epochMilliseconds(value);
+  if (!milliseconds || milliseconds < 1e9) return null;
+  return new Date(milliseconds).toLocaleString([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}

--- a/packages/talon-chat/src/session/artifacts.ts
+++ b/packages/talon-chat/src/session/artifacts.ts
@@ -2,6 +2,8 @@ export type SessionArtifact = {
   id: string;
   title: string;
   mediaType: string;
+  /** Immutable CAS/object-store key for detecting a revised artifact body. */
+  objectKey: string | undefined;
   sizeBytes: number | bigint | string | undefined;
   createdAt: number | bigint | string | undefined;
 };
@@ -25,12 +27,14 @@ export function normalizeSessionArtifact(value: unknown): SessionArtifact | null
   const object = objectRef && typeof objectRef === "object" ? objectRef as Record<string, unknown> : {};
   const title = valueOf(source, "title", "title");
   const mediaType = valueOf(source, "mediaType", "media_type");
+  const objectKey = valueOf(object, "key", "key");
   const sizeBytes = valueOf(object, "sizeBytes", "size_bytes");
   const createdAt = valueOf(source, "createdAt", "created_at");
   return {
     id,
     title: typeof title === "string" ? title : "",
     mediaType: typeof mediaType === "string" ? mediaType : "",
+    objectKey: typeof objectKey === "string" && objectKey ? objectKey : undefined,
     sizeBytes: typeof sizeBytes === "number" || typeof sizeBytes === "bigint" || typeof sizeBytes === "string"
       ? sizeBytes
       : undefined,

--- a/packages/talon-chat/src/session/hooks/useSessionArtifacts.ts
+++ b/packages/talon-chat/src/session/hooks/useSessionArtifacts.ts
@@ -35,9 +35,9 @@ export function useSessionArtifacts({ enabled, gatewayClient, target }: UseSessi
   const [error, setError] = useState<Error | null>(null);
   const isLoadingRef = useRef(false);
 
-  const load = useCallback(async (reset: boolean, pageToken = "") => {
-    if (!available || !target || !listArtifacts) return;
-    if (!reset && (!pageToken || isLoadingRef.current)) return;
+  const load = useCallback(async (reset: boolean, pageToken = ""): Promise<SessionArtifact[] | null> => {
+    if (!available || !target || !listArtifacts) return null;
+    if (!reset && (!pageToken || isLoadingRef.current)) return null;
     requestRef.current?.abort();
     const controller = new AbortController();
     requestRef.current = controller;
@@ -64,10 +64,12 @@ export function useSessionArtifacts({ enabled, gatewayClient, target }: UseSessi
       setNextPageToken(typeof (response?.nextPageToken ?? response?.next_page_token) === "string"
         ? response.nextPageToken ?? response.next_page_token
         : "");
+      return fetched;
     } catch (reason) {
       if (!controller.signal.aborted && requestRef.current === controller && scopeRef.current === requestScope) {
         setError(reason instanceof Error ? reason : new Error(String(reason)));
       }
+      return null;
     } finally {
       if (!controller.signal.aborted && requestRef.current === controller && scopeRef.current === requestScope) {
         isLoadingRef.current = false;

--- a/packages/talon-chat/src/session/hooks/useSessionArtifacts.ts
+++ b/packages/talon-chat/src/session/hooks/useSessionArtifacts.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { GatewayClientLike } from "../TalonSessionTypes";
+import {
+  mergeSessionArtifacts,
+  normalizeSessionArtifact,
+  type SessionArtifact,
+  type SessionArtifactTarget,
+} from "../artifacts";
+
+const PAGE_SIZE = 50;
+
+type UseSessionArtifactsOptions = {
+  enabled: boolean;
+  gatewayClient: GatewayClientLike;
+  target: SessionArtifactTarget | null;
+};
+
+function targetKey(target: SessionArtifactTarget | null) {
+  return target ? `${target.ns}\u0000${target.agent}\u0000${target.sessionId}` : "";
+}
+
+/** Loads a session-scoped Artifact catalog without allowing old requests to leak into a new session. */
+export function useSessionArtifacts({ enabled, gatewayClient, target }: UseSessionArtifactsOptions) {
+  const listArtifacts = gatewayClient.artifacts?.listArtifacts;
+  const available = Boolean(enabled && target && listArtifacts);
+  const scopeKey = targetKey(target);
+  const requestRef = useRef<AbortController | null>(null);
+  const scopeRef = useRef(scopeKey);
+  // Update during render so a response from the prior session cannot briefly
+  // populate the rail before the scope-change effect gets to abort it.
+  scopeRef.current = scopeKey;
+  const [artifacts, setArtifacts] = useState<SessionArtifact[]>([]);
+  const [nextPageToken, setNextPageToken] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const isLoadingRef = useRef(false);
+
+  const load = useCallback(async (reset: boolean, pageToken = "") => {
+    if (!available || !target || !listArtifacts) return;
+    if (!reset && (!pageToken || isLoadingRef.current)) return;
+    requestRef.current?.abort();
+    const controller = new AbortController();
+    requestRef.current = controller;
+    const requestScope = targetKey(target);
+    isLoadingRef.current = true;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await (listArtifacts as any)(
+        {
+          namespace: target.ns,
+          agent: target.agent,
+          sessionId: target.sessionId,
+          limit: PAGE_SIZE,
+          pageToken,
+        },
+        { signal: controller.signal },
+      );
+      if (controller.signal.aborted || requestRef.current !== controller || scopeRef.current !== requestScope) return;
+      const fetched = (Array.isArray(response?.artifacts) ? response.artifacts : [])
+        .map(normalizeSessionArtifact)
+        .filter((artifact): artifact is SessionArtifact => artifact !== null);
+      setArtifacts((current) => mergeSessionArtifacts(reset ? [] : current, fetched));
+      setNextPageToken(typeof (response?.nextPageToken ?? response?.next_page_token) === "string"
+        ? response.nextPageToken ?? response.next_page_token
+        : "");
+    } catch (reason) {
+      if (!controller.signal.aborted && requestRef.current === controller && scopeRef.current === requestScope) {
+        setError(reason instanceof Error ? reason : new Error(String(reason)));
+      }
+    } finally {
+      if (!controller.signal.aborted && requestRef.current === controller && scopeRef.current === requestScope) {
+        isLoadingRef.current = false;
+        setIsLoading(false);
+      }
+    }
+  }, [available, listArtifacts, target]);
+
+  const refresh = useCallback(() => load(true), [load]);
+  const loadMore = useCallback(() => load(false, nextPageToken), [load, nextPageToken]);
+
+  useEffect(() => {
+    scopeRef.current = scopeKey;
+    requestRef.current?.abort();
+    requestRef.current = null;
+    isLoadingRef.current = false;
+    setArtifacts([]);
+    setNextPageToken("");
+    setIsLoading(false);
+    setError(null);
+    if (available) void load(true);
+  }, [available, load, scopeKey]);
+
+  useEffect(() => () => requestRef.current?.abort(), []);
+
+  return { artifacts, available, error, hasMore: Boolean(nextPageToken), isLoading, loadMore, refresh };
+}

--- a/src/gateway/rpc/files.rs
+++ b/src/gateway/rpc/files.rs
@@ -2237,6 +2237,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_artifacts_returns_records_for_the_requested_session() {
+        let handler = handler_with_objects(Arc::new(InMemoryObjectStore::default()));
+        let namespace = "Tenant:acme:Workspace:main";
+        let agent = "writer";
+        let session_id = "session-1";
+        handler
+            .gateway
+            .kv
+            .set_msg(
+                &keys::artifact(namespace, agent, session_id, "draft"),
+                &data_proto::Artifact {
+                    id: "draft".to_string(),
+                    session_id: session_id.to_string(),
+                    title: "Draft".to_string(),
+                    media_type: "text/markdown".to_string(),
+                    object_ref: None,
+                    created_by_agent: agent.to_string(),
+                    created_at: chrono::Utc::now().timestamp_micros(),
+                    labels: HashMap::new(),
+                    metadata: HashMap::new(),
+                },
+            )
+            .await
+            .unwrap();
+        handler
+            .gateway
+            .kv
+            .set_msg(
+                &keys::artifact(namespace, agent, "other-session", "other"),
+                &data_proto::Artifact {
+                    id: "other".to_string(),
+                    session_id: "other-session".to_string(),
+                    title: "Other".to_string(),
+                    media_type: "text/plain".to_string(),
+                    object_ref: None,
+                    created_by_agent: agent.to_string(),
+                    created_at: chrono::Utc::now().timestamp_micros(),
+                    labels: HashMap::new(),
+                    metadata: HashMap::new(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let listed = proto::artifact_service_server::ArtifactService::list_artifacts(
+            &handler,
+            Request::new(proto::ListArtifactsRequest {
+                namespace: namespace.to_string(),
+                agent: agent.to_string(),
+                session_id: session_id.to_string(),
+                limit: 50,
+                page_token: String::new(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+        assert_eq!(listed.artifacts.len(), 1);
+        assert_eq!(listed.artifacts[0].id, "draft");
+    }
+
+    #[tokio::test]
     async fn namespace_jwt_can_read_artifact_content_and_metadata() {
         use crate::control::security::platform_jwt;
         use crate::gateway::auth::TalonGrantClaim;

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1406,15 +1406,16 @@ function DebuggerPageContent() {
                     agent={selectedSession.agent || 'default'}
                     sessionId={selectedSession.sessionId}
                     gatewayClient={getGatewayClient()}
-                  historyPageSize={positiveIntParam(searchParams, 'historyPageSize')}
-                  enabledBuiltInCommands={['clear', 'compact', 'doctor']}
-                  onImageUpload={sessionComposerRole === 'assistant' || !imageUploadsEnabled ? undefined : uploadTalonImage}
-                  objectUrlForRef={imageUploadsEnabled ? talonObjectUrl : undefined}
-                  disabled={!isConnected}
-                  allowMessageEditing
-                  enableDebugMessageEditing={Boolean(sessionConnectorMetadata)}
-                  composerVariant="expanded"
-                  composerStartAdornment={
+                    showSessionArtifacts
+                    historyPageSize={positiveIntParam(searchParams, 'historyPageSize')}
+                    enabledBuiltInCommands={['clear', 'compact', 'doctor']}
+                    onImageUpload={sessionComposerRole === 'assistant' || !imageUploadsEnabled ? undefined : uploadTalonImage}
+                    objectUrlForRef={imageUploadsEnabled ? talonObjectUrl : undefined}
+                    disabled={!isConnected}
+                    allowMessageEditing
+                    enableDebugMessageEditing={Boolean(sessionConnectorMetadata)}
+                    composerVariant="expanded"
+                    composerStartAdornment={
                     <div className="flex h-8 overflow-hidden rounded-full border border-border bg-background/80 p-0.5">
                       {(['user', 'assistant'] as const).map((role) => (
                         <button


### PR DESCRIPTION
## Summary

Adds an opt-in session Artifact browser to Talon chat, enabled in Sightline.

- Shows a compact, top-right Artifact card only when the active session has artifacts.
- Opens selected artifacts in the existing resource preview and refreshes after generation completes.
- Follows signed object-storage URLs for inline text/Markdown/JSON preview, fixing blank artifact documents.
- Improves artifact reading with a comfortable document width and a collapsed YAML-frontmatter metadata section.

## Why

Session artifacts were difficult to discover, and signed object-store responses returned empty inline bytes without the UI following the signed URL. That left Markdown previews blank.

## Validation

- `pnpm --filter @impalasys/talon-chat test`
- `pnpm --filter @impalasys/talon-chat build`
- `pnpm --dir ui lint`
- `cargo test list_artifacts_returns_records_for_the_requested_session --lib`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional session artifact catalog with pagination, loading states, metadata, and artifact selection.
  - Artifacts can open in the resource pane or through an external resource handler.
  - Added support for safely previewing signed text and JSON resources.
  - Markdown resources now display collapsible YAML document metadata.

- **Bug Fixes**
  - Improved resource loading safety for oversized or non-text content.
  - Refreshed artifact listings when live sessions end.

- **Documentation**
  - Documented session artifact configuration and split-pane viewing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->