### PR TITLE
Fix Talon chat browser package

### DIFF
--- a/packages/talon-chat/scripts/check-package.mjs
+++ b/packages/talon-chat/scripts/check-package.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, readdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { build } from "vite";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const tempRoot = await mkdtemp(join(tmpdir(), "talon-chat-package-"));
@@ -65,6 +66,29 @@ try {
   );
   execFileSync(process.execPath, [esmSmoke], { stdio: "inherit" });
   execFileSync(process.execPath, [cjsSmoke], { stdio: "inherit" });
+
+  const browserRoot = join(tempRoot, "browser-consumer");
+  await mkdir(browserRoot);
+  const canonicalBrowserRoot = await realpath(browserRoot);
+  await writeFile(join(browserRoot, "index.html"), '<script type="module" src="/main.js"></script>\n');
+  await writeFile(
+    join(browserRoot, "main.js"),
+    `import { TalonSession } from ${JSON.stringify(manifest.name)};\n` +
+      `if (typeof TalonSession !== "function") throw new Error("browser TalonSession export is missing");\n`,
+  );
+  await build({
+    root: canonicalBrowserRoot,
+    logLevel: "warn",
+    resolve: {
+      alias: {
+        [manifest.name]: resolve(packedRoot, manifest.module),
+      },
+    },
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+    },
+  });
 
   console.log(`Verified packed ${manifest.name}@${manifest.version} (${runtimeFiles.length} runtime files).`);
 } finally {

--- a/packages/talon-chat/tsup.config.ts
+++ b/packages/talon-chat/tsup.config.ts
@@ -1,15 +1,29 @@
-import { defineConfig } from "tsup";
+import { defineConfig, type Options } from "tsup";
 
-export default defineConfig({
+const common: Options = {
   entry: ["src/index.ts"],
-  format: ["esm", "cjs"],
   outDir: "dist",
   sourcemap: true,
-  clean: true,
   splitting: false,
   bundle: true,
   minify: false,
   target: "es2020",
-  external: ["@impalasys/talon-client", "react", "react-dom", "lucide-react"],
-  noExternal: ["streamdown"],
-});
+};
+
+const external = ["@impalasys/talon-client", "react", "react-dom", "lucide-react"];
+
+export default defineConfig([
+  {
+    ...common,
+    format: ["esm"],
+    clean: true,
+    external: [...external, "streamdown"],
+  },
+  {
+    ...common,
+    format: ["cjs"],
+    clean: false,
+    external,
+    noExternal: ["streamdown"],
+  },
+]);

--- a/packages/talon-chat/tsup.config.ts
+++ b/packages/talon-chat/tsup.config.ts
@@ -1,4 +1,7 @@
+import { rmSync } from "node:fs";
 import { defineConfig, type Options } from "tsup";
+
+rmSync("dist", { recursive: true, force: true });
 
 const common: Options = {
   entry: ["src/index.ts"],
@@ -16,7 +19,7 @@ export default defineConfig([
   {
     ...common,
     format: ["esm"],
-    clean: true,
+    clean: false,
     external: [...external, "streamdown"],
   },
   {


### PR DESCRIPTION
## Summary
- keep `streamdown` external in the ESM/browser build so Node-only transitive modules are not bundled
- continue bundling `streamdown` in CommonJS so `require()` remains supported
- build the packed ESM artifact with Vite in package verification to catch browser incompatibilities

## Regression cause
PR #296 added `noExternal: ["streamdown"]` to satisfy the CommonJS package smoke test. Because the same tsup config emitted both ESM and CJS, that also bundled Streamdown’s Node-oriented vfile dependency chain into the browser ESM artifact. The existing package test imported both formats only in Node and therefore missed the browser failure.

## Verification
- `pnpm --filter @impalasys/talon-chat test:package`
- `pnpm --filter @impalasys/talon-chat test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded package validation to include browser-based consumer testing and Vite build verification.
  - Continued smoke testing for both ESM and CommonJS package usage.

- **Build**
  - Updated build configuration to produce separate ESM and CommonJS outputs.
  - Improved dependency handling for each module format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->