### PR TITLE
Add session-local tool result catalogs

### DIFF
--- a/src/control/tool_output.rs
+++ b/src/control/tool_output.rs
@@ -206,7 +206,10 @@ pub fn compact_tool_result_catalog(tool_call_id: &str, parts: &[ChatContentPart]
                 format!("parts/{index}: text/plain ({} bytes)", text.len())
             }
             Some(chat_content_part::Content::ObjectRef(object)) => {
-                format!("parts/{index}: {} ({} bytes)", object.media_type, object.size_bytes)
+                format!(
+                    "parts/{index}: {} ({} bytes)",
+                    object.media_type, object.size_bytes
+                )
             }
             None => format!("parts/{index}: empty"),
         })
@@ -215,16 +218,22 @@ pub fn compact_tool_result_catalog(tool_call_id: &str, parts: &[ChatContentPart]
     truncate_utf8(
         &format!(
             "Tool result catalog {}: {}. Use read with ref '{}' to inspect a part.",
-            tool_result_handle(tool_call_id), entries, tool_result_handle(tool_call_id)
+            tool_result_handle(tool_call_id),
+            entries,
+            tool_result_handle(tool_call_id)
         ),
         TOOL_RESULT_DURABLE_SUMMARY_BYTES,
     )
 }
 
 fn truncate_utf8(value: &str, max_bytes: usize) -> String {
-    if value.len() <= max_bytes { return value.to_string(); }
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
     let mut end = max_bytes.saturating_sub(3);
-    while end > 0 && !value.is_char_boundary(end) { end -= 1; }
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
     format!("{}...", &value[..end])
 }
 
@@ -715,7 +724,9 @@ mod tests {
         .unwrap();
 
         assert!(normalized.summary.len() < TOOL_RESULT_OBJECT_THRESHOLD_BYTES);
-        assert!(normalized.summary.starts_with("Tool result catalog tr://call:"));
+        assert!(normalized
+            .summary
+            .starts_with("Tool result catalog tr://call:"));
         assert!(normalized.summary.contains("parts/0: text/plain"));
         let payload = tool_result_payload_json("call", &normalized).unwrap();
         assert!(payload.len() < TOOL_RESULT_OBJECT_THRESHOLD_BYTES);

--- a/src/control/tool_output.rs
+++ b/src/control/tool_output.rs
@@ -12,6 +12,8 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 
 pub const TOOL_RESULT_OBJECT_THRESHOLD_BYTES: usize = 2 * 1024;
+pub const TOOL_RESULT_INLINE_CONTEXT_BYTES: usize = 8 * 1024;
+pub const TOOL_RESULT_DURABLE_SUMMARY_BYTES: usize = 512;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ToolResultPayload {
@@ -180,6 +182,52 @@ pub fn display_text(output: &ToolOutput) -> String {
     })
 }
 
