### PR TITLE
Fix duplicate React import in chat timeline

### DIFF
--- a/packages/talon-chat/src/lib/chatTimeline.ts
+++ b/packages/talon-chat/src/lib/chatTimeline.ts
@@ -733,4 +733,3 @@ export function formatUsageSummary(usage: UsageSummary | null) {
   const total = typeof usage.totalTokens === "number" ? `${usage.totalTokens} total` : "";
   return [parts.join(" • "), total].filter(Boolean).join(" • ");
 }
-import type React from "react";

--- a/src/harness/llm/openai.rs
+++ b/src/harness/llm/openai.rs
@@ -1660,7 +1660,10 @@ mod tests {
     #[tokio::test]
     async fn serialize_messages_preserves_tool_protocol_fields() {
         let messages = vec![
-            assistant_tool_call_message("mcp_conic_execute_blog_post_publish", "{\"blogPostId\":\"page_1\"}"),
+            assistant_tool_call_message(
+                "mcp_conic_execute_blog_post_publish",
+                "{\"blogPostId\":\"page_1\"}",
+            ),
             tool_result_message("{\"url\":\"https://github.com/example/repo/pull/2\"}"),
         ];
 
@@ -1963,7 +1966,10 @@ mod tests {
             test_cas_store(),
         );
         let messages = vec![
-            assistant_tool_call_message("mcp_conic_execute_blog_post_publish", "{\"blogPostId\":\"page_1\"}"),
+            assistant_tool_call_message(
+                "mcp_conic_execute_blog_post_publish",
+                "{\"blogPostId\":\"page_1\"}",
+            ),
             tool_result_message("{\"url\":\"https://github.com/example/repo/pull/2\"}"),
         ];
 


### PR DESCRIPTION
## Summary

Remove the duplicate `import type React from "react"` declaration at the end of `packages/talon-chat/src/lib/chatTimeline.ts`.

The exported sync commit `c80cd6ff7d6a9bdf107808e5695f508532646d3f` fails the Talon Sightline build with:

`TS2300: Duplicate identifier 'React'`

## Verification

- `pnpm --dir ui build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused internal import; no user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->