### PR TITLE
Persist one streamed encrypted reasoning item

### DIFF
--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -381,6 +381,24 @@ async fn collect_session_tool_result_object_keys(
                     &mut keys_to_delete,
                 );
             }
+            if let Some(response) = entry
+                .payload
+                .as_ref()
+                .and_then(|payload| payload.payload.as_ref())
+                .and_then(|payload| match payload {
+                    data_proto::session_journal_entry_payload::Payload::LlmResponse(payload) => {
+                        payload.response.as_ref()
+                    }
+                    _ => None,
+                })
+            {
+                collect_tool_result_object_key(
+                    response.encrypted_reasoning.as_ref(),
+                    &expected_prefix,
+                    agent,
+                    &mut keys_to_delete,
+                );
+            }
         }
     }
 
@@ -2931,6 +2949,91 @@ mod tests {
                                 output: "large journal".to_string(),
                                 object: Some(object),
                                 tool_output: None,
+                            },
+                        ),
+                    ),
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+        handler
+            .handle_delete_session(tonic::Request::new(proto::DeleteSessionRequest {
+                ns: ns.to_string(),
+                agent: agent.to_string(),
+                session_id: session_id.to_string(),
+            }))
+            .await
+            .unwrap();
+
+        assert!(handler
+            .gateway
+            .objects
+            .get(object_key)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_session_removes_encrypted_reasoning_from_journal_only_response() {
+        let kv = Arc::new(MockKvStore::default());
+        let pubsub = Arc::new(RecordingPubSub::default());
+        let handler = handler(kv.clone(), pubsub);
+        let ns = "conic";
+        let agent = "coding";
+        let session_id = "session-1";
+        let submission_id = "submission-1";
+        let object_key = "cas/conic/sessions/session-1/messages/encrypted-reasoning/state.bin";
+        seed_session(kv.as_ref(), ns, agent, session_id).await;
+        let object = handler
+            .gateway
+            .objects
+            .put(
+                object_key,
+                b"opaque encrypted reasoning",
+                ObjectMetadata {
+                    media_type: "application/octet-stream".to_string(),
+                    metadata: HashMap::from([
+                        ("kind".to_string(), "encrypted_reasoning".to_string()),
+                        ("namespace".to_string(), ns.to_string()),
+                        ("agent".to_string(), agent.to_string()),
+                        ("session_id".to_string(), session_id.to_string()),
+                    ]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        kv.set_msg(
+            &keys::session_submission(ns, agent, session_id, submission_id),
+            &crate::harness::sessions::pending_submission(submission_id, session_id, "user-1", 1),
+        )
+        .await
+        .unwrap();
+        kv.set_msg(
+            &keys::session_journal_entry(ns, agent, session_id, submission_id, "000001"),
+            &data_proto::SessionJournalEntry {
+                journal_entry_id: "000001".to_string(),
+                submission_id: submission_id.to_string(),
+                attempt_id: "attempt-1".to_string(),
+                phase: data_proto::SessionExecutionPhase::LlmResponse as i32,
+                created_at: 1,
+                updated_at: 1,
+                committed_at: None,
+                committed_message_id: None,
+                payload: Some(data_proto::SessionJournalEntryPayload {
+                    payload: Some(
+                        data_proto::session_journal_entry_payload::Payload::LlmResponse(
+                            data_proto::SessionJournalEntryPayloadLlmResponse {
+                                response: Some(crate::harness::llm::ChatResponse {
+                                    content: String::new(),
+                                    tool_calls: Vec::new(),
+                                    usage: None,
+                                    encrypted_reasoning: Some(object),
+                                }),
+                                assistant_message_id: "assistant-1".to_string(),
                             },
                         ),
                     ),

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -1011,6 +1011,7 @@ impl AgentExecutor {
             let mut final_reply = String::new();
             let mut tool_calls_by_index: BTreeMap<usize, ToolCall> = BTreeMap::new();
             let mut final_usage: Option<TokenCounter> = None;
+            let mut encrypted_reasoning_items = Vec::new();
             let mut saw_tool_call_delta = false;
             let model = resolve_model_profile(self.agent_spec.model_policy.as_ref());
             let thinking = model.and_then(|model| model.thinking.clone());
@@ -1181,8 +1182,8 @@ impl AgentExecutor {
                         final_usage = Some(self.normalize_token_counter(usage));
                     }
                     ChatStreamEvent {
-                        event: Some(chat_stream_event::Event::EncryptedReasoning(_)),
-                    } => {}
+                        event: Some(chat_stream_event::Event::EncryptedReasoning(reasoning)),
+                    } => encrypted_reasoning_items.push(reasoning),
                     ChatStreamEvent { event: None } => {}
                 }
             }
@@ -1192,6 +1193,41 @@ impl AgentExecutor {
                 .filter(|tool| !tool.name.is_empty())
                 .collect();
 
+            let encrypted_reasoning = match encrypted_reasoning_items.len() {
+                0 => None,
+                1 => match CasStore::new(self.control_plane.objects.clone())
+                    .put_encrypted_reasoning(
+                        &self.namespace,
+                        &self.agent_id,
+                        &self.session_id,
+                        &self.llm_model,
+                        &encrypted_reasoning_items[0],
+                    )
+                    .await
+                {
+                    Ok(object_ref) => Some(object_ref),
+                    Err(error) => {
+                        tracing::warn!(
+                            namespace = %self.namespace,
+                            agent = %self.agent_id,
+                            session = %self.session_id,
+                            %error,
+                            "Failed to persist encrypted reasoning; omitting continuation state"
+                        );
+                        None
+                    }
+                },
+                count => {
+                    tracing::warn!(
+                        provider = %self.llm_provider_key,
+                        model = %self.llm_model,
+                        encrypted_reasoning_items = count,
+                        "Response contained multiple encrypted reasoning items; omitting continuation state"
+                    );
+                    None
+                }
+            };
+
             let llm_response = ChatResponse {
                 content: final_reply.clone(),
                 tool_calls: tool_calls.clone(),
@@ -1199,7 +1235,7 @@ impl AgentExecutor {
                     final_usage
                         .unwrap_or_else(|| self.normalize_token_counter(TokenCounter::default())),
                 ),
-                encrypted_reasoning: None,
+                encrypted_reasoning: encrypted_reasoning,
             };
             context_tokens = llm_response.usage.clone();
             telemetry::record_chat_output(


### PR DESCRIPTION
Collects stream state, writes exactly one opaque CAS object, attaches its ref to ChatResponse, and drops multiple items with a warning.