### PR TITLE
Retain indexed artifact revisions for session cleanup

### DIFF
--- a/src/control/keys.rs
+++ b/src/control/keys.rs
@@ -471,6 +471,31 @@ pub fn artifact_prefix(namespace: &str, agent: &str, session_id: &str) -> Resour
     )
 }
 
+/// Immutable CAS revisions retained for artifacts owned by a session. The
+/// current Artifact resource points at only its newest revision, so teardown
+/// uses this index to reclaim every prior revision safely.
+pub fn artifact_revision(
+    namespace: &str,
+    agent: &str,
+    session_id: &str,
+    revision_id: &str,
+) -> ResourceKey {
+    resource_key(
+        namespace,
+        &[("Agent", agent), ("Session", session_id)],
+        "ArtifactRevision",
+        revision_id,
+    )
+}
+
+pub fn artifact_revision_prefix(namespace: &str, agent: &str, session_id: &str) -> ResourceList {
+    direct_child_prefix(
+        namespace,
+        &[("Agent", agent), ("Session", session_id)],
+        Some("ArtifactRevision"),
+    )
+}
+
 pub fn goal(namespace: &str, agent: &str, session_id: &str, goal_id: &str) -> ResourceKey {
     resource_key(
         namespace,

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use super::{connectors as connector_rpc, data_proto, proto, GrpcGatewayHandler};
-use crate::control::cas::{session_object_key_prefix, SessionCasScope, METADATA_AGENT};
+use crate::control::cas::{
+    artifact_object_key_prefix, session_object_key_prefix, SessionCasScope, METADATA_AGENT,
+    METADATA_KIND, METADATA_KIND_ARTIFACT,
+};
 use crate::control::scheduling;
 use crate::control::session_queue;
 use crate::control::tool_output;
@@ -247,7 +250,32 @@ async fn collect_session_tool_result_object_keys(
     session_id: &str,
 ) -> anyhow::Result<Vec<String>> {
     let expected_prefix = session_object_key_prefix(&SessionCasScope::new(ns, agent, session_id));
+    let artifact_prefix = artifact_object_key_prefix(ns);
     let mut keys_to_delete = HashSet::new();
+    for key in kv
+        .list_keys(&keys::artifact_revision_prefix(ns, agent, session_id), None)
+        .await?
+    {
+        match kv.get_msg::<data_proto::ObjectRef>(&key).await {
+            Ok(Some(object))
+                if object.key.starts_with(&artifact_prefix)
+                    && object.metadata.get(METADATA_KIND).is_some_and(|kind| kind == METADATA_KIND_ARTIFACT)
+                    && object.metadata.get(METADATA_AGENT).is_some_and(|owner| owner == agent)
+                    && object.metadata.get("session_id").is_some_and(|owner_session| owner_session == session_id) =>
+            {
+                keys_to_delete.insert(object.key);
+            }
+            Ok(Some(_)) | Ok(None) => {}
+            Err(error) => tracing::warn!(
+                error = %error,
+                namespace = %ns,
+                agent = %agent,
+                session_id = %session_id,
+                key = %key,
+                "failed to decode artifact revision while collecting session objects for deletion"
+            ),
+        }
+    }
     for key in kv
         .list_keys(&keys::session_message_prefix(ns, agent, session_id), None)
         .await?

--- a/src/gateway/rpc/sessions/mod.rs
+++ b/src/gateway/rpc/sessions/mod.rs
@@ -259,9 +259,18 @@ async fn collect_session_tool_result_object_keys(
         match kv.get_msg::<data_proto::ObjectRef>(&key).await {
             Ok(Some(object))
                 if object.key.starts_with(&artifact_prefix)
-                    && object.metadata.get(METADATA_KIND).is_some_and(|kind| kind == METADATA_KIND_ARTIFACT)
-                    && object.metadata.get(METADATA_AGENT).is_some_and(|owner| owner == agent)
-                    && object.metadata.get("session_id").is_some_and(|owner_session| owner_session == session_id) =>
+                    && object
+                        .metadata
+                        .get(METADATA_KIND)
+                        .is_some_and(|kind| kind == METADATA_KIND_ARTIFACT)
+                    && object
+                        .metadata
+                        .get(METADATA_AGENT)
+                        .is_some_and(|owner| owner == agent)
+                    && object
+                        .metadata
+                        .get("session_id")
+                        .is_some_and(|owner_session| owner_session == session_id) =>
             {
                 keys_to_delete.insert(object.key);
             }

--- a/src/harness/native_tools/artifacts.rs
+++ b/src/harness/native_tools/artifacts.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::control::KeyValueStore;
 
 pub async fn create_artifact(
     cp: &ControlPlane,
@@ -45,6 +46,15 @@ pub async fn create_artifact(
         labels,
         metadata,
     };
+    record_artifact_revision(
+        cp.kv.as_ref(),
+        current_namespace,
+        current_agent,
+        current_session,
+        &artifact_id,
+        artifact.object_ref.as_ref().expect("new artifact object ref"),
+    )
+    .await?;
     cp.kv
         .set_msg(
             &keys::artifact(
@@ -142,10 +152,6 @@ pub async fn update_artifact(
         ))
         .await?
         .ok_or_else(|| anyhow!("Artifact '{}' not found", uri.artifact_id))?;
-    let previous_object_key = artifact
-        .object_ref
-        .as_ref()
-        .map(|object_ref| object_ref.key.clone());
     let media_type = opt_str(args, "media_type").unwrap_or(&artifact.media_type);
     if args.get("content").and_then(Value::as_str).is_none()
         && opt_str(args, "content_base64").is_none()
@@ -169,6 +175,15 @@ pub async fn update_artifact(
         .await?;
     artifact.media_type = media_type.to_string();
     artifact.object_ref = Some(object_ref);
+    record_artifact_revision(
+        cp.kv.as_ref(),
+        &uri.namespace,
+        &uri.agent,
+        &uri.session_id,
+        &uri.artifact_id,
+        artifact.object_ref.as_ref().expect("updated artifact object ref"),
+    )
+    .await?;
     let artifact_key = keys::artifact(
         &uri.namespace,
         &uri.agent,
@@ -191,25 +206,29 @@ pub async fn update_artifact(
         }
         return Err(error);
     }
-    if let Some(previous_object_key) = previous_object_key {
-        if artifact
-            .object_ref
-            .as_ref()
-            .is_none_or(|object_ref| object_ref.key != previous_object_key)
-        {
-            if let Err(error) = cas.delete_object(&previous_object_key).await {
-                tracing::warn!(
-                    error = %error,
-                    object_key = %previous_object_key,
-                    "failed to delete superseded artifact CAS object"
-                );
-            }
-        }
-    }
+    // Previous immutable revisions remain readable through durable history.
+    // Session teardown reclaims every indexed revision.
     Ok(serde_json::to_string_pretty(&json!({
         "artifact": artifact_json(&artifact),
         "artifactUri": uri.encode()
     }))?)
+}
+
+pub(crate) async fn record_artifact_revision(
+    kv: &dyn KeyValueStore,
+    namespace: &str,
+    agent: &str,
+    session_id: &str,
+    artifact_id: &str,
+    object_ref: &data_proto::ObjectRef,
+) -> Result<()> {
+    let revision_id = format!("{artifact_id}-{}", object_ref.sha256);
+    kv
+        .set_msg(
+            &keys::artifact_revision(namespace, agent, session_id, &revision_id),
+            object_ref,
+        )
+        .await
 }
 
 pub async fn get_artifact_metadata(

--- a/src/harness/native_tools/artifacts.rs
+++ b/src/harness/native_tools/artifacts.rs
@@ -52,7 +52,10 @@ pub async fn create_artifact(
         current_agent,
         current_session,
         &artifact_id,
-        artifact.object_ref.as_ref().expect("new artifact object ref"),
+        artifact
+            .object_ref
+            .as_ref()
+            .expect("new artifact object ref"),
     )
     .await?;
     cp.kv
@@ -181,7 +184,10 @@ pub async fn update_artifact(
         &uri.agent,
         &uri.session_id,
         &uri.artifact_id,
-        artifact.object_ref.as_ref().expect("updated artifact object ref"),
+        artifact
+            .object_ref
+            .as_ref()
+            .expect("updated artifact object ref"),
     )
     .await?;
     let artifact_key = keys::artifact(
@@ -223,12 +229,11 @@ pub(crate) async fn record_artifact_revision(
     object_ref: &data_proto::ObjectRef,
 ) -> Result<()> {
     let revision_id = format!("{artifact_id}-{}", object_ref.sha256);
-    kv
-        .set_msg(
-            &keys::artifact_revision(namespace, agent, session_id, &revision_id),
-            object_ref,
-        )
-        .await
+    kv.set_msg(
+        &keys::artifact_revision(namespace, agent, session_id, &revision_id),
+        object_ref,
+    )
+    .await
 }
 
 pub async fn get_artifact_metadata(

--- a/src/harness/native_tools/mod.rs
+++ b/src/harness/native_tools/mod.rs
@@ -1826,11 +1826,29 @@ mod tests {
             .as_str()
             .unwrap();
         assert_ne!(updated_object_key, object_key);
-        assert!(crate::control::cas::CasStore::new(cp.objects.clone())
-            .get_object_decoded(object_key)
+        assert_eq!(
+            crate::control::cas::CasStore::new(cp.objects.clone())
+                .get_object_decoded(object_key)
+                .await
+                .unwrap()
+                .unwrap()
+                .bytes,
+            b"draft body"
+        );
+        assert_eq!(
+            kv.list_keys(
+                &keys::artifact_revision_prefix(
+                    "Tenant:acme:Workspace:main",
+                    "writer",
+                    "session-1",
+                ),
+                None,
+            )
             .await
             .unwrap()
-            .is_none());
+            .len(),
+            2
+        );
 
         let read_updated_output = execute_tool_for_session(
             &cp,

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -825,7 +825,10 @@ impl PubSubSessionSink {
             &self.agent_id,
             &self.session_id,
             &artifact_id,
-            artifact.object_ref.as_ref().expect("inline artifact object ref"),
+            artifact
+                .object_ref
+                .as_ref()
+                .expect("inline artifact object ref"),
         )
         .await?;
         self.kv
@@ -2254,16 +2257,19 @@ mod tests {
             .unwrap()
             .expect("artifact object");
         assert_eq!(object.bytes, b"# Redline\n\n- edit");
-        assert_eq!(
-            kv.list_keys(
-                &keys::artifact_revision_prefix("conic", "infra", "session-1"),
-                None,
-            )
+        let revision_key = keys::artifact_revision(
+            "conic",
+            "infra",
+            "session-1",
+            &format!("{}-{}", artifact.id, object_ref.sha256),
+        )
+        .to_string();
+        assert!(kv
+            .entries
+            .lock()
             .await
-            .unwrap()
-            .len(),
-            1
-        );
+            .iter()
+            .any(|(key, _)| key == &revision_key));
     }
 
     #[tokio::test]

--- a/src/worker/sink.rs
+++ b/src/worker/sink.rs
@@ -819,6 +819,15 @@ impl PubSubSessionSink {
             labels: HashMap::new(),
             metadata,
         };
+        crate::harness::native_tools::artifacts::record_artifact_revision(
+            self.kv.as_ref(),
+            &self.ns,
+            &self.agent_id,
+            &self.session_id,
+            &artifact_id,
+            artifact.object_ref.as_ref().expect("inline artifact object ref"),
+        )
+        .await?;
         self.kv
             .set_msg(
                 &keys::artifact(&self.ns, &self.agent_id, &self.session_id, &artifact_id),
@@ -2245,6 +2254,16 @@ mod tests {
             .unwrap()
             .expect("artifact object");
         assert_eq!(object.bytes, b"# Redline\n\n- edit");
+        assert_eq!(
+            kv.list_keys(
+                &keys::artifact_revision_prefix("conic", "infra", "session-1"),
+                None,
+            )
+            .await
+            .unwrap()
+            .len(),
+            1
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Replacement for #329, which GitHub will not reopen after its historical close. This is the same stack layer, rebased onto the replacement generic-resource IO PR.