### PR TITLE
Retire legacy resource tools from model registry

### DIFF
--- a/src/harness/native_tools/mod.rs
+++ b/src/harness/native_tools/mod.rs
@@ -1305,7 +1305,9 @@ mod tests {
         );
 
         assert!(read_registry.get_tool(LIST_FILES_TOOL).is_some());
-        assert!(read_registry.get_tool(READ_FILE_TOOL).is_some());
+        assert!(read_registry.get_tool(READ_TOOL).is_some());
+        assert!(read_registry.get_tool(WRITE_TOOL).is_some());
+        assert!(read_registry.get_tool(READ_FILE_TOOL).is_none());
         assert!(read_registry.get_tool(GET_FILE_METADATA_TOOL).is_some());
         assert!(read_registry.get_tool(CREATE_FILE_TOOL).is_none());
         assert!(read_registry.get_tool(UPDATE_FILE_TOOL).is_none());
@@ -1318,8 +1320,10 @@ mod tests {
             &Config::default(),
         );
 
-        assert!(write_registry.get_tool(CREATE_FILE_TOOL).is_some());
-        assert!(write_registry.get_tool(UPDATE_FILE_TOOL).is_some());
+        assert!(write_registry.get_tool(CREATE_FILE_TOOL).is_none());
+        assert!(write_registry.get_tool(READ_TOOL).is_some());
+        assert!(write_registry.get_tool(WRITE_TOOL).is_some());
+        assert!(write_registry.get_tool(UPDATE_FILE_TOOL).is_none());
         assert!(write_registry.get_tool(DELETE_FILE_TOOL).is_some());
         assert!(write_registry.get_tool(READ_FILE_TOOL).is_none());
     }

--- a/src/harness/native_tools/registry.rs
+++ b/src/harness/native_tools/registry.rs
@@ -3,11 +3,11 @@
 use super::common::has_capability_action;
 use super::{
     ACTIVATE_SKILL_TOOL, BLOCK_GOAL_TOOL, CHANNEL_PUBLISH_TOOL, CHANNEL_SKIP_REPLY_TOOL,
-    COMPLETE_GOAL_TOOL, CREATE_FILE_TOOL, CREATE_GOAL_TOOL, CREATE_SCHEDULE_TOOL,
-    DEACTIVATE_SKILL_TOOL, DELETE_FILE_TOOL, DELETE_SCHEDULE_TOOL, FETCH_URL_TOOL,
-    GET_FILE_METADATA_TOOL, GET_GOAL_TOOL, GET_SCHEDULE_TOOL, LIST_FILES_TOOL, LIST_GOALS_TOOL,
-    LIST_SCHEDULES_TOOL, READ_FILE_TOOL, READ_SESSION_MESSAGES_TOOL, READ_TOOL, UPDATE_FILE_TOOL,
-    UPDATE_GOAL_TOOL, UPDATE_SCHEDULE_TOOL, WEB_SEARCH_TOOL, WRITE_TOOL,
+    COMPLETE_GOAL_TOOL, CREATE_GOAL_TOOL, CREATE_SCHEDULE_TOOL, DEACTIVATE_SKILL_TOOL,
+    DELETE_FILE_TOOL, DELETE_SCHEDULE_TOOL, FETCH_URL_TOOL, GET_FILE_METADATA_TOOL, GET_GOAL_TOOL,
+    GET_SCHEDULE_TOOL, LIST_FILES_TOOL, LIST_GOALS_TOOL, LIST_SCHEDULES_TOOL,
+    READ_SESSION_MESSAGES_TOOL, READ_TOOL, UPDATE_GOAL_TOOL, UPDATE_SCHEDULE_TOOL, WEB_SEARCH_TOOL,
+    WRITE_TOOL,
 };
 use crate::control::config::Config;
 use crate::gateway::rpc::manifests;
