### PR TITLE
Remove redundant Monty image smoke rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,12 +98,6 @@ jobs:
           cache-from: type=gha,scope=talon-runtime
           cache-to: type=gha,mode=max,scope=talon-runtime
 
-      - name: Smoke test packaged Monty runtime
-        run: |
-          docker build --file dockerfiles/oss-runtime.Dockerfile --tag talon-runtime:smoke .
-          docker run --rm --entrypoint /usr/local/bin/monty talon-runtime:smoke --version
-          docker run --rm --entrypoint /usr/local/bin/talon-node talon-runtime:smoke subprocess </dev/null
-
   acp_harness_image:
     name: ACP Harness Sandbox Image
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- remove the duplicate Docker rebuild from the Runtime Image CI job
- retain the runtime image build and rely on the existing Python/E2E stack coverage for embedded Monty subprocess execution

## Why

The smoke step rebuilt the same OSS image after Buildx had already built it, adding roughly 20 minutes to CI while validating a path covered by the E2E stack.

## Validation

- `git diff --check`
- based on the merged Monty implementation in `main`