### PR TITLE
Improve connector typing keepalive lifecycle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ protoc-gen-tonic = "0.4.0"
 aws-smithy-runtime-api = "1.11"
 aws-smithy-types = "1.4"
 tempfile = "3.0"
+tokio = { version = "1.0", features = ["test-util"] }
 
 [[bin]]
 name = "talon-server"

--- a/src/worker/connector.rs
+++ b/src/worker/connector.rs
@@ -1,0 +1,373 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use anyhow::{anyhow, Result};
+use futures::FutureExt;
+use std::future::Future;
+use std::panic::{resume_unwind, AssertUnwindSafe};
+use std::time::Duration;
+
+use super::WorkerEventHandler;
+use crate::control::ProtoKeyValueStoreExt;
+use crate::gateway::rpc::connectors as connector_rpc;
+use crate::gateway::rpc::data_proto;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+pub(super) const CONNECTOR_TYPING_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(20);
+
+const LABEL_MESSAGE_SOURCE: &str = "talon.impalasys.com/message-source";
+const LABEL_CONNECTOR_REGISTRATION: &str = "talon.impalasys.com/connector-registration";
+const LABEL_CHANNEL_TRIGGER: &str = "talon.impalasys.com/channel-trigger";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ConnectorTypingActivity {
+    pub(super) activity_id: String,
+    pub(super) phase: &'static str,
+    pub(super) status_text: &'static str,
+}
+
+impl ConnectorTypingActivity {
+    fn start(submission_id: &str) -> Self {
+        Self {
+            activity_id: format!("{submission_id}:typing:start"),
+            phase: "start",
+            status_text: "is thinking...",
+        }
+    }
+
+    fn active() -> Self {
+        Self {
+            activity_id: uuid::Uuid::now_v7().to_string(),
+            phase: "active",
+            status_text: "is thinking...",
+        }
+    }
+
+    fn stop(submission_id: &str) -> Self {
+        Self {
+            activity_id: format!("{submission_id}:typing:stop"),
+            phase: "stop",
+            status_text: "",
+        }
+    }
+}
+
+pub(super) enum ConnectorTypingDelivery {
+    Ineligible,
+    Eligible(Result<()>),
+}
+
+enum ConnectorTypingActivityOutcome {
+    Ineligible,
+    Continue,
+    Retry,
+}
+
+#[derive(Clone)]
+pub(super) struct ConnectorTypingLogContext {
+    pub(super) agent: String,
+    pub(super) session_id: String,
+    pub(super) submission_id: String,
+}
+
+pub(super) struct ConnectorTypingKeepalive {
+    context: ConnectorTypingLogContext,
+    heartbeat_cancellation: CancellationToken,
+    heartbeat_task: Option<JoinHandle<()>>,
+    stop_signal: Option<oneshot::Sender<()>>,
+    stop_task: Option<JoinHandle<()>>,
+}
+
+async fn send_connector_typing_activity_best_effort<S, SFut>(
+    sender: &S,
+    context: &ConnectorTypingLogContext,
+    activity: ConnectorTypingActivity,
+) -> ConnectorTypingActivityOutcome
+where
+    S: Fn(ConnectorTypingActivity) -> SFut,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>>,
+{
+    let activity_id = activity.activity_id.clone();
+    let phase = activity.phase;
+    match sender(activity).await {
+        Ok(ConnectorTypingDelivery::Ineligible) => ConnectorTypingActivityOutcome::Ineligible,
+        Ok(ConnectorTypingDelivery::Eligible(Ok(()))) => ConnectorTypingActivityOutcome::Continue,
+        Ok(ConnectorTypingDelivery::Eligible(Err(error))) => {
+            tracing::warn!(
+                error = %error,
+                agent = %context.agent,
+                session = %context.session_id,
+                submission = %context.submission_id,
+                activity_id = %activity_id,
+                phase,
+                "failed to send connector typing activity"
+            );
+            // Once a session reaches the sender, an endpoint failure must not
+            // prevent later heartbeats or the final stop attempt.
+            ConnectorTypingActivityOutcome::Continue
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                agent = %context.agent,
+                session = %context.session_id,
+                submission = %context.submission_id,
+                activity_id = %activity_id,
+                phase,
+                "failed to resolve connector typing activity routing"
+            );
+            // A routing failure is not proof that the session is ineligible.
+            // Keep the lifecycle alive and retry the next scheduled heartbeat.
+            ConnectorTypingActivityOutcome::Retry
+        }
+    }
+}
+
+async fn run_connector_typing_keepalive<S, SFut>(
+    cancellation: CancellationToken,
+    interval: Duration,
+    context: ConnectorTypingLogContext,
+    sender: S,
+    heartbeat_finished: oneshot::Sender<()>,
+) where
+    S: Fn(ConnectorTypingActivity) -> SFut + Send + Sync + 'static,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
+{
+    let first_tick = tokio::time::Instant::now() + interval;
+    let mut ticks = tokio::time::interval_at(first_tick, interval);
+    ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => break,
+            _ = ticks.tick() => {
+                let activity = ConnectorTypingActivity::active();
+                let send = send_connector_typing_activity_best_effort(
+                    &sender,
+                    &context,
+                    activity,
+                );
+                tokio::pin!(send);
+                let outcome = tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => {
+                        // Do not abandon an active request after it may have
+                        // reached the connector. Stop delivery must wait for
+                        // this request to settle to preserve activity order.
+                        let _ = send.await;
+                        ConnectorTypingActivityOutcome::Ineligible
+                    },
+                    outcome = &mut send => outcome
+                };
+                if matches!(outcome, ConnectorTypingActivityOutcome::Ineligible) {
+                    break;
+                }
+            }
+        }
+    }
+
+    let _ = heartbeat_finished.send(());
+}
+
+async fn run_connector_typing_stop<S, SFut>(
+    context: ConnectorTypingLogContext,
+    sender: S,
+    stop_signal: oneshot::Receiver<()>,
+    heartbeat_finished: oneshot::Receiver<()>,
+) where
+    S: Fn(ConnectorTypingActivity) -> SFut + Send + Sync + 'static,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
+{
+    if stop_signal.await.is_ok() {
+        // The heartbeat task drains any request already in flight before it
+        // signals completion. This prevents a late active activity from
+        // arriving after stop.
+        let _ = heartbeat_finished.await;
+        let _ = send_connector_typing_activity_best_effort(
+            &sender,
+            &context,
+            ConnectorTypingActivity::stop(&context.submission_id),
+        )
+        .await;
+    }
+}
+
+async fn start_connector_typing_keepalive<S, SFut>(
+    context: ConnectorTypingLogContext,
+    interval: Duration,
+    sender: S,
+) -> Option<ConnectorTypingKeepalive>
+where
+    S: Fn(ConnectorTypingActivity) -> SFut + Clone + Send + Sync + 'static,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
+{
+    let start_outcome = send_connector_typing_activity_best_effort(
+        &sender,
+        &context,
+        ConnectorTypingActivity::start(&context.submission_id),
+    )
+    .await;
+    if !matches!(start_outcome, ConnectorTypingActivityOutcome::Continue) {
+        return None;
+    }
+
+    let heartbeat_cancellation = CancellationToken::new();
+    let (heartbeat_finished, heartbeat_finished_receiver) = oneshot::channel();
+    let heartbeat_task = tokio::spawn(run_connector_typing_keepalive(
+        heartbeat_cancellation.clone(),
+        interval,
+        context.clone(),
+        sender.clone(),
+        heartbeat_finished,
+    ));
+    let (stop_signal, stop_receiver) = oneshot::channel();
+    let stop_task = tokio::spawn(run_connector_typing_stop(
+        context.clone(),
+        sender,
+        stop_receiver,
+        heartbeat_finished_receiver,
+    ));
+
+    Some(ConnectorTypingKeepalive {
+        context,
+        heartbeat_cancellation,
+        heartbeat_task: Some(heartbeat_task),
+        stop_signal: Some(stop_signal),
+        stop_task: Some(stop_task),
+    })
+}
+
+impl ConnectorTypingKeepalive {
+    async fn cancel_and_join_heartbeat(&mut self) {
+        self.heartbeat_cancellation.cancel();
+        if let Some(task) = self.heartbeat_task.take() {
+            if let Err(error) = task.await {
+                tracing::warn!(
+                    error = %error,
+                    agent = %self.context.agent,
+                    session = %self.context.session_id,
+                    submission = %self.context.submission_id,
+                    "connector typing keepalive task failed"
+                );
+            }
+        }
+    }
+
+    pub(super) async fn stop_after_release(mut self) {
+        self.cancel_and_join_heartbeat().await;
+
+        let Some(stop_signal) = self.stop_signal.take() else {
+            return;
+        };
+        if stop_signal.send(()).is_err() {
+            return;
+        }
+
+        if let Some(task) = self.stop_task.take() {
+            if let Err(error) = task.await {
+                tracing::warn!(
+                    error = %error,
+                    agent = %self.context.agent,
+                    session = %self.context.session_id,
+                    submission = %self.context.submission_id,
+                    "connector typing stop task failed"
+                );
+            }
+        }
+    }
+}
+
+impl Drop for ConnectorTypingKeepalive {
+    fn drop(&mut self) {
+        self.heartbeat_cancellation.cancel();
+        if let Some(stop_signal) = self.stop_signal.take() {
+            let _ = stop_signal.send(());
+        }
+    }
+}
+
+pub(super) async fn with_connector_typing_keepalive<S, SFut, F, T>(
+    context: ConnectorTypingLogContext,
+    interval: Duration,
+    sender: S,
+    work: F,
+) -> (T, Option<ConnectorTypingKeepalive>)
+where
+    S: Fn(ConnectorTypingActivity) -> SFut + Clone + Send + Sync + 'static,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
+    F: Future<Output = T>,
+{
+    let Some(mut keepalive) = start_connector_typing_keepalive(context, interval, sender).await
+    else {
+        return (work.await, None);
+    };
+
+    let outcome = AssertUnwindSafe(work).catch_unwind().await;
+    keepalive.cancel_and_join_heartbeat().await;
+
+    match outcome {
+        Ok(value) => (value, Some(keepalive)),
+        Err(panic) => {
+            keepalive.stop_after_release().await;
+            resume_unwind(panic);
+        }
+    }
+}
+
+impl WorkerEventHandler {
+    pub(super) async fn maybe_send_connector_session_activity(
+        &self,
+        ns: &str,
+        agent: &str,
+        session_id: &str,
+        activity_id: &str,
+        phase: &str,
+        status_text: &str,
+    ) -> Result<ConnectorTypingDelivery> {
+        let session = self
+            .cp
+            .kv
+            .get_msg::<data_proto::Session>(&crate::control::keys::session(ns, agent, session_id))
+            .await?
+            .ok_or_else(|| anyhow!("session not found"))?;
+        if !session.labels.contains_key(LABEL_CONNECTOR_REGISTRATION) {
+            return Ok(ConnectorTypingDelivery::Ineligible);
+        }
+        if session
+            .labels
+            .get(LABEL_MESSAGE_SOURCE)
+            .is_some_and(|source| source != "connector")
+        {
+            return Ok(ConnectorTypingDelivery::Ineligible);
+        }
+        if session.labels.contains_key(LABEL_CHANNEL_TRIGGER) {
+            return Ok(ConnectorTypingDelivery::Ineligible);
+        }
+        Ok(ConnectorTypingDelivery::Eligible(
+            connector_rpc::send_connector_session_activity(
+                &self.cp,
+                &session,
+                activity_id,
+                phase,
+                status_text,
+            )
+            .await,
+        ))
+    }
+
+    pub(super) async fn maybe_deliver_connector_session_reply(
+        &self,
+        ns: &str,
+        agent: &str,
+        session_id: &str,
+        message_id: &str,
+    ) -> Result<()> {
+        connector_rpc::maybe_deliver_connector_session_message(
+            &self.cp, ns, agent, session_id, message_id,
+        )
+        .await
+    }
+}

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, Result};
 use prost::Message;
 use std::sync::Arc;
 
