### PR TITLE
Recover encrypted reasoning from session journal

### DIFF
--- a/src/worker/sessions/recovery.rs
+++ b/src/worker/sessions/recovery.rs
@@ -19,11 +19,14 @@ use crate::harness::sessions::{
     SessionJournalEntryExt,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(super) enum PreparedSubmissionState {
     ContinueExecution,
     StopAfterToolResult,
-    FinalResponseReady { content: String },
+    FinalResponseReady {
+        content: String,
+        encrypted_reasoning: Option<data_proto::ObjectRef>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -43,6 +46,10 @@ enum RecoveredProjectionPart {
         id: String,
         name: String,
         result: String,
+    },
+    EncryptedReasoning {
+        part_id: String,
+        object: data_proto::ObjectRef,
     },
 }
 
@@ -179,10 +186,21 @@ pub(super) async fn recover_claimed_submission(
                     .await?;
                 sink.advance_next_part_id_past(part_id);
             }
+            RecoveredProjectionPart::EncryptedReasoning { part_id, object } => {
+                sink.seed_recovered_encrypted_reasoning_part(part_id, object.clone());
+                sink.advance_next_part_id_past(part_id);
+            }
         }
     }
-    if let PreparedSubmissionState::FinalResponseReady { content } = &prepared.state {
+    if let PreparedSubmissionState::FinalResponseReady {
+        content,
+        encrypted_reasoning,
+    } = &prepared.state
+    {
         sink.seed_recovered_final_text_part(content);
+        if let Some(object) = encrypted_reasoning {
+            sink.seed_recovered_final_encrypted_reasoning_part(object.clone());
+        }
     }
 
     Ok(prepared.state)
@@ -386,12 +404,19 @@ async fn replay_claimed_submission_journal(
         let tool_calls = response.tool_calls.clone();
         let mut assistant_message = LoopMessage::text("assistant", response.content.clone());
         assistant_message.tool_calls = Some(tool_calls.clone());
+        assistant_message.encrypted_reasoning = response.encrypted_reasoning.clone();
         runtime.context.push(assistant_message);
         if !response.content.is_empty() {
             let part_id = next_recovered_part_id(&mut next_projection_part_index);
             projection_parts.push(RecoveredProjectionPart::Text {
                 part_id,
                 content: response.content.clone(),
+            });
+        }
+        if let Some(object) = response.encrypted_reasoning.clone() {
+            projection_parts.push(RecoveredProjectionPart::EncryptedReasoning {
+                part_id: next_recovered_part_id(&mut next_projection_part_index),
+                object,
             });
         }
 
@@ -533,6 +558,7 @@ async fn replay_claimed_submission_journal(
         return Ok(PreparedSubmission {
             state: PreparedSubmissionState::FinalResponseReady {
                 content: response.content,
+                encrypted_reasoning: response.encrypted_reasoning,
             },
             projection_parts,
             latest_appended_journal_entry_id,
@@ -863,6 +889,12 @@ mod tests {
             usage: None,
             encrypted_reasoning: None,
         };
+        let reasoning = data_proto::ObjectRef {
+            key: "cas/ns/sessions/session-1/encrypted-reasoning.bin".to_string(),
+            media_type: "application/octet-stream".to_string(),
+            size_bytes: 42,
+            ..Default::default()
+        };
         sessions::append_llm_response(
             kv.as_ref(),
             "ns",
@@ -918,7 +950,7 @@ mod tests {
                 content: "continued after recovery".to_string(),
                 tool_calls: Vec::new(),
                 usage: None,
-                encrypted_reasoning: None,
+                encrypted_reasoning: Some(reasoning.clone()),
             },
             50,
         )
@@ -961,6 +993,7 @@ mod tests {
             prepared.state,
             PreparedSubmissionState::FinalResponseReady {
                 content: "continued after recovery".to_string(),
+                encrypted_reasoning: Some(reasoning),
             }
         );
         assert_eq!(runtime.context.history.len(), 1);

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -669,6 +669,28 @@ impl PubSubSessionSink {
         );
     }
 
+    pub(crate) fn seed_recovered_encrypted_reasoning_part(
+        &self,
+        part_id: &str,
+        object: data_proto::ObjectRef,
+    ) {
+        self.record_part_with_id_and_object(
+            part_id.to_string(),
+            data_proto::SessionMessagePartType::EncryptedReasoning,
+            String::new(),
+            String::new(),
+            String::new(),
+            Some(object),
+        );
+    }
+
+    pub(crate) fn seed_recovered_final_encrypted_reasoning_part(
+        &self,
+        object: data_proto::ObjectRef,
+    ) {
+        self.seed_recovered_encrypted_reasoning_part(&self.next_part_id(), object);
+    }
+
     pub(crate) fn seed_recovered_tool_call_part(
         &self,
         part_id: &str,


### PR DESCRIPTION
Restores journaled encrypted-reasoning references into the live context and canonical session-message projection if a crash interrupted the normal append.

The recovery path covers both tool-call and final response states.

Test: cargo test --lib worker::sessions::recovery::tests