### PR TITLE
Test the published Talon chat package artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,7 @@ jobs:
         run: |
           pnpm --filter @impalasys/talon-chat build
           pnpm --filter @impalasys/talon-chat test
+          pnpm --filter @impalasys/talon-chat test:package
 
   python_e2e:
     name: Python E2E

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -352,6 +352,9 @@ jobs:
       - name: Build Talon chat package
         run: pnpm --filter @impalasys/talon-chat build
 
+      - name: Verify Talon chat package artifact
+        run: pnpm --filter @impalasys/talon-chat test:package
+
       - name: Build JS SDK packages
         run: |
           pnpm --filter @impalasys/talon-client build

--- a/packages/talon-chat/package.json
+++ b/packages/talon-chat/package.json
@@ -41,7 +41,8 @@
     "prebuild-storybook": "pnpm --dir ../../sdk/js/talon-client build",
     "screenshots": "node scripts/capture-storybook-screenshots.mjs",
     "storybook": "storybook dev -p 6006",
-    "test": "node --experimental-strip-types --test \"src/**/*.test.{ts,tsx}\""
+    "test": "node --experimental-strip-types --test \"src/**/*.test.{ts,tsx}\"",
+    "test:package": "pnpm --dir ../../sdk/js/talon-client build && node scripts/check-package.mjs"
   },
   "engines": {
     "node": ">=22.6"

--- a/packages/talon-chat/scripts/check-package.mjs
+++ b/packages/talon-chat/scripts/check-package.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const tempRoot = await mkdtemp(join(tmpdir(), "talon-chat-package-"));
+
+try {
+  const packDir = join(tempRoot, "pack");
+  const extractDir = join(tempRoot, "extract");
+  await mkdir(packDir);
+  await mkdir(extractDir);
+
+  execFileSync("pnpm", ["pack", "--pack-destination", packDir], {
+    cwd: packageRoot,
+    stdio: "inherit",
+  });
+
+  const archives = (await readdir(packDir)).filter((name) => name.endsWith(".tgz"));
+  assert.equal(archives.length, 1, `expected one package archive, found ${archives.length}`);
+  execFileSync("tar", ["-xzf", join(packDir, archives[0]), "-C", extractDir], { stdio: "inherit" });
+
+  const packedRoot = join(extractDir, "package");
+  const manifest = JSON.parse(await readFile(join(packedRoot, "package.json"), "utf8"));
+  const entrypoints = new Set([manifest.main, manifest.module, manifest.types]);
+  collectExportTargets(manifest.exports, entrypoints);
+
+  for (const entrypoint of entrypoints) {
+    if (typeof entrypoint !== "string") continue;
+    const absolutePath = resolve(packedRoot, entrypoint);
+    assert.ok(
+      absolutePath.startsWith(`${packedRoot}/`),
+      `package entrypoint escapes the archive: ${entrypoint}`,
+    );
+    await readFile(absolutePath);
+  }
+
+  const runtimeFiles = await findRuntimeFiles(join(packedRoot, "dist"));
+  assert.ok(runtimeFiles.length > 0, "package archive contains no JavaScript runtime files");
+  const invalidImports = [];
+  const typedImportPattern = /(?:\bfrom\s*|\bimport\s*(?:\(\s*)?|\brequire\s*\()\s*["']([^"']+\.(?:ts|tsx|mts|cts)(?:[?#][^"']*)?)["']/g;
+  for (const file of runtimeFiles) {
+    const source = await readFile(file, "utf8");
+    for (const match of source.matchAll(typedImportPattern)) {
+      invalidImports.push(`${relative(packedRoot, file)} imports ${match[1]}`);
+    }
+  }
+  assert.deepEqual(invalidImports, [], `package contains TypeScript runtime imports:\n${invalidImports.join("\n")}`);
+
+  await symlink(join(packageRoot, "node_modules"), join(packedRoot, "node_modules"), "dir");
+  const esmSmoke = join(packedRoot, "package-smoke.mjs");
+  const cjsSmoke = join(packedRoot, "package-smoke.cjs");
+  await writeFile(
+    esmSmoke,
+    `import * as pkg from ${JSON.stringify(manifest.name)};\n` +
+      `if (typeof pkg.TalonSession !== "function") throw new Error("ESM TalonSession export is missing");\n`,
+  );
+  await writeFile(
+    cjsSmoke,
+    `const pkg = require(${JSON.stringify(manifest.name)});\n` +
+      `if (typeof pkg.TalonSession !== "function") throw new Error("CommonJS TalonSession export is missing");\n`,
+  );
+  execFileSync(process.execPath, [esmSmoke], { stdio: "inherit" });
+  execFileSync(process.execPath, [cjsSmoke], { stdio: "inherit" });
+
+  console.log(`Verified packed ${manifest.name}@${manifest.version} (${runtimeFiles.length} runtime files).`);
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
+
+function collectExportTargets(value, targets) {
+  if (typeof value === "string") {
+    targets.add(value);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const child of Object.values(value)) collectExportTargets(child, targets);
+}
+
+async function findRuntimeFiles(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await findRuntimeFiles(path));
+    } else if (/\.(?:js|cjs|mjs)$/.test(entry.name)) {
+      files.push(path);
+    }
+  }
+  return files;
+}

--- a/packages/talon-chat/tsup.config.ts
+++ b/packages/talon-chat/tsup.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
   bundle: true,
   minify: false,
   target: "es2020",
-  external: ["@impalasys/talon-client", "react", "react-dom", "lucide-react", "streamdown"],
+  external: ["@impalasys/talon-client", "react", "react-dom", "lucide-react"],
+  noExternal: ["streamdown"],
 });


### PR DESCRIPTION
Add a release-artifact smoke test for `@impalasys/talon-chat` so source tests and compilation cannot mask a broken npm tarball.

The test runs the real `pnpm pack`/`prepack` path, extracts the tarball, verifies every declared package entrypoint exists, rejects TypeScript import specifiers in runtime JavaScript, and loads the package through both its ESM and CommonJS exports. It runs in pull-request CI and immediately before publishing.

The CommonJS smoke test exposed an existing packaging defect: `streamdown` is ESM-only but was externalized from the CJS bundle. Bundle it into the artifact so the advertised `require` export works.

Verified:
- `pnpm --filter @impalasys/talon-chat test:package`
- `pnpm --filter @impalasys/talon-chat test` (50 passed)
- `git diff --check`