### PR TITLE
Restart errored sessions from interactive input

### DIFF
--- a/src/control/scheduling.rs
+++ b/src/control/scheduling.rs
@@ -1688,6 +1688,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_message_restarts_error_session_without_stranding_input() {
+        let kv = Arc::new(MockKvStore::default());
+        let pubsub = Arc::new(MockPubSub::default());
+        let session = data_proto::Session {
+            id: "session-1".to_string(),
+            agent: "assistant".to_string(),
+            ns: "conic:test".to_string(),
+            status: "ERROR".to_string(),
+            created_at: 0,
+            last_active: 0,
+            metadata: HashMap::new(),
+            labels: HashMap::new(),
+            skill_state: None,
+            context_tokens: None,
+        };
+        kv.set_msg(
+            &keys::session("conic:test", "assistant", "session-1"),
+            &session,
+        )
+        .await
+        .unwrap();
+
+        let now = DateTime::parse_from_rfc3339("2026-05-02T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let submission_id = send_message(
+            kv.as_ref(),
+            pubsub.as_ref(),
+            "conic:test",
+            "assistant",
+            "session-1",
+            "recover the session",
+            HashMap::new(),
+            now,
+        )
+        .await
+        .unwrap();
+
+        assert!(!submission_id.is_empty());
+        assert_eq!(
+            kv.get_msg::<data_proto::Session>(&keys::session(
+                "conic:test",
+                "assistant",
+                "session-1",
+            ))
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+            "PROCESSING"
+        );
+        assert!(kv
+            .list_keys(
+                &keys::session_queue_prefix(
+                    "conic:test",
+                    "assistant",
+                    "session-1",
+                    crate::control::session_queue::STEER_QUEUE,
+                ),
+                None,
+            )
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
     async fn send_message_rejects_empty_content() {
         let kv = Arc::new(MockKvStore::default());
         let pubsub = Arc::new(MockPubSub::default());

--- a/src/control/session_queue.rs
+++ b/src/control/session_queue.rs
@@ -366,7 +366,12 @@ pub async fn dispatch_next_queued_message(
         {
             return Ok(None);
         }
-        if session.status != "IDLE" && session.status != "PROCESSING" {
+        // An errored session has no active worker, so a fresh interactive
+        // message in STEER should retain send_session_message's restart
+        // behavior. Keep NEXT/A2A entries blocked so a failed turn's backlog
+        // is not retried implicitly.
+        let can_restart_error = session.status == "ERROR" && queue == STEER_QUEUE;
+        if session.status != "IDLE" && session.status != "PROCESSING" && !can_restart_error {
             return Ok(None);
         }
         session.status = "PROCESSING".to_string();
@@ -1080,6 +1085,63 @@ mod tests {
             .unwrap()
             .len(),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_restarts_error_session_from_steer_queue() {
+        let kv = Arc::new(MockKvStore::new());
+        let pubsub = Arc::new(RecordingPubSub::default());
+        put_session(&kv, "ERROR").await;
+        let queued = queue_text_message(
+            kv.as_ref(),
+            "Tenant:acme:Ops",
+            "agent",
+            "session-1",
+            STEER_QUEUE,
+            "recover from the failed turn",
+            Default::default(),
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+
+        let dispatched = dispatch_next_queued_message(
+            kv.as_ref(),
+            pubsub.as_ref(),
+            "Tenant:acme:Ops",
+            "agent",
+            "session-1",
+            STEER_QUEUE,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .expect("interactive input should restart an errored session");
+
+        assert_eq!(dispatched.entry_id, queued.entry_id);
+        assert!(kv
+            .get(&keys::session_queue_entry(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+                STEER_QUEUE,
+                &queued.entry_id,
+            ))
+            .await
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            kv.get_msg::<data_proto::Session>(&keys::session(
+                "Tenant:acme:Ops",
+                "agent",
+                "session-1",
+            ))
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+            "PROCESSING"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Preserve interactive `SendMessage` behavior after a failed session turn.
- Allow a queued `STEER` message to restart an `ERROR` session.
- Keep `NEXT` and A2A backlog blocked while the session is errored.

## Root cause

After all interactive input moved to `STEER`, `send_message` queued input and called `dispatch_next_queued_message`. That dispatcher rejected `ERROR` sessions and returned `Ok(None)`, so `send_message` reported the queue-entry ID as accepted even though no worker would consume it.

Previously, `send_session_message` transitioned an errored session back to `PROCESSING` and dispatched a new submission.

## Changes

- Permit `STEER` dispatch to atomically transition `ERROR -> PROCESSING`.
- Continue rejecting dispatch from `NEXT`/A2A while errored, preventing failed-turn backlog from being retried implicitly.
- Add regression tests for direct interactive sends and queue dispatch.
- Preserve the existing test that `NEXT` entries remain blocked on an errored session.

## Validation

- `cargo test --lib --quiet` — 948 passed
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Steering messages can now restart sessions that are in an error state.
  - Restarted sessions transition correctly to processing and create a submission.
  - Prevented steering messages from remaining stuck in the queue.
  - Other message types remain blocked for errored sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->