### PR TITLE
Route interactive messages through the steer queue

### DIFF
--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -617,6 +617,13 @@ pub async fn send_message(
     if message.trim().is_empty() {
         return Err(EmptyMessageError.into());
     }
+    if kv
+        .get(&keys::session(ns, agent, session_id))
+        .await?
+        .is_none()
+    {
+        return Err(SessionNotFoundError.into());
+    }
     let now_micros = now.timestamp_micros();
     let user_msg = data_proto::SessionMessage {
         id: crate::control::uuid::session_message_id(),
@@ -634,44 +641,43 @@ pub async fn send_message(
         }],
     };
 
-    // Interactive ingress is steerable while a healthy turn is running. The
-    // active worker will absorb this durable queue entry at its next tool
-    // boundary; idle sessions continue through the normal submission path.
-    if let Some(session) = kv
-        .get_msg::<data_proto::Session>(&keys::session(ns, agent, session_id))
-        .await?
+    // Interactive input uses STEER as its single durable inbox. When the
+    // session is idle, dispatch promotes the oldest entry into a new
+    // submission; while a worker is active, the worker drains it as steering.
+    let queued = crate::control::session_queue::queue_session_message(
+        kv,
+        ns,
+        agent,
+        session_id,
+        crate::control::session_queue::STEER_QUEUE,
+        user_msg,
+        now,
+    )
+    .await?;
+    match crate::control::session_queue::dispatch_next_queued_message(
+        kv,
+        pubsub,
+        ns,
+        agent,
+        session_id,
+        crate::control::session_queue::STEER_QUEUE,
+        now,
+    )
+    .await
     {
-        if session.status == "PROCESSING"
-            && now_micros.saturating_sub(session.last_active) <= session_processing_timeout_micros()
-        {
-            let queued = crate::control::session_queue::queue_interactive_session_message(
-                kv, ns, agent, session_id, user_msg, now,
-            )
-            .await?;
-            if let Err(err) = crate::control::session_queue::dispatch_next_queued_message(
-                kv,
-                pubsub,
-                ns,
-                agent,
-                session_id,
-                crate::control::session_queue::STEER_QUEUE,
-                now,
-            )
-            .await
-            {
-                tracing::warn!(
-                    namespace = %ns,
-                    agent = %agent,
-                    session = %session_id,
-                    error = %err,
-                    "failed to recheck queued interactive message after admission"
-                );
-            }
-            return Ok(queued.entry_id);
+        Ok(Some(dispatched)) => Ok(dispatched.submission_id),
+        Ok(None) => Ok(queued.entry_id),
+        Err(err) => {
+            tracing::warn!(
+                namespace = %ns,
+                agent = %agent,
+                session = %session_id,
+                error = %err,
+                "failed to recheck queued interactive message after admission"
+            );
+            Err(err)
         }
     }
-
-    send_session_message(kv, pubsub, ns, agent, session_id, user_msg, now).await
 }
 
 pub async fn enqueue_message_without_dispatch(
@@ -1618,6 +1624,19 @@ mod tests {
             keys::session_message("conic:test", "assistant", "session-1", &dispatch.message_id)
                 .canonical()
         );
+        assert!(kv
+            .list_keys(
+                &keys::session_queue_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                    crate::control::session_queue::NEXT_QUEUE,
+                ),
+                None,
+            )
+            .await
+            .unwrap()
+            .is_empty());
         let submission = cp
             .kv
             .get_msg::<crate::harness::sessions::SessionSubmission>(&keys::session_submission(

--- a/src/control/session_queue.rs
+++ b/src/control/session_queue.rs
@@ -303,32 +303,6 @@ pub async fn queue_session_message(
     })
 }
 
-/// Route an interactive ingress message to the active turn when one is
-/// healthy; otherwise leave it in NEXT so it starts the next turn.
-pub async fn queue_interactive_session_message(
-    kv: &dyn KeyValueStore,
-    ns: &str,
-    agent: &str,
-    session_id: &str,
-    message: data_proto::SessionMessage,
-    now: DateTime<Utc>,
-) -> Result<QueuedSessionMessage> {
-    let queue = match kv
-        .get_msg::<data_proto::Session>(&keys::session(ns, agent, session_id))
-        .await?
-    {
-        Some(session)
-            if session.status == "PROCESSING"
-                && now.timestamp_micros().saturating_sub(session.last_active)
-                    <= scheduling::session_processing_timeout_micros() =>
-        {
-            STEER_QUEUE
-        }
-        _ => NEXT_QUEUE,
-    };
-    queue_session_message(kv, ns, agent, session_id, queue, message, now).await
-}
-
 /// Move steering entries to NEXT when the active attempt has failed. The
 /// destination is written before the source is deleted so a crash can leave a
 /// duplicate queue copy, but never lose the input.
