### PR TITLE
Restore missing Talon chat tsup config

### DIFF
--- a/packages/talon-chat/tsup.config.ts
+++ b/packages/talon-chat/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  outDir: "dist",
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  bundle: true,
+  minify: false,
+  target: "es2020",
+  external: ["@impalasys/talon-client", "react", "react-dom", "lucide-react", "streamdown"],
+});


### PR DESCRIPTION
## Summary

- restore `packages/talon-chat/tsup.config.ts` required by the OSS UI Dockerfile
- unblock the UI image build after the config was deleted during the TypeScript build migration

## Verification

- `pnpm --filter @impalasys/talon-chat build`
- `pnpm --dir ui build`
- `docker buildx build --file dockerfiles/oss-ui.Dockerfile --tag talon-ui:tsup-config-fix --load .`