+pub mod connector;
 pub mod controllers;
 pub mod fanout;
 pub mod mcp_registry;

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -24,6 +24,8 @@ use crate::gateway::rpc::data_proto::{
 use crate::harness::executor::{tool_output_loop_message, ExecutionSink, LoopMessage};
 use crate::harness::llm::ToolOutput;
 use crate::harness::sessions::{self, ClaimOutcome};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
@@ -78,6 +80,14 @@ struct ConnectorTypingLogContext {
     agent: String,
     session_id: String,
     submission_id: String,
+}
+
+struct ConnectorTypingKeepalive {
+    context: ConnectorTypingLogContext,
+    heartbeat_cancellation: CancellationToken,
+    heartbeat_task: Option<JoinHandle<()>>,
+    stop_signal: Option<oneshot::Sender<()>>,
+    stop_task: Option<JoinHandle<()>>,
 }
 
 async fn send_connector_typing_activity_best_effort<S, SFut>(
@@ -161,16 +171,32 @@ async fn run_connector_typing_keepalive<S, SFut>(
     }
 }
 
-async fn with_connector_typing_keepalive<S, SFut, F, T>(
+async fn run_connector_typing_stop<S, SFut>(
+    context: ConnectorTypingLogContext,
+    sender: S,
+    stop_signal: oneshot::Receiver<()>,
+) where
+    S: Fn(ConnectorTypingActivity) -> SFut + Send + Sync + 'static,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
+{
+    if stop_signal.await.is_ok() {
+        let _ = send_connector_typing_activity_best_effort(
+            &sender,
+            &context,
+            ConnectorTypingActivity::stop(&context.submission_id),
+        )
+        .await;
+    }
+}
+
+async fn start_connector_typing_keepalive<S, SFut>(
     context: ConnectorTypingLogContext,
     interval: Duration,
     sender: S,
-    work: F,
-) -> T
+) -> Option<ConnectorTypingKeepalive>
 where
     S: Fn(ConnectorTypingActivity) -> SFut + Clone + Send + Sync + 'static,
     SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
-    F: Future<Output = T>,
 {
     let eligible = send_connector_typing_activity_best_effort(
         &sender,
@@ -179,42 +205,106 @@ where
     )
     .await;
     if !eligible {
-        return work.await;
+        return None;
     }
 
-    // This token scopes only the typing keepalive. It must never be shared
-    // with or derived from the agent execution cancellation token.
-    let keepalive_cancellation = CancellationToken::new();
-    let keepalive_task = tokio::spawn(run_connector_typing_keepalive(
-        keepalive_cancellation.clone(),
+    let heartbeat_cancellation = CancellationToken::new();
+    let heartbeat_task = tokio::spawn(run_connector_typing_keepalive(
+        heartbeat_cancellation.clone(),
         interval,
         context.clone(),
         sender.clone(),
     ));
+    let (stop_signal, stop_receiver) = oneshot::channel();
+    let stop_task = tokio::spawn(run_connector_typing_stop(
+        context.clone(),
+        sender,
+        stop_receiver,
+    ));
 
-    let outcome = AssertUnwindSafe(work).catch_unwind().await;
+    Some(ConnectorTypingKeepalive {
+        context,
+        heartbeat_cancellation,
+        heartbeat_task: Some(heartbeat_task),
+        stop_signal: Some(stop_signal),
+        stop_task: Some(stop_task),
+    })
+}
 
-    keepalive_cancellation.cancel();
-    if let Err(error) = keepalive_task.await {
-        tracing::warn!(
-            error = %error,
-            agent = %context.agent,
-            session = %context.session_id,
-            submission = %context.submission_id,
-            "connector typing keepalive task failed"
-        );
+impl ConnectorTypingKeepalive {
+    async fn cancel_and_join_heartbeat(&mut self) {
+        self.heartbeat_cancellation.cancel();
+        if let Some(task) = self.heartbeat_task.take() {
+            if let Err(error) = task.await {
+                tracing::warn!(
+                    error = %error,
+                    agent = %self.context.agent,
+                    session = %self.context.session_id,
+                    submission = %self.context.submission_id,
+                    "connector typing keepalive task failed"
+                );
+            }
+        }
     }
 
-    let _ = send_connector_typing_activity_best_effort(
-        &sender,
-        &context,
-        ConnectorTypingActivity::stop(&context.submission_id),
-    )
-    .await;
+    async fn stop_after_release(mut self) {
+        self.cancel_and_join_heartbeat().await;
+
+        let Some(stop_signal) = self.stop_signal.take() else {
+            return;
+        };
+        if stop_signal.send(()).is_err() {
+            return;
+        }
+
+        if let Some(task) = self.stop_task.take() {
+            if let Err(error) = task.await {
+                tracing::warn!(
+                    error = %error,
+                    agent = %self.context.agent,
+                    session = %self.context.session_id,
+                    submission = %self.context.submission_id,
+                    "connector typing stop task failed"
+                );
+            }
+        }
+    }
+}
+
+impl Drop for ConnectorTypingKeepalive {
+    fn drop(&mut self) {
+        self.heartbeat_cancellation.cancel();
+        if let Some(stop_signal) = self.stop_signal.take() {
+            let _ = stop_signal.send(());
+        }
+    }
+}
+
+async fn with_connector_typing_keepalive<S, SFut, F, T>(
+    context: ConnectorTypingLogContext,
+    interval: Duration,
+    sender: S,
+    work: F,
+) -> (T, Option<ConnectorTypingKeepalive>)
+where
+    S: Fn(ConnectorTypingActivity) -> SFut + Clone + Send + Sync + 'static,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
+    F: Future<Output = T>,
+{
+    let Some(mut keepalive) = start_connector_typing_keepalive(context, interval, sender).await
+    else {
+        return (work.await, None);
+    };
+
+    let outcome = AssertUnwindSafe(work).catch_unwind().await;
+    keepalive.cancel_and_join_heartbeat().await;
 
     match outcome {
-        Ok(value) => value,
-        Err(panic) => resume_unwind(panic),
+        Ok(value) => (value, Some(keepalive)),
+        Err(panic) => {
+            keepalive.stop_after_release().await;
+            resume_unwind(panic);
+        }
     }
 }
 
@@ -1070,7 +1160,7 @@ impl WorkerEventHandler {
             .await
             .map(|status| (status, sink.summary()))
         });
-        let outcome = with_connector_typing_keepalive(
+        let (outcome, typing_keepalive) = with_connector_typing_keepalive(
             typing_context,
             CONNECTOR_TYPING_KEEPALIVE_INTERVAL,
             activity_sender,
@@ -1100,6 +1190,10 @@ impl WorkerEventHandler {
             "WorkerEventHandler.release_session_lock"
         ))
         .await;
+
+        if let Some(typing_keepalive) = typing_keepalive {
+            typing_keepalive.stop_after_release().await;
+        }
 
         if completion_status == SessionCompletionStatus::Completed {
             let is_delegated_task = self
@@ -1576,7 +1670,7 @@ mod tests {
     use std::collections::HashMap;
     use std::panic::AssertUnwindSafe;
     use std::pin::Pin;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::time::Duration;
@@ -2169,13 +2263,17 @@ mod tests {
     async fn connector_typing_short_run_sends_start_then_stop() {
         let activities = Arc::new(Mutex::new(Vec::new()));
 
-        let result = with_connector_typing_keepalive(
+        let (result, typing_keepalive) = with_connector_typing_keepalive(
             typing_test_context(),
             Duration::from_secs(20),
             recording_typing_sender(activities.clone()),
             async { "completed" },
         )
         .await;
+        typing_keepalive
+            .expect("eligible session should own keepalive")
+            .stop_after_release()
+            .await;
 
         assert_eq!(result, "completed");
         assert_eq!(typing_phases(&activities), vec!["start", "stop"]);
@@ -2205,10 +2303,10 @@ mod tests {
         tokio::task::yield_now().await;
         tokio::time::advance(Duration::from_secs(60)).await;
         tokio::task::yield_now().await;
-        assert_eq!(typing_phases(&attempted_activities), vec!["start"]);
-
         complete_tx.send(()).unwrap();
-        assert_eq!(task.await.unwrap(), "completed");
+        let (result, typing_keepalive) = task.await.unwrap();
+        assert_eq!(result, "completed");
+        assert!(typing_keepalive.is_none());
         assert_eq!(typing_phases(&attempted_activities), vec!["start"]);
     }
 
@@ -2258,7 +2356,12 @@ mod tests {
         }
 
         complete_tx.send(()).unwrap();
-        assert_eq!(task.await.unwrap(), "completed");
+        let (result, typing_keepalive) = task.await.unwrap();
+        typing_keepalive
+            .expect("eligible session should own keepalive")
+            .stop_after_release()
+            .await;
+        assert_eq!(result, "completed");
         assert_eq!(
             typing_phases(&activities),
             vec!["start", "active", "active", "stop"]
@@ -2268,6 +2371,79 @@ mod tests {
         tokio::time::advance(Duration::from_secs(60)).await;
         tokio::task::yield_now().await;
         assert_eq!(activities.lock().unwrap().len(), activity_count_after_stop);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_typing_abort_cancels_heartbeat_and_attempts_stop() {
+        let activities = Arc::new(Mutex::new(Vec::new()));
+        let (_complete_tx, complete_rx) = oneshot::channel::<()>();
+        let task = tokio::spawn(with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            recording_typing_sender(activities.clone()),
+            async move {
+                complete_rx.await.unwrap();
+                "unreachable"
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(20)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(typing_phases(&activities), vec!["start", "active"]);
+
+        task.abort();
+        let abort_error = match task.await {
+            Ok(_) => panic!("wrapper task should be aborted"),
+            Err(error) => error,
+        };
+        assert!(abort_error.is_cancelled());
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(60)).await;
+        tokio::task::yield_now().await;
+
+        let phases = typing_phases(&activities);
+        assert_eq!(phases.iter().filter(|phase| **phase == "active").count(), 1);
+        assert_eq!(phases.iter().filter(|phase| **phase == "stop").count(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_typing_stop_is_deferred_until_after_release() {
+        let released = Arc::new(AtomicBool::new(false));
+        let stop_observations = Arc::new(Mutex::new(Vec::new()));
+        let activities = Arc::new(Mutex::new(Vec::new()));
+        let sender = {
+            let released = released.clone();
+            let stop_observations = stop_observations.clone();
+            let activities = activities.clone();
+            move |activity: ConnectorTypingActivity| {
+                if activity.phase == "stop" {
+                    stop_observations
+                        .lock()
+                        .unwrap()
+                        .push(released.load(Ordering::SeqCst));
+                }
+                activities.lock().unwrap().push(activity);
+                std::future::ready(Ok(ConnectorTypingDelivery::Eligible(Ok(()))))
+            }
+        };
+
+        let (result, typing_keepalive) = with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            sender,
+            async { "completed" },
+        )
+        .await;
+
+        assert_eq!(result, "completed");
+        assert!(stop_observations.lock().unwrap().is_empty());
+        released.store(true, Ordering::SeqCst);
+        typing_keepalive
+            .expect("eligible session should own keepalive")
+            .stop_after_release()
+            .await;
+        assert_eq!(*stop_observations.lock().unwrap(), vec![true]);
     }
 
     #[tokio::test(start_paused = true)]
@@ -2286,28 +2462,42 @@ mod tests {
         ));
         tokio::task::yield_now().await;
         cancel_work.cancel();
-        assert_eq!(cancelled_task.await.unwrap(), "cancelled");
+        let (result, typing_keepalive) = cancelled_task.await.unwrap();
+        typing_keepalive
+            .expect("eligible session should own keepalive")
+            .stop_after_release()
+            .await;
+        assert_eq!(result, "cancelled");
         assert_eq!(typing_phases(&cancelled_activities), vec!["start", "stop"]);
 
         let error_activities = Arc::new(Mutex::new(Vec::new()));
-        let error_result: anyhow::Result<()> = with_connector_typing_keepalive(
-            typing_test_context(),
-            Duration::from_secs(20),
-            recording_typing_sender(error_activities.clone()),
-            async { Err(anyhow::anyhow!("work failed")) },
-        )
-        .await;
+        let (error_result, typing_keepalive): (anyhow::Result<()>, _) =
+            with_connector_typing_keepalive(
+                typing_test_context(),
+                Duration::from_secs(20),
+                recording_typing_sender(error_activities.clone()),
+                async { Err(anyhow::anyhow!("work failed")) },
+            )
+            .await;
+        typing_keepalive
+            .expect("eligible session should own keepalive")
+            .stop_after_release()
+            .await;
         assert!(error_result.is_err());
         assert_eq!(typing_phases(&error_activities), vec!["start", "stop"]);
 
         let waiting_activities = Arc::new(Mutex::new(Vec::new()));
-        let waiting_status = with_connector_typing_keepalive(
+        let (waiting_status, typing_keepalive) = with_connector_typing_keepalive(
             typing_test_context(),
             Duration::from_secs(20),
             recording_typing_sender(waiting_activities.clone()),
             async { SessionCompletionStatus::Waiting },
         )
         .await;
+        typing_keepalive
+            .expect("eligible session should own keepalive")
+            .stop_after_release()
+            .await;
         assert_eq!(waiting_status, SessionCompletionStatus::Waiting);
         assert_eq!(typing_phases(&waiting_activities), vec!["start", "stop"]);
 
@@ -2354,7 +2544,12 @@ mod tests {
         tokio::task::yield_now().await;
         complete_tx.send(()).unwrap();
 
-        assert_eq!(task.await.unwrap(), "session completed");
+        let (result, typing_keepalive) = task.await.unwrap();
+        typing_keepalive
+            .expect("eligible session should own keepalive")
+            .stop_after_release()
+            .await;
+        assert_eq!(result, "session completed");
         assert_eq!(
             typing_phases(&attempted_activities),
             vec!["start", "active", "stop"]

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -6,9 +6,7 @@ use futures::FutureExt;
 use prost::Message;
 use serde_json::Value;
 use std::collections::BTreeMap;
-use std::future::Future;
-use std::panic::{resume_unwind, AssertUnwindSafe};
-use std::time::Duration;
+use std::panic::AssertUnwindSafe;
 
 use super::runtime::AgentRuntime;
 use super::sink::PubSubSessionSink;
@@ -24,306 +22,14 @@ use crate::gateway::rpc::data_proto::{
 use crate::harness::executor::{tool_output_loop_message, ExecutionSink, LoopMessage};
 use crate::harness::llm::ToolOutput;
 use crate::harness::sessions::{self, ClaimOutcome};
-use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
+
+use super::connector;
 
 const MAX_SESSION_RELEASE_CAS_RETRIES: usize = 8;
 const SESSION_RELEASE_CAS_BACKOFF_MS: u64 = 10;
 const DEFAULT_FANOUT_SUBSCRIBER_GRACE_MS: u64 = 100;
-const CONNECTOR_TYPING_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(20);
-const LABEL_MESSAGE_SOURCE: &str = "talon.impalasys.com/message-source";
-const LABEL_CONNECTOR_REGISTRATION: &str = "talon.impalasys.com/connector-registration";
-const LABEL_CHANNEL_TRIGGER: &str = "talon.impalasys.com/channel-trigger";
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct ConnectorTypingActivity {
-    activity_id: String,
-    phase: &'static str,
-    status_text: &'static str,
-}
-
-impl ConnectorTypingActivity {
-    fn start(submission_id: &str) -> Self {
-        Self {
-            activity_id: format!("{submission_id}:typing:start"),
-            phase: "start",
-            status_text: "is thinking...",
-        }
-    }
-
-    fn active() -> Self {
-        Self {
-            activity_id: uuid::Uuid::now_v7().to_string(),
-            phase: "active",
-            status_text: "is thinking...",
-        }
-    }
-
-    fn stop(submission_id: &str) -> Self {
-        Self {
-            activity_id: format!("{submission_id}:typing:stop"),
-            phase: "stop",
-            status_text: "",
-        }
-    }
-}
-
-enum ConnectorTypingDelivery {
-    Ineligible,
-    Eligible(Result<()>),
-}
-
-#[derive(Clone)]
-struct ConnectorTypingLogContext {
-    agent: String,
-    session_id: String,
-    submission_id: String,
-}
-
-struct ConnectorTypingKeepalive {
-    context: ConnectorTypingLogContext,
-    heartbeat_cancellation: CancellationToken,
-    heartbeat_task: Option<JoinHandle<()>>,
-    stop_signal: Option<oneshot::Sender<()>>,
-    stop_task: Option<JoinHandle<()>>,
-}
-
-async fn send_connector_typing_activity_best_effort<S, SFut>(
-    sender: &S,
-    context: &ConnectorTypingLogContext,
-    activity: ConnectorTypingActivity,
-) -> bool
-where
-    S: Fn(ConnectorTypingActivity) -> SFut,
-    SFut: Future<Output = Result<ConnectorTypingDelivery>>,
-{
-    let activity_id = activity.activity_id.clone();
-    let phase = activity.phase;
-    match sender(activity).await {
-        Ok(ConnectorTypingDelivery::Ineligible) => false,
-        Ok(ConnectorTypingDelivery::Eligible(Ok(()))) => true,
-        Ok(ConnectorTypingDelivery::Eligible(Err(error))) => {
-            tracing::warn!(
-                error = %error,
-                agent = %context.agent,
-                session = %context.session_id,
-                submission = %context.submission_id,
-                activity_id = %activity_id,
-                phase,
-                "failed to send connector typing activity"
-            );
-            // Once a session reaches the sender, an endpoint failure must not
-            // prevent later heartbeats or the final stop attempt.
-            true
-        }
-        Err(error) => {
-            tracing::warn!(
-                error = %error,
-                agent = %context.agent,
-                session = %context.session_id,
-                submission = %context.submission_id,
-                activity_id = %activity_id,
-                phase,
-                "failed to resolve connector typing activity routing"
-            );
-            false
-        }
-    }
-}
-
-async fn run_connector_typing_keepalive<S, SFut>(
-    cancellation: CancellationToken,
-    interval: Duration,
-    context: ConnectorTypingLogContext,
-    sender: S,
-    heartbeat_finished: oneshot::Sender<()>,
-) where
-    S: Fn(ConnectorTypingActivity) -> SFut + Send + Sync + 'static,
-    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
-{
-    let first_tick = tokio::time::Instant::now() + interval;
-    let mut ticks = tokio::time::interval_at(first_tick, interval);
-    ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-    loop {
-        tokio::select! {
-            biased;
-            _ = cancellation.cancelled() => break,
-            _ = ticks.tick() => {
-                let activity = ConnectorTypingActivity::active();
-                let send = send_connector_typing_activity_best_effort(
-                    &sender,
-                    &context,
-                    activity,
-                );
-                tokio::pin!(send);
-                let sent = tokio::select! {
-                    biased;
-                    _ = cancellation.cancelled() => {
-                        // Do not abandon an active request after it may have
-                        // reached the connector. Stop delivery must wait for
-                        // this request to settle to preserve activity order.
-                        let _ = send.await;
-                        false
-                    },
-                    sent = &mut send => sent
-                };
-                if !sent {
-                    break;
-                }
-            }
-        }
-    }
-
-    let _ = heartbeat_finished.send(());
-}
-
-async fn run_connector_typing_stop<S, SFut>(
-    context: ConnectorTypingLogContext,
-    sender: S,
-    stop_signal: oneshot::Receiver<()>,
-    heartbeat_finished: oneshot::Receiver<()>,
-) where
-    S: Fn(ConnectorTypingActivity) -> SFut + Send + Sync + 'static,
-    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
-{
-    if stop_signal.await.is_ok() {
-        // The heartbeat task drains any request already in flight before it
-        // signals completion. This prevents a late active activity from
-        // arriving after stop.
-        let _ = heartbeat_finished.await;
-        let _ = send_connector_typing_activity_best_effort(
-            &sender,
-            &context,
-            ConnectorTypingActivity::stop(&context.submission_id),
-        )
-        .await;
-    }
-}
-
-async fn start_connector_typing_keepalive<S, SFut>(
-    context: ConnectorTypingLogContext,
-    interval: Duration,
-    sender: S,
-) -> Option<ConnectorTypingKeepalive>
-where
-    S: Fn(ConnectorTypingActivity) -> SFut + Clone + Send + Sync + 'static,
-    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
-{
-    let eligible = send_connector_typing_activity_best_effort(
-        &sender,
-        &context,
-        ConnectorTypingActivity::start(&context.submission_id),
-    )
-    .await;
-    if !eligible {
-        return None;
-    }
-
-    let heartbeat_cancellation = CancellationToken::new();
-    let (heartbeat_finished, heartbeat_finished_receiver) = oneshot::channel();
-    let heartbeat_task = tokio::spawn(run_connector_typing_keepalive(
-        heartbeat_cancellation.clone(),
-        interval,
-        context.clone(),
-        sender.clone(),
-        heartbeat_finished,
-    ));
-    let (stop_signal, stop_receiver) = oneshot::channel();
-    let stop_task = tokio::spawn(run_connector_typing_stop(
-        context.clone(),
-        sender,
-        stop_receiver,
-        heartbeat_finished_receiver,
-    ));
-
-    Some(ConnectorTypingKeepalive {
-        context,
-        heartbeat_cancellation,
-        heartbeat_task: Some(heartbeat_task),
-        stop_signal: Some(stop_signal),
-        stop_task: Some(stop_task),
-    })
-}
-
-impl ConnectorTypingKeepalive {
-    async fn cancel_and_join_heartbeat(&mut self) {
-        self.heartbeat_cancellation.cancel();
-        if let Some(task) = self.heartbeat_task.take() {
-            if let Err(error) = task.await {
-                tracing::warn!(
-                    error = %error,
-                    agent = %self.context.agent,
-                    session = %self.context.session_id,
-                    submission = %self.context.submission_id,
-                    "connector typing keepalive task failed"
-                );
-            }
-        }
-    }
-
-    async fn stop_after_release(mut self) {
-        self.cancel_and_join_heartbeat().await;
-
-        let Some(stop_signal) = self.stop_signal.take() else {
-            return;
-        };
-        if stop_signal.send(()).is_err() {
-            return;
-        }
-
-        if let Some(task) = self.stop_task.take() {
-            if let Err(error) = task.await {
-                tracing::warn!(
-                    error = %error,
-                    agent = %self.context.agent,
-                    session = %self.context.session_id,
-                    submission = %self.context.submission_id,
-                    "connector typing stop task failed"
-                );
-            }
-        }
-    }
-}
-
-impl Drop for ConnectorTypingKeepalive {
-    fn drop(&mut self) {
-        self.heartbeat_cancellation.cancel();
-        if let Some(stop_signal) = self.stop_signal.take() {
-            let _ = stop_signal.send(());
-        }
-    }
-}
-
-async fn with_connector_typing_keepalive<S, SFut, F, T>(
-    context: ConnectorTypingLogContext,
-    interval: Duration,
-    sender: S,
-    work: F,
-) -> (T, Option<ConnectorTypingKeepalive>)
-where
-    S: Fn(ConnectorTypingActivity) -> SFut + Clone + Send + Sync + 'static,
-    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
-    F: Future<Output = T>,
-{
-    let Some(mut keepalive) = start_connector_typing_keepalive(context, interval, sender).await
-    else {
-        return (work.await, None);
-    };
-
-    let outcome = AssertUnwindSafe(work).catch_unwind().await;
-    keepalive.cancel_and_join_heartbeat().await;
-
-    match outcome {
-        Ok(value) => (value, Some(keepalive)),
-        Err(panic) => {
-            keepalive.stop_after_release().await;
-            resume_unwind(panic);
-        }
-    }
-}
 
 fn fanout_subscriber_grace() -> std::time::Duration {
     let millis = match std::env::var("TALON_WORKER_FANOUT_SUBSCRIBER_GRACE_MS") {
@@ -965,7 +671,7 @@ impl WorkerEventHandler {
             return Ok(());
         }
 
-        let typing_context = ConnectorTypingLogContext {
+        let typing_context = connector::ConnectorTypingLogContext {
             agent: event.agent.clone(),
             session_id: event.session_id.clone(),
             submission_id: submission.submission_id.clone(),
@@ -974,7 +680,7 @@ impl WorkerEventHandler {
         let activity_ns = ns.to_string();
         let activity_agent = event.agent.clone();
         let activity_session_id = event.session_id.clone();
-        let activity_sender = move |activity: ConnectorTypingActivity| {
+        let activity_sender = move |activity: connector::ConnectorTypingActivity| {
             let handler = activity_handler.clone();
             let ns = activity_ns.clone();
             let agent = activity_agent.clone();
@@ -1177,9 +883,9 @@ impl WorkerEventHandler {
             .await
             .map(|status| (status, sink.summary()))
         });
-        let (outcome, typing_keepalive) = with_connector_typing_keepalive(
+        let (outcome, typing_keepalive) = connector::with_connector_typing_keepalive(
             typing_context,
-            CONNECTOR_TYPING_KEEPALIVE_INTERVAL,
+            connector::CONNECTOR_TYPING_KEEPALIVE_INTERVAL,
             activity_sender,
             execution,
         )
@@ -1365,59 +1071,6 @@ impl WorkerEventHandler {
         }
 
         outcome.map(|_| ())
-    }
-
-    async fn maybe_send_connector_session_activity(
-        &self,
-        ns: &str,
-        agent: &str,
-        session_id: &str,
-        activity_id: &str,
-        phase: &str,
-        status_text: &str,
-    ) -> Result<ConnectorTypingDelivery> {
-        let session = self
-            .cp
-            .kv
-            .get_msg::<data_proto::Session>(&crate::control::keys::session(ns, agent, session_id))
-            .await?
-            .ok_or_else(|| anyhow!("session not found"))?;
-        if !session.labels.contains_key(LABEL_CONNECTOR_REGISTRATION) {
-            return Ok(ConnectorTypingDelivery::Ineligible);
-        }
-        if session
-            .labels
-            .get(LABEL_MESSAGE_SOURCE)
-            .is_some_and(|source| source != "connector")
-        {
-            return Ok(ConnectorTypingDelivery::Ineligible);
-        }
-        if session.labels.contains_key(LABEL_CHANNEL_TRIGGER) {
-            return Ok(ConnectorTypingDelivery::Ineligible);
-        }
-        Ok(ConnectorTypingDelivery::Eligible(
-            connector_rpc::send_connector_session_activity(
-                &self.cp,
-                &session,
-                activity_id,
-                phase,
-                status_text,
-            )
-            .await,
-        ))
-    }
-
-    async fn maybe_deliver_connector_session_reply(
-        &self,
-        ns: &str,
-        agent: &str,
-        session_id: &str,
-        message_id: &str,
-    ) -> Result<()> {
-        connector_rpc::maybe_deliver_connector_session_message(
-            &self.cp, ns, agent, session_id, message_id,
-        )
-        .await
     }
 
     async fn maybe_auto_forward_a2a_final_message(
@@ -1658,9 +1311,7 @@ fn next_recovered_part_id(next_projection_part_index: &mut usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        execute_with_panic_boundary, session_message_artifact_uris,
-        with_connector_typing_keepalive, ConnectorTypingActivity, ConnectorTypingDelivery,
-        ConnectorTypingLogContext, SessionCompletionStatus,
+        execute_with_panic_boundary, session_message_artifact_uris, SessionCompletionStatus,
     };
     use crate::control::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::object_store::ObjectMetadata;
@@ -1674,6 +1325,10 @@ mod tests {
     use crate::harness::executor::ExecutionSink;
     use crate::harness::sessions;
     use crate::test_support::MockKvStore;
+    use crate::worker::connector::{
+        with_connector_typing_keepalive, ConnectorTypingActivity, ConnectorTypingDelivery,
+        ConnectorTypingLogContext,
+    };
     use crate::worker::{
         mcp_registry::McpRegistry, scheduler_auth::SchedulerRequestAuthenticator,
         WorkerEventHandler,
@@ -2625,6 +2280,60 @@ mod tests {
         tokio::task::yield_now().await;
         complete_tx.send(()).unwrap();
 
+        let (result, typing_keepalive) = task.await.unwrap();
+        typing_keepalive
+            .expect("eligible session should own keepalive")
+            .stop_after_release()
+            .await;
+        assert_eq!(result, "session completed");
+        assert_eq!(
+            typing_phases(&attempted_activities),
+            vec!["start", "active", "stop"]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_typing_routing_failures_retry_future_heartbeats() {
+        let attempted_activities = Arc::new(Mutex::new(Vec::new()));
+        let active_attempts = Arc::new(AtomicUsize::new(0));
+        let sender = {
+            let attempted_activities = attempted_activities.clone();
+            let active_attempts = active_attempts.clone();
+            move |activity: ConnectorTypingActivity| {
+                let attempted_activities = attempted_activities.clone();
+                let active_attempts = active_attempts.clone();
+                async move {
+                    if activity.phase == "active"
+                        && active_attempts.fetch_add(1, Ordering::SeqCst) == 0
+                    {
+                        return Err(anyhow::anyhow!("routing temporarily unavailable"));
+                    }
+                    attempted_activities.lock().unwrap().push(activity);
+                    Ok(ConnectorTypingDelivery::Eligible(Ok(())))
+                }
+            }
+        };
+        let (complete_tx, complete_rx) = oneshot::channel();
+        let task = tokio::spawn(with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            sender,
+            async move {
+                complete_rx.await.unwrap();
+                "session completed"
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(20)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(active_attempts.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(20)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(active_attempts.load(Ordering::SeqCst), 2);
+
+        complete_tx.send(()).unwrap();
         let (result, typing_keepalive) = task.await.unwrap();
         typing_keepalive
             .expect("eligible session should own keepalive")

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -138,6 +138,7 @@ async fn run_connector_typing_keepalive<S, SFut>(
     interval: Duration,
     context: ConnectorTypingLogContext,
     sender: S,
+    heartbeat_finished: oneshot::Sender<()>,
 ) where
     S: Fn(ConnectorTypingActivity) -> SFut + Send + Sync + 'static,
     SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
@@ -160,7 +161,13 @@ async fn run_connector_typing_keepalive<S, SFut>(
                 tokio::pin!(send);
                 let sent = tokio::select! {
                     biased;
-                    _ = cancellation.cancelled() => break,
+                    _ = cancellation.cancelled() => {
+                        // Do not abandon an active request after it may have
+                        // reached the connector. Stop delivery must wait for
+                        // this request to settle to preserve activity order.
+                        let _ = send.await;
+                        false
+                    },
                     sent = &mut send => sent
                 };
                 if !sent {
@@ -169,17 +176,24 @@ async fn run_connector_typing_keepalive<S, SFut>(
             }
         }
     }
+
+    let _ = heartbeat_finished.send(());
 }
 
 async fn run_connector_typing_stop<S, SFut>(
     context: ConnectorTypingLogContext,
     sender: S,
     stop_signal: oneshot::Receiver<()>,
+    heartbeat_finished: oneshot::Receiver<()>,
 ) where
     S: Fn(ConnectorTypingActivity) -> SFut + Send + Sync + 'static,
     SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
 {
     if stop_signal.await.is_ok() {
+        // The heartbeat task drains any request already in flight before it
+        // signals completion. This prevents a late active activity from
+        // arriving after stop.
+        let _ = heartbeat_finished.await;
         let _ = send_connector_typing_activity_best_effort(
             &sender,
             &context,
@@ -209,17 +223,20 @@ where
     }
 
     let heartbeat_cancellation = CancellationToken::new();
+    let (heartbeat_finished, heartbeat_finished_receiver) = oneshot::channel();
     let heartbeat_task = tokio::spawn(run_connector_typing_keepalive(
         heartbeat_cancellation.clone(),
         interval,
         context.clone(),
         sender.clone(),
+        heartbeat_finished,
     ));
     let (stop_signal, stop_receiver) = oneshot::channel();
     let stop_task = tokio::spawn(run_connector_typing_stop(
         context.clone(),
         sender,
         stop_receiver,
+        heartbeat_finished_receiver,
     ));
 
     Some(ConnectorTypingKeepalive {
@@ -2405,6 +2422,70 @@ mod tests {
         let phases = typing_phases(&activities);
         assert_eq!(phases.iter().filter(|phase| **phase == "active").count(), 1);
         assert_eq!(phases.iter().filter(|phase| **phase == "stop").count(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_typing_abort_drains_in_flight_heartbeat_before_stop() {
+        let activities = Arc::new(Mutex::new(Vec::new()));
+        let (active_started_tx, active_started_rx) = oneshot::channel();
+        let (active_release_tx, active_release_rx) = oneshot::channel();
+        let active_started = Arc::new(Mutex::new(Some(active_started_tx)));
+        let active_release = Arc::new(Mutex::new(Some(active_release_rx)));
+        let sender = {
+            let activities = activities.clone();
+            let active_started = active_started.clone();
+            let active_release = active_release.clone();
+            move |activity: ConnectorTypingActivity| {
+                let phase = activity.phase;
+                let activities = activities.clone();
+                let active_started = active_started.clone();
+                let active_release = active_release.clone();
+                async move {
+                    activities.lock().unwrap().push(activity);
+                    if phase == "active" {
+                        if let Some(signal) = active_started.lock().unwrap().take() {
+                            let _ = signal.send(());
+                        }
+                        let release = { active_release.lock().unwrap().take() };
+                        if let Some(release) = release {
+                            let _ = release.await;
+                        }
+                    }
+                    Ok(ConnectorTypingDelivery::Eligible(Ok(())))
+                }
+            }
+        };
+
+        let (_complete_tx, complete_rx) = oneshot::channel::<()>();
+        let task = tokio::spawn(with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            sender,
+            async move {
+                complete_rx.await.unwrap();
+                "unreachable"
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(20)).await;
+        active_started_rx.await.unwrap();
+        assert_eq!(typing_phases(&activities), vec!["start", "active"]);
+
+        task.abort();
+        let abort_error = match task.await {
+            Ok(_) => panic!("wrapper task should be aborted"),
+            Err(error) => error,
+        };
+        assert!(abort_error.is_cancelled());
+        tokio::task::yield_now().await;
+        assert_eq!(typing_phases(&activities), vec!["start", "active"]);
+
+        active_release_tx.send(()).unwrap();
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(typing_phases(&activities), vec!["start", "active", "stop"]);
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/worker/sessions.rs
+++ b/src/worker/sessions.rs
@@ -6,7 +6,9 @@ use futures::FutureExt;
 use prost::Message;
 use serde_json::Value;
 use std::collections::BTreeMap;
-use std::panic::AssertUnwindSafe;
+use std::future::Future;
+use std::panic::{resume_unwind, AssertUnwindSafe};
+use std::time::Duration;
 
 use super::runtime::AgentRuntime;
 use super::sink::PubSubSessionSink;
@@ -28,9 +30,193 @@ use tracing::Instrument;
 const MAX_SESSION_RELEASE_CAS_RETRIES: usize = 8;
 const SESSION_RELEASE_CAS_BACKOFF_MS: u64 = 10;
 const DEFAULT_FANOUT_SUBSCRIBER_GRACE_MS: u64 = 100;
+const CONNECTOR_TYPING_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(20);
 const LABEL_MESSAGE_SOURCE: &str = "talon.impalasys.com/message-source";
 const LABEL_CONNECTOR_REGISTRATION: &str = "talon.impalasys.com/connector-registration";
 const LABEL_CHANNEL_TRIGGER: &str = "talon.impalasys.com/channel-trigger";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ConnectorTypingActivity {
+    activity_id: String,
+    phase: &'static str,
+    status_text: &'static str,
+}
+
+impl ConnectorTypingActivity {
+    fn start(submission_id: &str) -> Self {
+        Self {
+            activity_id: format!("{submission_id}:typing:start"),
+            phase: "start",
+            status_text: "is thinking...",
+        }
+    }
+
+    fn active() -> Self {
+        Self {
+            activity_id: uuid::Uuid::now_v7().to_string(),
+            phase: "active",
+            status_text: "is thinking...",
+        }
+    }
+
+    fn stop(submission_id: &str) -> Self {
+        Self {
+            activity_id: format!("{submission_id}:typing:stop"),
+            phase: "stop",
+            status_text: "",
+        }
+    }
+}
+
+enum ConnectorTypingDelivery {
+    Ineligible,
+    Eligible(Result<()>),
+}
+
+#[derive(Clone)]
+struct ConnectorTypingLogContext {
+    agent: String,
+    session_id: String,
+    submission_id: String,
+}
+
+async fn send_connector_typing_activity_best_effort<S, SFut>(
+    sender: &S,
+    context: &ConnectorTypingLogContext,
+    activity: ConnectorTypingActivity,
+) -> bool
+where
+    S: Fn(ConnectorTypingActivity) -> SFut,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>>,
+{
+    let activity_id = activity.activity_id.clone();
+    let phase = activity.phase;
+    match sender(activity).await {
+        Ok(ConnectorTypingDelivery::Ineligible) => false,
+        Ok(ConnectorTypingDelivery::Eligible(Ok(()))) => true,
+        Ok(ConnectorTypingDelivery::Eligible(Err(error))) => {
+            tracing::warn!(
+                error = %error,
+                agent = %context.agent,
+                session = %context.session_id,
+                submission = %context.submission_id,
+                activity_id = %activity_id,
+                phase,
+                "failed to send connector typing activity"
+            );
+            // Once a session reaches the sender, an endpoint failure must not
+            // prevent later heartbeats or the final stop attempt.
+            true
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                agent = %context.agent,
+                session = %context.session_id,
+                submission = %context.submission_id,
+                activity_id = %activity_id,
+                phase,
+                "failed to resolve connector typing activity routing"
+            );
+            false
+        }
+    }
+}
+
+async fn run_connector_typing_keepalive<S, SFut>(
+    cancellation: CancellationToken,
+    interval: Duration,
+    context: ConnectorTypingLogContext,
+    sender: S,
+) where
+    S: Fn(ConnectorTypingActivity) -> SFut + Send + Sync + 'static,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
+{
+    let first_tick = tokio::time::Instant::now() + interval;
+    let mut ticks = tokio::time::interval_at(first_tick, interval);
+    ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => break,
+            _ = ticks.tick() => {
+                let activity = ConnectorTypingActivity::active();
+                let send = send_connector_typing_activity_best_effort(
+                    &sender,
+                    &context,
+                    activity,
+                );
+                tokio::pin!(send);
+                let sent = tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => break,
+                    sent = &mut send => sent
+                };
+                if !sent {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn with_connector_typing_keepalive<S, SFut, F, T>(
+    context: ConnectorTypingLogContext,
+    interval: Duration,
+    sender: S,
+    work: F,
+) -> T
+where
+    S: Fn(ConnectorTypingActivity) -> SFut + Clone + Send + Sync + 'static,
+    SFut: Future<Output = Result<ConnectorTypingDelivery>> + Send + 'static,
+    F: Future<Output = T>,
+{
+    let eligible = send_connector_typing_activity_best_effort(
+        &sender,
+        &context,
+        ConnectorTypingActivity::start(&context.submission_id),
+    )
+    .await;
+    if !eligible {
+        return work.await;
+    }
+
+    // This token scopes only the typing keepalive. It must never be shared
+    // with or derived from the agent execution cancellation token.
+    let keepalive_cancellation = CancellationToken::new();
+    let keepalive_task = tokio::spawn(run_connector_typing_keepalive(
+        keepalive_cancellation.clone(),
+        interval,
+        context.clone(),
+        sender.clone(),
+    ));
+
+    let outcome = AssertUnwindSafe(work).catch_unwind().await;
+
+    keepalive_cancellation.cancel();
+    if let Err(error) = keepalive_task.await {
+        tracing::warn!(
+            error = %error,
+            agent = %context.agent,
+            session = %context.session_id,
+            submission = %context.submission_id,
+            "connector typing keepalive task failed"
+        );
+    }
+
+    let _ = send_connector_typing_activity_best_effort(
+        &sender,
+        &context,
+        ConnectorTypingActivity::stop(&context.submission_id),
+    )
+    .await;
+
+    match outcome {
+        Ok(value) => value,
+        Err(panic) => resume_unwind(panic),
+    }
+}
 
 fn fanout_subscriber_grace() -> std::time::Duration {
     let millis = match std::env::var("TALON_WORKER_FANOUT_SUBSCRIBER_GRACE_MS") {
@@ -672,27 +858,35 @@ impl WorkerEventHandler {
             return Ok(());
         }
 
-        if let Err(err) = self
-            .maybe_send_connector_session_activity(
-                ns,
-                &event.agent,
-                &event.session_id,
-                &submission.submission_id,
-                "start",
-                "is thinking...",
-            )
-            .await
-        {
-            tracing::warn!(
-                error = %err,
-                agent = %event.agent,
-                session = %event.session_id,
-                submission = %submission.submission_id,
-                "failed to send connector typing start activity"
-            );
-        }
+        let typing_context = ConnectorTypingLogContext {
+            agent: event.agent.clone(),
+            session_id: event.session_id.clone(),
+            submission_id: submission.submission_id.clone(),
+        };
+        let activity_handler = self.clone();
+        let activity_ns = ns.to_string();
+        let activity_agent = event.agent.clone();
+        let activity_session_id = event.session_id.clone();
+        let activity_sender = move |activity: ConnectorTypingActivity| {
+            let handler = activity_handler.clone();
+            let ns = activity_ns.clone();
+            let agent = activity_agent.clone();
+            let session_id = activity_session_id.clone();
+            async move {
+                handler
+                    .maybe_send_connector_session_activity(
+                        &ns,
+                        &agent,
+                        &session_id,
+                        &activity.activity_id,
+                        activity.phase,
+                        activity.status_text,
+                    )
+                    .await
+            }
+        };
 
-        let outcome = async {
+        let execution = Box::pin(async {
             // Load the agent resource before deciding which runtime owns the
             // rest of the session execution.
             let store = crate::control::resources::ResourceStore::new(
@@ -875,7 +1069,13 @@ impl WorkerEventHandler {
             .instrument(tracing::info_span!("WorkerEventHandler.execute_session"))
             .await
             .map(|status| (status, sink.summary()))
-        }
+        });
+        let outcome = with_connector_typing_keepalive(
+            typing_context,
+            CONNECTOR_TYPING_KEEPALIVE_INTERVAL,
+            activity_sender,
+            execution,
+        )
         .await;
 
         self.session_cancellations.remove(&cancellation_key).await;
@@ -900,26 +1100,6 @@ impl WorkerEventHandler {
             "WorkerEventHandler.release_session_lock"
         ))
         .await;
-
-        if let Err(err) = self
-            .maybe_send_connector_session_activity(
-                ns,
-                &event.agent,
-                &event.session_id,
-                &submission.submission_id,
-                "stop",
-                "",
-            )
-            .await
-        {
-            tracing::warn!(
-                error = %err,
-                agent = %event.agent,
-                session = %event.session_id,
-                submission = %submission.submission_id,
-                "failed to send connector typing stop activity"
-            );
-        }
 
         if completion_status == SessionCompletionStatus::Completed {
             let is_delegated_task = self
@@ -1081,10 +1261,10 @@ impl WorkerEventHandler {
         ns: &str,
         agent: &str,
         session_id: &str,
-        submission_id: &str,
+        activity_id: &str,
         phase: &str,
         status_text: &str,
-    ) -> Result<()> {
+    ) -> Result<ConnectorTypingDelivery> {
         let session = self
             .cp
             .kv
@@ -1092,26 +1272,28 @@ impl WorkerEventHandler {
             .await?
             .ok_or_else(|| anyhow!("session not found"))?;
         if !session.labels.contains_key(LABEL_CONNECTOR_REGISTRATION) {
-            return Ok(());
+            return Ok(ConnectorTypingDelivery::Ineligible);
         }
         if session
             .labels
             .get(LABEL_MESSAGE_SOURCE)
             .is_some_and(|source| source != "connector")
         {
-            return Ok(());
+            return Ok(ConnectorTypingDelivery::Ineligible);
         }
         if session.labels.contains_key(LABEL_CHANNEL_TRIGGER) {
-            return Ok(());
+            return Ok(ConnectorTypingDelivery::Ineligible);
         }
-        connector_rpc::send_connector_session_activity(
-            &self.cp,
-            &session,
-            &format!("{submission_id}:typing:{phase}"),
-            phase,
-            status_text,
-        )
-        .await
+        Ok(ConnectorTypingDelivery::Eligible(
+            connector_rpc::send_connector_session_activity(
+                &self.cp,
+                &session,
+                activity_id,
+                phase,
+                status_text,
+            )
+            .await,
+        ))
     }
 
     async fn maybe_deliver_connector_session_reply(
@@ -1365,7 +1547,9 @@ fn next_recovered_part_id(next_projection_part_index: &mut usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        execute_with_panic_boundary, session_message_artifact_uris, SessionCompletionStatus,
+        execute_with_panic_boundary, session_message_artifact_uris,
+        with_connector_typing_keepalive, ConnectorTypingActivity, ConnectorTypingDelivery,
+        ConnectorTypingLogContext, SessionCompletionStatus,
     };
     use crate::control::config::{proto, Config, ProviderConfig, Secret};
     use crate::control::object_store::ObjectMetadata;
@@ -1384,17 +1568,50 @@ mod tests {
         WorkerEventHandler,
     };
     use async_trait::async_trait;
-    use axum::{extract::State, routing::post, Json, Router};
-    use futures::stream;
+    use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
+    use futures::{stream, FutureExt};
     use prost::Message;
     use serde_json::json;
     use serde_json::Value;
     use std::collections::HashMap;
+    use std::panic::AssertUnwindSafe;
     use std::pin::Pin;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::sync::Mutex;
+    use std::time::Duration;
     use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+    use tokio_util::sync::CancellationToken;
+
+    fn typing_test_context() -> ConnectorTypingLogContext {
+        ConnectorTypingLogContext {
+            agent: "assistant".to_string(),
+            session_id: "session-1".to_string(),
+            submission_id: "submission-1".to_string(),
+        }
+    }
+
+    fn recording_typing_sender(
+        activities: Arc<Mutex<Vec<ConnectorTypingActivity>>>,
+    ) -> impl Fn(
+        ConnectorTypingActivity,
+    ) -> std::future::Ready<anyhow::Result<ConnectorTypingDelivery>>
+           + Clone {
+        move |activity| {
+            activities.lock().unwrap().push(activity);
+            std::future::ready(Ok(ConnectorTypingDelivery::Eligible(Ok(()))))
+        }
+    }
+
+    fn typing_phases(activities: &Arc<Mutex<Vec<ConnectorTypingActivity>>>) -> Vec<&'static str> {
+        activities
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|activity| activity.phase)
+            .collect()
+    }
 
     struct CaptureErrorSink {
         errors: Mutex<Vec<String>>,
@@ -1946,6 +2163,202 @@ mod tests {
                 ..Config::default()
             },
         )
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_typing_short_run_sends_start_then_stop() {
+        let activities = Arc::new(Mutex::new(Vec::new()));
+
+        let result = with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            recording_typing_sender(activities.clone()),
+            async { "completed" },
+        )
+        .await;
+
+        assert_eq!(result, "completed");
+        assert_eq!(typing_phases(&activities), vec!["start", "stop"]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_typing_ineligible_session_does_not_start_keepalive() {
+        let attempted_activities = Arc::new(Mutex::new(Vec::new()));
+        let sender = {
+            let attempted_activities = attempted_activities.clone();
+            move |activity: ConnectorTypingActivity| {
+                attempted_activities.lock().unwrap().push(activity);
+                std::future::ready(Ok(ConnectorTypingDelivery::Ineligible))
+            }
+        };
+        let (complete_tx, complete_rx) = oneshot::channel();
+        let task = tokio::spawn(with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            sender,
+            async move {
+                complete_rx.await.unwrap();
+                "completed"
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(60)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(typing_phases(&attempted_activities), vec!["start"]);
+
+        complete_tx.send(()).unwrap();
+        assert_eq!(task.await.unwrap(), "completed");
+        assert_eq!(typing_phases(&attempted_activities), vec!["start"]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_typing_long_run_sends_unique_actives_until_stop() {
+        let activities = Arc::new(Mutex::new(Vec::new()));
+        let (complete_tx, complete_rx) = oneshot::channel();
+        let task = tokio::spawn(with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            recording_typing_sender(activities.clone()),
+            async move {
+                complete_rx.await.unwrap();
+                "completed"
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        assert_eq!(typing_phases(&activities), vec!["start"]);
+
+        tokio::time::advance(Duration::from_secs(19)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(typing_phases(&activities), vec!["start"]);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(typing_phases(&activities), vec!["start", "active"]);
+
+        tokio::time::advance(Duration::from_secs(20)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            typing_phases(&activities),
+            vec!["start", "active", "active"]
+        );
+
+        let active_ids = activities
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|activity| activity.phase == "active")
+            .map(|activity| activity.activity_id.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(active_ids.len(), 2);
+        assert_ne!(active_ids[0], active_ids[1]);
+        for activity_id in &active_ids {
+            uuid::Uuid::parse_str(activity_id).expect("active activity id should be a UUID");
+        }
+
+        complete_tx.send(()).unwrap();
+        assert_eq!(task.await.unwrap(), "completed");
+        assert_eq!(
+            typing_phases(&activities),
+            vec!["start", "active", "active", "stop"]
+        );
+
+        let activity_count_after_stop = activities.lock().unwrap().len();
+        tokio::time::advance(Duration::from_secs(60)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(activities.lock().unwrap().len(), activity_count_after_stop);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_typing_cleans_up_after_cancellation_error_and_panic() {
+        let cancelled_activities = Arc::new(Mutex::new(Vec::new()));
+        let work_cancellation = CancellationToken::new();
+        let cancel_work = work_cancellation.clone();
+        let cancelled_task = tokio::spawn(with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            recording_typing_sender(cancelled_activities.clone()),
+            async move {
+                work_cancellation.cancelled().await;
+                "cancelled"
+            },
+        ));
+        tokio::task::yield_now().await;
+        cancel_work.cancel();
+        assert_eq!(cancelled_task.await.unwrap(), "cancelled");
+        assert_eq!(typing_phases(&cancelled_activities), vec!["start", "stop"]);
+
+        let error_activities = Arc::new(Mutex::new(Vec::new()));
+        let error_result: anyhow::Result<()> = with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            recording_typing_sender(error_activities.clone()),
+            async { Err(anyhow::anyhow!("work failed")) },
+        )
+        .await;
+        assert!(error_result.is_err());
+        assert_eq!(typing_phases(&error_activities), vec!["start", "stop"]);
+
+        let waiting_activities = Arc::new(Mutex::new(Vec::new()));
+        let waiting_status = with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            recording_typing_sender(waiting_activities.clone()),
+            async { SessionCompletionStatus::Waiting },
+        )
+        .await;
+        assert_eq!(waiting_status, SessionCompletionStatus::Waiting);
+        assert_eq!(typing_phases(&waiting_activities), vec!["start", "stop"]);
+
+        let panic_activities = Arc::new(Mutex::new(Vec::new()));
+        let panic_result = AssertUnwindSafe(with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            recording_typing_sender(panic_activities.clone()),
+            async {
+                panic!("work panicked");
+            },
+        ))
+        .catch_unwind()
+        .await;
+        assert!(panic_result.is_err());
+        assert_eq!(typing_phases(&panic_activities), vec!["start", "stop"]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connector_typing_endpoint_failures_do_not_fail_session_work() {
+        let attempted_activities = Arc::new(Mutex::new(Vec::new()));
+        let sender = {
+            let attempted_activities = attempted_activities.clone();
+            move |activity: ConnectorTypingActivity| {
+                attempted_activities.lock().unwrap().push(activity);
+                std::future::ready(Ok(ConnectorTypingDelivery::Eligible(Err(anyhow::anyhow!(
+                    "activity endpoint unavailable"
+                )))))
+            }
+        };
+        let (complete_tx, complete_rx) = oneshot::channel();
+        let task = tokio::spawn(with_connector_typing_keepalive(
+            typing_test_context(),
+            Duration::from_secs(20),
+            sender,
+            async move {
+                complete_rx.await.unwrap();
+                "session completed"
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(20)).await;
+        tokio::task::yield_now().await;
+        complete_tx.send(()).unwrap();
+
+        assert_eq!(task.await.unwrap(), "session completed");
+        assert_eq!(
+            typing_phases(&attempted_activities),
+            vec!["start", "active", "stop"]
+        );
     }
 
     #[tokio::test]
@@ -2549,7 +2962,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_session_message_delivers_connector_error_reply() {
+    async fn handle_session_message_ignores_activity_failures_and_delivers_error_reply() {
         let kv = Arc::new(MockKvStore::default());
         let deliveries: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
         let app = Router::new()
@@ -2570,11 +2983,14 @@ mod tests {
             .route(
                 "/v1/activities",
                 post(|| async {
-                    Json(json!({
-                        "accepted": true,
-                        "disposition": "accepted",
-                        "error": ""
-                    }))
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        Json(json!({
+                            "accepted": false,
+                            "disposition": "unavailable",
+                            "error": "activity endpoint unavailable"
+                        })),
+                    )
                 }),
             )
             .with_state(deliveries.clone());
@@ -2927,6 +3343,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connector_typing_activity_skips_non_connector_and_channel_triggered_sessions() {
+        let kv = Arc::new(MockKvStore::default());
+        let handler = handler_with_kv(kv.clone());
+
+        put_connector_session_and_assistant_message(
+            kv.clone(),
+            HashMap::new(),
+            HashMap::new(),
+            "non-connector reply",
+        )
+        .await;
+        let sent = handler
+            .maybe_send_connector_session_activity(
+                "conic:test",
+                "assistant",
+                "session-1",
+                "non-connector-activity",
+                "active",
+                "is thinking...",
+            )
+            .await
+            .expect("non-connector activity should be skipped");
+        assert!(matches!(sent, ConnectorTypingDelivery::Ineligible));
+
+        put_connector_session_and_assistant_message(
+            kv,
+            connector_session_labels([("talon.impalasys.com/channel-trigger", "true")]),
+            HashMap::new(),
+            "channel-triggered reply",
+        )
+        .await;
+        let sent = handler
+            .maybe_send_connector_session_activity(
+                "conic:test",
+                "assistant",
+                "session-1",
+                "channel-triggered-activity",
+                "active",
+                "is thinking...",
+            )
+            .await
+            .expect("channel-triggered activity should be skipped");
+        assert!(matches!(sent, ConnectorTypingDelivery::Ineligible));
+    }
+
+    #[tokio::test]
     async fn send_connector_session_activity_derives_request_from_connector() {
         let kv = Arc::new(MockKvStore::default());
         let activities: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
@@ -2986,6 +3448,7 @@ mod tests {
         let activities = activities.lock().unwrap().clone();
         assert_eq!(activities.len(), 1);
         let activity = &activities[0];
+        assert_eq!(activity["activityId"], "activity-1");
         assert_eq!(
             activity["registrationId"],
             "Namespace/conic%3Atest/ConnectorClass/slack"


### PR DESCRIPTION
## Summary

- Isolate connector typing lifecycle management in the worker.
- Make connector typing cleanup cancellation-safe.
- Drain the final typing heartbeat before stopping.

## Validation

This PR is the base for the follow-up steer queue PR.
