### PR TITLE
Trust repository branches for CLA checks

### DIFF
--- a/.github/scripts/cla.js
+++ b/.github/scripts/cla.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const ORGANIZATION_ASSOCIATIONS = new Set(["MEMBER", "OWNER"]);
+
+function isTrustedRepositoryContributor(pullRequest) {
+  const headRepositoryId = pullRequest.head?.repo?.id;
+  const baseRepositoryId = pullRequest.base?.repo?.id;
+  const usesTrustedRepositoryBranch =
+    headRepositoryId != null && headRepositoryId === baseRepositoryId;
+
+  return (
+    usesTrustedRepositoryBranch ||
+    ORGANIZATION_ASSOCIATIONS.has(pullRequest.author_association)
+  );
+}
+
+module.exports = { isTrustedRepositoryContributor };

--- a/.github/scripts/cla.test.js
+++ b/.github/scripts/cla.test.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { isTrustedRepositoryContributor } = require("./cla");
+
+function pullRequest({ association, headRepositoryId, baseRepositoryId = 42 }) {
+  return {
+    author_association: association,
+    head: { repo: headRepositoryId == null ? null : { id: headRepositoryId } },
+    base: { repo: { id: baseRepositoryId } },
+  };
+}
+
+test("trusts a same-repository branch when private membership is hidden", () => {
+  assert.equal(
+    isTrustedRepositoryContributor(
+      pullRequest({ association: "CONTRIBUTOR", headRepositoryId: 42 })
+    ),
+    true
+  );
+});
+
+test("trusts a visible organization member contributing from a fork", () => {
+  assert.equal(
+    isTrustedRepositoryContributor(
+      pullRequest({ association: "MEMBER", headRepositoryId: 99 })
+    ),
+    true
+  );
+});
+
+test("requires a CLA signature from an external fork contributor", () => {
+  assert.equal(
+    isTrustedRepositoryContributor(
+      pullRequest({ association: "CONTRIBUTOR", headRepositoryId: 99 })
+    ),
+    false
+  );
+});
+
+test("does not trust a deleted or unavailable fork", () => {
+  assert.equal(
+    isTrustedRepositoryContributor(
+      pullRequest({ association: "NONE", headRepositoryId: null })
+    ),
+    false
+  );
+});

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,20 +1,30 @@
 name: Talon CLA
 
-# This workflow intentionally never checks out pull-request code. It runs with
-# pull_request_target so it can create a check run on pull requests from forks.
+# This workflow intentionally never checks out pull-request code. The validation
+# job runs with pull_request_target so it can create checks for fork pull requests,
+# and only checks out the trusted base/default branch to load the CLA helper.
 on:
+  pull_request:
+    paths:
+      - ".github/scripts/cla.js"
+      - ".github/scripts/cla.test.js"
+      - ".github/workflows/cla.yml"
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
   issue_comment:
     types: [created, edited]
 
-permissions:
-  checks: write
-  contents: read
-  issues: read
-  pull-requests: read
-
 jobs:
+  test:
+    if: github.event_name == 'pull_request'
+    name: Test CLA policy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - run: node --test .github/scripts/cla.test.js
+
   validate:
     # issue_comment also fires for issues; only process comments on pull requests.
     if: >-
@@ -22,11 +32,24 @@ jobs:
       github.event.issue.pull_request != null
     name: Validate CLA signature
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
+      # pull_request_target checks out the base commit; issue_comment checks out
+      # the default branch. Neither path executes contributor-controlled code.
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Publish CLA status
         uses: actions/github-script@v8
         with:
           script: |
+            const {
+              isTrustedRepositoryContributor,
+            } = require("./.github/scripts/cla");
             const { owner, repo } = context.repo;
             const signature = "I have read and agree to the Talon CLA.";
             const checkName = "Talon CLA Agreement";
@@ -38,18 +61,9 @@ jobs:
               repo,
               pull_number: pullRequestNumber,
             });