+pub fn tool_result_handle(tool_call_id: &str) -> String {
+    format!("tr://{}", urlencoding::encode(tool_call_id))
+}
+
+pub fn tool_result_part_handle(tool_call_id: &str, index: usize) -> String {
+    format!("{}/parts/{index}", tool_result_handle(tool_call_id))
+}
+
+pub fn is_tool_result_object_ref(object_ref: &data_proto::ObjectRef) -> bool {
+    object_ref
+        .metadata
+        .get(crate::control::cas::METADATA_KIND)
+        .is_some_and(|kind| kind == crate::control::cas::METADATA_KIND_TOOL_RESULT)
+}
+
+pub fn compact_tool_result_catalog(tool_call_id: &str, parts: &[ChatContentPart]) -> String {
+    let entries = parts
+        .iter()
+        .enumerate()
+        .map(|(index, part)| match part.content.as_ref() {
+            Some(chat_content_part::Content::Text(text)) => {
+                format!("parts/{index}: text/plain ({} bytes)", text.len())
+            }
+            Some(chat_content_part::Content::ObjectRef(object)) => {
+                format!("parts/{index}: {} ({} bytes)", object.media_type, object.size_bytes)
+            }
+            None => format!("parts/{index}: empty"),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    truncate_utf8(
+        &format!(
+            "Tool result catalog {}: {}. Use read with ref '{}' to inspect a part.",
+            tool_result_handle(tool_call_id), entries, tool_result_handle(tool_call_id)
+        ),
+        TOOL_RESULT_DURABLE_SUMMARY_BYTES,
+    )
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes { return value.to_string(); }
+    let mut end = max_bytes.saturating_sub(3);
+    while end > 0 && !value.is_char_boundary(end) { end -= 1; }
+    format!("{}...", &value[..end])
+}
+
 pub async fn normalize_for_session_storage(
     cas: &CasStore,
     ctx: ToolOutputStorageContext<'_>,
@@ -216,14 +264,8 @@ pub async fn normalize_for_session_storage(
         content_parts.push(object_ref_part(object_ref));
         stored_large_text = true;
     }
-    let summary = if stored_large_text
-        && output.summary.as_bytes().len() >= TOOL_RESULT_OBJECT_THRESHOLD_BYTES
-    {
-        summary(&ToolOutput {
-            content_parts: content_parts.clone(),
-            summary: String::new(),
-            byte_range: None,
-        })
+    let summary = if stored_large_text {
+        compact_tool_result_catalog(ctx.tool_call_id, &content_parts)
     } else {
         output.summary.clone()
     };
@@ -673,7 +715,8 @@ mod tests {
         .unwrap();
 
         assert!(normalized.summary.len() < TOOL_RESULT_OBJECT_THRESHOLD_BYTES);
-        assert!(normalized.summary.starts_with("[Object: call.txt ("));
+        assert!(normalized.summary.starts_with("Tool result catalog tr://call:"));
+        assert!(normalized.summary.contains("parts/0: text/plain"));
         let payload = tool_result_payload_json("call", &normalized).unwrap();
         assert!(payload.len() < TOOL_RESULT_OBJECT_THRESHOLD_BYTES);
         assert!(!payload.contains(&"x".repeat(128)));

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -262,7 +262,12 @@ pub trait ExecutionSink: Send + Sync {
     /// The tool returned a result.
     async fn on_tool_result(&self, id: &str, name: &str, result: &ToolOutput);
     /// A tool result has been durably recorded.
-    async fn on_tool_result_recorded(&self, _: &str, _: &str, result: &ToolOutput) -> Result<ToolOutput> {
+    async fn on_tool_result_recorded(
+        &self,
+        _: &str,
+        _: &str,
+        result: &ToolOutput,
+    ) -> Result<ToolOutput> {
         Ok(result.clone())
     }
     /// Claim and return interactive inputs that should be incorporated before
@@ -294,7 +299,12 @@ impl ExecutionSink for NullSink {
         Ok(())
     }
     async fn on_tool_result(&self, _: &str, _: &str, _: &ToolOutput) {}
-    async fn on_tool_result_recorded(&self, _: &str, _: &str, result: &ToolOutput) -> Result<ToolOutput> {
+    async fn on_tool_result_recorded(
+        &self,
+        _: &str,
+        _: &str,
+        result: &ToolOutput,
+    ) -> Result<ToolOutput> {
         Ok(result.clone())
     }
     async fn on_request_permission(&self, _: &str, _: &str, _: &Value) {}
@@ -372,7 +382,12 @@ impl ExecutionSink for CaptureSink {
             output: tool_output::display_text(result),
         });
     }
-    async fn on_tool_result_recorded(&self, _: &str, _: &str, result: &ToolOutput) -> Result<ToolOutput> {
+    async fn on_tool_result_recorded(
+        &self,
+        _: &str,
+        _: &str,
+        result: &ToolOutput,
+    ) -> Result<ToolOutput> {
         Ok(result.clone())
     }
     async fn on_request_permission(&self, id: &str, action: &str, payload: &Value) {
@@ -1334,7 +1349,8 @@ impl AgentExecutor {
                     let result = executed.result;
                     let result_text = result.summary();
                     telemetry::record_tool_result(&tool_span, &result_text);
-                    let recorded_result = sink.on_tool_result_recorded(&tool.id, &tool.name, &result)
+                    let recorded_result = sink
+                        .on_tool_result_recorded(&tool.id, &tool.name, &result)
                         .await?;
                     crate::control::usage::charge_namespace_usage(
                         self.control_plane.kv.as_ref(),
@@ -1346,7 +1362,8 @@ impl AgentExecutor {
                         chrono::Utc::now().timestamp(),
                     )
                     .await?;
-                    sink.on_tool_result(&tool.id, &tool.name, &recorded_result).await;
+                    sink.on_tool_result(&tool.id, &tool.name, &recorded_result)
+                        .await;
                     context.push(tool_output_loop_message(&tool.id, &recorded_result));
                     if stop_after_result {
                         stop_after_tool_result = Some(result_text);
@@ -1453,7 +1470,9 @@ pub fn tool_output_loop_message(tool_call_id: &str, result: &ToolOutput) -> Loop
             .map(|(index, part)| match part.content.as_ref() {
                 Some(crate::harness::llm::chat_content_part::Content::ObjectRef(object))
                     if crate::control::tool_output::is_tool_result_object_ref(object)
-                        && crate::control::tool_output::is_text_object_media_type(&object.media_type) =>
+                        && crate::control::tool_output::is_text_object_media_type(
+                            &object.media_type,
+                        ) =>
                 {
                     crate::harness::llm::text_part(format!(
                         "Large text is available at {}.",

--- a/src/harness/executor/runtime.rs
+++ b/src/harness/executor/runtime.rs
@@ -262,8 +262,8 @@ pub trait ExecutionSink: Send + Sync {
     /// The tool returned a result.
     async fn on_tool_result(&self, id: &str, name: &str, result: &ToolOutput);
     /// A tool result has been durably recorded.
-    async fn on_tool_result_recorded(&self, _: &str, _: &str, _: &ToolOutput) -> Result<()> {
-        Ok(())
+    async fn on_tool_result_recorded(&self, _: &str, _: &str, result: &ToolOutput) -> Result<ToolOutput> {
+        Ok(result.clone())
     }
     /// Claim and return interactive inputs that should be incorporated before
     /// the next LLM request in the active execution.
@@ -294,8 +294,8 @@ impl ExecutionSink for NullSink {
         Ok(())
     }
     async fn on_tool_result(&self, _: &str, _: &str, _: &ToolOutput) {}
-    async fn on_tool_result_recorded(&self, _: &str, _: &str, _: &ToolOutput) -> Result<()> {
-        Ok(())
+    async fn on_tool_result_recorded(&self, _: &str, _: &str, result: &ToolOutput) -> Result<ToolOutput> {
+        Ok(result.clone())
     }
     async fn on_request_permission(&self, _: &str, _: &str, _: &Value) {}
     async fn on_permission_result(&self, _: &str, _: &Value) {}
@@ -372,8 +372,8 @@ impl ExecutionSink for CaptureSink {
             output: tool_output::display_text(result),
         });
     }
-    async fn on_tool_result_recorded(&self, _: &str, _: &str, _: &ToolOutput) -> Result<()> {
-        Ok(())
+    async fn on_tool_result_recorded(&self, _: &str, _: &str, result: &ToolOutput) -> Result<ToolOutput> {
+        Ok(result.clone())
     }
     async fn on_request_permission(&self, id: &str, action: &str, payload: &Value) {
         self.events
@@ -1334,7 +1334,7 @@ impl AgentExecutor {
                     let result = executed.result;
                     let result_text = result.summary();
                     telemetry::record_tool_result(&tool_span, &result_text);
-                    sink.on_tool_result_recorded(&tool.id, &tool.name, &result)
+                    let recorded_result = sink.on_tool_result_recorded(&tool.id, &tool.name, &result)
                         .await?;
                     crate::control::usage::charge_namespace_usage(
                         self.control_plane.kv.as_ref(),
@@ -1346,8 +1346,8 @@ impl AgentExecutor {
                         chrono::Utc::now().timestamp(),
                     )
                     .await?;
-                    sink.on_tool_result(&tool.id, &tool.name, &result).await;
-                    context.push(tool_output_loop_message(&tool.id, &result));
+                    sink.on_tool_result(&tool.id, &tool.name, &recorded_result).await;
+                    context.push(tool_output_loop_message(&tool.id, &recorded_result));
                     if stop_after_result {
                         stop_after_tool_result = Some(result_text);
                         break;
@@ -1446,7 +1446,23 @@ pub fn tool_result_loop_message(tool_call_id: &str, result: &str) -> LoopMessage
 pub fn tool_output_loop_message(tool_call_id: &str, result: &ToolOutput) -> LoopMessage {
     LoopMessage {
         role: "tool".to_string(),
-        content_parts: result.content_parts(),
+        content_parts: result
+            .content_parts()
+            .into_iter()
+            .enumerate()
+            .map(|(index, part)| match part.content.as_ref() {
+                Some(crate::harness::llm::chat_content_part::Content::ObjectRef(object))
+                    if crate::control::tool_output::is_tool_result_object_ref(object)
+                        && crate::control::tool_output::is_text_object_media_type(&object.media_type) =>
+                {
+                    crate::harness::llm::text_part(format!(
+                        "Large text is available at {}.",
+                        crate::control::tool_output::tool_result_part_handle(tool_call_id, index)
+                    ))
+                }
+                _ => part,
+            })
+            .collect(),
         tool_calls: None,
         tool_call_id: Some(tool_call_id.to_string()),
         encrypted_reasoning: None,

--- a/src/harness/native_tools/resources.rs
+++ b/src/harness/native_tools/resources.rs
@@ -125,7 +125,10 @@ async fn read_session_tool_result(
     let mut found = None;
     for submission in cp
         .kv
-        .list_keys(&keys::session_submission_prefix(namespace, agent, session_id), None)
+        .list_keys(
+            &keys::session_submission_prefix(namespace, agent, session_id),
+            None,
+        )
         .await?
     {
         for (_, bytes) in cp
@@ -182,7 +185,9 @@ async fn read_session_tool_result(
             .content_parts
             .get(index)
             .cloned()
-            .map(|part| ToolOutput::from_content_parts(vec![part], format!("Tool result part {index}.")))
+            .map(|part| {
+                ToolOutput::from_content_parts(vec![part], format!("Tool result part {index}."))
+            })
             .ok_or_else(|| anyhow!("tool result part {index} does not exist")),
     }
 }

--- a/src/harness/native_tools/resources.rs
+++ b/src/harness/native_tools/resources.rs
@@ -50,6 +50,16 @@ pub(crate) async fn read_resource_tool(
         require_file_read(spec)?;
         return read_file_tool(cp, current_namespace, args).await;
     };
+    if reference.starts_with("tr://") {
+        return read_session_tool_result(
+            cp,
+            current_namespace,
+            current_agent,
+            current_session,
+            reference,
+        )
+        .await;
+    }
     if reference.starts_with("artifact://") {
         return read_artifact(
             cp,
@@ -70,7 +80,111 @@ pub(crate) async fn read_resource_tool(
         )
         .await;
     }
-    Err(anyhow!("read.ref must start with file:// or artifact://"))
+    Err(anyhow!(
+        "read.ref must start with file://, artifact://, or tr://"
+    ))
+}
+
+async fn read_session_tool_result(
+    cp: &ControlPlane,
+    namespace: &str,
+    agent: &str,
+    session_id: &str,
+    reference: &str,
+) -> Result<ToolOutput> {
+    if session_id.is_empty() {
+        return Err(anyhow!("tr:// references require an active session"));
+    }
+    let raw = reference
+        .strip_prefix("tr://")
+        .ok_or_else(|| anyhow!("invalid tr:// reference"))?;
+    let (encoded_id, index) = match raw.rsplit_once("/parts/") {
+        Some((id, index)) => (
+            id,
+            Some(
+                index
+                    .parse::<usize>()
+                    .map_err(|_| anyhow!("tool result part index must be a zero-based integer"))?,
+            ),
+        ),
+        None => (raw, None),
+    };
+    if encoded_id.is_empty() || encoded_id.contains('/') {
+        return Err(anyhow!(
+            "tr:// reference must include one encoded tool call id"
+        ));
+    }
+    let tool_call_id = urlencoding::decode(encoded_id)
+        .map_err(|_| anyhow!("tool call id is not valid percent-encoding"))?
+        .into_owned();
+    if crate::control::tool_output::tool_result_handle(&tool_call_id)
+        != format!("tr://{encoded_id}")
+    {
+        return Err(anyhow!("tool call id is not canonically encoded"));
+    }
+    let mut found = None;
+    for submission in cp
+        .kv
+        .list_keys(&keys::session_submission_prefix(namespace, agent, session_id), None)
+        .await?
+    {
+        for (_, bytes) in cp
+            .kv
+            .list_entries(
+                &keys::session_journal_entry_prefix(namespace, agent, session_id, &submission.name),
+                None,
+            )
+            .await?
+        {
+            let entry = data_proto::SessionJournalEntry::decode(bytes.as_slice())?;
+            let Some(result) = entry
+                .payload
+                .as_ref()
+                .and_then(|payload| payload.payload.as_ref())
+                .and_then(|payload| match payload {
+                    data_proto::session_journal_entry_payload::Payload::ToolResult(result) => {
+                        Some(result)
+                    }
+                    _ => None,
+                })
+            else {
+                continue;
+            };
+            if result.tool_call_id != tool_call_id {
+                continue;
+            }
+            let output = result
+                .tool_output
+                .clone()
+                .unwrap_or_else(|| ToolOutput::text(result.output.clone()));
+            if found.replace(output).is_some() {
+                return Err(anyhow!(
+                    "tool result reference '{}' is ambiguous in this session",
+                    tool_call_id
+                ));
+            }
+        }
+    }
+    let output = found.ok_or_else(|| {
+        anyhow!(
+            "tool result '{}' was not found in the current session",
+            tool_call_id
+        )
+    })?;
+    match index {
+        None => Ok(ToolOutput::text(
+            crate::control::tool_output::compact_tool_result_catalog(
+                &tool_call_id,
+                &output.content_parts,
+            ),
+        )),
+        Some(index) => output
+            .content_parts
+            .get(index)
+            .cloned()
+            .map(|part| ToolOutput::from_content_parts(vec![part], format!("Tool result part {index}.")))
+            .ok_or_else(|| anyhow!("tool result part {index} does not exist")),
+    }
 }
 
 pub(crate) async fn write_resource_tool(
@@ -83,6 +197,9 @@ pub(crate) async fn write_resource_tool(
     args: &Value,
 ) -> Result<String> {
     match opt_str(args, "ref") {
+        Some(reference) if reference.starts_with("tr://") => {
+            Err(anyhow!("tool-result references are read-only"))
+        }
         Some(reference) if reference.starts_with("artifact://") => {
             update_artifact(
                 cp,

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -1502,7 +1502,7 @@ impl ExecutionSink for PubSubSessionSink {
         id: &str,
         name: &str,
         result: &ToolOutput,
-    ) -> Result<()> {
+    ) -> Result<ToolOutput> {
         let part_id = self.next_part_id();
         let cas = CasStore::new(self.objects.clone());
         let entry = sessions::append_tool_result(
@@ -1536,11 +1536,11 @@ impl ExecutionSink for PubSubSessionSink {
             id.to_string(),
             RecordedToolResult {
                 part_id: part_id.clone(),
-                output,
+                output: output.clone(),
             },
         );
         *self.latest_journal_entry_id.lock().unwrap() = Some(entry.journal_entry_id);
-        Ok(())
+        Ok(output)
     }
 
     async fn take_steering_messages(&self) -> Result<Vec<crate::harness::executor::LoopMessage>> {


### PR DESCRIPTION
## Summary
- project large normalized text as bounded session-local tr:// catalogs
- resolve catalog roots and zero-based parts through generic read
- feed normalized outputs back into the live execution loop

## Validation
- cargo check --tests -q
- cargo test control::tool_output::tests --lib -q
- cargo test harness::executor::runtime::tests --lib -q

Stacked on #329.