### PR TITLE
Add durable steer queue batching and E2E coverage

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -166,6 +166,7 @@ fn main() -> std::io::Result<()> {
         ".talon.data.WorkflowRunEvent",
         ".talon.data.WorkflowStepRun",
         ".talon.data.SessionJournalEntryPayloadCompaction",
+        ".talon.data.SessionJournalEntryPayloadSteerInput",
         ".talon.events.WorkflowDispatchEvent",
         ".talon.external.ConnectorActivityRequest",
         ".talon.external.ConnectorAckResponse",

--- a/proto/data/session_journal_entry.proto
+++ b/proto/data/session_journal_entry.proto
@@ -24,6 +24,10 @@ enum SessionExecutionPhase {
   // Durable model context compaction completed. The journal entry references
   // an immutable summary object without storing a provider transcript snapshot.
   SESSION_EXECUTION_PHASE_COMPACTION = 4;
+
+  // Interactive user input was absorbed into the active execution after a
+  // completed tool-call batch.
+  SESSION_EXECUTION_PHASE_STEER_INPUT = 5;
 }
 
 message SessionJournalEntryPayloadLlmResponse {
@@ -47,12 +51,19 @@ message SessionJournalEntryPayloadCompaction {
   ObjectRef summary = 1;
 }
 
+message SessionJournalEntryPayloadSteerInput {
+  // Canonical user SessionMessage ids appended to the active execution
+  // context, in admission order.
+  repeated string message_ids = 1;
+}
+
 message SessionJournalEntryPayload {
   oneof payload {
     SessionJournalEntryPayloadLlmResponse llm_response = 1;
     SessionJournalEntryPayloadToolResult tool_result = 2;
     SessionJournalEntryPayloadCommit commit = 3;
     SessionJournalEntryPayloadCompaction compaction = 5;
+    SessionJournalEntryPayloadSteerInput steer_input = 6;
   }
 }
 

--- a/scripts/sdk/generate.sh
+++ b/scripts/sdk/generate.sh
@@ -196,7 +196,7 @@ JAVA_GRPC_PLUGIN="$ROOT/.tools/protoc-gen-grpc-java/protoc-gen-grpc-java-${JAVA_
 if [[ ! -x "$JAVA_GRPC_PLUGIN" ]]; then
   mkdir -p "$(dirname "$JAVA_GRPC_PLUGIN")"
   curl -fL -o "$JAVA_GRPC_PLUGIN" \
-    "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${JAVA_GRPC_VERSION}/protoc-gen-grpc-java-${JAVA_GRPC_VERSION}-${JAVA_GRPC_PLATFORM}.exe"
+    "https://repo.maven.apache.org/maven2/io/grpc/protoc-gen-grpc-java/${JAVA_GRPC_VERSION}/protoc-gen-grpc-java-${JAVA_GRPC_VERSION}-${JAVA_GRPC_PLATFORM}.exe"
   chmod +x "$JAVA_GRPC_PLUGIN"
 fi
 

--- a/sdk/go/talon-client/talon/data/session_journal_entry.pb.go
+++ b/sdk/go/talon-client/talon/data/session_journal_entry.pb.go
@@ -38,6 +38,9 @@ const (
 	// Durable model context compaction completed. The journal entry references
 	// an immutable summary object without storing a provider transcript snapshot.
 	SessionExecutionPhase_SESSION_EXECUTION_PHASE_COMPACTION SessionExecutionPhase = 4
+	// Interactive user input was absorbed into the active execution after a
+	// completed tool-call batch.
+	SessionExecutionPhase_SESSION_EXECUTION_PHASE_STEER_INPUT SessionExecutionPhase = 5
 )
 
 // Enum value maps for SessionExecutionPhase.
@@ -48,6 +51,7 @@ var (
 		2: "SESSION_EXECUTION_PHASE_TOOL_RESULT",
 		3: "SESSION_EXECUTION_PHASE_COMMITTED",
 		4: "SESSION_EXECUTION_PHASE_COMPACTION",
+		5: "SESSION_EXECUTION_PHASE_STEER_INPUT",
 	}
 	SessionExecutionPhase_value = map[string]int32{
 		"SESSION_EXECUTION_PHASE_UNSPECIFIED":  0,
@@ -55,6 +59,7 @@ var (
 		"SESSION_EXECUTION_PHASE_TOOL_RESULT":  2,
 		"SESSION_EXECUTION_PHASE_COMMITTED":    3,
 		"SESSION_EXECUTION_PHASE_COMPACTION":   4,
+		"SESSION_EXECUTION_PHASE_STEER_INPUT":  5,
 	}
 )
 
@@ -294,6 +299,52 @@ func (x *SessionJournalEntryPayloadCompaction) GetSummary() *ObjectRef {
 	return nil
 }
 
+type SessionJournalEntryPayloadSteerInput struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Canonical user SessionMessage ids appended to the active execution
+	// context, in admission order.
+	MessageIds    []string `protobuf:"bytes,1,rep,name=message_ids,json=messageIds,proto3" json:"message_ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionJournalEntryPayloadSteerInput) Reset() {
+	*x = SessionJournalEntryPayloadSteerInput{}
+	mi := &file_proto_data_session_journal_entry_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionJournalEntryPayloadSteerInput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionJournalEntryPayloadSteerInput) ProtoMessage() {}
+
+func (x *SessionJournalEntryPayloadSteerInput) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_data_session_journal_entry_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionJournalEntryPayloadSteerInput.ProtoReflect.Descriptor instead.
+func (*SessionJournalEntryPayloadSteerInput) Descriptor() ([]byte, []int) {
+	return file_proto_data_session_journal_entry_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *SessionJournalEntryPayloadSteerInput) GetMessageIds() []string {
+	if x != nil {
+		return x.MessageIds
+	}
+	return nil
+}
+
 type SessionJournalEntryPayload struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Payload:
@@ -302,6 +353,7 @@ type SessionJournalEntryPayload struct {
 	//	*SessionJournalEntryPayload_ToolResult
 	//	*SessionJournalEntryPayload_Commit
 	//	*SessionJournalEntryPayload_Compaction
+	//	*SessionJournalEntryPayload_SteerInput
 	Payload       isSessionJournalEntryPayload_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -309,7 +361,7 @@ type SessionJournalEntryPayload struct {
 
 func (x *SessionJournalEntryPayload) Reset() {
 	*x = SessionJournalEntryPayload{}
-	mi := &file_proto_data_session_journal_entry_proto_msgTypes[4]
+	mi := &file_proto_data_session_journal_entry_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -321,7 +373,7 @@ func (x *SessionJournalEntryPayload) String() string {
 func (*SessionJournalEntryPayload) ProtoMessage() {}
 
 func (x *SessionJournalEntryPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_data_session_journal_entry_proto_msgTypes[4]
+	mi := &file_proto_data_session_journal_entry_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -334,7 +386,7 @@ func (x *SessionJournalEntryPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionJournalEntryPayload.ProtoReflect.Descriptor instead.
 func (*SessionJournalEntryPayload) Descriptor() ([]byte, []int) {
-	return file_proto_data_session_journal_entry_proto_rawDescGZIP(), []int{4}
+	return file_proto_data_session_journal_entry_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *SessionJournalEntryPayload) GetPayload() isSessionJournalEntryPayload_Payload {
@@ -380,6 +432,15 @@ func (x *SessionJournalEntryPayload) GetCompaction() *SessionJournalEntryPayload
 	return nil
 }
 
+func (x *SessionJournalEntryPayload) GetSteerInput() *SessionJournalEntryPayloadSteerInput {
+	if x != nil {
+		if x, ok := x.Payload.(*SessionJournalEntryPayload_SteerInput); ok {
+			return x.SteerInput
+		}
+	}
+	return nil
+}
+
 type isSessionJournalEntryPayload_Payload interface {
 	isSessionJournalEntryPayload_Payload()
 }
@@ -400,6 +461,10 @@ type SessionJournalEntryPayload_Compaction struct {
 	Compaction *SessionJournalEntryPayloadCompaction `protobuf:"bytes,5,opt,name=compaction,proto3,oneof"`
 }
 
+type SessionJournalEntryPayload_SteerInput struct {
+	SteerInput *SessionJournalEntryPayloadSteerInput `protobuf:"bytes,6,opt,name=steer_input,json=steerInput,proto3,oneof"`
+}
+
 func (*SessionJournalEntryPayload_LlmResponse) isSessionJournalEntryPayload_Payload() {}
 
 func (*SessionJournalEntryPayload_ToolResult) isSessionJournalEntryPayload_Payload() {}
@@ -407,6 +472,8 @@ func (*SessionJournalEntryPayload_ToolResult) isSessionJournalEntryPayload_Paylo
 func (*SessionJournalEntryPayload_Commit) isSessionJournalEntryPayload_Payload() {}
 
 func (*SessionJournalEntryPayload_Compaction) isSessionJournalEntryPayload_Payload() {}
+
+func (*SessionJournalEntryPayload_SteerInput) isSessionJournalEntryPayload_Payload() {}
 
 type SessionJournalEntry struct {
 	state          protoimpl.MessageState      `protogen:"open.v1"`
@@ -428,7 +495,7 @@ type SessionJournalEntry struct {
 
 func (x *SessionJournalEntry) Reset() {
 	*x = SessionJournalEntry{}
-	mi := &file_proto_data_session_journal_entry_proto_msgTypes[5]
+	mi := &file_proto_data_session_journal_entry_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -440,7 +507,7 @@ func (x *SessionJournalEntry) String() string {
 func (*SessionJournalEntry) ProtoMessage() {}
 
 func (x *SessionJournalEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_data_session_journal_entry_proto_msgTypes[5]
+	mi := &file_proto_data_session_journal_entry_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -453,7 +520,7 @@ func (x *SessionJournalEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionJournalEntry.ProtoReflect.Descriptor instead.
 func (*SessionJournalEntry) Descriptor() ([]byte, []int) {
-	return file_proto_data_session_journal_entry_proto_rawDescGZIP(), []int{5}
+	return file_proto_data_session_journal_entry_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SessionJournalEntry) GetSubmissionId() string {
@@ -538,7 +605,10 @@ const file_proto_data_session_journal_entry_proto_rawDesc = "" +
 	" SessionJournalEntryPayloadCommit\x120\n" +
 	"\x14committed_message_id\x18\x01 \x01(\tR\x12committedMessageId\"W\n" +
 	"$SessionJournalEntryPayloadCompaction\x12/\n" +
-	"\asummary\x18\x01 \x01(\v2\x15.talon.data.ObjectRefR\asummary\"\xf0\x02\n" +
+	"\asummary\x18\x01 \x01(\v2\x15.talon.data.ObjectRefR\asummary\"G\n" +
+	"$SessionJournalEntryPayloadSteerInput\x12\x1f\n" +
+	"\vmessage_ids\x18\x01 \x03(\tR\n" +
+	"messageIds\"\xc5\x03\n" +
 	"\x1aSessionJournalEntryPayload\x12V\n" +
 	"\fllm_response\x18\x01 \x01(\v21.talon.data.SessionJournalEntryPayloadLlmResponseH\x00R\vllmResponse\x12S\n" +
 	"\vtool_result\x18\x02 \x01(\v20.talon.data.SessionJournalEntryPayloadToolResultH\x00R\n" +
@@ -546,7 +616,9 @@ const file_proto_data_session_journal_entry_proto_rawDesc = "" +
 	"\x06commit\x18\x03 \x01(\v2,.talon.data.SessionJournalEntryPayloadCommitH\x00R\x06commit\x12R\n" +
 	"\n" +
 	"compaction\x18\x05 \x01(\v20.talon.data.SessionJournalEntryPayloadCompactionH\x00R\n" +
-	"compactionB\t\n" +
+	"compaction\x12S\n" +
+	"\vsteer_input\x18\x06 \x01(\v20.talon.data.SessionJournalEntryPayloadSteerInputH\x00R\n" +
+	"steerInputB\t\n" +
 	"\apayload\"\xc5\x03\n" +
 	"\x13SessionJournalEntry\x12#\n" +
 	"\rsubmission_id\x18\x01 \x01(\tR\fsubmissionId\x12(\n" +
@@ -562,13 +634,14 @@ const file_proto_data_session_journal_entry_proto_rawDesc = "" +
 	"\fcommitted_at\x18\b \x01(\x03H\x00R\vcommittedAt\x88\x01\x01\x125\n" +
 	"\x14committed_message_id\x18\t \x01(\tH\x01R\x12committedMessageId\x88\x01\x01B\x0f\n" +
 	"\r_committed_atB\x17\n" +
-	"\x15_committed_message_id*\xe2\x01\n" +
+	"\x15_committed_message_id*\x8b\x02\n" +
 	"\x15SessionExecutionPhase\x12'\n" +
 	"#SESSION_EXECUTION_PHASE_UNSPECIFIED\x10\x00\x12(\n" +
 	"$SESSION_EXECUTION_PHASE_LLM_RESPONSE\x10\x01\x12'\n" +
 	"#SESSION_EXECUTION_PHASE_TOOL_RESULT\x10\x02\x12%\n" +
 	"!SESSION_EXECUTION_PHASE_COMMITTED\x10\x03\x12&\n" +
-	"\"SESSION_EXECUTION_PHASE_COMPACTION\x10\x04b\x06proto3"
+	"\"SESSION_EXECUTION_PHASE_COMPACTION\x10\x04\x12'\n" +
+	"#SESSION_EXECUTION_PHASE_STEER_INPUT\x10\x05b\x06proto3"
 
 var (
 	file_proto_data_session_journal_entry_proto_rawDescOnce sync.Once
@@ -583,35 +656,37 @@ func file_proto_data_session_journal_entry_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_data_session_journal_entry_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_proto_data_session_journal_entry_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_proto_data_session_journal_entry_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_proto_data_session_journal_entry_proto_goTypes = []any{
 	(SessionExecutionPhase)(0),                    // 0: talon.data.SessionExecutionPhase
 	(*SessionJournalEntryPayloadLlmResponse)(nil), // 1: talon.data.SessionJournalEntryPayloadLlmResponse
 	(*SessionJournalEntryPayloadToolResult)(nil),  // 2: talon.data.SessionJournalEntryPayloadToolResult
 	(*SessionJournalEntryPayloadCommit)(nil),      // 3: talon.data.SessionJournalEntryPayloadCommit
 	(*SessionJournalEntryPayloadCompaction)(nil),  // 4: talon.data.SessionJournalEntryPayloadCompaction
-	(*SessionJournalEntryPayload)(nil),            // 5: talon.data.SessionJournalEntryPayload
-	(*SessionJournalEntry)(nil),                   // 6: talon.data.SessionJournalEntry
-	(*ChatResponse)(nil),                          // 7: talon.harness.ChatResponse
-	(*ObjectRef)(nil),                             // 8: talon.data.ObjectRef
-	(*ToolOutput)(nil),                            // 9: talon.harness.ToolOutput
+	(*SessionJournalEntryPayloadSteerInput)(nil),  // 5: talon.data.SessionJournalEntryPayloadSteerInput
+	(*SessionJournalEntryPayload)(nil),            // 6: talon.data.SessionJournalEntryPayload
+	(*SessionJournalEntry)(nil),                   // 7: talon.data.SessionJournalEntry
+	(*ChatResponse)(nil),                          // 8: talon.harness.ChatResponse
+	(*ObjectRef)(nil),                             // 9: talon.data.ObjectRef
+	(*ToolOutput)(nil),                            // 10: talon.harness.ToolOutput
 }
 var file_proto_data_session_journal_entry_proto_depIdxs = []int32{
-	7,  // 0: talon.data.SessionJournalEntryPayloadLlmResponse.response:type_name -> talon.harness.ChatResponse
-	8,  // 1: talon.data.SessionJournalEntryPayloadToolResult.object:type_name -> talon.data.ObjectRef
-	9,  // 2: talon.data.SessionJournalEntryPayloadToolResult.tool_output:type_name -> talon.harness.ToolOutput
-	8,  // 3: talon.data.SessionJournalEntryPayloadCompaction.summary:type_name -> talon.data.ObjectRef
+	8,  // 0: talon.data.SessionJournalEntryPayloadLlmResponse.response:type_name -> talon.harness.ChatResponse
+	9,  // 1: talon.data.SessionJournalEntryPayloadToolResult.object:type_name -> talon.data.ObjectRef
+	10, // 2: talon.data.SessionJournalEntryPayloadToolResult.tool_output:type_name -> talon.harness.ToolOutput
+	9,  // 3: talon.data.SessionJournalEntryPayloadCompaction.summary:type_name -> talon.data.ObjectRef
 	1,  // 4: talon.data.SessionJournalEntryPayload.llm_response:type_name -> talon.data.SessionJournalEntryPayloadLlmResponse
 	2,  // 5: talon.data.SessionJournalEntryPayload.tool_result:type_name -> talon.data.SessionJournalEntryPayloadToolResult
 	3,  // 6: talon.data.SessionJournalEntryPayload.commit:type_name -> talon.data.SessionJournalEntryPayloadCommit
 	4,  // 7: talon.data.SessionJournalEntryPayload.compaction:type_name -> talon.data.SessionJournalEntryPayloadCompaction
-	0,  // 8: talon.data.SessionJournalEntry.phase:type_name -> talon.data.SessionExecutionPhase
-	5,  // 9: talon.data.SessionJournalEntry.payload:type_name -> talon.data.SessionJournalEntryPayload
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	5,  // 8: talon.data.SessionJournalEntryPayload.steer_input:type_name -> talon.data.SessionJournalEntryPayloadSteerInput
+	0,  // 9: talon.data.SessionJournalEntry.phase:type_name -> talon.data.SessionExecutionPhase
+	6,  // 10: talon.data.SessionJournalEntry.payload:type_name -> talon.data.SessionJournalEntryPayload
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_proto_data_session_journal_entry_proto_init() }
@@ -621,20 +696,21 @@ func file_proto_data_session_journal_entry_proto_init() {
 	}
 	file_proto_data_data_proto_init()
 	file_proto_harness_llm_proto_init()
-	file_proto_data_session_journal_entry_proto_msgTypes[4].OneofWrappers = []any{
+	file_proto_data_session_journal_entry_proto_msgTypes[5].OneofWrappers = []any{
 		(*SessionJournalEntryPayload_LlmResponse)(nil),
 		(*SessionJournalEntryPayload_ToolResult)(nil),
 		(*SessionJournalEntryPayload_Commit)(nil),
 		(*SessionJournalEntryPayload_Compaction)(nil),
+		(*SessionJournalEntryPayload_SteerInput)(nil),
 	}
-	file_proto_data_session_journal_entry_proto_msgTypes[5].OneofWrappers = []any{}
+	file_proto_data_session_journal_entry_proto_msgTypes[6].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_data_session_journal_entry_proto_rawDesc), len(file_proto_data_session_journal_entry_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   6,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/sdk/java/talon-client/src/main/java/talon/data/SessionJournalEntryOuterClass.java
+++ b/sdk/java/talon-client/src/main/java/talon/data/SessionJournalEntryOuterClass.java
@@ -75,6 +75,15 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
      * <code>SESSION_EXECUTION_PHASE_COMPACTION = 4;</code>
      */
     SESSION_EXECUTION_PHASE_COMPACTION(4),
+    /**
+     * <pre>
+     * Interactive user input was absorbed into the active execution after a
+     * completed tool-call batch.
+     * </pre>
+     *
+     * <code>SESSION_EXECUTION_PHASE_STEER_INPUT = 5;</code>
+     */
+    SESSION_EXECUTION_PHASE_STEER_INPUT(5),
     UNRECOGNIZED(-1),
     ;
 
@@ -131,6 +140,15 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
      * <code>SESSION_EXECUTION_PHASE_COMPACTION = 4;</code>
      */
     public static final int SESSION_EXECUTION_PHASE_COMPACTION_VALUE = 4;
+    /**
+     * <pre>
+     * Interactive user input was absorbed into the active execution after a
+     * completed tool-call batch.
+     * </pre>
+     *
+     * <code>SESSION_EXECUTION_PHASE_STEER_INPUT = 5;</code>
+     */
+    public static final int SESSION_EXECUTION_PHASE_STEER_INPUT_VALUE = 5;
 
 
     public final int getNumber() {
@@ -162,6 +180,7 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
         case 2: return SESSION_EXECUTION_PHASE_TOOL_RESULT;
         case 3: return SESSION_EXECUTION_PHASE_COMMITTED;
         case 4: return SESSION_EXECUTION_PHASE_COMPACTION;
+        case 5: return SESSION_EXECUTION_PHASE_STEER_INPUT;
         default: return null;
       }
     }
@@ -3162,6 +3181,671 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
 
   }
 
+  public interface SessionJournalEntryPayloadSteerInputOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:talon.data.SessionJournalEntryPayloadSteerInput)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Canonical user SessionMessage ids appended to the active execution
+     * context, in admission order.
+     * </pre>
+     *
+     * <code>repeated string message_ids = 1;</code>
+     * @return A list containing the messageIds.
+     */
+    java.util.List<java.lang.String>
+        getMessageIdsList();
+    /**
+     * <pre>
+     * Canonical user SessionMessage ids appended to the active execution
+     * context, in admission order.
+     * </pre>
+     *
+     * <code>repeated string message_ids = 1;</code>
+     * @return The count of messageIds.
+     */
+    int getMessageIdsCount();
+    /**
+     * <pre>
+     * Canonical user SessionMessage ids appended to the active execution
+     * context, in admission order.
+     * </pre>
+     *
+     * <code>repeated string message_ids = 1;</code>
+     * @param index The index of the element to return.
+     * @return The messageIds at the given index.
+     */
+    java.lang.String getMessageIds(int index);
+    /**
+     * <pre>
+     * Canonical user SessionMessage ids appended to the active execution
+     * context, in admission order.
+     * </pre>
+     *
+     * <code>repeated string message_ids = 1;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the messageIds at the given index.
+     */
+    com.google.protobuf.ByteString
+        getMessageIdsBytes(int index);
+  }
+  /**
+   * Protobuf type {@code talon.data.SessionJournalEntryPayloadSteerInput}
+   */
+  public static final class SessionJournalEntryPayloadSteerInput extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:talon.data.SessionJournalEntryPayloadSteerInput)
+      SessionJournalEntryPayloadSteerInputOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 34,
+        /* patch= */ 1,
+        /* suffix= */ "",
+        "SessionJournalEntryPayloadSteerInput");
+    }
+    // Use SessionJournalEntryPayloadSteerInput.newBuilder() to construct.
+    private SessionJournalEntryPayloadSteerInput(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private SessionJournalEntryPayloadSteerInput() {
+      messageIds_ =
+          com.google.protobuf.LazyStringArrayList.emptyList();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return talon.data.SessionJournalEntryOuterClass.internal_static_talon_data_SessionJournalEntryPayloadSteerInput_descriptor;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return talon.data.SessionJournalEntryOuterClass.internal_static_talon_data_SessionJournalEntryPayloadSteerInput_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return talon.data.SessionJournalEntryOuterClass.internal_static_talon_data_SessionJournalEntryPayloadSteerInput_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.class, talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.Builder.class);
+    }
+
+    public static final int MESSAGE_IDS_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
+    private com.google.protobuf.LazyStringArrayList messageIds_ =
+        com.google.protobuf.LazyStringArrayList.emptyList();
+    /**
+     * <pre>
+     * Canonical user SessionMessage ids appended to the active execution
+     * context, in admission order.
+     * </pre>
+     *
+     * <code>repeated string message_ids = 1;</code>
+     * @return A list containing the messageIds.
+     */
+    public com.google.protobuf.ProtocolStringList
+        getMessageIdsList() {
+      return messageIds_;
+    }
+    /**
+     * <pre>
+     * Canonical user SessionMessage ids appended to the active execution
+     * context, in admission order.
+     * </pre>
+     *
+     * <code>repeated string message_ids = 1;</code>
+     * @return The count of messageIds.
+     */
+    public int getMessageIdsCount() {
+      return messageIds_.size();
+    }
+    /**
+     * <pre>
+     * Canonical user SessionMessage ids appended to the active execution
+     * context, in admission order.
+     * </pre>
+     *
+     * <code>repeated string message_ids = 1;</code>
+     * @param index The index of the element to return.
+     * @return The messageIds at the given index.
+     */
+    public java.lang.String getMessageIds(int index) {
+      return messageIds_.get(index);
+    }
+    /**
+     * <pre>
+     * Canonical user SessionMessage ids appended to the active execution
+     * context, in admission order.
+     * </pre>
+     *
+     * <code>repeated string message_ids = 1;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the messageIds at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getMessageIdsBytes(int index) {
+      return messageIds_.getByteString(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < messageIds_.size(); i++) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, messageIds_.getRaw(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      {
+        int dataSize = 0;
+        for (int i = 0; i < messageIds_.size(); i++) {
+          dataSize += computeStringSizeNoTag(messageIds_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getMessageIdsList().size();
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput)) {
+        return super.equals(obj);
+      }
+      talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput other = (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) obj;
+
+      if (!getMessageIdsList()
+          .equals(other.getMessageIdsList())) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getMessageIdsCount() > 0) {
+        hash = (37 * hash) + MESSAGE_IDS_FIELD_NUMBER;
+        hash = (53 * hash) + getMessageIdsList().hashCode();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code talon.data.SessionJournalEntryPayloadSteerInput}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:talon.data.SessionJournalEntryPayloadSteerInput)
+        talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInputOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return talon.data.SessionJournalEntryOuterClass.internal_static_talon_data_SessionJournalEntryPayloadSteerInput_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return talon.data.SessionJournalEntryOuterClass.internal_static_talon_data_SessionJournalEntryPayloadSteerInput_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.class, talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.Builder.class);
+      }
+
+      // Construct using talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        messageIds_ =
+            com.google.protobuf.LazyStringArrayList.emptyList();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return talon.data.SessionJournalEntryOuterClass.internal_static_talon_data_SessionJournalEntryPayloadSteerInput_descriptor;
+      }
+
+      @java.lang.Override
+      public talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput getDefaultInstanceForType() {
+        return talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput build() {
+        talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput buildPartial() {
+        talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput result = new talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          messageIds_.makeImmutable();
+          result.messageIds_ = messageIds_;
+        }
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) {
+          return mergeFrom((talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput other) {
+        if (other == talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.getDefaultInstance()) return this;
+        if (!other.messageIds_.isEmpty()) {
+          if (messageIds_.isEmpty()) {
+            messageIds_ = other.messageIds_;
+            bitField0_ |= 0x00000001;
+          } else {
+            ensureMessageIdsIsMutable();
+            messageIds_.addAll(other.messageIds_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                ensureMessageIdsIsMutable();
+                messageIds_.add(input.readStringRequireUtf8());
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private com.google.protobuf.LazyStringArrayList messageIds_ =
+          com.google.protobuf.LazyStringArrayList.emptyList();
+      private void ensureMessageIdsIsMutable() {
+        if (!messageIds_.isModifiable()) {
+          messageIds_ = new com.google.protobuf.LazyStringArrayList(messageIds_);
+        }
+        bitField0_ |= 0x00000001;
+      }
+      /**
+       * <pre>
+       * Canonical user SessionMessage ids appended to the active execution
+       * context, in admission order.
+       * </pre>
+       *
+       * <code>repeated string message_ids = 1;</code>
+       * @return A list containing the messageIds.
+       */
+      public com.google.protobuf.ProtocolStringList
+          getMessageIdsList() {
+        messageIds_.makeImmutable();
+        return messageIds_;
+      }
+      /**
+       * <pre>
+       * Canonical user SessionMessage ids appended to the active execution
+       * context, in admission order.
+       * </pre>
+       *
+       * <code>repeated string message_ids = 1;</code>
+       * @return The count of messageIds.
+       */
+      public int getMessageIdsCount() {
+        return messageIds_.size();
+      }
+      /**
+       * <pre>
+       * Canonical user SessionMessage ids appended to the active execution
+       * context, in admission order.
+       * </pre>
+       *
+       * <code>repeated string message_ids = 1;</code>
+       * @param index The index of the element to return.
+       * @return The messageIds at the given index.
+       */
+      public java.lang.String getMessageIds(int index) {
+        return messageIds_.get(index);
+      }
+      /**
+       * <pre>
+       * Canonical user SessionMessage ids appended to the active execution
+       * context, in admission order.
+       * </pre>
+       *
+       * <code>repeated string message_ids = 1;</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the messageIds at the given index.
+       */
+      public com.google.protobuf.ByteString
+          getMessageIdsBytes(int index) {
+        return messageIds_.getByteString(index);
+      }
+      /**
+       * <pre>
+       * Canonical user SessionMessage ids appended to the active execution
+       * context, in admission order.
+       * </pre>
+       *
+       * <code>repeated string message_ids = 1;</code>
+       * @param index The index to set the value at.
+       * @param value The messageIds to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMessageIds(
+          int index, java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        ensureMessageIdsIsMutable();
+        messageIds_.set(index, value);
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Canonical user SessionMessage ids appended to the active execution
+       * context, in admission order.
+       * </pre>
+       *
+       * <code>repeated string message_ids = 1;</code>
+       * @param value The messageIds to add.
+       * @return This builder for chaining.
+       */
+      public Builder addMessageIds(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        ensureMessageIdsIsMutable();
+        messageIds_.add(value);
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Canonical user SessionMessage ids appended to the active execution
+       * context, in admission order.
+       * </pre>
+       *
+       * <code>repeated string message_ids = 1;</code>
+       * @param values The messageIds to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllMessageIds(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureMessageIdsIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, messageIds_);
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Canonical user SessionMessage ids appended to the active execution
+       * context, in admission order.
+       * </pre>
+       *
+       * <code>repeated string message_ids = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearMessageIds() {
+        messageIds_ =
+          com.google.protobuf.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Canonical user SessionMessage ids appended to the active execution
+       * context, in admission order.
+       * </pre>
+       *
+       * <code>repeated string message_ids = 1;</code>
+       * @param value The bytes of the messageIds to add.
+       * @return This builder for chaining.
+       */
+      public Builder addMessageIdsBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        ensureMessageIdsIsMutable();
+        messageIds_.add(value);
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:talon.data.SessionJournalEntryPayloadSteerInput)
+    }
+
+    // @@protoc_insertion_point(class_scope:talon.data.SessionJournalEntryPayloadSteerInput)
+    private static final talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput();
+    }
+
+    public static talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<SessionJournalEntryPayloadSteerInput>
+        PARSER = new com.google.protobuf.AbstractParser<SessionJournalEntryPayloadSteerInput>() {
+      @java.lang.Override
+      public SessionJournalEntryPayloadSteerInput parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<SessionJournalEntryPayloadSteerInput> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<SessionJournalEntryPayloadSteerInput> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface SessionJournalEntryPayloadOrBuilder extends
       // @@protoc_insertion_point(interface_extends:talon.data.SessionJournalEntryPayload)
       com.google.protobuf.MessageOrBuilder {
@@ -3226,6 +3910,21 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
      */
     talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadCompactionOrBuilder getCompactionOrBuilder();
 
+    /**
+     * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+     * @return Whether the steerInput field is set.
+     */
+    boolean hasSteerInput();
+    /**
+     * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+     * @return The steerInput.
+     */
+    talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput getSteerInput();
+    /**
+     * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+     */
+    talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInputOrBuilder getSteerInputOrBuilder();
+
     talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayload.PayloadCase getPayloadCase();
   }
   /**
@@ -3280,6 +3979,7 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
       TOOL_RESULT(2),
       COMMIT(3),
       COMPACTION(5),
+      STEER_INPUT(6),
       PAYLOAD_NOT_SET(0);
       private final int value;
       private PayloadCase(int value) {
@@ -3301,6 +4001,7 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
           case 2: return TOOL_RESULT;
           case 3: return COMMIT;
           case 5: return COMPACTION;
+          case 6: return STEER_INPUT;
           case 0: return PAYLOAD_NOT_SET;
           default: return null;
         }
@@ -3440,6 +4141,37 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
       return talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadCompaction.getDefaultInstance();
     }
 
+    public static final int STEER_INPUT_FIELD_NUMBER = 6;
+    /**
+     * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+     * @return Whether the steerInput field is set.
+     */
+    @java.lang.Override
+    public boolean hasSteerInput() {
+      return payloadCase_ == 6;
+    }
+    /**
+     * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+     * @return The steerInput.
+     */
+    @java.lang.Override
+    public talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput getSteerInput() {
+      if (payloadCase_ == 6) {
+         return (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) payload_;
+      }
+      return talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.getDefaultInstance();
+    }
+    /**
+     * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+     */
+    @java.lang.Override
+    public talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInputOrBuilder getSteerInputOrBuilder() {
+      if (payloadCase_ == 6) {
+         return (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) payload_;
+      }
+      return talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.getDefaultInstance();
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -3466,6 +4198,9 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
       if (payloadCase_ == 5) {
         output.writeMessage(5, (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadCompaction) payload_);
       }
+      if (payloadCase_ == 6) {
+        output.writeMessage(6, (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) payload_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -3490,6 +4225,10 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
       if (payloadCase_ == 5) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(5, (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadCompaction) payload_);
+      }
+      if (payloadCase_ == 6) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(6, (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) payload_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -3524,6 +4263,10 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
           if (!getCompaction()
               .equals(other.getCompaction())) return false;
           break;
+        case 6:
+          if (!getSteerInput()
+              .equals(other.getSteerInput())) return false;
+          break;
         case 0:
         default:
       }
@@ -3554,6 +4297,10 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
         case 5:
           hash = (37 * hash) + COMPACTION_FIELD_NUMBER;
           hash = (53 * hash) + getCompaction().hashCode();
+          break;
+        case 6:
+          hash = (37 * hash) + STEER_INPUT_FIELD_NUMBER;
+          hash = (53 * hash) + getSteerInput().hashCode();
           break;
         case 0:
         default:
@@ -3701,6 +4448,9 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
         if (compactionBuilder_ != null) {
           compactionBuilder_.clear();
         }
+        if (steerInputBuilder_ != null) {
+          steerInputBuilder_.clear();
+        }
         payloadCase_ = 0;
         payload_ = null;
         return this;
@@ -3758,6 +4508,10 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
             compactionBuilder_ != null) {
           result.payload_ = compactionBuilder_.build();
         }
+        if (payloadCase_ == 6 &&
+            steerInputBuilder_ != null) {
+          result.payload_ = steerInputBuilder_.build();
+        }
       }
 
       @java.lang.Override
@@ -3787,6 +4541,10 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
           }
           case COMPACTION: {
             mergeCompaction(other.getCompaction());
+            break;
+          }
+          case STEER_INPUT: {
+            mergeSteerInput(other.getSteerInput());
             break;
           }
           case PAYLOAD_NOT_SET: {
@@ -3847,6 +4605,13 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
                 payloadCase_ = 5;
                 break;
               } // case 42
+              case 50: {
+                input.readMessage(
+                    internalGetSteerInputFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                payloadCase_ = 6;
+                break;
+              } // case 50
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -4445,6 +5210,148 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
         payloadCase_ = 5;
         onChanged();
         return compactionBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilder<
+          talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput, talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.Builder, talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInputOrBuilder> steerInputBuilder_;
+      /**
+       * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+       * @return Whether the steerInput field is set.
+       */
+      @java.lang.Override
+      public boolean hasSteerInput() {
+        return payloadCase_ == 6;
+      }
+      /**
+       * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+       * @return The steerInput.
+       */
+      @java.lang.Override
+      public talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput getSteerInput() {
+        if (steerInputBuilder_ == null) {
+          if (payloadCase_ == 6) {
+            return (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) payload_;
+          }
+          return talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.getDefaultInstance();
+        } else {
+          if (payloadCase_ == 6) {
+            return steerInputBuilder_.getMessage();
+          }
+          return talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+       */
+      public Builder setSteerInput(talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput value) {
+        if (steerInputBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          payload_ = value;
+          onChanged();
+        } else {
+          steerInputBuilder_.setMessage(value);
+        }
+        payloadCase_ = 6;
+        return this;
+      }
+      /**
+       * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+       */
+      public Builder setSteerInput(
+          talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.Builder builderForValue) {
+        if (steerInputBuilder_ == null) {
+          payload_ = builderForValue.build();
+          onChanged();
+        } else {
+          steerInputBuilder_.setMessage(builderForValue.build());
+        }
+        payloadCase_ = 6;
+        return this;
+      }
+      /**
+       * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+       */
+      public Builder mergeSteerInput(talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput value) {
+        if (steerInputBuilder_ == null) {
+          if (payloadCase_ == 6 &&
+              payload_ != talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.getDefaultInstance()) {
+            payload_ = talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.newBuilder((talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) payload_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            payload_ = value;
+          }
+          onChanged();
+        } else {
+          if (payloadCase_ == 6) {
+            steerInputBuilder_.mergeFrom(value);
+          } else {
+            steerInputBuilder_.setMessage(value);
+          }
+        }
+        payloadCase_ = 6;
+        return this;
+      }
+      /**
+       * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+       */
+      public Builder clearSteerInput() {
+        if (steerInputBuilder_ == null) {
+          if (payloadCase_ == 6) {
+            payloadCase_ = 0;
+            payload_ = null;
+            onChanged();
+          }
+        } else {
+          if (payloadCase_ == 6) {
+            payloadCase_ = 0;
+            payload_ = null;
+          }
+          steerInputBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+       */
+      public talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.Builder getSteerInputBuilder() {
+        return internalGetSteerInputFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+       */
+      @java.lang.Override
+      public talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInputOrBuilder getSteerInputOrBuilder() {
+        if ((payloadCase_ == 6) && (steerInputBuilder_ != null)) {
+          return steerInputBuilder_.getMessageOrBuilder();
+        } else {
+          if (payloadCase_ == 6) {
+            return (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) payload_;
+          }
+          return talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput, talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.Builder, talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInputOrBuilder>
+          internalGetSteerInputFieldBuilder() {
+        if (steerInputBuilder_ == null) {
+          if (!(payloadCase_ == 6)) {
+            payload_ = talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.getDefaultInstance();
+          }
+          steerInputBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput, talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput.Builder, talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInputOrBuilder>(
+                  (talon.data.SessionJournalEntryOuterClass.SessionJournalEntryPayloadSteerInput) payload_,
+                  getParentForChildren(),
+                  isClean());
+          payload_ = null;
+        }
+        payloadCase_ = 6;
+        onChanged();
+        return steerInputBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:talon.data.SessionJournalEntryPayload)
@@ -6134,6 +7041,11 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_talon_data_SessionJournalEntryPayloadCompaction_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_talon_data_SessionJournalEntryPayloadSteerInput_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_talon_data_SessionJournalEntryPayloadSteerInput_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_talon_data_SessionJournalEntryPayload_descriptor;
   private static final
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -6164,30 +7076,34 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
       "olOutput\"@\n SessionJournalEntryPayloadCo" +
       "mmit\022\034\n\024committed_message_id\030\001 \001(\t\"N\n$Se" +
       "ssionJournalEntryPayloadCompaction\022&\n\007su" +
-      "mmary\030\001 \001(\0132\025.talon.data.ObjectRef\"\303\002\n\032S" +
-      "essionJournalEntryPayload\022I\n\014llm_respons" +
-      "e\030\001 \001(\01321.talon.data.SessionJournalEntry" +
-      "PayloadLlmResponseH\000\022G\n\013tool_result\030\002 \001(" +
-      "\01320.talon.data.SessionJournalEntryPayloa" +
-      "dToolResultH\000\022>\n\006commit\030\003 \001(\0132,.talon.da" +
-      "ta.SessionJournalEntryPayloadCommitH\000\022F\n" +
-      "\ncompaction\030\005 \001(\01320.talon.data.SessionJo" +
-      "urnalEntryPayloadCompactionH\000B\t\n\007payload" +
-      "\"\325\002\n\023SessionJournalEntry\022\025\n\rsubmission_i" +
-      "d\030\001 \001(\t\022\030\n\020journal_entry_id\030\002 \001(\t\022\022\n\natt" +
-      "empt_id\030\003 \001(\t\0220\n\005phase\030\004 \001(\0162!.talon.dat" +
-      "a.SessionExecutionPhase\0227\n\007payload\030\005 \001(\013" +
-      "2&.talon.data.SessionJournalEntryPayload" +
-      "\022\022\n\ncreated_at\030\006 \001(\003\022\022\n\nupdated_at\030\007 \001(\003" +
-      "\022\031\n\014committed_at\030\010 \001(\003H\000\210\001\001\022!\n\024committed" +
-      "_message_id\030\t \001(\tH\001\210\001\001B\017\n\r_committed_atB" +
-      "\027\n\025_committed_message_id*\342\001\n\025SessionExec" +
-      "utionPhase\022\'\n#SESSION_EXECUTION_PHASE_UN" +
-      "SPECIFIED\020\000\022(\n$SESSION_EXECUTION_PHASE_L" +
-      "LM_RESPONSE\020\001\022\'\n#SESSION_EXECUTION_PHASE" +
-      "_TOOL_RESULT\020\002\022%\n!SESSION_EXECUTION_PHAS" +
-      "E_COMMITTED\020\003\022&\n\"SESSION_EXECUTION_PHASE" +
-      "_COMPACTION\020\004b\006proto3"
+      "mmary\030\001 \001(\0132\025.talon.data.ObjectRef\";\n$Se" +
+      "ssionJournalEntryPayloadSteerInput\022\023\n\013me" +
+      "ssage_ids\030\001 \003(\t\"\214\003\n\032SessionJournalEntryP" +
+      "ayload\022I\n\014llm_response\030\001 \001(\01321.talon.dat" +
+      "a.SessionJournalEntryPayloadLlmResponseH" +
+      "\000\022G\n\013tool_result\030\002 \001(\01320.talon.data.Sess" +
+      "ionJournalEntryPayloadToolResultH\000\022>\n\006co" +
+      "mmit\030\003 \001(\0132,.talon.data.SessionJournalEn" +
+      "tryPayloadCommitH\000\022F\n\ncompaction\030\005 \001(\01320" +
+      ".talon.data.SessionJournalEntryPayloadCo" +
+      "mpactionH\000\022G\n\013steer_input\030\006 \001(\01320.talon." +
+      "data.SessionJournalEntryPayloadSteerInpu" +
+      "tH\000B\t\n\007payload\"\325\002\n\023SessionJournalEntry\022\025" +
+      "\n\rsubmission_id\030\001 \001(\t\022\030\n\020journal_entry_i" +
+      "d\030\002 \001(\t\022\022\n\nattempt_id\030\003 \001(\t\0220\n\005phase\030\004 \001" +
+      "(\0162!.talon.data.SessionExecutionPhase\0227\n" +
+      "\007payload\030\005 \001(\0132&.talon.data.SessionJourn" +
+      "alEntryPayload\022\022\n\ncreated_at\030\006 \001(\003\022\022\n\nup" +
+      "dated_at\030\007 \001(\003\022\031\n\014committed_at\030\010 \001(\003H\000\210\001" +
+      "\001\022!\n\024committed_message_id\030\t \001(\tH\001\210\001\001B\017\n\r" +
+      "_committed_atB\027\n\025_committed_message_id*\213" +
+      "\002\n\025SessionExecutionPhase\022\'\n#SESSION_EXEC" +
+      "UTION_PHASE_UNSPECIFIED\020\000\022(\n$SESSION_EXE" +
+      "CUTION_PHASE_LLM_RESPONSE\020\001\022\'\n#SESSION_E" +
+      "XECUTION_PHASE_TOOL_RESULT\020\002\022%\n!SESSION_" +
+      "EXECUTION_PHASE_COMMITTED\020\003\022&\n\"SESSION_E" +
+      "XECUTION_PHASE_COMPACTION\020\004\022\'\n#SESSION_E" +
+      "XECUTION_PHASE_STEER_INPUT\020\005b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -6219,14 +7135,20 @@ public final class SessionJournalEntryOuterClass extends com.google.protobuf.Gen
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_talon_data_SessionJournalEntryPayloadCompaction_descriptor,
         new java.lang.String[] { "Summary", });
-    internal_static_talon_data_SessionJournalEntryPayload_descriptor =
+    internal_static_talon_data_SessionJournalEntryPayloadSteerInput_descriptor =
       getDescriptor().getMessageType(4);
+    internal_static_talon_data_SessionJournalEntryPayloadSteerInput_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_talon_data_SessionJournalEntryPayloadSteerInput_descriptor,
+        new java.lang.String[] { "MessageIds", });
+    internal_static_talon_data_SessionJournalEntryPayload_descriptor =
+      getDescriptor().getMessageType(5);
     internal_static_talon_data_SessionJournalEntryPayload_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_talon_data_SessionJournalEntryPayload_descriptor,
-        new java.lang.String[] { "LlmResponse", "ToolResult", "Commit", "Compaction", "Payload", });
+        new java.lang.String[] { "LlmResponse", "ToolResult", "Commit", "Compaction", "SteerInput", "Payload", });
     internal_static_talon_data_SessionJournalEntry_descriptor =
-      getDescriptor().getMessageType(5);
+      getDescriptor().getMessageType(6);
     internal_static_talon_data_SessionJournalEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_talon_data_SessionJournalEntry_descriptor,

--- a/sdk/js/talon-client/src/gen/proto/data/session_journal_entry_pb.ts
+++ b/sdk/js/talon-client/src/gen/proto/data/session_journal_entry_pb.ts
@@ -50,6 +50,14 @@ export enum SessionExecutionPhase {
    * @generated from enum value: SESSION_EXECUTION_PHASE_COMPACTION = 4;
    */
   COMPACTION = 4,
+
+  /**
+   * Interactive user input was absorbed into the active execution after a
+   * completed tool-call batch.
+   *
+   * @generated from enum value: SESSION_EXECUTION_PHASE_STEER_INPUT = 5;
+   */
+  STEER_INPUT = 5,
 }
 // Retrieve enum metadata with: proto3.getEnumType(SessionExecutionPhase)
 proto3.util.setEnumType(SessionExecutionPhase, "talon.data.SessionExecutionPhase", [
@@ -58,6 +66,7 @@ proto3.util.setEnumType(SessionExecutionPhase, "talon.data.SessionExecutionPhase
   { no: 2, name: "SESSION_EXECUTION_PHASE_TOOL_RESULT" },
   { no: 3, name: "SESSION_EXECUTION_PHASE_COMMITTED" },
   { no: 4, name: "SESSION_EXECUTION_PHASE_COMPACTION" },
+  { no: 5, name: "SESSION_EXECUTION_PHASE_STEER_INPUT" },
 ]);
 
 /**
@@ -235,6 +244,46 @@ export class SessionJournalEntryPayloadCompaction extends Message<SessionJournal
 }
 
 /**
+ * @generated from message talon.data.SessionJournalEntryPayloadSteerInput
+ */
+export class SessionJournalEntryPayloadSteerInput extends Message<SessionJournalEntryPayloadSteerInput> {
+  /**
+   * Canonical user SessionMessage ids appended to the active execution
+   * context, in admission order.
+   *
+   * @generated from field: repeated string message_ids = 1;
+   */
+  messageIds: string[] = [];
+
+  constructor(data?: PartialMessage<SessionJournalEntryPayloadSteerInput>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "talon.data.SessionJournalEntryPayloadSteerInput";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "message_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SessionJournalEntryPayloadSteerInput {
+    return new SessionJournalEntryPayloadSteerInput().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): SessionJournalEntryPayloadSteerInput {
+    return new SessionJournalEntryPayloadSteerInput().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): SessionJournalEntryPayloadSteerInput {
+    return new SessionJournalEntryPayloadSteerInput().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: SessionJournalEntryPayloadSteerInput | PlainMessage<SessionJournalEntryPayloadSteerInput> | undefined, b: SessionJournalEntryPayloadSteerInput | PlainMessage<SessionJournalEntryPayloadSteerInput> | undefined): boolean {
+    return proto3.util.equals(SessionJournalEntryPayloadSteerInput, a, b);
+  }
+}
+
+/**
  * @generated from message talon.data.SessionJournalEntryPayload
  */
 export class SessionJournalEntryPayload extends Message<SessionJournalEntryPayload> {
@@ -265,6 +314,12 @@ export class SessionJournalEntryPayload extends Message<SessionJournalEntryPaylo
      */
     value: SessionJournalEntryPayloadCompaction;
     case: "compaction";
+  } | {
+    /**
+     * @generated from field: talon.data.SessionJournalEntryPayloadSteerInput steer_input = 6;
+     */
+    value: SessionJournalEntryPayloadSteerInput;
+    case: "steerInput";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   constructor(data?: PartialMessage<SessionJournalEntryPayload>) {
@@ -279,6 +334,7 @@ export class SessionJournalEntryPayload extends Message<SessionJournalEntryPaylo
     { no: 2, name: "tool_result", kind: "message", T: SessionJournalEntryPayloadToolResult, oneof: "payload" },
     { no: 3, name: "commit", kind: "message", T: SessionJournalEntryPayloadCommit, oneof: "payload" },
     { no: 5, name: "compaction", kind: "message", T: SessionJournalEntryPayloadCompaction, oneof: "payload" },
+    { no: 6, name: "steer_input", kind: "message", T: SessionJournalEntryPayloadSteerInput, oneof: "payload" },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SessionJournalEntryPayload {

--- a/sdk/python/talon-client/src/talon_client/data.py
+++ b/sdk/python/talon-client/src/talon_client/data.py
@@ -6,7 +6,7 @@ from talon_client.proto.data.data_pb2 import MessageRole, ROLE_UNSPECIFIED, ROLE
 from talon_client.proto.data.routing_pb2 import ResourceRef, SessionMessageConsumer, ChannelMessageConsumer, WorkflowMessageConsumer, MessageConsumer
 from talon_client.proto.data.search_pb2 import DocumentSource, DocumentRef, Document
 from talon_client.proto.data.session_submission_pb2 import SessionSubmissionStatus, SESSION_SUBMISSION_STATUS_UNSPECIFIED, SESSION_SUBMISSION_STATUS_PENDING, SESSION_SUBMISSION_STATUS_CLAIMED, SESSION_SUBMISSION_STATUS_COMMITTED, SESSION_SUBMISSION_STATUS_FAILED, SESSION_SUBMISSION_STATUS_INTERRUPTED, SessionSubmissionKind, SESSION_SUBMISSION_KIND_USER_TURN, SESSION_SUBMISSION_KIND_COMPACT, SessionSubmission
-from talon_client.proto.data.session_journal_entry_pb2 import SessionExecutionPhase, SESSION_EXECUTION_PHASE_UNSPECIFIED, SESSION_EXECUTION_PHASE_LLM_RESPONSE, SESSION_EXECUTION_PHASE_TOOL_RESULT, SESSION_EXECUTION_PHASE_COMMITTED, SESSION_EXECUTION_PHASE_COMPACTION, SessionJournalEntryPayloadLlmResponse, SessionJournalEntryPayloadToolResult, SessionJournalEntryPayloadCommit, SessionJournalEntryPayloadCompaction, SessionJournalEntryPayload, SessionJournalEntry
+from talon_client.proto.data.session_journal_entry_pb2 import SessionExecutionPhase, SESSION_EXECUTION_PHASE_UNSPECIFIED, SESSION_EXECUTION_PHASE_LLM_RESPONSE, SESSION_EXECUTION_PHASE_TOOL_RESULT, SESSION_EXECUTION_PHASE_COMMITTED, SESSION_EXECUTION_PHASE_COMPACTION, SESSION_EXECUTION_PHASE_STEER_INPUT, SessionJournalEntryPayloadLlmResponse, SessionJournalEntryPayloadToolResult, SessionJournalEntryPayloadCommit, SessionJournalEntryPayloadCompaction, SessionJournalEntryPayloadSteerInput, SessionJournalEntryPayload, SessionJournalEntry
 
 __all__ = [
     "ApiKeyGrant",
@@ -83,10 +83,12 @@ __all__ = [
     "SESSION_EXECUTION_PHASE_TOOL_RESULT",
     "SESSION_EXECUTION_PHASE_COMMITTED",
     "SESSION_EXECUTION_PHASE_COMPACTION",
+    "SESSION_EXECUTION_PHASE_STEER_INPUT",
     "SessionJournalEntryPayloadLlmResponse",
     "SessionJournalEntryPayloadToolResult",
     "SessionJournalEntryPayloadCommit",
     "SessionJournalEntryPayloadCompaction",
+    "SessionJournalEntryPayloadSteerInput",
     "SessionJournalEntryPayload",
     "SessionJournalEntry",
 ]

--- a/sdk/python/talon-client/src/talon_client/proto/data/session_journal_entry_pb2.py
+++ b/sdk/python/talon-client/src/talon_client/proto/data/session_journal_entry_pb2.py
@@ -26,15 +26,15 @@ from talon_client.proto.data import data_pb2 as proto_dot_data_dot_data__pb2
 from talon_client.proto.harness import llm_pb2 as proto_dot_harness_dot_llm__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n&proto/data/session_journal_entry.proto\x12\ntalon.data\x1a\x15proto/data/data.proto\x1a\x17proto/harness/llm.proto\"V\n%SessionJournalEntryPayloadLlmResponse\x12-\n\x08response\x18\x01 \x01(\x0b\x32\x1b.talon.harness.ChatResponse\"\xb1\x01\n$SessionJournalEntryPayloadToolResult\x12\x14\n\x0ctool_call_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0e\n\x06output\x18\x03 \x01(\t\x12%\n\x06object\x18\x04 \x01(\x0b\x32\x15.talon.data.ObjectRef\x12.\n\x0btool_output\x18\x05 \x01(\x0b\x32\x19.talon.harness.ToolOutput\"@\n SessionJournalEntryPayloadCommit\x12\x1c\n\x14\x63ommitted_message_id\x18\x01 \x01(\t\"N\n$SessionJournalEntryPayloadCompaction\x12&\n\x07summary\x18\x01 \x01(\x0b\x32\x15.talon.data.ObjectRef\"\xc3\x02\n\x1aSessionJournalEntryPayload\x12I\n\x0cllm_response\x18\x01 \x01(\x0b\x32\x31.talon.data.SessionJournalEntryPayloadLlmResponseH\x00\x12G\n\x0btool_result\x18\x02 \x01(\x0b\x32\x30.talon.data.SessionJournalEntryPayloadToolResultH\x00\x12>\n\x06\x63ommit\x18\x03 \x01(\x0b\x32,.talon.data.SessionJournalEntryPayloadCommitH\x00\x12\x46\n\ncompaction\x18\x05 \x01(\x0b\x32\x30.talon.data.SessionJournalEntryPayloadCompactionH\x00\x42\t\n\x07payload\"\xd5\x02\n\x13SessionJournalEntry\x12\x15\n\rsubmission_id\x18\x01 \x01(\t\x12\x18\n\x10journal_entry_id\x18\x02 \x01(\t\x12\x12\n\nattempt_id\x18\x03 \x01(\t\x12\x30\n\x05phase\x18\x04 \x01(\x0e\x32!.talon.data.SessionExecutionPhase\x12\x37\n\x07payload\x18\x05 \x01(\x0b\x32&.talon.data.SessionJournalEntryPayload\x12\x12\n\ncreated_at\x18\x06 \x01(\x03\x12\x12\n\nupdated_at\x18\x07 \x01(\x03\x12\x19\n\x0c\x63ommitted_at\x18\x08 \x01(\x03H\x00\x88\x01\x01\x12!\n\x14\x63ommitted_message_id\x18\t \x01(\tH\x01\x88\x01\x01\x42\x0f\n\r_committed_atB\x17\n\x15_committed_message_id*\xe2\x01\n\x15SessionExecutionPhase\x12\'\n#SESSION_EXECUTION_PHASE_UNSPECIFIED\x10\x00\x12(\n$SESSION_EXECUTION_PHASE_LLM_RESPONSE\x10\x01\x12\'\n#SESSION_EXECUTION_PHASE_TOOL_RESULT\x10\x02\x12%\n!SESSION_EXECUTION_PHASE_COMMITTED\x10\x03\x12&\n\"SESSION_EXECUTION_PHASE_COMPACTION\x10\x04\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n&proto/data/session_journal_entry.proto\x12\ntalon.data\x1a\x15proto/data/data.proto\x1a\x17proto/harness/llm.proto\"V\n%SessionJournalEntryPayloadLlmResponse\x12-\n\x08response\x18\x01 \x01(\x0b\x32\x1b.talon.harness.ChatResponse\"\xb1\x01\n$SessionJournalEntryPayloadToolResult\x12\x14\n\x0ctool_call_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0e\n\x06output\x18\x03 \x01(\t\x12%\n\x06object\x18\x04 \x01(\x0b\x32\x15.talon.data.ObjectRef\x12.\n\x0btool_output\x18\x05 \x01(\x0b\x32\x19.talon.harness.ToolOutput\"@\n SessionJournalEntryPayloadCommit\x12\x1c\n\x14\x63ommitted_message_id\x18\x01 \x01(\t\"N\n$SessionJournalEntryPayloadCompaction\x12&\n\x07summary\x18\x01 \x01(\x0b\x32\x15.talon.data.ObjectRef\";\n$SessionJournalEntryPayloadSteerInput\x12\x13\n\x0bmessage_ids\x18\x01 \x03(\t\"\x8c\x03\n\x1aSessionJournalEntryPayload\x12I\n\x0cllm_response\x18\x01 \x01(\x0b\x32\x31.talon.data.SessionJournalEntryPayloadLlmResponseH\x00\x12G\n\x0btool_result\x18\x02 \x01(\x0b\x32\x30.talon.data.SessionJournalEntryPayloadToolResultH\x00\x12>\n\x06\x63ommit\x18\x03 \x01(\x0b\x32,.talon.data.SessionJournalEntryPayloadCommitH\x00\x12\x46\n\ncompaction\x18\x05 \x01(\x0b\x32\x30.talon.data.SessionJournalEntryPayloadCompactionH\x00\x12G\n\x0bsteer_input\x18\x06 \x01(\x0b\x32\x30.talon.data.SessionJournalEntryPayloadSteerInputH\x00\x42\t\n\x07payload\"\xd5\x02\n\x13SessionJournalEntry\x12\x15\n\rsubmission_id\x18\x01 \x01(\t\x12\x18\n\x10journal_entry_id\x18\x02 \x01(\t\x12\x12\n\nattempt_id\x18\x03 \x01(\t\x12\x30\n\x05phase\x18\x04 \x01(\x0e\x32!.talon.data.SessionExecutionPhase\x12\x37\n\x07payload\x18\x05 \x01(\x0b\x32&.talon.data.SessionJournalEntryPayload\x12\x12\n\ncreated_at\x18\x06 \x01(\x03\x12\x12\n\nupdated_at\x18\x07 \x01(\x03\x12\x19\n\x0c\x63ommitted_at\x18\x08 \x01(\x03H\x00\x88\x01\x01\x12!\n\x14\x63ommitted_message_id\x18\t \x01(\tH\x01\x88\x01\x01\x42\x0f\n\r_committed_atB\x17\n\x15_committed_message_id*\x8b\x02\n\x15SessionExecutionPhase\x12\'\n#SESSION_EXECUTION_PHASE_UNSPECIFIED\x10\x00\x12(\n$SESSION_EXECUTION_PHASE_LLM_RESPONSE\x10\x01\x12\'\n#SESSION_EXECUTION_PHASE_TOOL_RESULT\x10\x02\x12%\n!SESSION_EXECUTION_PHASE_COMMITTED\x10\x03\x12&\n\"SESSION_EXECUTION_PHASE_COMPACTION\x10\x04\x12\'\n#SESSION_EXECUTION_PHASE_STEER_INPUT\x10\x05\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'proto.data.session_journal_entry_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_SESSIONEXECUTIONPHASE']._serialized_start=1187
-  _globals['_SESSIONEXECUTIONPHASE']._serialized_end=1413
+  _globals['_SESSIONEXECUTIONPHASE']._serialized_start=1321
+  _globals['_SESSIONEXECUTIONPHASE']._serialized_end=1588
   _globals['_SESSIONJOURNALENTRYPAYLOADLLMRESPONSE']._serialized_start=102
   _globals['_SESSIONJOURNALENTRYPAYLOADLLMRESPONSE']._serialized_end=188
   _globals['_SESSIONJOURNALENTRYPAYLOADTOOLRESULT']._serialized_start=191
@@ -43,8 +43,10 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_SESSIONJOURNALENTRYPAYLOADCOMMIT']._serialized_end=434
   _globals['_SESSIONJOURNALENTRYPAYLOADCOMPACTION']._serialized_start=436
   _globals['_SESSIONJOURNALENTRYPAYLOADCOMPACTION']._serialized_end=514
-  _globals['_SESSIONJOURNALENTRYPAYLOAD']._serialized_start=517
-  _globals['_SESSIONJOURNALENTRYPAYLOAD']._serialized_end=840
-  _globals['_SESSIONJOURNALENTRY']._serialized_start=843
-  _globals['_SESSIONJOURNALENTRY']._serialized_end=1184
+  _globals['_SESSIONJOURNALENTRYPAYLOADSTEERINPUT']._serialized_start=516
+  _globals['_SESSIONJOURNALENTRYPAYLOADSTEERINPUT']._serialized_end=575
+  _globals['_SESSIONJOURNALENTRYPAYLOAD']._serialized_start=578
+  _globals['_SESSIONJOURNALENTRYPAYLOAD']._serialized_end=974
+  _globals['_SESSIONJOURNALENTRY']._serialized_start=977
+  _globals['_SESSIONJOURNALENTRY']._serialized_end=1318
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/talon-client/src/talon_client/proto/data/session_journal_entry_pb2.pyi
+++ b/sdk/python/talon-client/src/talon_client/proto/data/session_journal_entry_pb2.pyi
@@ -1,9 +1,10 @@
 from talon_client.proto.data import data_pb2 as _data_pb2
 from talon_client.proto.harness import llm_pb2 as _llm_pb2
+from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from collections.abc import Mapping as _Mapping
+from collections.abc import Iterable as _Iterable, Mapping as _Mapping
 from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
 
 DESCRIPTOR: _descriptor.FileDescriptor
@@ -15,11 +16,13 @@ class SessionExecutionPhase(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     SESSION_EXECUTION_PHASE_TOOL_RESULT: _ClassVar[SessionExecutionPhase]
     SESSION_EXECUTION_PHASE_COMMITTED: _ClassVar[SessionExecutionPhase]
     SESSION_EXECUTION_PHASE_COMPACTION: _ClassVar[SessionExecutionPhase]
+    SESSION_EXECUTION_PHASE_STEER_INPUT: _ClassVar[SessionExecutionPhase]
 SESSION_EXECUTION_PHASE_UNSPECIFIED: SessionExecutionPhase
 SESSION_EXECUTION_PHASE_LLM_RESPONSE: SessionExecutionPhase
 SESSION_EXECUTION_PHASE_TOOL_RESULT: SessionExecutionPhase
 SESSION_EXECUTION_PHASE_COMMITTED: SessionExecutionPhase
 SESSION_EXECUTION_PHASE_COMPACTION: SessionExecutionPhase
+SESSION_EXECUTION_PHASE_STEER_INPUT: SessionExecutionPhase
 
 class SessionJournalEntryPayloadLlmResponse(_message.Message):
     __slots__ = ("response",)
@@ -53,17 +56,25 @@ class SessionJournalEntryPayloadCompaction(_message.Message):
     summary: _data_pb2.ObjectRef
     def __init__(self, summary: _Optional[_Union[_data_pb2.ObjectRef, _Mapping]] = ...) -> None: ...
 
+class SessionJournalEntryPayloadSteerInput(_message.Message):
+    __slots__ = ("message_ids",)
+    MESSAGE_IDS_FIELD_NUMBER: _ClassVar[int]
+    message_ids: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, message_ids: _Optional[_Iterable[str]] = ...) -> None: ...
+
 class SessionJournalEntryPayload(_message.Message):
-    __slots__ = ("llm_response", "tool_result", "commit", "compaction")
+    __slots__ = ("llm_response", "tool_result", "commit", "compaction", "steer_input")
     LLM_RESPONSE_FIELD_NUMBER: _ClassVar[int]
     TOOL_RESULT_FIELD_NUMBER: _ClassVar[int]
     COMMIT_FIELD_NUMBER: _ClassVar[int]
     COMPACTION_FIELD_NUMBER: _ClassVar[int]
+    STEER_INPUT_FIELD_NUMBER: _ClassVar[int]
     llm_response: SessionJournalEntryPayloadLlmResponse
     tool_result: SessionJournalEntryPayloadToolResult
     commit: SessionJournalEntryPayloadCommit
     compaction: SessionJournalEntryPayloadCompaction
-    def __init__(self, llm_response: _Optional[_Union[SessionJournalEntryPayloadLlmResponse, _Mapping]] = ..., tool_result: _Optional[_Union[SessionJournalEntryPayloadToolResult, _Mapping]] = ..., commit: _Optional[_Union[SessionJournalEntryPayloadCommit, _Mapping]] = ..., compaction: _Optional[_Union[SessionJournalEntryPayloadCompaction, _Mapping]] = ...) -> None: ...
+    steer_input: SessionJournalEntryPayloadSteerInput
+    def __init__(self, llm_response: _Optional[_Union[SessionJournalEntryPayloadLlmResponse, _Mapping]] = ..., tool_result: _Optional[_Union[SessionJournalEntryPayloadToolResult, _Mapping]] = ..., commit: _Optional[_Union[SessionJournalEntryPayloadCommit, _Mapping]] = ..., compaction: _Optional[_Union[SessionJournalEntryPayloadCompaction, _Mapping]] = ..., steer_input: _Optional[_Union[SessionJournalEntryPayloadSteerInput, _Mapping]] = ...) -> None: ...
 
 class SessionJournalEntry(_message.Message):
     __slots__ = ("submission_id", "journal_entry_id", "attempt_id", "phase", "payload", "created_at", "updated_at", "committed_at", "committed_message_id")

--- a/sdk/rust/talon-client/src/generated/talon.data.rs
+++ b/sdk/rust/talon-client/src/generated/talon.data.rs
@@ -760,8 +760,15 @@ pub struct SessionJournalEntryPayloadCompaction {
     pub summary: ::core::option::Option<ObjectRef>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SessionJournalEntryPayloadSteerInput {
+    /// Canonical user SessionMessage ids appended to the active execution
+    /// context, in admission order.
+    #[prost(string, repeated, tag = "1")]
+    pub message_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SessionJournalEntryPayload {
-    #[prost(oneof = "session_journal_entry_payload::Payload", tags = "1, 2, 3, 5")]
+    #[prost(oneof = "session_journal_entry_payload::Payload", tags = "1, 2, 3, 5, 6")]
     pub payload: ::core::option::Option<session_journal_entry_payload::Payload>,
 }
 /// Nested message and enum types in `SessionJournalEntryPayload`.
@@ -776,6 +783,8 @@ pub mod session_journal_entry_payload {
         Commit(super::SessionJournalEntryPayloadCommit),
         #[prost(message, tag = "5")]
         Compaction(super::SessionJournalEntryPayloadCompaction),
+        #[prost(message, tag = "6")]
+        SteerInput(super::SessionJournalEntryPayloadSteerInput),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -819,6 +828,9 @@ pub enum SessionExecutionPhase {
     /// Durable model context compaction completed. The journal entry references
     /// an immutable summary object without storing a provider transcript snapshot.
     Compaction = 4,
+    /// Interactive user input was absorbed into the active execution after a
+    /// completed tool-call batch.
+    SteerInput = 5,
 }
 impl SessionExecutionPhase {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -832,6 +844,7 @@ impl SessionExecutionPhase {
             Self::ToolResult => "SESSION_EXECUTION_PHASE_TOOL_RESULT",
             Self::Committed => "SESSION_EXECUTION_PHASE_COMMITTED",
             Self::Compaction => "SESSION_EXECUTION_PHASE_COMPACTION",
+            Self::SteerInput => "SESSION_EXECUTION_PHASE_STEER_INPUT",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -842,6 +855,7 @@ impl SessionExecutionPhase {
             "SESSION_EXECUTION_PHASE_TOOL_RESULT" => Some(Self::ToolResult),
             "SESSION_EXECUTION_PHASE_COMMITTED" => Some(Self::Committed),
             "SESSION_EXECUTION_PHASE_COMPACTION" => Some(Self::Compaction),
+            "SESSION_EXECUTION_PHASE_STEER_INPUT" => Some(Self::SteerInput),
             _ => None,
         }
     }

--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -648,6 +648,25 @@ pub async fn send_message(
                 kv, ns, agent, session_id, user_msg, now,
             )
             .await?;
+            if let Err(err) = crate::control::session_queue::dispatch_next_queued_message(
+                kv,
+                pubsub,
+                ns,
+                agent,
+                session_id,
+                crate::control::session_queue::STEER_QUEUE,
+                now,
+            )
+            .await
+            {
+                tracing::warn!(
+                    namespace = %ns,
+                    agent = %agent,
+                    session = %session_id,
+                    error = %err,
+                    "failed to recheck queued interactive message after admission"
+                );
+            }
             return Ok(queued.entry_id);
         }
     }
@@ -922,6 +941,12 @@ pub async fn send_session_message(
     Ok(submission_id)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum A2aSessionMessageDisposition {
+    Submitted,
+    Queued,
+}
+
 /// A2A requests are serialized turns. If a session is already busy, retain
 /// the request in NEXT and let the normal release path dispatch it later.
 pub async fn send_or_queue_a2a_session_message(
@@ -932,9 +957,9 @@ pub async fn send_or_queue_a2a_session_message(
     session_id: &str,
     user_msg: data_proto::SessionMessage,
     now: DateTime<Utc>,
-) -> Result<String> {
+) -> Result<(String, A2aSessionMessageDisposition)> {
     match send_session_message(kv, pubsub, ns, agent, session_id, user_msg.clone(), now).await {
-        Ok(submission_id) => Ok(submission_id),
+        Ok(submission_id) => Ok((submission_id, A2aSessionMessageDisposition::Submitted)),
         Err(err)
             if err
                 .downcast_ref::<SessionCurrentlyProcessingError>()
@@ -954,7 +979,7 @@ pub async fn send_or_queue_a2a_session_message(
                 now,
             )
             .await?;
-            Ok(queued.id)
+            Ok((queued.id, A2aSessionMessageDisposition::Queued))
         }
         Err(err) => Err(err),
     }

--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -634,6 +634,24 @@ pub async fn send_message(
         }],
     };
 
+    // Interactive ingress is steerable while a healthy turn is running. The
+    // active worker will absorb this durable queue entry at its next tool
+    // boundary; idle sessions continue through the normal submission path.
+    if let Some(session) = kv
+        .get_msg::<data_proto::Session>(&keys::session(ns, agent, session_id))
+        .await?
+    {
+        if session.status == "PROCESSING"
+            && now_micros.saturating_sub(session.last_active) <= session_processing_timeout_micros()
+        {
+            let queued = crate::control::session_queue::queue_interactive_session_message(
+                kv, ns, agent, session_id, user_msg, now,
+            )
+            .await?;
+            return Ok(queued.entry_id);
+        }
+    }
+
     send_session_message(kv, pubsub, ns, agent, session_id, user_msg, now).await
 }
 
@@ -902,6 +920,44 @@ pub async fn send_session_message(
         "Queued scheduled message for session dispatch"
     );
     Ok(submission_id)
+}
+
+/// A2A requests are serialized turns. If a session is already busy, retain
+/// the request in NEXT and let the normal release path dispatch it later.
+pub async fn send_or_queue_a2a_session_message(
+    kv: &dyn KeyValueStore,
+    pubsub: &dyn MessagePublisher,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+    user_msg: data_proto::SessionMessage,
+    now: DateTime<Utc>,
+) -> Result<String> {
+    match send_session_message(kv, pubsub, ns, agent, session_id, user_msg.clone(), now).await {
+        Ok(submission_id) => Ok(submission_id),
+        Err(err)
+            if err
+                .downcast_ref::<SessionCurrentlyProcessingError>()
+                .is_some() =>
+        {
+            let mut queued = user_msg;
+            if queued.id.is_empty() {
+                queued.id = crate::control::uuid::session_message_id();
+            }
+            crate::control::session_queue::queue_session_message(
+                kv,
+                ns,
+                agent,
+                session_id,
+                crate::control::session_queue::NEXT_QUEUE,
+                queued.clone(),
+                now,
+            )
+            .await?;
+            Ok(queued.id)
+        }
+        Err(err) => Err(err),
+    }
 }
 
 /// Queue a maintenance compaction without creating a synthetic user message.
@@ -1557,7 +1613,7 @@ mod tests {
         assert_eq!(submission.completed_at, None);
         assert_eq!(submission.committed_message_id, None);
 
-        let err = send_message(
+        let queued_entry_id = send_message(
             cp.kv.as_ref(),
             cp.pubsub.as_ref(),
             "conic:test",
@@ -1568,10 +1624,23 @@ mod tests {
             now,
         )
         .await
-        .unwrap_err();
-        assert!(err
-            .downcast_ref::<SessionCurrentlyProcessingError>()
-            .is_some());
+        .unwrap();
+        assert!(!queued_entry_id.is_empty());
+        assert_eq!(
+            kv.list_keys(
+                &keys::session_queue_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                    crate::control::session_queue::STEER_QUEUE,
+                ),
+                None,
+            )
+            .await
+            .unwrap()
+            .len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/control/session_queue.rs
+++ b/src/control/session_queue.rs
@@ -82,7 +82,25 @@ pub async fn prepare_steer_batch(
             continue;
         };
         let original_bytes = bytes.clone();
-        let mut message = data_proto::SessionMessage::decode(bytes.as_slice())?;
+        let mut message = match data_proto::SessionMessage::decode(bytes.as_slice()) {
+            Ok(message) => message,
+            Err(error) => {
+                tracing::warn!(
+                    %entry_id,
+                    error = %error,
+                    "dropping undecodable steer queue entry"
+                );
+                kv.delete(&keys::session_queue_entry(
+                    ns,
+                    agent,
+                    session_id,
+                    STEER_QUEUE,
+                    &entry_id,
+                ))
+                .await?;
+                continue;
+            }
+        };
         let text_chars = message
             .parts
             .iter()
@@ -120,7 +138,8 @@ pub async fn prepare_steer_batch(
             {
                 // Another worker claimed and canonicalized this entry. It will
                 // either commit it or make it visible on the next attempt.
-                continue;
+                // Stop here so the batch stays contiguous in admission order.
+                break;
             }
             message_id
         } else {
@@ -263,6 +282,27 @@ pub async fn queue_interactive_session_message(
         _ => NEXT_QUEUE,
     };
     queue_session_message(kv, ns, agent, session_id, queue, message, now).await
+}
+
+/// Move steering entries to NEXT when the active attempt has failed. The
+/// destination is written before the source is deleted so a crash can leave a
+/// duplicate queue copy, but never lose the input.
+pub async fn reclassify_steer_queue_to_next(
+    kv: &dyn KeyValueStore,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+) -> Result<()> {
+    let steer_prefix = keys::session_queue_prefix(ns, agent, session_id, STEER_QUEUE);
+    for (entry_key, bytes) in kv.list_entries(&steer_prefix, None).await? {
+        let Some(entry_id) = keys::direct_child_name(&steer_prefix, &entry_key) else {
+            continue;
+        };
+        let next_key = keys::session_queue_entry(ns, agent, session_id, NEXT_QUEUE, &entry_id);
+        kv.compare_and_swap(&next_key, None, &bytes).await?;
+        kv.delete(&entry_key).await?;
+    }
+    Ok(())
 }
 
 pub async fn dispatch_next_queued_message(
@@ -642,6 +682,108 @@ mod tests {
             .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn steer_batch_drops_malformed_entries_and_keeps_valid_entries() {
+        let kv = MockKvStore::new();
+        put_session(&kv, "PROCESSING").await;
+        let malformed_id = "00000000000000000001-malformed";
+        kv.set(
+            &keys::session_queue_entry(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                STEER_QUEUE,
+                malformed_id,
+            ),
+            b"not-a-session-message",
+        )
+        .await
+        .unwrap();
+        queue_text_message(
+            &kv,
+            "Tenant:acme:Ops",
+            "agent",
+            "session-1",
+            STEER_QUEUE,
+            "valid",
+            Default::default(),
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+
+        let batch = prepare_steer_batch(
+            &kv,
+            "Tenant:acme:Ops",
+            "agent",
+            "session-1",
+            8,
+            100,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].message.parts[0].content, "valid");
+        assert!(kv
+            .get(&keys::session_queue_entry(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                STEER_QUEUE,
+                malformed_id,
+            ))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn reclassify_steer_entries_to_next_preserves_entries() {
+        let kv = MockKvStore::new();
+        put_session(&kv, "ERROR").await;
+        let queued = queue_text_message(
+            &kv,
+            "Tenant:acme:Ops",
+            "agent",
+            "session-1",
+            STEER_QUEUE,
+            "recover me",
+            Default::default(),
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+
+        reclassify_steer_queue_to_next(&kv, "Tenant:acme:Ops", "agent", "session-1")
+            .await
+            .unwrap();
+
+        assert!(kv
+            .get(&keys::session_queue_entry(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                STEER_QUEUE,
+                &queued.entry_id,
+            ))
+            .await
+            .unwrap()
+            .is_none());
+        assert!(kv
+            .get(&keys::session_queue_entry(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                NEXT_QUEUE,
+                &queued.entry_id,
+            ))
+            .await
+            .unwrap()
+            .is_some());
     }
 
     #[tokio::test]

--- a/src/control/session_queue.rs
+++ b/src/control/session_queue.rs
@@ -16,6 +16,8 @@ pub const A2A_QUEUE: &str = "a2a";
 pub const NEXT_QUEUE: &str = "next";
 pub const STEER_QUEUE: &str = "steer";
 const MAX_QUEUE_DISPATCH_CAS_RETRIES: usize = 8;
+pub const DEFAULT_STEER_BATCH_MAX_MESSAGES: usize = 8;
+pub const DEFAULT_STEER_BATCH_MAX_CHARS: usize = 16_000;
 
 fn validate_queue_name(queue: &str) -> Result<()> {
     match queue {
@@ -43,6 +45,115 @@ pub struct DispatchedQueuedSessionMessage {
     pub entry_id: String,
     pub message_id: String,
     pub submission_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SteeredQueuedSessionMessage {
+    pub entry_id: String,
+    pub message_id: String,
+    pub message: data_proto::SessionMessage,
+}
+
+/// Materialize a bounded, ordered batch of interactive messages for the
+/// active worker. Queue entries remain present until the caller has written
+/// the steering journal boundary, so a crash cannot lose an input between
+/// canonicalization and durable execution state.
+pub async fn prepare_steer_batch(
+    kv: &dyn KeyValueStore,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+    max_messages: usize,
+    max_chars: usize,
+    now: DateTime<Utc>,
+) -> Result<Vec<SteeredQueuedSessionMessage>> {
+    validate_queue_name(STEER_QUEUE)?;
+    if max_messages == 0 || max_chars == 0 {
+        return Ok(Vec::new());
+    }
+    let prefix = keys::session_queue_prefix(ns, agent, session_id, STEER_QUEUE);
+    let entries = kv
+        .list_entries(&prefix, Some(ListOptions::default().limit(max_messages)))
+        .await?;
+    let mut total_chars = 0usize;
+    let mut prepared = Vec::with_capacity(entries.len());
+    for (entry_key, bytes) in entries {
+        let Some(entry_id) = keys::direct_child_name(&prefix, &entry_key) else {
+            continue;
+        };
+        let original_bytes = bytes.clone();
+        let mut message = data_proto::SessionMessage::decode(bytes.as_slice())?;
+        let text_chars = message
+            .parts
+            .iter()
+            .map(|part| part.content.chars().count())
+            .sum::<usize>();
+        if !prepared.is_empty() && total_chars.saturating_add(text_chars) > max_chars {
+            break;
+        }
+        let message_id = if message.id.is_empty() {
+            let message_id = crate::control::uuid::session_message_id();
+            message.id = message_id.clone();
+            if message.created_at == 0 {
+                message.created_at = now.timestamp_micros();
+            }
+            for (index, part) in message.parts.iter_mut().enumerate() {
+                if part.id.is_empty() {
+                    part.id = format!("{index:06}");
+                }
+                if part.created_at == 0 {
+                    part.created_at = message.created_at;
+                }
+            }
+            kv.set_msg(
+                &keys::session_message(ns, agent, session_id, &message_id),
+                &message,
+            )
+            .await?;
+            if !kv
+                .compare_and_swap(
+                    &keys::session_queue_entry(ns, agent, session_id, STEER_QUEUE, &entry_id),
+                    Some(original_bytes.as_slice()),
+                    &message.encode_to_vec(),
+                )
+                .await?
+            {
+                // Another worker claimed and canonicalized this entry. It will
+                // either commit it or make it visible on the next attempt.
+                continue;
+            }
+            message_id
+        } else {
+            message.id.clone()
+        };
+        total_chars = total_chars.saturating_add(text_chars);
+        prepared.push(SteeredQueuedSessionMessage {
+            entry_id,
+            message_id,
+            message,
+        });
+    }
+    Ok(prepared)
+}
+
+pub async fn commit_steer_batch(
+    kv: &dyn KeyValueStore,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+    batch: &[SteeredQueuedSessionMessage],
+) -> Result<()> {
+    for item in batch {
+        kv.delete(&keys::session_queue_entry(
+            ns,
+            agent,
+            session_id,
+            STEER_QUEUE,
+            &item.entry_id,
+        ))
+        .await?;
+    }
+    Ok(())
 }
 
 pub async fn queue_text_message(
@@ -126,6 +237,32 @@ pub async fn queue_session_message(
         entry_id,
         message_id: String::new(),
     })
+}
+
+/// Route an interactive ingress message to the active turn when one is
+/// healthy; otherwise leave it in NEXT so it starts the next turn.
+pub async fn queue_interactive_session_message(
+    kv: &dyn KeyValueStore,
+    ns: &str,
+    agent: &str,
+    session_id: &str,
+    message: data_proto::SessionMessage,
+    now: DateTime<Utc>,
+) -> Result<QueuedSessionMessage> {
+    let queue = match kv
+        .get_msg::<data_proto::Session>(&keys::session(ns, agent, session_id))
+        .await?
+    {
+        Some(session)
+            if session.status == "PROCESSING"
+                && now.timestamp_micros().saturating_sub(session.last_active)
+                    <= scheduling::session_processing_timeout_micros() =>
+        {
+            STEER_QUEUE
+        }
+        _ => NEXT_QUEUE,
+    };
+    queue_session_message(kv, ns, agent, session_id, queue, message, now).await
 }
 
 pub async fn dispatch_next_queued_message(
@@ -442,6 +579,69 @@ mod tests {
             .unwrap()
             .expect("queued message should be stored");
         assert!(stored.id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn steer_batch_is_bounded_canonicalized_and_committed() {
+        let kv = MockKvStore::new();
+        put_session(&kv, "PROCESSING").await;
+        for text in ["one", "two", "three"] {
+            queue_text_message(
+                &kv,
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                STEER_QUEUE,
+                text,
+                Default::default(),
+                Utc::now(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let batch = prepare_steer_batch(
+            &kv,
+            "Tenant:acme:Ops",
+            "agent",
+            "session-1",
+            2,
+            100,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].message.parts[0].content, "one");
+        assert_eq!(batch[1].message.parts[0].content, "two");
+        assert!(batch.iter().all(|item| !item.message_id.is_empty()));
+
+        let raw = kv
+            .get_msg::<data_proto::SessionMessage>(&keys::session_queue_entry(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                STEER_QUEUE,
+                &batch[0].entry_id,
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(raw.id, batch[0].message_id);
+
+        commit_steer_batch(&kv, "Tenant:acme:Ops", "agent", "session-1", &batch)
+            .await
+            .unwrap();
+        assert_eq!(
+            kv.list_keys(
+                &keys::session_queue_prefix("Tenant:acme:Ops", "agent", "session-1", STEER_QUEUE),
+                None,
+            )
+            .await
+            .unwrap()
+            .len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -4,6 +4,7 @@
 use std::convert::Infallible;
 use std::sync::Arc;
 
+use anyhow::Error as AnyhowError;
 use axum::{
     body::Bytes,
     extract::{Host, OriginalUri, Path, State},
@@ -190,7 +191,7 @@ async fn stream_message(
         }
     });
 
-    if let Err(err) = scheduling::send_or_queue_a2a_session_message(
+    let (_, disposition) = match scheduling::send_or_queue_a2a_session_message(
         gateway.kv.as_ref(),
         gateway.pubsub.as_ref(),
         &route.ns,
@@ -201,8 +202,17 @@ async fn stream_message(
     )
     .await
     {
+        Ok(result) => result,
+        Err(err) => {
+            watcher_cancel.cancel();
+            return scheduling_error_response(err);
+        }
+    };
+    if disposition == scheduling::A2aSessionMessageDisposition::Queued {
         watcher_cancel.cancel();
-        return scheduling_error_response(err);
+        return scheduling_error_response(AnyhowError::new(
+            scheduling::SessionCurrentlyProcessingError,
+        ));
     }
 
     let stream_gateway = gateway.clone();

--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -4,7 +4,6 @@
 use std::convert::Infallible;
 use std::sync::Arc;
 
-use anyhow::Error as AnyhowError;
 use axum::{
     body::Bytes,
     extract::{Host, OriginalUri, Path, State},
@@ -210,9 +209,7 @@ async fn stream_message(
     };
     if disposition == scheduling::A2aSessionMessageDisposition::Queued {
         watcher_cancel.cancel();
-        return scheduling_error_response(AnyhowError::new(
-            scheduling::SessionCurrentlyProcessingError,
-        ));
+        return queued_a2a_stream_response(&task_id, &context_id);
     }
 
     let stream_gateway = gateway.clone();
@@ -675,6 +672,33 @@ fn a2a_sse_line(value: Value) -> String {
         "data: {}\n\n",
         serde_json::to_string(&value).unwrap_or_else(|_| "{}".to_string())
     )
+}
+
+fn queued_a2a_stream_response(task_id: &str, context_id: &str) -> Response {
+    let task_id = task_id.to_string();
+    let context_id = context_id.to_string();
+    let stream = async_stream::stream! {
+        yield Ok::<_, Infallible>(a2a_sse_line(json!({
+            "task": {
+                "id": task_id.clone(),
+                "contextId": context_id.clone(),
+                "status": { "state": "TASK_STATE_SUBMITTED" }
+            }
+        })));
+        yield Ok::<_, Infallible>(a2a_sse_line(a2a_stream_status_update_value(
+            &task_id,
+            &context_id,
+            "TASK_STATE_SUBMITTED",
+            None,
+            true,
+        )));
+    };
+
+    (
+        [(header::CONTENT_TYPE, "text/event-stream; charset=utf-8")],
+        axum::body::Body::from_stream(stream),
+    )
+        .into_response()
 }
 
 fn a2a_stream_status_update_value(

--- a/src/gateway/rest/a2a/handlers.rs
+++ b/src/gateway/rest/a2a/handlers.rs
@@ -190,7 +190,7 @@ async fn stream_message(
         }
     });
 
-    if let Err(err) = scheduling::send_session_message(
+    if let Err(err) = scheduling::send_or_queue_a2a_session_message(
         gateway.kv.as_ref(),
         gateway.pubsub.as_ref(),
         &route.ns,
@@ -388,7 +388,7 @@ async fn send_message(
         return response;
     }
 
-    if let Err(err) = scheduling::send_session_message(
+    if let Err(err) = scheduling::send_or_queue_a2a_session_message(
         gateway.kv.as_ref(),
         gateway.pubsub.as_ref(),
         &route.ns,

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -1231,28 +1231,29 @@ async fn dispatch_to_session(
         elapsed_ms = started.elapsed().as_millis(),
         "connector message dispatching to session"
     );
-    crate::control::session_queue::queue_session_message(
+    let queued = crate::control::session_queue::queue_interactive_session_message(
         cp.kv.as_ref(),
         &agent_namespace,
         agent_name,
         &session_id,
-        crate::control::session_queue::NEXT_QUEUE,
         message,
         chrono::Utc::now(),
     )
     .await
     .map_err(map_dispatch_error)?;
-    crate::control::session_queue::dispatch_next_queued_message(
-        cp.kv.as_ref(),
-        cp.pubsub.as_ref(),
-        &agent_namespace,
-        agent_name,
-        &session_id,
-        crate::control::session_queue::NEXT_QUEUE,
-        chrono::Utc::now(),
-    )
-    .await
-    .map_err(map_dispatch_error)?;
+    if queued.queue == crate::control::session_queue::NEXT_QUEUE {
+        crate::control::session_queue::dispatch_next_queued_message(
+            cp.kv.as_ref(),
+            cp.pubsub.as_ref(),
+            &agent_namespace,
+            agent_name,
+            &session_id,
+            crate::control::session_queue::NEXT_QUEUE,
+            chrono::Utc::now(),
+        )
+        .await
+        .map_err(map_dispatch_error)?;
+    }
     tracing::info!(
         registration_id = %event.registration_id,
         connector_class = %event.connector_class,
@@ -2083,7 +2084,7 @@ mod tests {
                     TEST_NAMESPACE,
                     TEST_AGENT,
                     TEST_SESSION,
-                    crate::control::session_queue::NEXT_QUEUE,
+                    crate::control::session_queue::STEER_QUEUE,
                 ),
                 None,
             )

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -1241,19 +1241,18 @@ async fn dispatch_to_session(
     )
     .await
     .map_err(map_dispatch_error)?;
-    if queued.queue == crate::control::session_queue::NEXT_QUEUE {
-        crate::control::session_queue::dispatch_next_queued_message(
-            cp.kv.as_ref(),
-            cp.pubsub.as_ref(),
-            &agent_namespace,
-            agent_name,
-            &session_id,
-            crate::control::session_queue::NEXT_QUEUE,
-            chrono::Utc::now(),
-        )
-        .await
-        .map_err(map_dispatch_error)?;
-    }
+    let dispatch_queue = queued.queue.as_str();
+    crate::control::session_queue::dispatch_next_queued_message(
+        cp.kv.as_ref(),
+        cp.pubsub.as_ref(),
+        &agent_namespace,
+        agent_name,
+        &session_id,
+        dispatch_queue,
+        chrono::Utc::now(),
+    )
+    .await
+    .map_err(map_dispatch_error)?;
     tracing::info!(
         registration_id = %event.registration_id,
         connector_class = %event.connector_class,

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -262,6 +262,11 @@ pub trait ExecutionSink: Send + Sync {
     async fn on_tool_result_recorded(&self, _: &str, _: &str, _: &ToolOutput) -> Result<()> {
         Ok(())
     }
+    /// Claim and return interactive inputs that should be incorporated before
+    /// the next LLM request in the active execution.
+    async fn take_steering_messages(&self) -> Result<Vec<LoopMessage>> {
+        Ok(Vec::new())
+    }
     /// The agent requested permission from the user/client.
     async fn on_request_permission(&self, _: &str, _: &str, _: &Value) {}
     /// The permission request was answered or cancelled.
@@ -1297,6 +1302,8 @@ impl AgentExecutor {
                     sink.on_done().await;
                     return Ok(result);
                 }
+                let steering = sink.take_steering_messages().await?;
+                context.push_many(steering);
                 continue;
             }
 

--- a/src/harness/sessions/journal.rs
+++ b/src/harness/sessions/journal.rs
@@ -12,7 +12,8 @@ use crate::control::{keys, KeyValueStore, ListOptions};
 use crate::gateway::rpc::data_proto::{
     session_journal_entry_payload, SessionExecutionPhase, SessionJournalEntryPayload,
     SessionJournalEntryPayloadCommit, SessionJournalEntryPayloadCompaction,
-    SessionJournalEntryPayloadLlmResponse, SessionJournalEntryPayloadToolResult,
+    SessionJournalEntryPayloadLlmResponse, SessionJournalEntryPayloadSteerInput,
+    SessionJournalEntryPayloadToolResult,
 };
 use crate::harness::llm::ChatResponse;
 use crate::harness::llm::ToolOutput;
@@ -187,6 +188,39 @@ pub async fn append_tool_result(
                     output: String::new(),
                     object: None,
                     tool_output: Some(result),
+                },
+            )),
+        }),
+        None,
+        now_micros,
+    )
+    .await
+}
+
+pub async fn append_steer_input(
+    kv: &dyn KeyValueStore,
+    ns: &str,
+    agent_id: &str,
+    session_id: &str,
+    submission_id: &str,
+    attempt_id: &str,
+    message_ids: &[String],
+    now_micros: i64,
+) -> Result<SessionJournalEntry> {
+    ensure_submission_attempt_current(kv, ns, agent_id, session_id, submission_id, attempt_id)
+        .await?;
+    append_journal_entry(
+        kv,
+        ns,
+        agent_id,
+        session_id,
+        submission_id,
+        attempt_id,
+        SessionExecutionPhase::SteerInput as i32,
+        Some(SessionJournalEntryPayload {
+            payload: Some(session_journal_entry_payload::Payload::SteerInput(
+                SessionJournalEntryPayloadSteerInput {
+                    message_ids: message_ids.to_vec(),
                 },
             )),
         }),

--- a/src/harness/sessions/mod.rs
+++ b/src/harness/sessions/mod.rs
@@ -18,6 +18,7 @@ pub const SESSION_PROJECTION_STATE_COMMITTED: &str = "committed";
 pub const SESSION_PROJECTION_STATE_FAILED: &str = "failed";
 
 pub use crate::gateway::rpc::data_proto::{SessionJournalEntry, SessionSubmission};
+pub use journal::append_steer_input;
 pub use journal::{
     append_compaction, list_journal_entries, mark_terminal, repair_submission_pointer_to_latest,
 };

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -1253,6 +1253,24 @@ impl WorkerEventHandler {
                 "failed to dispatch workflow from completed child session"
             );
         }
+        if session.status == "ERROR" {
+            if let Err(err) = crate::control::session_queue::reclassify_steer_queue_to_next(
+                self.cp.kv.as_ref(),
+                ns,
+                agent_id,
+                session_id,
+            )
+            .await
+            {
+                tracing::warn!(
+                    namespace = %ns,
+                    agent = %agent_id,
+                    session = %session_id,
+                    error = %err,
+                    "failed to recover steering queue after session error"
+                );
+            }
+        }
         if completion_status != SessionCompletionStatus::Waiting {
             let delegated_completion = match completion_status {
                 SessionCompletionStatus::Completed => {

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -187,6 +187,36 @@ async fn prepare_context_for_claimed_submission(
     journal_entries: &[sessions::SessionJournalEntry],
     runtime: &mut AgentRuntime,
 ) -> Result<PreparedSubmission> {
+    async fn hydrate_steering_input(
+        cp: &ControlPlane,
+        ns: &str,
+        agent: &str,
+        session_id: &str,
+        entry: &sessions::SessionJournalEntry,
+        runtime: &mut AgentRuntime,
+    ) -> Result<()> {
+        let Some(session_journal_entry_payload::Payload::SteerInput(payload)) = entry
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.payload.as_ref())
+        else {
+            return Err(anyhow!("STEER_INPUT entry is missing payload"));
+        };
+        for message_id in &payload.message_ids {
+            let key = crate::control::keys::session_message(ns, agent, session_id, message_id);
+            let bytes =
+                cp.kv.get(&key).await?.ok_or_else(|| {
+                    anyhow!("STEER_INPUT references missing message '{message_id}'")
+                })?;
+            let message = data_proto::SessionMessage::decode(bytes.as_slice())?;
+            runtime.context.push(LoopMessage::text(
+                "user",
+                crate::control::scheduling::session_message_text_projection(&message),
+            ));
+        }
+        Ok(())
+    }
+
     let mut latest_final_response = None;
     let mut projection_parts = Vec::new();
     let mut next_projection_part_index = 0usize;
@@ -230,6 +260,12 @@ async fn prepare_context_for_claimed_submission(
                 return Err(anyhow!("COMPACTION entry is missing payload"));
             }
 
+            index += 1;
+            continue;
+        }
+
+        if entry.phase == SessionExecutionPhase::SteerInput as i32 {
+            hydrate_steering_input(cp, ns, agent, session_id, entry, runtime).await?;
             index += 1;
             continue;
         }
@@ -301,6 +337,7 @@ async fn prepare_context_for_claimed_submission(
         index += 1;
         let mut stop_after_tool_results = false;
         let mut results_by_call_id = BTreeMap::new();
+        let mut steering_entries = Vec::new();
         while index < journal_entries.len() {
             let entry = &journal_entries[index];
             if entry.phase == SessionExecutionPhase::LlmResponse as i32
@@ -334,6 +371,11 @@ async fn prepare_context_for_claimed_submission(
                 }
                 (phase, None) if phase == SessionExecutionPhase::ToolResult as i32 => {
                     return Err(anyhow!("TOOL_RESULT entry is missing payload"));
+                }
+                (phase, Some(session_journal_entry_payload::Payload::SteerInput(_)))
+                    if phase == SessionExecutionPhase::SteerInput as i32 =>
+                {
+                    steering_entries.push(entry.clone());
                 }
                 _ => {}
             }
@@ -403,6 +445,9 @@ async fn prepare_context_for_claimed_submission(
                 .push(tool_output_loop_message(&tool.id, &result_output));
             stop_after_tool_results |=
                 crate::harness::native_tools::tool_requests_worker_stop(&tool.name);
+        }
+        for entry in steering_entries {
+            hydrate_steering_input(cp, ns, agent, session_id, &entry, runtime).await?;
         }
         if stop_after_tool_results {
             return Ok(PreparedSubmission {
@@ -1234,24 +1279,46 @@ impl WorkerEventHandler {
                 );
             }
         }
-        if let Err(err) = crate::control::session_queue::dispatch_next_queued_message(
+        let dispatched_steer = crate::control::session_queue::dispatch_next_queued_message(
             self.cp.kv.as_ref(),
             self.cp.pubsub.as_ref(),
             ns,
             agent_id,
             session_id,
-            crate::control::session_queue::NEXT_QUEUE,
+            crate::control::session_queue::STEER_QUEUE,
             chrono::Utc::now(),
         )
-        .await
-        {
-            tracing::warn!(
+        .await;
+        match dispatched_steer {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                if let Err(err) = crate::control::session_queue::dispatch_next_queued_message(
+                    self.cp.kv.as_ref(),
+                    self.cp.pubsub.as_ref(),
+                    ns,
+                    agent_id,
+                    session_id,
+                    crate::control::session_queue::NEXT_QUEUE,
+                    chrono::Utc::now(),
+                )
+                .await
+                {
+                    tracing::warn!(
+                        namespace = %ns,
+                        agent = %agent_id,
+                        session = %session_id,
+                        error = %err,
+                        "failed to dispatch NEXT queued session message after session release"
+                    );
+                }
+            }
+            Err(err) => tracing::warn!(
                 namespace = %ns,
                 agent = %agent_id,
                 session = %session_id,
                 error = %err,
-                "failed to dispatch next queued session message after session release"
-            );
+                "failed to dispatch queued session message after session release"
+            ),
         }
     }
 }

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -14,6 +14,7 @@ use crate::control::delegation;
 use crate::control::events::{SessionMessagePartEvent, SessionMessagePartEventKind};
 use crate::control::object_store::{default_object_store, ObjectStore};
 use crate::control::resources::ResourceStore;
+use crate::control::session_queue;
 use crate::control::tool_output::{self, ToolOutputExt, ToolOutputStorageContext};
 use crate::control::{
     keys::{self, ResourceKey},
@@ -367,6 +368,7 @@ pub struct PubSubSessionSink {
     last_flush: Mutex<Instant>, // Last time the UI projection was considered for persistence.
     latest_journal_entry_id: Mutex<Option<String>>, // Latest durable boundary reflected in projection labels.
     recorded_tool_results: Mutex<std::collections::HashMap<String, RecordedToolResult>>,
+    steer_drains: Mutex<u8>,
     persist_lock: Arc<AsyncMutex<()>>, // Serializes projection writes with final message commit.
 
     // Run summary counters for logs/telemetry.
@@ -530,6 +532,7 @@ impl PubSubSessionSink {
             last_flush: Mutex::new(Instant::now()),
             latest_journal_entry_id: Mutex::new(None),
             recorded_tool_results: Mutex::new(std::collections::HashMap::new()),
+            steer_drains: Mutex::new(0),
             persist_lock: Arc::new(AsyncMutex::new(())),
             input_token_chunks: Mutex::new(0),
             input_token_chars: Mutex::new(0),
@@ -1451,6 +1454,76 @@ impl ExecutionSink for PubSubSessionSink {
         );
         *self.latest_journal_entry_id.lock().unwrap() = Some(entry.journal_entry_id);
         Ok(())
+    }
+
+    async fn take_steering_messages(&self) -> Result<Vec<crate::harness::executor::LoopMessage>> {
+        const MAX_STEER_DRAINS: u8 = 4;
+        {
+            let mut drains = self.steer_drains.lock().unwrap();
+            if *drains >= MAX_STEER_DRAINS {
+                return Ok(Vec::new());
+            }
+            *drains += 1;
+        }
+
+        let mut batch = session_queue::prepare_steer_batch(
+            self.kv.as_ref(),
+            &self.ns,
+            &self.agent_id,
+            &self.session_id,
+            session_queue::DEFAULT_STEER_BATCH_MAX_MESSAGES,
+            session_queue::DEFAULT_STEER_BATCH_MAX_CHARS,
+            chrono::Utc::now(),
+        )
+        .await?;
+        if batch.is_empty() {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            batch = session_queue::prepare_steer_batch(
+                self.kv.as_ref(),
+                &self.ns,
+                &self.agent_id,
+                &self.session_id,
+                session_queue::DEFAULT_STEER_BATCH_MAX_MESSAGES,
+                session_queue::DEFAULT_STEER_BATCH_MAX_CHARS,
+                chrono::Utc::now(),
+            )
+            .await?;
+        }
+        if batch.is_empty() {
+            return Ok(Vec::new());
+        }
+        let message_ids = batch
+            .iter()
+            .map(|message| message.message_id.clone())
+            .collect::<Vec<_>>();
+        sessions::append_steer_input(
+            self.kv.as_ref(),
+            &self.ns,
+            &self.agent_id,
+            &self.session_id,
+            &self.submission_id,
+            &self.attempt_id,
+            &message_ids,
+            chrono::Utc::now().timestamp_micros(),
+        )
+        .await?;
+        session_queue::commit_steer_batch(
+            self.kv.as_ref(),
+            &self.ns,
+            &self.agent_id,
+            &self.session_id,
+            &batch,
+        )
+        .await?;
+        Ok(batch
+            .into_iter()
+            .map(|message| {
+                crate::harness::executor::LoopMessage::text(
+                    "user",
+                    crate::control::scheduling::session_message_text_projection(&message.message),
+                )
+            })
+            .collect())
     }
 
     async fn on_tool_result(&self, id: &str, name: &str, result: &ToolOutput) {

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -4,7 +4,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex as AsyncMutex;
@@ -1458,13 +1458,14 @@ impl ExecutionSink for PubSubSessionSink {
 
     async fn take_steering_messages(&self) -> Result<Vec<crate::harness::executor::LoopMessage>> {
         const MAX_STEER_DRAINS: u8 = 4;
-        {
+        let drain_attempt = {
             let mut drains = self.steer_drains.lock().unwrap();
             if *drains >= MAX_STEER_DRAINS {
                 return Ok(Vec::new());
             }
             *drains += 1;
-        }
+            *drains
+        };
 
         let mut batch = session_queue::prepare_steer_batch(
             self.kv.as_ref(),
@@ -1476,8 +1477,8 @@ impl ExecutionSink for PubSubSessionSink {
             chrono::Utc::now(),
         )
         .await?;
-        if batch.is_empty() {
-            tokio::time::sleep(Duration::from_millis(500)).await;
+        if batch.is_empty() && drain_attempt == 1 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
             batch = session_queue::prepare_steer_batch(
                 self.kv.as_ref(),
                 &self.ns,
@@ -1489,6 +1490,51 @@ impl ExecutionSink for PubSubSessionSink {
             )
             .await?;
         }
+        if batch.is_empty() {
+            return Ok(Vec::new());
+        }
+        let journaled_message_ids = sessions::list_journal_entries(
+            self.kv.as_ref(),
+            &self.ns,
+            &self.agent_id,
+            &self.session_id,
+            &self.submission_id,
+        )
+        .await?
+        .into_iter()
+        .filter(|entry| {
+            entry.phase
+                == crate::gateway::rpc::data_proto::SessionExecutionPhase::SteerInput as i32
+        })
+        .filter_map(|entry| {
+            entry
+                .payload
+                .and_then(|payload| payload.payload)
+                .and_then(|payload| match payload {
+                    crate::gateway::rpc::data_proto::session_journal_entry_payload::Payload::SteerInput(
+                        payload,
+                    ) => Some(payload.message_ids),
+                    _ => None,
+                })
+        })
+        .flatten()
+        .collect::<HashSet<_>>();
+        let mut fresh_batch = Vec::with_capacity(batch.len());
+        for item in batch {
+            if journaled_message_ids.contains(&item.message_id) {
+                session_queue::commit_steer_batch(
+                    self.kv.as_ref(),
+                    &self.ns,
+                    &self.agent_id,
+                    &self.session_id,
+                    std::slice::from_ref(&item),
+                )
+                .await?;
+            } else {
+                fresh_batch.push(item);
+            }
+        }
+        let batch = fresh_batch;
         if batch.is_empty() {
             return Ok(Vec::new());
         }

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -424,6 +424,114 @@ def test_stop_generation_cancels_an_inflight_mcp_tool_call(
         mock_control("POST", "/__control/reset")
 
 
+def test_interactive_messages_are_steered_and_batched_after_tool_result(
+    stack: E2EStack,
+    client: TalonClient,
+) -> None:
+    """A burst received during a tool call becomes one follow-up model turn."""
+    namespace = f"talon-steer-{stack.name}-{uuid.uuid4().hex[:8]}"
+    agent = "steering-agent"
+    mcp_server = "durable-slow"
+    ensure_namespace(client, namespace)
+    create_resource(
+        client,
+        namespace,
+        "McpServer",
+        mcp_server,
+        ResourceSpec(
+            mcp_server=McpServerSpec(
+                transport="http",
+                target=f"http://127.0.0.1:{MOCK_LLM_PORT}/mcp",
+            )
+        ),
+    )
+    create_agent_resource(
+        client,
+        namespace,
+        agent,
+        AgentSpec(
+            mcp_server_refs=[mcp_server],
+            model_policy={
+                "profiles": [
+                    {
+                        "name": "default",
+                        "model": Model(
+                            provider="mock",
+                            name="minimax-m2.7",
+                            temperature=0.0,
+                        ),
+                    }
+                ]
+            },
+            system_prompt="Use the MCP lookup tool when asked.",
+        ),
+    )
+    session_id = client.sessions.Create(
+        CreateSessionRequest(agent=agent, ns=namespace)
+    ).session_id
+
+    mock_control("POST", "/__control/reset")
+    mock_control("POST", "/__control/block_mcp_tool")
+    try:
+        client.sessions.SendMessage(
+            SendMessageRequest(
+                agent=agent,
+                session_id=session_id,
+                ns=namespace,
+                message="Please run a blocking lookup docs.example.com.",
+            )
+        )
+        wait_for_mock_mcp_tool_blocked()
+
+        for text in (
+            "first steering message",
+            "second steering message",
+            "third steering message",
+        ):
+            client.sessions.SendMessage(
+                SendMessageRequest(
+                    agent=agent,
+                    session_id=session_id,
+                    ns=namespace,
+                    message=text,
+                )
+            )
+
+        mock_control("POST", "/__control/unblock_mcp_tool")
+
+        for _ in range(100):
+            session = client.sessions.Get(
+                GetSessionRequest(agent=agent, session_id=session_id, ns=namespace)
+            )
+            assistant = last_assistant_message(session.messages)
+            if (
+                session.state == "IDLE"
+                and assistant is not None
+                and "third steering message" in message_text(assistant)
+            ):
+                break
+            time.sleep(0.1)
+        else:
+            raise AssertionError("steered session did not complete with the latest input")
+
+        state = mock_control("GET", "/__control/state")
+        requests_seen = state["chat_requests"]
+        assert len(requests_seen) == 2, "steering burst should trigger one follow-up model request"
+        follow_up_users = [
+            message_text(message)
+            for message in requests_seen[-1]["messages"]
+            if message.get("role") == "user"
+        ]
+        assert follow_up_users[-3:] == [
+            "first steering message",
+            "second steering message",
+            "third steering message",
+        ]
+    finally:
+        mock_control("POST", "/__control/unblock_mcp_tool")
+        mock_control("POST", "/__control/reset")
+
+
 def test_streaming_chat(
     stack: E2EStack,
     client: TalonClient,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -518,7 +518,7 @@ def test_interactive_messages_are_steered_and_batched_after_tool_result(
         requests_seen = state["chat_requests"]
         assert len(requests_seen) == 2, "steering burst should trigger one follow-up model request"
         follow_up_users = [
-            message_text(message)
+            message.get("content", "")
             for message in requests_seen[-1]["messages"]
             if message.get("role") == "user"
         ]


### PR DESCRIPTION
## What changed

- Add E2EStack Python coverage for interactive messages queued during an in-flight MCP tool call.
- Verify a burst of three messages is absorbed after the tool result and produces one follow-up model request.
- Verify the messages remain ordered in the model context and the latest input drives the final reply.
- Include the durable steer queue implementation, recovery journal boundary, interactive/A2A routing, and Rust regression coverage.

## Why

Interactive channels such as iMessage can deliver several user messages while an agent is working. They should be steered into the active turn and batched instead of processed as separate one-message turns. A2A requests remain serialized through NEXT_QUEUE.

## Validation

- `cargo check`
- `cargo test --lib --quiet` (917 passed)
- `python -m py_compile tests/test_chat.py`
- `git diff --check`

The Python pytest environment is not installed in this checkout, so the new E2E test was not executed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive message steering for sessions that are currently processing.
  * Queued messages are delivered in order after tool execution, preserving follow-up input.
  * Added steering session journal support across Java and Python SDKs.
  * Added configurable limits for batched steering messages.

* **Bug Fixes**
  * Messages sent during busy sessions are now queued instead of rejected.
  * Session recovery correctly restores deferred steering messages.

* **Tests**
  * Added end-to-end coverage for multiple messages received during tool execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->