@@ -978,6 +952,92 @@ mod tests {
             .await
             .iter()
             .any(|(topic, _)| topic == topics::SESSION_DISPATCH_TOPIC));
+    }
+
+    #[tokio::test]
+    async fn steer_queue_bootstraps_idle_session_and_preserves_later_entries() {
+        let kv = Arc::new(MockKvStore::new());
+        let pubsub = Arc::new(RecordingPubSub::default());
+        put_session(&kv, "IDLE").await;
+        let first = queue_text_message(
+            kv.as_ref(),
+            "Tenant:acme:Ops",
+            "agent",
+            "session-1",
+            STEER_QUEUE,
+            "first interactive message",
+            Default::default(),
+            DateTime::<Utc>::from_timestamp_micros(1_000_000).unwrap(),
+        )
+        .await
+        .unwrap();
+        let second = queue_text_message(
+            kv.as_ref(),
+            "Tenant:acme:Ops",
+            "agent",
+            "session-1",
+            STEER_QUEUE,
+            "second interactive message",
+            Default::default(),
+            DateTime::<Utc>::from_timestamp_micros(2_000_000).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let dispatched = dispatch_next_queued_message(
+            kv.as_ref(),
+            pubsub.as_ref(),
+            "Tenant:acme:Ops",
+            "agent",
+            "session-1",
+            STEER_QUEUE,
+            DateTime::<Utc>::from_timestamp_micros(3_000_000).unwrap(),
+        )
+        .await
+        .unwrap()
+        .expect("oldest interactive message should bootstrap the session");
+
+        let message = kv
+            .get_msg::<data_proto::SessionMessage>(&keys::session_message(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                &dispatched.message_id,
+            ))
+            .await
+            .unwrap()
+            .expect("bootstrapped user message should be canonicalized");
+        assert_eq!(message.parts[0].content, "first interactive message");
+        assert!(kv
+            .get(&keys::session_queue_entry(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                STEER_QUEUE,
+                &first.entry_id,
+            ))
+            .await
+            .unwrap()
+            .is_none());
+        assert!(kv
+            .get(&keys::session_queue_entry(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                STEER_QUEUE,
+                &second.entry_id,
+            ))
+            .await
+            .unwrap()
+            .is_some());
+        assert!(kv
+            .list_keys(
+                &keys::session_queue_prefix("Tenant:acme:Ops", "agent", "session-1", NEXT_QUEUE,),
+                None,
+            )
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/src/gateway/rpc/connectors.rs
+++ b/src/gateway/rpc/connectors.rs
@@ -1231,24 +1231,24 @@ async fn dispatch_to_session(
         elapsed_ms = started.elapsed().as_millis(),
         "connector message dispatching to session"
     );
-    let queued = crate::control::session_queue::queue_interactive_session_message(
+    crate::control::session_queue::queue_session_message(
         cp.kv.as_ref(),
         &agent_namespace,
         agent_name,
         &session_id,
+        crate::control::session_queue::STEER_QUEUE,
         message,
         chrono::Utc::now(),
     )
     .await
     .map_err(map_dispatch_error)?;
-    let dispatch_queue = queued.queue.as_str();
     crate::control::session_queue::dispatch_next_queued_message(
         cp.kv.as_ref(),
         cp.pubsub.as_ref(),
         &agent_namespace,
         agent_name,
         &session_id,
-        dispatch_queue,
+        crate::control::session_queue::STEER_QUEUE,
         chrono::Utc::now(),
     )
     .await


### PR DESCRIPTION
## Summary

- Remove state-dependent interactive queue routing.
- Put all interactive session messages into the durable `STEER` inbox before dispatch.
- Preserve FIFO admission when the first message bootstraps an idle session and later messages arrive during processing.

## Root cause

Interactive ingress previously split messages between `NEXT` and `STEER` based on the session state observed at admission. Worker release drains `STEER` before `NEXT`, so a later message routed to `STEER` could be processed before an earlier message routed to `NEXT`.

## Changes

- Removed `queue_interactive_session_message`.
- Updated scheduling and connector ingress to call `queue_session_message(..., STEER_QUEUE, ...)`, followed by STEER dispatch.
- Added regression coverage verifying the oldest STEER message bootstraps an idle session while later entries remain ordered in STEER.
- Added scheduling assertions that interactive sends do not populate NEXT.

## Validation

- `cargo test --lib --quiet` — 946 passed
- Focused connector E2E — passed
- `cargo fmt --all -- --check`
- `git diff --check`