@@ -72,6 +72,8 @@ pub fn register_channel_tools(registry: &mut ToolRegistry) {
 }
 
 pub fn register_tools(registry: &mut ToolRegistry, spec: &manifests::AgentSpec, config: &Config) {
+    // Only metadata/grant artifact operations remain model-visible. Artifact
+    // content flows through the generic read/write resource tools.
     super::artifact_tools::register(registry);
     registry.register_builtin(
         READ_TOOL,
@@ -199,18 +201,6 @@ pub fn register_tools(registry: &mut ToolRegistry, spec: &manifests::AgentSpec, 
             }),
         );
         registry.register_builtin(
-            READ_FILE_TOOL,
-            "Read a namespace File by file:// URI or logical path.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "uri": { "type": "string", "description": "Optional file://<namespace>/<path> URI returned by Talon or Conic." },
-                    "namespace": { "type": "string", "description": "File namespace. Defaults to current namespace." },
-                    "path": { "type": "string", "description": "Logical File path, for example /content/pages/<id>/content.md." }
-                }
-            }),
-        );
-        registry.register_builtin(
             GET_FILE_METADATA_TOOL,
             "Get File metadata by file:// URI or logical path without reading content.",
             json!({
@@ -224,20 +214,6 @@ pub fn register_tools(registry: &mut ToolRegistry, spec: &manifests::AgentSpec, 
         );
     }
 
-    if has_capability_action(spec, "files", "create") {
-        registry.register_builtin(
-            CREATE_FILE_TOOL,
-            "Create a namespace File. Defaults to purpose=ARTIFACT, index_policy=SEARCH, and retention=RETAINED.",
-            file_write_schema(),
-        );
-    }
-    if has_capability_action(spec, "files", "update") {
-        registry.register_builtin(
-            UPDATE_FILE_TOOL,
-            "Update an existing namespace File by file:// URI or logical path.",
-            file_write_schema(),
-        );
-    }
     if has_capability_action(spec, "files", "delete") {
         registry.register_builtin(
             DELETE_FILE_TOOL,
@@ -435,22 +411,5 @@ fn memory_write_schema() -> Value {
             "media_type": { "type": "string", "description": "Media type. Defaults to text/markdown." }
         },
         "required": ["path", "content"]
-    })
-}
-
-fn file_write_schema() -> Value {
-    json!({
-        "type": "object",
-        "properties": {
-            "uri": { "type": "string", "description": "Optional file://<namespace>/<path> URI for updates." },
-            "namespace": { "type": "string", "description": "File namespace. Defaults to current namespace." },
-            "path": { "type": "string", "description": "Logical File path, for example /content/pages/<id>/content.md." },
-            "content": { "type": "string", "description": "Markdown, HTML, or text content to store." },
-            "media_type": { "type": "string", "description": "Media type. Defaults to text/markdown." },
-            "purpose": { "type": "string", "description": "File purpose: ARTIFACT, MEMORY, or SKILL. Defaults to ARTIFACT." },
-            "index_policy": { "type": "string", "description": "Index policy: NONE, SEARCH, or RETRIEVAL. Defaults to SEARCH." },
-            "retention": { "type": "string", "description": "Retention policy: RETAINED. Defaults to RETAINED." }
-        },
-        "required": ["content"]
     })
 }

--- a/src/harness/tools/artifacts.rs
+++ b/src/harness/tools/artifacts.rs
@@ -11,47 +11,6 @@ use crate::harness::skills::registry::ToolRegistry;
 
 pub(super) fn register(registry: &mut ToolRegistry) {
     registry.register_builtin(
-        super::CREATE_ARTIFACT_TOOL,
-        "Create a session-scoped artifact and return an artifact:// URI that can be read or granted to another agent.",
-        json!({
-            "type": "object",
-            "properties": {
-                "title": { "type": "string", "description": "Human-readable artifact title." },
-                "media_type": { "type": "string", "description": "Media type. Defaults to text/markdown." },
-                "content": { "type": "string", "description": "Full text content to store. Required unless content_base64 is provided." },
-                "content_base64": { "type": "string", "description": "Base64 bytes to store instead of content." },
-                "labels": { "type": "object", "additionalProperties": { "type": "string" } },
-                "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
-            },
-            "required": ["title"]
-        }),
-    );
-    registry.register_builtin(
-        super::READ_ARTIFACT_TOOL,
-        "Read an artifact by artifact:// URI.",
-        json!({
-            "type": "object",
-            "properties": {
-                "artifact_uri": { "type": "string" }
-            },
-            "required": ["artifact_uri"]
-        }),
-    );
-    registry.register_builtin(
-        super::UPDATE_ARTIFACT_TOOL,
-        "Update an artifact owned by the current agent/session. Writes a new immutable object and keeps the same artifact:// URI.",
-        json!({
-            "type": "object",
-            "properties": {
-                "artifact_uri": { "type": "string" },
-                "media_type": { "type": "string", "description": "Media type. Defaults to the artifact's current media type." },
-                "content": { "type": "string", "description": "Full text content to store. Required unless content_base64 is provided." },
-                "content_base64": { "type": "string", "description": "Base64 bytes to store instead of content." }
-            },
-            "required": ["artifact_uri"]
-        }),
-    );
-    registry.register_builtin(
         super::GET_ARTIFACT_METADATA_TOOL,
         "Return artifact metadata for an artifact:// URI without reading bytes.",
         json!({

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -394,9 +394,6 @@ fn builtin_tool_names() -> &'static [&'static str] {
         crate::harness::native_tools::READ_SESSION_MESSAGES_TOOL,
         crate::harness::native_tools::READ_TOOL,
         crate::harness::native_tools::WRITE_TOOL,
-        crate::harness::native_tools::CREATE_ARTIFACT_TOOL,
-        crate::harness::native_tools::UPDATE_ARTIFACT_TOOL,
-        crate::harness::native_tools::READ_ARTIFACT_TOOL,
         crate::harness::native_tools::GET_ARTIFACT_METADATA_TOOL,
         crate::harness::native_tools::GRANT_ARTIFACT_TOOL,
         crate::harness::native_tools::FETCH_URL_TOOL,
@@ -713,8 +710,8 @@ mod tests {
         assert!(names.contains(&crate::harness::native_tools::WRITE_TOOL));
         assert!(names.contains(&crate::harness::native_tools::CREATE_GOAL_TOOL));
         assert!(names.contains(&crate::harness::native_tools::LIST_GOALS_TOOL));
-        assert!(names.contains(&crate::harness::native_tools::CREATE_ARTIFACT_TOOL));
-        assert!(names.contains(&crate::harness::native_tools::UPDATE_ARTIFACT_TOOL));
+        assert!(!names.contains(&crate::harness::native_tools::CREATE_ARTIFACT_TOOL));
+        assert!(!names.contains(&crate::harness::native_tools::UPDATE_ARTIFACT_TOOL));
         assert!(names.contains(&crate::harness::native_tools::DELEGATE_TASK_TOOL));
         assert!(names.contains(&crate::harness::native_tools::AGENT_WAIT_FOR_MESSAGE_TOOL));
         assert!(names.contains(&crate::harness::native_tools::READ_SESSION_MESSAGES_TOOL));


### PR DESCRIPTION
Completes the migration to generic read/write. Legacy file and artifact create/read/update handlers remain executable only for historical journal compatibility, but are no longer advertised to models or accepted as current built-ins.