### PR TITLE
Make CLI resource support self-checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Reject oneof in resource-facing protos
         run: python3 scripts/check_resource_proto_oneofs.py
 
+      - name: Verify CLI resource support metadata
+        run: |
+          python3 scripts/check_resource_cli_support.py
+          python3 -m unittest discover -s scripts -p 'test_check_resource_cli_support.py'
+
   cargo:
     name: Cargo
     runs-on: ubuntu-latest

--- a/proto/resources.toml
+++ b/proto/resources.toml
@@ -1,0 +1,252 @@
+[[resource]]
+kind = "Agent"
+aliases = ["agent", "agents"]
+apply_route = "legacy"
+lookup_namespace = "agent"
+list_namespace = "default"
+name_policy = "agent"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Template"
+aliases = ["agenttemplate", "templates", "template"]
+apply_route = "generic"
+lookup_namespace = "system"
+list_namespace = "system"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "McpServer"
+aliases = ["mcpserver", "mcpservers", "mcp"]
+apply_route = "legacy"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Worker"
+aliases = ["worker", "workers"]
+apply_route = "internal"
+lookup_namespace = "system_fixed"
+list_namespace = "system"
+name_policy = "plain"
+user_authorable = false
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Knowledge"
+aliases = ["knowledge", "knowledgeartifact", "knowledgeartifacts"]
+apply_route = "legacy"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "File"
+aliases = ["file", "files"]
+apply_route = "legacy"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Task"
+aliases = ["task", "tasks"]
+apply_route = "legacy"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Secret"
+aliases = ["secret", "secrets"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Schedule"
+aliases = ["schedule", "schedules"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Channel"
+aliases = ["channel", "channels"]
+apply_route = "legacy"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "ChannelSubscription"
+aliases = ["channelsubscription", "channelsubscriptions", "channel-subscription", "channel-subscriptions"]
+apply_route = "legacy"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "channel_subscription"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Workflow"
+aliases = ["workflow", "workflows"]
+apply_route = "legacy"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Deployment"
+aliases = ["deployment", "deployments"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "DeploymentReplica"
+aliases = ["deploymentreplica", "deploymentreplicas", "deployment-replica", "deployment-replicas"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "SandboxClass"
+aliases = ["sandboxclass", "sandboxclasses", "sandbox-class", "sandbox-classes"]
+apply_route = "generic"
+lookup_namespace = "system"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "SandboxPolicy"
+aliases = ["sandboxpolicy", "sandboxpolicies", "sandbox-policy", "sandbox-policies"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Sandbox"
+aliases = ["sandbox", "sandboxes"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "UsagePolicy"
+aliases = ["usagepolicy", "usagepolicies", "usage-policy", "usage-policies"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "ConnectorClass"
+aliases = ["connectorclass", "connectorclasses", "connector-class", "connector-classes"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Connector"
+aliases = ["connector", "connectors"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Namespace"
+aliases = ["namespace", "namespaces"]
+apply_route = "namespace"
+lookup_namespace = "none"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = false
+cli_list = false
+
+[[resource]]
+kind = "Session"
+aliases = ["session", "sessions"]
+apply_route = "internal"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = false
+cli_lookup = false
+cli_list = false
+
+[[resource]]
+kind = "Skill"
+aliases = ["skill", "skills"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true

--- a/scripts/check_resource_cli_support.py
+++ b/scripts/check_resource_cli_support.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Check that every resource envelope arm has CLI capability metadata."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.11+ is used in CI.
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PROTO = ROOT / "proto/resources/resource.proto"
+DEFAULT_REGISTRY = ROOT / "proto/resources.toml"
+EXPECTED_ROUTES = {"generic", "legacy", "namespace", "internal"}
+IGNORED_KINDS = {"Raw"}
+
+
+def _block(source: str, pattern: str) -> str:
+    match = re.search(pattern, source)
+    if not match:
+        raise ValueError(f"could not find {pattern!r}")
+    opening = source.find("{", match.start())
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    raise ValueError(f"unterminated block for {pattern!r}")
+
+
+def _pascal_case(value: str) -> str:
+    return "".join(part[:1].upper() + part[1:] for part in value.split("_"))
+
+
+def protobuf_resource_kinds(source: str) -> set[str]:
+    kinds: set[str] = set()
+    for message in ("ResourceSpec", "ResourceStatus"):
+        body = _block(source, rf"message\s+{message}\s*\{{")
+        oneof = _block(body, r"oneof\s+kind\s*\{")
+        for field in re.finditer(
+            r"^\s*[A-Za-z_][A-Za-z0-9_.]*\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*\d+\s*;",
+            oneof,
+            re.MULTILINE,
+        ):
+            kinds.add(_pascal_case(field.group(1)))
+    return kinds - IGNORED_KINDS
+
+
+def registry_kinds(registry_text: str) -> tuple[dict[str, dict], list[str]]:
+    data = tomllib.loads(registry_text)
+    resources = data.get("resource")
+    if not isinstance(resources, list):
+        return {}, ["registry must define one or more [[resource]] entries"]
+
+    entries: dict[str, dict] = {}
+    errors: list[str] = []
+    aliases: dict[str, str] = {}
+    required = {
+        "kind",
+        "aliases",
+        "apply_route",
+        "lookup_namespace",
+        "list_namespace",
+        "name_policy",
+        "user_authorable",
+        "cli_lookup",
+        "cli_list",
+    }
+    for index, entry in enumerate(resources, start=1):
+        if not isinstance(entry, dict):
+            errors.append(f"registry resource entry {index} must be a table")
+            continue
+        missing = sorted(required - entry.keys())
+        if missing:
+            errors.append(
+                f"registry resource entry {index} is missing: {', '.join(missing)}"
+            )
+            continue
+        kind = entry["kind"]
+        if not isinstance(kind, str) or not kind:
+            errors.append(f"registry resource entry {index} has an invalid kind")
+            continue
+        if kind in entries:
+            errors.append(f"duplicate registry kind: {kind}")
+        entries[kind] = entry
+
+        if entry["apply_route"] not in EXPECTED_ROUTES:
+            errors.append(
+                f"{kind}: unsupported apply_route {entry['apply_route']!r}"
+            )
+        if entry["user_authorable"] and entry["apply_route"] == "internal":
+            errors.append(f"{kind}: user_authorable resources cannot be internal")
+        if not isinstance(entry["aliases"], list):
+            errors.append(f"{kind}: aliases must be an array")
+            continue
+        for alias in [kind, *entry["aliases"]]:
+            if not isinstance(alias, str) or not alias:
+                errors.append(f"{kind}: aliases must contain non-empty strings")
+                continue
+            normalized = alias.casefold()
+            previous = aliases.get(normalized)
+            if previous and previous != kind:
+                errors.append(f"alias {alias!r} is claimed by both {previous} and {kind}")
+            aliases[normalized] = kind
+    return entries, errors
+
+
+def validate(proto_text: str, registry_text: str) -> list[str]:
+    try:
+        proto_kinds = protobuf_resource_kinds(proto_text)
+    except ValueError as error:
+        return [f"protobuf resource envelope: {error}"]
+    try:
+        entries, errors = registry_kinds(registry_text)
+    except Exception as error:  # TOML parser errors should be actionable in CI.
+        return [f"resource registry is invalid: {error}"]
+
+    registered = set(entries)
+    for kind in sorted(proto_kinds - registered):
+        errors.append(f"{kind}: missing from proto/resources.toml")
+    for kind in sorted(registered - proto_kinds):
+        errors.append(f"{kind}: registry entry has no ResourceSpec/ResourceStatus arm")
+    for kind, entry in sorted(entries.items()):
+        if entry.get("user_authorable") and entry.get("apply_route") not in EXPECTED_ROUTES:
+            errors.append(f"{kind}: user-authorable resource has no valid apply route")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--proto", type=Path, default=DEFAULT_PROTO)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    args = parser.parse_args()
+
+    errors = validate(args.proto.read_text(), args.registry.read_text())
+    if errors:
+        print("Resource CLI support check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("Resource CLI support metadata matches the protobuf resource envelope.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_resource_cli_support.py
+++ b/scripts/check_resource_cli_support.py
@@ -18,6 +18,16 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PROTO = ROOT / "proto/resources/resource.proto"
 DEFAULT_REGISTRY = ROOT / "proto/resources.toml"
 EXPECTED_ROUTES = {"generic", "legacy", "namespace", "internal"}
+EXPECTED_LOOKUP_NAMESPACES = {
+    "agent",
+    "default",
+    "none",
+    "required",
+    "system",
+    "system_fixed",
+}
+EXPECTED_LIST_NAMESPACES = {"default", "system"}
+EXPECTED_NAME_POLICIES = {"agent", "channel_subscription", "plain"}
 IGNORED_KINDS = {"Raw"}
 
 
@@ -41,9 +51,10 @@ def _pascal_case(value: str) -> str:
     return "".join(part[:1].upper() + part[1:] for part in value.split("_"))
 
 
-def protobuf_resource_kinds(source: str) -> set[str]:
-    kinds: set[str] = set()
+def protobuf_resource_kinds(source: str) -> tuple[set[str], set[str]]:
+    envelope_kinds: dict[str, set[str]] = {}
     for message in ("ResourceSpec", "ResourceStatus"):
+        kinds: set[str] = set()
         body = _block(source, rf"message\s+{message}\s*\{{")
         oneof = _block(body, r"oneof\s+kind\s*\{")
         for field in re.finditer(
@@ -52,7 +63,17 @@ def protobuf_resource_kinds(source: str) -> set[str]:
             re.MULTILINE,
         ):
             kinds.add(_pascal_case(field.group(1)))
-    return kinds - IGNORED_KINDS
+        envelope_kinds[message] = kinds - IGNORED_KINDS
+    return envelope_kinds["ResourceSpec"], envelope_kinds["ResourceStatus"]
+
+
+def _validate_enum(
+    errors: list[str], kind: str, field: str, value: object, expected: set[str]
+) -> None:
+    if not isinstance(value, str) or value not in expected:
+        errors.append(
+            f"{kind}: {field} must be one of {', '.join(sorted(expected))}; got {value!r}"
+        )
 
 
 def registry_kinds(registry_text: str) -> tuple[dict[str, dict], list[str]]:
@@ -93,10 +114,24 @@ def registry_kinds(registry_text: str) -> tuple[dict[str, dict], list[str]]:
             errors.append(f"duplicate registry kind: {kind}")
         entries[kind] = entry
 
-        if entry["apply_route"] not in EXPECTED_ROUTES:
-            errors.append(
-                f"{kind}: unsupported apply_route {entry['apply_route']!r}"
-            )
+        _validate_enum(errors, kind, "apply_route", entry["apply_route"], EXPECTED_ROUTES)
+        _validate_enum(
+            errors,
+            kind,
+            "lookup_namespace",
+            entry["lookup_namespace"],
+            EXPECTED_LOOKUP_NAMESPACES,
+        )
+        _validate_enum(
+            errors,
+            kind,
+            "list_namespace",
+            entry["list_namespace"],
+            EXPECTED_LIST_NAMESPACES,
+        )
+        _validate_enum(
+            errors, kind, "name_policy", entry["name_policy"], EXPECTED_NAME_POLICIES
+        )
         if entry["user_authorable"] and entry["apply_route"] == "internal":
             errors.append(f"{kind}: user_authorable resources cannot be internal")
         if not isinstance(entry["aliases"], list):
@@ -116,7 +151,7 @@ def registry_kinds(registry_text: str) -> tuple[dict[str, dict], list[str]]:
 
 def validate(proto_text: str, registry_text: str) -> list[str]:
     try:
-        proto_kinds = protobuf_resource_kinds(proto_text)
+        spec_kinds, status_kinds = protobuf_resource_kinds(proto_text)
     except ValueError as error:
         return [f"protobuf resource envelope: {error}"]
     try:
@@ -124,10 +159,20 @@ def validate(proto_text: str, registry_text: str) -> list[str]:
     except Exception as error:  # TOML parser errors should be actionable in CI.
         return [f"resource registry is invalid: {error}"]
 
+    if spec_kinds != status_kinds:
+        for kind in sorted(spec_kinds - status_kinds):
+            errors.append(f"{kind}: ResourceSpec arm is missing from ResourceStatus")
+        for kind in sorted(status_kinds - spec_kinds):
+            errors.append(f"{kind}: ResourceStatus arm is missing from ResourceSpec")
+
     registered = set(entries)
-    for kind in sorted(proto_kinds - registered):
-        errors.append(f"{kind}: missing from proto/resources.toml")
-    for kind in sorted(registered - proto_kinds):
+    for envelope, proto_kinds in (
+        ("ResourceSpec", spec_kinds),
+        ("ResourceStatus", status_kinds),
+    ):
+        for kind in sorted(proto_kinds - registered):
+            errors.append(f"{kind}: missing from proto/resources.toml ({envelope})")
+    for kind in sorted(registered - (spec_kinds | status_kinds)):
         errors.append(f"{kind}: registry entry has no ResourceSpec/ResourceStatus arm")
     for kind, entry in sorted(entries.items()):
         if entry.get("user_authorable") and entry.get("apply_route") not in EXPECTED_ROUTES:

--- a/scripts/test_check_resource_cli_support.py
+++ b/scripts/test_check_resource_cli_support.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from check_resource_cli_support import validate  # noqa: E402
+
+
+PROTO = """
+message ResourceSpec {
+  oneof kind {
+    AgentSpec agent = 1;
+    SkillSpec skill = 2;
+    WorkerSpec worker = 3;
+  }
+}
+message ResourceStatus {
+  oneof kind {
+    AgentStatus agent = 1;
+    CommonResourceStatus skill = 2;
+    WorkerStatus worker = 3;
+  }
+}
+"""
+
+REGISTRY = """
+[[resource]]
+kind = "Agent"
+aliases = ["agent"]
+apply_route = "legacy"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Skill"
+aliases = ["skill", "skills"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+
+[[resource]]
+kind = "Worker"
+aliases = ["worker"]
+apply_route = "internal"
+lookup_namespace = "system"
+list_namespace = "system"
+name_policy = "plain"
+user_authorable = false
+cli_lookup = true
+cli_list = true
+"""
+
+
+class ResourceCliSupportCheckTests(unittest.TestCase):
+    def test_valid_registry(self) -> None:
+        self.assertEqual(validate(PROTO, REGISTRY), [])
+
+    def test_missing_resource_is_reported(self) -> None:
+        self.assertIn(
+            "Skill: missing from proto/resources.toml",
+            validate(PROTO, REGISTRY.replace('kind = "Skill"', 'kind = "Missing"', 1)),
+        )
+
+    def test_stale_resource_is_reported(self) -> None:
+        stale = REGISTRY + """
+
+[[resource]]
+kind = "Missing"
+aliases = ["missing"]
+apply_route = "generic"
+lookup_namespace = "required"
+list_namespace = "default"
+name_policy = "plain"
+user_authorable = true
+cli_lookup = true
+cli_list = true
+"""
+        self.assertIn(
+            "Missing: registry entry has no ResourceSpec/ResourceStatus arm",
+            validate(PROTO, stale),
+        )
+
+    def test_internal_resource_cannot_be_user_authorable(self) -> None:
+        invalid = REGISTRY.replace("user_authorable = false", "user_authorable = true", 1)
+        self.assertTrue(any("Worker: user_authorable resources" in error for error in validate(PROTO, invalid)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_resource_cli_support.py
+++ b/scripts/test_check_resource_cli_support.py
@@ -69,8 +69,15 @@ class ResourceCliSupportCheckTests(unittest.TestCase):
 
     def test_missing_resource_is_reported(self) -> None:
         self.assertIn(
-            "Skill: missing from proto/resources.toml",
+            "Skill: missing from proto/resources.toml (ResourceSpec)",
             validate(PROTO, REGISTRY.replace('kind = "Skill"', 'kind = "Missing"', 1)),
+        )
+
+    def test_resource_envelopes_are_checked_independently(self) -> None:
+        status_missing_skill = PROTO.replace("CommonResourceStatus skill = 2;", "")
+        self.assertIn(
+            "Skill: ResourceSpec arm is missing from ResourceStatus",
+            validate(status_missing_skill, REGISTRY),
         )
 
     def test_stale_resource_is_reported(self) -> None:
@@ -95,6 +102,17 @@ cli_list = true
     def test_internal_resource_cannot_be_user_authorable(self) -> None:
         invalid = REGISTRY.replace("user_authorable = false", "user_authorable = true", 1)
         self.assertTrue(any("Worker: user_authorable resources" in error for error in validate(PROTO, invalid)))
+
+    def test_runtime_policy_enums_are_validated(self) -> None:
+        invalid = (
+            REGISTRY.replace('lookup_namespace = "required"', 'lookup_namespace = "agnet"', 1)
+            .replace('list_namespace = "default"', 'list_namespace = "defualt"', 1)
+            .replace('name_policy = "plain"', 'name_policy = "plian"', 1)
+        )
+        errors = validate(PROTO, invalid)
+        self.assertTrue(any("lookup_namespace" in error for error in errors))
+        self.assertTrue(any("list_namespace" in error for error in errors))
+        self.assertTrue(any("name_policy" in error for error in errors))
 
 
 if __name__ == "__main__":

--- a/src/cli/commands/apply.rs
+++ b/src/cli/commands/apply.rs
@@ -79,40 +79,18 @@ fn is_yaml_file(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn is_generic_resource_kind(kind: &str) -> bool {
-    matches!(
-        kind,
-        "Agent"
-            | "McpServer"
-            | "MCPServer"
-            | "Knowledge"
-            | "File"
-            | "Task"
-            | "Secret"
-            | "Channel"
-            | "ChannelSubscription"
-            | "Schedule"
-            | "Workflow"
-            | "Template"
-            | "Deployment"
-            | "DeploymentReplica"
-            | "SandboxClass"
-            | "SandboxPolicy"
-            | "Sandbox"
-            | "UsagePolicy"
-            | "ConnectorClass"
-            | "Connector"
-    )
-}
-
 fn resource_manifest_from_manifest(
     raw: &crate::control::manifest::RawManifest,
     content: &str,
 ) -> Result<(String, String, String, resources_proto::ResourceManifest)> {
     use resources_proto::resource_spec::Kind as SpecKind;
 
-    let mut manifest = match raw.kind.as_str() {
-        "MCPServer" | "McpServer" => {
+    let canonical_kind = crate::cli::canonical_resource_kind(&raw.kind)
+        .with_context(|| format!("Unsupported manifest kind '{}'", raw.kind))?;
+    let resource = crate::cli::resource_kind(canonical_kind).expect("canonical resource kind");
+
+    let mut manifest = match resource.apply_route.as_str() {
+        "legacy" if canonical_kind == "McpServer" => {
             let server = crate::control::manifest::parse_mcp_server(content)?;
             resources_proto::ResourceManifest {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -125,7 +103,7 @@ fn resource_manifest_from_manifest(
                 }),
             }
         }
-        "Agent" => {
+        "legacy" if canonical_kind == "Agent" => {
             let agent = crate::control::manifest::parse_agent(content)?;
             resources_proto::ResourceManifest {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -138,7 +116,7 @@ fn resource_manifest_from_manifest(
                 }),
             }
         }
-        "Knowledge" => {
+        "legacy" if canonical_kind == "Knowledge" => {
             let knowledge = crate::control::manifest::parse_knowledge(content)?;
             resources_proto::ResourceManifest {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -151,7 +129,7 @@ fn resource_manifest_from_manifest(
                 }),
             }
         }
-        "File" => {
+        "legacy" if canonical_kind == "File" => {
             let file: resources_proto::File =
                 serde_yaml::from_str(content).context("Failed to parse File manifest")?;
             resources_proto::ResourceManifest {
@@ -165,7 +143,7 @@ fn resource_manifest_from_manifest(
                 }),
             }
         }
-        "Task" => {
+        "legacy" if canonical_kind == "Task" => {
             let task: resources_proto::Task =
                 serde_yaml::from_str(content).context("Failed to parse Task manifest")?;
             resources_proto::ResourceManifest {
@@ -179,7 +157,7 @@ fn resource_manifest_from_manifest(
                 }),
             }
         }
-        "Channel" => {
+        "legacy" if canonical_kind == "Channel" => {
             let channel = crate::control::manifest::parse_channel(content)?;
             resources_proto::ResourceManifest {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -192,7 +170,7 @@ fn resource_manifest_from_manifest(
                 }),
             }
         }
-        "ChannelSubscription" => {
+        "legacy" if canonical_kind == "ChannelSubscription" => {
             let subscription = crate::control::manifest::parse_channel_subscription(content)?;
             resources_proto::ResourceManifest {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -208,7 +186,7 @@ fn resource_manifest_from_manifest(
                 }),
             }
         }
-        "Workflow" => {
+        "legacy" if canonical_kind == "Workflow" => {
             let workflow = crate::control::manifest::parse_workflow(content)?;
             resources_proto::ResourceManifest {
                 api_version: "talon.impalasys.com/v1".to_string(),
@@ -221,10 +199,12 @@ fn resource_manifest_from_manifest(
                 }),
             }
         }
-        kind if is_generic_resource_kind(kind) => {
+        "generic" => {
             crate::control::manifest::parse_resource_manifest(content)?
         }
-        other => anyhow::bail!("Unsupported manifest kind '{}'", other),
+        "namespace" => anyhow::bail!("Namespace manifests must be applied through the namespace path"),
+        "internal" => anyhow::bail!("Unsupported manifest kind '{}'", canonical_kind),
+        route => anyhow::bail!("Unsupported manifest route '{}' for kind '{}'", route, canonical_kind),
     };
     let meta = manifest
         .metadata
@@ -444,6 +424,37 @@ spec:
         assert_eq!(plans.len(), 2);
         assert!(matches!(plans[0], ApplyPlan::Namespace { .. }));
         assert!(matches!(plans[1], ApplyPlan::Resource { .. }));
+    }
+
+    #[test]
+    fn build_apply_plans_accepts_skill_manifests() {
+        let plans = build_apply_plans(
+            r#"
+apiVersion: talon.impalasys.com/v1
+kind: Skill
+metadata:
+  name: review
+  namespace: customers
+spec:
+  description: Review code
+"#,
+        )
+        .expect("Skill manifests should be accepted by apply");
+
+        let ApplyPlan::Resource {
+            ns, kind, name, manifest,
+        } = &plans[0]
+        else {
+            panic!("expected a resource apply plan");
+        };
+        assert_eq!(ns, "customers");
+        assert_eq!(kind, "Skill");
+        assert_eq!(name, "review");
+        assert!(matches!(
+            manifest.spec.as_ref().and_then(|spec| spec.kind.as_ref()),
+            Some(resources_proto::resource_spec::Kind::Skill(spec))
+                if spec.description == "Review code"
+        ));
     }
 
     #[test]

--- a/src/cli/commands/delete.rs
+++ b/src/cli/commands/delete.rs
@@ -9,7 +9,7 @@ use talon_client::v1::DeleteResourceRequest;
 
 #[derive(clap::Args)]
 pub(crate) struct DeleteCommand {
-    /// Type of resource to delete: template, mcp-server, knowledge, channel, channel-subscription
+    /// Type of resource to delete, such as agent, skill, template, or workflow.
     #[arg(value_name = "KIND")]
     kind: String,
     /// Name of the resource

--- a/src/cli/commands/get.rs
+++ b/src/cli/commands/get.rs
@@ -11,7 +11,7 @@ use talon_client::v1::{GetResourceRequest, ListNamespacesRequest, ListResourcesR
 
 #[derive(clap::Args)]
 pub(crate) struct GetCommand {
-    /// Type of resource to get: agent, template, mcp-server, worker, knowledge, file, task, secret, schedule, channel, channel-subscription
+    /// Type of resource to get, such as agent, skill, template, or workflow.
     #[arg(value_name = "KIND")]
     pub(crate) kind: String,
     /// Name of the resource. Omit to list resources of this kind.
@@ -87,103 +87,25 @@ fn resource_list_target(kind: &str, namespace: Option<&String>) -> Result<Resour
         "namespace" | "namespaces" => Ok(ResourceListTarget::Namespaces {
             parent: namespace.cloned(),
         }),
-        "agent" | "agents" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("Agent".to_string()),
-        }),
-        "agenttemplate" | "templates" | "template" => Ok(ResourceListTarget::Resources {
-            ns: namespace.cloned().unwrap_or_else(system_ns),
-            kind: Some("Template".to_string()),
-        }),
-        "mcpserver" | "mcpservers" | "mcp" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("McpServer".to_string()),
-        }),
-        "worker" | "workers" => Ok(ResourceListTarget::Resources {
-            ns: system_ns(),
-            kind: Some("Worker".to_string()),
-        }),
-        "knowledge" | "knowledgeartifact" | "knowledgeartifacts" => {
+        _ => {
+            let resource = crate::cli::resource_kind(kind)
+                .with_context(|| format!("Unsupported resource kind '{}'", kind))?;
+            if !resource.cli_list {
+                anyhow::bail!("Unsupported resource kind '{}'", kind);
+            }
+            let ns = match resource.list_namespace.as_str() {
+                "default" => ns_or_default(),
+                "system" => system_ns(),
+                policy => anyhow::bail!(
+                    "Unsupported list namespace policy '{}'; check resource registry",
+                    policy
+                ),
+            };
             Ok(ResourceListTarget::Resources {
-                ns: ns_or_default(),
-                kind: Some("Knowledge".to_string()),
+                ns,
+                kind: Some(resource.kind.clone()),
             })
         }
-        "file" | "files" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("File".to_string()),
-        }),
-        "task" | "tasks" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("Task".to_string()),
-        }),
-        "secret" | "secrets" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("Secret".to_string()),
-        }),
-        "schedule" | "schedules" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("Schedule".to_string()),
-        }),
-        "channel" | "channels" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("Channel".to_string()),
-        }),
-        "channelsubscription"
-        | "channelsubscriptions"
-        | "channel-subscription"
-        | "channel-subscriptions" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("ChannelSubscription".to_string()),
-        }),
-        "workflow" | "workflows" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("Workflow".to_string()),
-        }),
-        "deployment" | "deployments" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("Deployment".to_string()),
-        }),
-        "deploymentreplica"
-        | "deploymentreplicas"
-        | "deployment-replica"
-        | "deployment-replicas" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("DeploymentReplica".to_string()),
-        }),
-        "sandboxclass" | "sandboxclasses" | "sandbox-class" | "sandbox-classes" => {
-            Ok(ResourceListTarget::Resources {
-                ns: ns_or_default(),
-                kind: Some("SandboxClass".to_string()),
-            })
-        }
-        "sandboxpolicy" | "sandboxpolicies" | "sandbox-policy" | "sandbox-policies" => {
-            Ok(ResourceListTarget::Resources {
-                ns: ns_or_default(),
-                kind: Some("SandboxPolicy".to_string()),
-            })
-        }
-        "sandbox" | "sandboxes" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("Sandbox".to_string()),
-        }),
-        "usagepolicy" | "usagepolicies" | "usage-policy" | "usage-policies" => {
-            Ok(ResourceListTarget::Resources {
-                ns: ns_or_default(),
-                kind: Some("UsagePolicy".to_string()),
-            })
-        }
-        "connectorclass" | "connectorclasses" | "connector-class" | "connector-classes" => {
-            Ok(ResourceListTarget::Resources {
-                ns: ns_or_default(),
-                kind: Some("ConnectorClass".to_string()),
-            })
-        }
-        "connector" | "connectors" => Ok(ResourceListTarget::Resources {
-            ns: ns_or_default(),
-            kind: Some("Connector".to_string()),
-        }),
-        other => anyhow::bail!("Unsupported resource kind '{}'", other),
     }
 }
 