-            let pullRequest = (await getPullRequest()).data;
-            const isImpalasysMember = () =>
-              pullRequest.author_association === "MEMBER" ||
-              pullRequest.author_association === "OWNER";
-
-            // GitHub can briefly return a stale author association immediately
-            // after creating an internal pull request. Re-fetch before asking an
-            // organization member to sign the CLA.
-            for (let attempt = 0; attempt < 3 && !isImpalasysMember(); attempt++) {
-              await new Promise((resolve) => setTimeout(resolve, 5_000));
-              pullRequest = (await getPullRequest()).data;
-            }
+            const pullRequest = (await getPullRequest()).data;
+            const trustedRepositoryContributor =
+              isTrustedRepositoryContributor(pullRequest);
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
@@ -57,17 +71,20 @@ jobs:
               issue_number: pullRequest.number,
               per_page: 100,
             });
-            const signed = isImpalasysMember() || comments.some((comment) =>
+            const acceptedByComment = comments.some((comment) =>
               comment.user?.id === pullRequest.user.id &&
               comment.body
                 ?.replace(/\r/g, "")
                 .split("\n")
                 .some((line) => line.trim() === signature)
             );
+            const satisfied = trustedRepositoryContributor || acceptedByComment;
 
             const detailsUrl = `https://github.com/${owner}/${repo}/blob/${pullRequest.base.ref}/CLA.md`;
-            const summary = signed
-              ? `The pull request author accepted the [Talon CLA](${detailsUrl}).`
+            const summary = trustedRepositoryContributor
+              ? "The CLA requirement is satisfied for this trusted repository contributor."
+              : acceptedByComment
+                ? `The pull request author accepted the [Talon CLA](${detailsUrl}).`
               : [
                   `Before this pull request can be merged, its author must accept the [Talon CLA](${detailsUrl}).`,
                   "",
@@ -82,9 +99,9 @@ jobs:
               head_sha: pullRequest.head.sha,
               external_id: `talon-cla:${pullRequest.number}`,
               status: "completed",
-              conclusion: signed ? "success" : "action_required",
+              conclusion: satisfied ? "success" : "action_required",
               output: {
-                title: signed ? "CLA accepted" : "CLA signature required",
+                title: satisfied ? "CLA requirement satisfied" : "CLA signature required",
                 summary,
               },
             };

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,12 @@ tests/                Python end-to-end tests
 
 ## Contributor License Agreement
 
-Before a pull request can be merged, its author must accept the
-[Talon Contributor License Agreement](./CLA.md). Post the following exact
-sentence in a comment on each pull request you open:
+Before a pull request can be merged, its author must satisfy the
+[Talon Contributor License Agreement](./CLA.md). Pull requests from branches
+in this repository, and pull requests whose authors GitHub identifies as
+organization members or owners, are recognized automatically.
+
+For other pull requests, post the following exact sentence in a comment:
 
 ```text
 I have read and agree to the Talon CLA.


### PR DESCRIPTION
## Summary

- Treat pull requests whose head and base repositories have the same stable repository ID as trusted repository contributions.
- Preserve the existing `MEMBER` and `OWNER` exemptions for membership that GitHub exposes.
- Remove the ineffective delayed `author_association` retries.
- Add regression tests for hidden private membership, visible organization membership, external forks, and unavailable fork metadata.
- Document when the CLA workflow recognizes a contribution automatically.

## Root cause

The workflow runs with the repository-scoped `GITHUB_TOKEN`. Private impalasys membership is not visible through that credential, so an internal author can be reported as `CONTRIBUTOR` even though a user token with `read:org` reports `MEMBER`. Retrying the same under-privileged pull-request lookup cannot change that result.

All affected internal PRs use branches hosted directly in `impalasys/talon`. Comparing the stable head and base repository IDs makes that trusted provenance explicit without adding an organization token or weakening the fork security boundary.

## Security

The privileged `pull_request_target` job continues to execute only trusted base/default-branch code. Policy tests run separately under the unprivileged `pull_request` event.

## Validation

- `node --test .github/scripts/cla.test.js`
- Parsed `.github/workflows/cla.yml` with Ruby YAML
- Checked the embedded `github-script` JavaScript syntax inside an async function
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically recognizes qualifying contributions from trusted repository contributors for CLA validation.
  * Requires other contributors to provide the exact CLA signature in a pull request comment.
  * CLA checks now run across relevant pull request updates and comments.

* **Documentation**
  * Updated contribution guidelines to explain automatic qualification and signature requirements.

* **Bug Fixes**
  * Improved CLA validation for contributions from forks, including unavailable or deleted forks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->