@@ -586,6 +508,13 @@ mod tests {
             ResourceListTarget::Resources {
                 ns: "customers:acme".to_string(),
                 kind: Some("SandboxClass".to_string()),
+            }
+        );
+        assert_eq!(
+            resource_list_target("skills", Some(&namespace)).unwrap(),
+            ResourceListTarget::Resources {
+                ns: "customers:acme".to_string(),
+                kind: Some("Skill".to_string()),
             }
         );
         assert_eq!(

--- a/src/cli/commands/render.rs
+++ b/src/cli/commands/render.rs
@@ -62,8 +62,10 @@ fn render_json_payload(content: &str) -> Result<serde_json::Value> {
     let raw = parse_raw_manifest(content)?;
     let manifest_value: serde_yaml::Value =
         serde_yaml::from_str(content).context("Failed to parse rendered manifest")?;
-    match raw.kind.as_str() {
-        "MCPServer" | "McpServer" => Ok(json!({ "server": manifest_value })),
+    let canonical_kind = crate::cli::canonical_resource_kind(&raw.kind)
+        .with_context(|| format!("Unsupported manifest kind '{}'", raw.kind))?;
+    match canonical_kind {
+        "McpServer" => Ok(json!({ "server": manifest_value })),
         "Agent" => Ok(json!({ "agent": manifest_value })),
         "Namespace" => {
             let namespace = crate::control::manifest::parse_namespace(content)?;
@@ -90,9 +92,9 @@ fn render_json_payload(content: &str) -> Result<serde_json::Value> {
             let workflow = crate::control::manifest::parse_workflow(content)?;
             Ok(json!({ "ns": workflow.namespace(), "workflow": workflow }))
         }
-        "Template" | "Deployment" | "DeploymentReplica" | "Schedule" | "SandboxClass"
-        | "SandboxPolicy" | "Sandbox" | "UsagePolicy" | "ConnectorClass" | "Connector"
-        | "Skill" | "File" | "Task" => Ok(json!({ "resource": manifest_value })),
+        kind if crate::cli::resource_kind(kind)
+            .map(|resource| resource.user_authorable)
+            .unwrap_or(false) => Ok(json!({ "resource": manifest_value })),
         other => anyhow::bail!("Unsupported manifest kind '{}'", other),
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@
 
 include!("prelude.rs");
 include!("proto_bridge.rs");
+include!("resource_kinds.rs");
 include!("resource_targets.rs");
 include!("entry.rs");
 include!("manifest_render.rs");

--- a/src/cli/resource_kinds.rs
+++ b/src/cli/resource_kinds.rs
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Impala Systems, Inc.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use std::sync::OnceLock;
+
+#[derive(Debug, Deserialize)]
+struct ResourceKindRegistry {
+    resource: Vec<ResourceKindSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ResourceKindSpec {
+    pub(super) kind: String,
+    pub(super) aliases: Vec<String>,
+    pub(super) apply_route: String,
+    pub(super) lookup_namespace: String,
+    pub(super) list_namespace: String,
+    pub(super) name_policy: String,
+    pub(super) user_authorable: bool,
+    pub(super) cli_lookup: bool,
+    pub(super) cli_list: bool,
+}
+
+fn resource_registry() -> &'static [ResourceKindSpec] {
+    static REGISTRY: OnceLock<Vec<ResourceKindSpec>> = OnceLock::new();
+    REGISTRY
+        .get_or_init(|| {
+            let config = include_str!("../../proto/resources.toml");
+            toml::from_str::<ResourceKindRegistry>(config)
+                .expect("proto/resources.toml must be valid")
+                .resource
+        })
+        .as_slice()
+}
+
+pub(super) fn resource_kind(input: &str) -> Option<&'static ResourceKindSpec> {
+    let input = input.to_ascii_lowercase();
+    resource_registry().iter().find(|resource| {
+        resource.kind.to_ascii_lowercase() == input
+            || resource
+                .aliases
+                .iter()
+                .any(|alias| alias.to_ascii_lowercase() == input)
+    })
+}
+
+pub(super) fn canonical_resource_kind(input: &str) -> Option<&'static str> {
+    resource_kind(input).map(|resource| resource.kind.as_str())
+}
+
+#[cfg(test)]
+mod resource_kind_tests {
+    use super::*;
+
+    #[test]
+    fn skill_is_a_namespaced_generic_resource() {
+        let skill = resource_kind("skills").expect("Skill registry entry");
+        assert_eq!(skill.kind, "Skill");
+        assert_eq!(skill.apply_route, "generic");
+        assert_eq!(skill.lookup_namespace, "required");
+        assert!(skill.user_authorable);
+    }
+
+    #[test]
+    fn worker_remains_internal_and_not_applyable() {
+        let worker = resource_kind("worker").expect("Worker registry entry");
+        assert_eq!(worker.apply_route, "internal");
+        assert!(!worker.user_authorable);
+    }
+}

--- a/src/cli/resource_targets.rs
+++ b/src/cli/resource_targets.rs
@@ -21,112 +21,37 @@ pub(super) fn resource_lookup_target(
     name: &str,
     namespace: Option<&String>,
 ) -> Result<(String, String, String)> {
-    match kind.to_lowercase().as_str() {
-        "agent" | "agents" => {
-            let (ns, agent_name) = agent_lookup_target(name, namespace);
-            Ok((ns, "Agent".to_string(), agent_name))
-        }
-        "agenttemplate" | "templates" | "template" => Ok((
-            namespace
-                .cloned()
-                .unwrap_or_else(|| crate::control::ns::TALON_SYSTEM.to_string()),
-            "Template".to_string(),
-            name.to_string(),
-        )),
-        "mcpserver" | "mcpservers" | "mcp" => Ok((
-            namespace.cloned().context("McpServer requires --namespace")?,
-            "McpServer".to_string(),
-            name.to_string(),
-        )),
-        "worker" | "workers" => Ok((
-            crate::control::ns::TALON_SYSTEM.to_string(),
-            "Worker".to_string(),
-            name.to_string(),
-        )),
-        "knowledge" | "knowledgeartifact" | "knowledgeartifacts" => {
-            let ns = namespace.cloned().context("Knowledge requires --namespace")?;
-            Ok((ns, "Knowledge".to_string(), name.to_string()))
-        }
-        "file" | "files" => {
-            let ns = namespace.cloned().context("File requires --namespace")?;
-            Ok((ns, "File".to_string(), name.to_string()))
-        }
-        "task" | "tasks" => {
-            let ns = namespace.cloned().context("Task requires --namespace")?;
-            Ok((ns, "Task".to_string(), name.to_string()))
-        }
-        "secret" | "secrets" => {
-            let ns = namespace.cloned().context("Secret requires --namespace")?;
-            Ok((ns, "Secret".to_string(), name.to_string()))
-        }
-        "schedule" | "schedules" => {
-            let ns = namespace.cloned().context("Schedule requires --namespace")?;
-            Ok((ns, "Schedule".to_string(), name.to_string()))
-        }
-        "channel" | "channels" => {
-            let ns = namespace.cloned().context("Channel requires --namespace")?;
-            Ok((ns, "Channel".to_string(), name.to_string()))
-        }
-        "channelsubscription"
-        | "channelsubscriptions"
-        | "channel-subscription"
-        | "channel-subscriptions" => {
-            let ns = namespace
-                .cloned()
-                .context("ChannelSubscription requires --namespace")?;
-            let subscription = name
-                .split_once('/')
-                .map(|(_, subscription)| subscription)
-                .unwrap_or(name);
-            Ok((
-                ns,
-                "ChannelSubscription".to_string(),
-                subscription.to_string(),
-            ))
-        }
-        "workflow" | "workflows" => {
-            let ns = namespace.cloned().context("Workflow requires --namespace")?;
-            Ok((ns, "Workflow".to_string(), name.to_string()))
-        }
-        "deployment" | "deployments" => {
-            let ns = namespace.cloned().context("Deployment requires --namespace")?;
-            Ok((ns, "Deployment".to_string(), name.to_string()))
-        }
-        "sandboxclass" | "sandboxclasses" | "sandbox-class" | "sandbox-classes" => Ok((
-            namespace
-                .cloned()
-                .unwrap_or_else(|| crate::control::ns::TALON_SYSTEM.to_string()),
-            "SandboxClass".to_string(),
-            name.to_string(),
-        )),
-        "sandboxpolicy" | "sandboxpolicies" | "sandbox-policy" | "sandbox-policies" => {
-            let ns = namespace
-                .cloned()
-                .context("SandboxPolicy requires --namespace")?;
-            Ok((ns, "SandboxPolicy".to_string(), name.to_string()))
-        }
-        "sandbox" | "sandboxes" => {
-            let ns = namespace.cloned().context("Sandbox requires --namespace")?;
-            Ok((ns, "Sandbox".to_string(), name.to_string()))
-        }
-        "usagepolicy" | "usagepolicies" | "usage-policy" | "usage-policies" => {
-            let ns = namespace
-                .cloned()
-                .context("UsagePolicy requires --namespace")?;
-            Ok((ns, "UsagePolicy".to_string(), name.to_string()))
-        }
-        "connectorclass" | "connectorclasses" | "connector-class" | "connector-classes" => {
-            let ns = namespace
-                .cloned()
-                .context("ConnectorClass requires --namespace")?;
-            Ok((ns, "ConnectorClass".to_string(), name.to_string()))
-        }
-        "connector" | "connectors" => {
-            let ns = namespace.cloned().context("Connector requires --namespace")?;
-            Ok((ns, "Connector".to_string(), name.to_string()))
-        }
-        other => anyhow::bail!("Unsupported resource kind '{}'", other),
+    let resource = crate::cli::resource_kind(kind)
+        .with_context(|| format!("Unsupported resource kind '{}'", kind))?;
+    if !resource.cli_lookup {
+        anyhow::bail!("Unsupported resource kind '{}'", kind);
     }
+
+    let final_namespace = match resource.lookup_namespace.as_str() {
+        "agent" => agent_lookup_target(name, namespace).0,
+        "default" => namespace.cloned().unwrap_or_else(|| "default".to_string()),
+        "required" => namespace
+            .cloned()
+            .with_context(|| format!("{} requires --namespace", resource.kind))?,
+        "system" => namespace
+            .cloned()
+            .unwrap_or_else(|| crate::control::ns::TALON_SYSTEM.to_string()),
+        "system_fixed" => crate::control::ns::TALON_SYSTEM.to_string(),
+        policy => anyhow::bail!("Unsupported lookup namespace policy '{}'; check resource registry", policy),
+    };
+
+    let final_name = match resource.name_policy.as_str() {
+        "agent" => agent_lookup_target(name, namespace).1,
+        "channel_subscription" => name
+            .split_once('/')
+            .map(|(_, subscription)| subscription)
+            .unwrap_or(name)
+            .to_string(),
+        "plain" => name.to_string(),
+        policy => anyhow::bail!("Unsupported name policy '{}'; check resource registry", policy),
+    };
+
+    Ok((final_namespace, resource.kind.clone(), final_name))
 }
 
 #[cfg(test)]
@@ -159,5 +84,20 @@ mod tests {
                 "docker-codex".to_string(),
             )
         );
+    }
+
+    #[test]
+    fn skill_lookup_requires_namespace_and_accepts_plural_alias() {
+        let namespace = "customers:source".to_string();
+
+        assert_eq!(
+            resource_lookup_target("skills", "review", Some(&namespace)).unwrap(),
+            (
+                "customers:source".to_string(),
+                "Skill".to_string(),
+                "review".to_string(),
+            )
+        );
+        assert!(resource_lookup_target("skill", "review", None).is_err());
     }
 }


### PR DESCRIPTION
## What changed

- Added a declarative resource capability registry covering canonical kinds, aliases, apply routes, namespace policies, and internal-resource protection.
- Enabled Skill registration and CLI lookup/list/delete/render support.
- Replaced duplicated hardcoded CLI resource-kind dispatch with registry-driven behavior.
- Added a CI checker that compares the registry against ResourceSpec and ResourceStatus protobuf arms.
- Added checker fixtures/tests and Skill CLI regression coverage.

## Why

The CLI rejected valid Skill manifests with Unsupported manifest kind 'Skill' because Skill was implemented in the resource and manifest layers but omitted from the CLI apply allowlist. The registry and PR-time consistency check prevent future resource additions from silently missing CLI support.

## Validation

- cargo test --lib (949 passed)
- python3 scripts/check_resource_cli_support.py
- Python checker unit tests (4 passed)
- cargo fmt --all --check
- git diff --check